### PR TITLE
Changed distr_1d members to Float to prevent Enoki baking them into kernels

### DIFF
--- a/src/libcore/tests/test_distr_1d.py
+++ b/src/libcore/tests/test_distr_1d.py
@@ -55,7 +55,7 @@ def test04_discr_basic(variants_vec_backends_once):
     )
 
     assert repr(x) == 'DiscreteDistribution[\n  size = 3,' \
-        '\n  sum = 6,\n  pmf = [1, 3, 2]\n]'
+        '\n  sum = [6],\n  pmf = [1, 3, 2]\n]'
 
     x.pmf()[:] = [1, 1, 1]
     x.update()

--- a/src/librender/mesh.cpp
+++ b/src/librender/mesh.cpp
@@ -382,7 +382,7 @@ Mesh<Float, Spectrum>::primitive_count() const {
 MTS_VARIANT typename Mesh<Float, Spectrum>::ScalarFloat
 Mesh<Float, Spectrum>::surface_area() const {
     ensure_pmf_built();
-    return m_area_pmf.sum();
+    return ek::hsum(m_area_pmf.sum());
 }
 
 MTS_VARIANT typename Mesh<Float, Spectrum>::PositionSample3f


### PR DESCRIPTION
## Description

Changed the members of `ContinuousDistribution` from `ScalarFloat` to `Float` to prevent Enoki from baking them into kernels, hence slowing down iterative algorithms that perform changes in the distributions. See example below. Also renamed the template argument so it is now clearer that it may not be only `Float`, but any `Value`, e.g., `Wavelength`.

## Testing

There are no automated tests, but I prepared the following Python script to show the difference.

The test first creates a uniform `ContinuousDistribution` from 400 to 700 nm, then samples from it 1 million times, and computes the mean sampled wavelength (which should be 550 nm at the beginning). It does this for 100 iterations that each modifies the distribution, increasing the chance to sample higher wavelengths.

**Without this PR**, every new iteration creates a new kernel that causes a cache miss and recompilation.

**With this PR**, the distribution is no longer baked into the kernels, so only the first iteration is slow and each of the rest runs in less than a millisecond.

Note: Don't forget to `rm -r ~/.enoki/*` before repeating the tests

| Without this PR | With this PR |
|--|--|
| ![image](https://user-images.githubusercontent.com/10374559/120332860-6dcc2600-c2ef-11eb-8564-9d66fb732d1e.png) | ![image](https://user-images.githubusercontent.com/10374559/120341083-df5ba280-c2f6-11eb-8e23-4a9a3c15b46b.png) |

```python
from timeit import default_timer as timer
import enoki as ek
import mitsuba
mitsuba.set_variant('cuda_spectral')

seed = 42
wavefront_size = int(1e6)
iterations = int(1e2)

sampler = mitsuba.core.xml.load_dict({"type": "independent", "sample_count": 1, "seed": seed})
sampler.seed(seed, wavefront_size)

distr = mitsuba.core.ContinuousDistribution(range=mitsuba.core.ScalarVector2f(400.0,700.0), pdf=[0.1,0.1,0.1,0.1,0.1])

results = []
times = []

for i in range(iterations):
    start = timer()
    sampler.seed(i, wavefront_size) # reset sampler to break the dependency chain
    
    # Modify the PDF, increase the probability of higher wavelengths:
    distr.pdf()[2:] *= 1.1
    distr.update()

    wavelengths = distr.sample(sampler.next_1d())
    result = ek.hsum_async(wavelengths) / wavefront_size
    
    results.append(result)
    times.append(1000 * (timer() - start))

import matplotlib.pyplot as plt
plt.plot(times)
plt.xlabel("Iteration")
plt.ylabel("Time per iteration [ms]")
plt.ylim(0,100)
plt.show()

plt.plot(results)
plt.xlabel("Iteration")
plt.ylabel("Mean sampled wavelength [nm]")
plt.show()
```

## Checklist:

*Please make sure to complete this checklist before requesting a review.*

- [x] My code follows the [style guidelines](https://mitsuba2.readthedocs.io/en/latest/src/developer_guide/intro.html#introduction) of this project
- [x] My changes generate no new warnings
- [x] My code also compiles for `cuda_*` and `llvm_*` variants. If you can't test this, please leave below
- [x] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 2 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba2/blob/master/LICENSE)