### PR TITLE
Add Python binding for Sensor helper functions

### DIFF
--- a/include/mitsuba/python/docstr.h
+++ b/include/mitsuba/python/docstr.h
@@ -9338,7 +9338,7 @@ Returns:
     The index corresponding to the input index in the pseudorandom
     permutation vector.)doc";
 
-static const char *__doc_mitsuba_perspective_projection = R"doc()doc";
+static const char *__doc_mitsuba_perspective_projection = R"doc(Helper function to create a perspective projection transformation matrix)doc";
 
 static const char *__doc_mitsuba_prepare_ias =
 R"doc(Prepares and fills the OptixInstance array associated with a given

--- a/include/mitsuba/render/sensor.h
+++ b/include/mitsuba/render/sensor.h
@@ -192,6 +192,7 @@ protected:
 /// Helper function to parse the field of view field of a camera
 extern MTS_EXPORT_RENDER float parse_fov(const Properties &props, float aspect);
 
+/// Helper function to create a perspective projection transformation matrix
 template <typename Float> Transform<Point<Float, 4>>
 perspective_projection(const Vector<int, 2> &film_size,
                        const Vector<int, 2> &crop_size,

--- a/src/librender/python/CMakeLists.txt
+++ b/src/librender/python/CMakeLists.txt
@@ -60,6 +60,7 @@ pybind11_add_module(render_ext
   interaction.cpp
   microfacet.cpp
   phase.cpp
+  sensor.cpp
   spiral.cpp
 )
 

--- a/src/librender/python/main.cpp
+++ b/src/librender/python/main.cpp
@@ -5,6 +5,7 @@ MTS_PY_DECLARE(EmitterExtras);
 MTS_PY_DECLARE(HitComputeFlags);
 MTS_PY_DECLARE(MicrofacetType);
 MTS_PY_DECLARE(PhaseFunctionExtras);
+MTS_PY_DECLARE(Sensor);
 MTS_PY_DECLARE(Spiral);
 MTS_PY_DECLARE(VolumeGrid);
 
@@ -17,6 +18,7 @@ PYBIND11_MODULE(render_ext, m) {
     MTS_PY_IMPORT(HitComputeFlags);
     MTS_PY_IMPORT(MicrofacetType);
     MTS_PY_IMPORT(PhaseFunctionExtras);
+    MTS_PY_IMPORT(Sensor);
     MTS_PY_IMPORT(Spiral);
 
     // Change module name back to correct value

--- a/src/librender/python/sensor.cpp
+++ b/src/librender/python/sensor.cpp
@@ -1,0 +1,7 @@
+#include <mitsuba/render/sensor.h>
+#include <mitsuba/core/properties.h>
+#include <mitsuba/python/python.h>
+
+MTS_PY_EXPORT(Sensor) {
+    m.def("parse_fov", &parse_fov, "props"_a, "aspect"_a, D(parse_fov));
+}

--- a/src/librender/python/sensor_v.cpp
+++ b/src/librender/python/sensor_v.cpp
@@ -72,4 +72,8 @@ MTS_PY_EXPORT(Sensor) {
         .def_method(ProjectiveCamera, near_clip)
         .def_method(ProjectiveCamera, far_clip)
         .def_method(ProjectiveCamera, focus_distance);
+
+    m.def("perspective_projection", &perspective_projection<Float>,
+          "film_size"_a, "crop_size"_a, "crop_offset"_a, "fov_x"_a, "near_clip"_a, "far_clip"_a,
+          D(perspective_projection));
 }

--- a/src/librender/tests/test_sensor.py
+++ b/src/librender/tests/test_sensor.py
@@ -1,0 +1,63 @@
+import numpy as np
+import enoki as ek
+import mitsuba
+
+def test01_parse_fov(variant_scalar_rgb):
+    from mitsuba.core import Properties
+    from mitsuba.render import parse_fov
+    
+    # Focal length re-calculation tests:
+    props = Properties()
+    props["focal_length"] = "50mm"
+    assert ek.allclose(parse_fov(props, aspect=0.5), 21.90213966369629)
+    assert ek.allclose(parse_fov(props, aspect=1.0), 34.02204132080078)
+    assert ek.allclose(parse_fov(props, aspect=1.5), 39.597713470458984)
+    props["focal_length"] = "25mm"
+    assert ek.allclose(parse_fov(props, aspect=1.0), 62.923526763916016)
+    props["fov_axis"] = "y" # should have no effect
+    assert ek.allclose(parse_fov(props, aspect=1.0), 62.923526763916016)
+
+    # Direct FOV input tests with aspect == 1.0:
+    props = Properties()
+    props["fov"] = 35.0
+    assert ek.allclose(parse_fov(props, aspect=1.0), 35.0)
+    for axis in ["x", "y", "smaller", "larger"]:
+        # Should have no effect:
+        props["fov_axis"] = axis
+        assert ek.allclose(parse_fov(props, aspect=1.0), 35.0)
+    props["fov_axis"] = "diagonal"
+    assert ek.allclose(parse_fov(props, aspect=1.0), 25.137083053588867)
+
+    # Direct FOV input tests with aspect != 1.0:
+    props = Properties()
+    props["fov"] = 35.0
+    for axis, result in [
+        ("x", 35.0), ("smaller", 35.0),
+        ("y", 17.917831420898438), ("larger", 17.917831420898438),
+        ("diagonal", 16.052263259887695)
+    ]:
+        props["fov_axis"] = axis
+        assert ek.allclose(parse_fov(props, aspect=0.5), result)
+    for axis, result in [
+        ("x", 35.0), ("larger", 35.0),
+        ("y", 50.6234245300293), ("smaller", 50.6234245300293),
+        ("diagonal", 29.399948120117188)
+    ]:
+        props["fov_axis"] = axis
+        assert ek.allclose(parse_fov(props, aspect=1.5), result)
+
+def test02_perspective_projection(variant_scalar_rgb):
+    from mitsuba.core import Matrix4f
+    from mitsuba.render import perspective_projection
+
+    assert ek.allclose(perspective_projection(
+        film_size=[128,32],
+        crop_size=[16,8],
+        crop_offset=[8,4],
+        fov_x = 35.0,
+        near_clip = 10.0,
+        far_clip = 1000.0).matrix,
+        Matrix4f([[-12.686378479003906, 0.0, 3.5, 0.0],
+                  [0.0, -25.372756958007812, 1.5, 0.0],
+                  [0.0, 0.0, 1.010101079940796, -10.1010103225708],
+                  [0, 0, 1, 0]]))


### PR DESCRIPTION
## Description

Added Python bindings for `parse_fov` and `perspective_projection`, which are useful when creating custom sensors.

(At some later time, it might be useful to also create unit tests for these two functions separately)

## Checklist:

*Please make sure to complete this checklist before requesting a review.*

- [x] My code follows the [style guidelines](https://mitsuba2.readthedocs.io/en/latest/src/developer_guide/intro.html#introduction) of this project
- [x] My changes generate no new warnings
- [x] My code also compiles for `cuda_*` and `llvm_*` variants. If you can't test this, please leave below
- [x] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 2 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba2/blob/master/LICENSE)