### PR TITLE
irradiancemeter: Fix to_string()

### DIFF
--- a/src/sensors/irradiancemeter.cpp
+++ b/src/sensors/irradiancemeter.cpp
@@ -99,10 +99,17 @@ public:
     ScalarBoundingBox3f bbox() const override { return m_shape->bbox(); }
 
     std::string to_string() const override {
+        using string::indent;
+
         std::ostringstream oss;
         oss << "IrradianceMeter[" << std::endl
-            << "  shape = " << m_shape << "," << std::endl
-            << "  film = " << m_film << "," << std::endl
+            << "  surface_area = ";
+
+        if (m_shape) oss << m_shape->surface_area();
+            else         oss << " <no shape attached!>";
+        oss << "," << std::endl;
+
+        oss << "  film = " << indent(m_film) << "," << std::endl
             << "]";
         return oss.str();
     }


### PR DESCRIPTION
This PR fixes the `to_string()` method of the `irradiancemeter` plugin. The `m_shape` member display would have it recurse and eventually segfault. It also adds the sensor's surface area and proper indentation to members which need it.

## Testing

None required. Existing tests pass.

## Checklist

- [x] My code follows the [style guidelines](https://mitsuba2.readthedocs.io/en/latest/src/developer_guide/intro.html#introduction) of this project
- [x] My changes generate no new warnings
- [ ] My code also compiles for `cuda_*` and `llvm_*` variants. If you can't test this, please leave below
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 2 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba2/blob/master/LICENSE)

Compiled with the `llvm_rgb` variant only.