### PR TITLE
Implementation of OptiX Denoiser from OptiX 7.2 SDK. 2021 spring semester project

### DIFF
--- a/include/mitsuba/python/docstr.h
+++ b/include/mitsuba/python/docstr.h
@@ -7978,6 +7978,10 @@ Parameter ``frame``:
 
 static const char *__doc_mitsuba_coordinate_system = R"doc(Complete the set {a} to an orthonormal basis {a, b, c})doc";
 
+static const char *__doc_mitsuba_denoise = R"doc(Denoise a given bitmap using albedo and normals map and the OptiX denoiser)doc";
+
+static const char *__doc_mitsuba_denoise_2 = R"doc(Denoise a given bitmap using the OptiX denoiser)doc";
+
 static const char *__doc_mitsuba_depolarize =
 R"doc(Return the (1,1) entry of a Mueller matrix. Identity function for all
 other-types.)doc";

--- a/include/mitsuba/render/bsdf.h
+++ b/include/mitsuba/render/bsdf.h
@@ -1,7 +1,6 @@
 /*
     Mitsuba 2: A Retargetable Forward and Inverse Renderer
     Copyright 2019, Realistic Graphics Lab, EPFL.
-
     All rights reserved. Use of this source code is governed by a
     BSD-style license that can be found in the LICENSE.txt file.
 */
@@ -477,6 +476,9 @@ public:
     /// Set a string identifier
     void set_id(const std::string& id) override { m_id = id; };
 
+    /// Return the diffuse reflectance value (if any)
+    virtual Spectrum get_diffuse_reflectance(const SurfaceInteraction3f &si, Mask active = true) const;
+
     /// Return a human-readable representation of the BSDF
     std::string to_string() const override = 0;
 
@@ -556,6 +558,7 @@ ENOKI_VCALL_TEMPLATE_BEGIN(mitsuba::BSDF)
     ENOKI_VCALL_METHOD(eval_null_transmission)
     ENOKI_VCALL_METHOD(pdf)
     ENOKI_VCALL_METHOD(eval_pdf)
+    ENOKI_VCALL_METHOD(get_diffuse_reflectance)
     ENOKI_VCALL_GETTER(flags, uint32_t)
     auto needs_differentials() const {
         return has_flag(flags(), mitsuba::BSDFFlags::NeedsDifferentials);

--- a/include/mitsuba/render/denoiser.h
+++ b/include/mitsuba/render/denoiser.h
@@ -6,7 +6,6 @@
 #include <enoki-jit/optix.h>
 #include <enoki/array.h>
 #include <iostream>
-#include <exception>
 
 #define optix_check(call) if(call != 0) {std::cerr << "Optix call failed" << std::endl; return Float(0.0);}                  
 
@@ -35,10 +34,6 @@ Float denoise (const Bitmap& noisy, Bitmap* albedo, Bitmap* normals) {
         optix_check(optixDenoiserComputeMemoryResources(denoiser, noisy.width(), noisy.height(), &sizes));
         scratch_size = static_cast<uint32_t>(sizes.withoutOverlapScratchSizeInBytes);
         state_size = static_cast<uint32_t>(sizes.stateSizeInBytes);
-        // const uint64_t frame_size = noisy.pixel_count() * noisy.bytes_per_pixel();
-
-        std::cout << scratch_size << std::endl;
-        std::cout << state_size << std::endl;
 
         Float intensity_float = ek::zero<Float>(1);
         Float scratch_float = ek::zero<Float>(scratch_size / sizeof(float));
@@ -57,23 +52,18 @@ Float denoise (const Bitmap& noisy, Bitmap* albedo, Bitmap* normals) {
 
         output.width = noisy.width();
         output.height = noisy.height();
-        output.format = OPTIX_PIXEL_FORMAT_FLOAT4;
+        output.format = noisy.has_alpha() ? OPTIX_PIXEL_FORMAT_FLOAT4 : OPTIX_PIXEL_FORMAT_FLOAT3;
         output.rowStrideInBytes = noisy.width() * noisy.bytes_per_pixel();
         output.pixelStrideInBytes = noisy.bytes_per_pixel();
+
         DynamicBuffer<Float> noisy_data = ek::load<DynamicBuffer<Float>>(noisy.data(), noisy.pixel_count() * noisy.channel_count());
         inputs[0].data = noisy_data.data();
         inputs[0].width = noisy.width();
         inputs[0].height = noisy.height();
-        inputs[0].format = OPTIX_PIXEL_FORMAT_FLOAT4;
+        inputs[0].format = noisy.has_alpha() ? OPTIX_PIXEL_FORMAT_FLOAT4 : OPTIX_PIXEL_FORMAT_FLOAT3;
         inputs[0].rowStrideInBytes = noisy.width() * noisy.bytes_per_pixel();
         inputs[0].pixelStrideInBytes = noisy.bytes_per_pixel();
-
-        // std::cout << noisy.pixel_format() << std::endl;
-        // std::cout << noisy.has_alpha() << std::endl;
-        // std::cout << noisy.bytes_per_pixel() << std::endl;
-        std::cout << noisy_data << std::endl;
         
-
         unsigned int nb_channels = 1;
         if(albedo != nullptr) {
 
@@ -81,7 +71,7 @@ Float denoise (const Bitmap& noisy, Bitmap* albedo, Bitmap* normals) {
             inputs[1].data = albedo_data.data();
             inputs[1].width = albedo->width();
             inputs[1].height = albedo->height();
-            inputs[1].format = OPTIX_PIXEL_FORMAT_FLOAT4;
+            inputs[1].format = albedo->has_alpha() ? OPTIX_PIXEL_FORMAT_FLOAT4 : OPTIX_PIXEL_FORMAT_FLOAT3;
             inputs[1].rowStrideInBytes = albedo->width() * albedo->bytes_per_pixel();
             inputs[1].pixelStrideInBytes = albedo->bytes_per_pixel();
             nb_channels++;
@@ -91,7 +81,7 @@ Float denoise (const Bitmap& noisy, Bitmap* albedo, Bitmap* normals) {
             inputs[2].data = normals_data.data();
             inputs[2].width = normals->width();
             inputs[2].height = normals->height();
-            inputs[2].format = OPTIX_PIXEL_FORMAT_FLOAT4;
+            inputs[2].format = normals->has_alpha() ? OPTIX_PIXEL_FORMAT_FLOAT4 : OPTIX_PIXEL_FORMAT_FLOAT3;
             inputs[2].rowStrideInBytes = normals->width() * normals->bytes_per_pixel();
             inputs[2].pixelStrideInBytes = normals->bytes_per_pixel();
             nb_channels++;
@@ -108,12 +98,9 @@ Float denoise (const Bitmap& noisy, Bitmap* albedo, Bitmap* normals) {
                                         0, 0, &output, scratch, scratch_size));
 
         Float denoised_data = ek::map<Float>(output.data, noisy.pixel_count() * noisy.channel_count());
-        // Float denoised_data = ek::map<Float>(output.data, 114688);
-
         ek::eval();
         ek::sync_thread();
 
-        std::cout << denoised_data << std::endl;
         optix_check(optixDenoiserDestroy(denoiser));
         return denoised_data;
     }

--- a/include/mitsuba/render/denoiser.h
+++ b/include/mitsuba/render/denoiser.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <mitsuba/core/bitmap.h>
+#include <mitsuba/render/optix_api.h>
+
+NAMESPACE_BEGIN(mitsuba)
+
+void denoise (Bitmap& noisy, const Bitmap* albedo, const Bitmap* normals) {
+    noisy.data();
+    albedo->data();
+    normals->data();
+}
+
+void denoise (Bitmap& noisy) {
+    denoise(noisy, nullptr, nullptr);
+}
+
+NAMESPACE_END(mitsuba)

--- a/include/mitsuba/render/denoiser.h
+++ b/include/mitsuba/render/denoiser.h
@@ -2,17 +2,113 @@
 
 #include <mitsuba/core/bitmap.h>
 #include <mitsuba/render/optix_api.h>
+#include <enoki-jit/optix.h>
+#include <enoki/array.h>
 
 NAMESPACE_BEGIN(mitsuba)
 
+template <typename Float>
 void denoise (Bitmap& noisy, const Bitmap* albedo, const Bitmap* normals) {
-    noisy.data();
-    albedo->data();
-    normals->data();
+    OptixDeviceContext context = jit_optix_context();
+
+    OptixDenoiser* denoiser = new OptixDenoiser();        
+    OptixDenoiserSizes* sizes = new OptixDenoiserSizes();
+    OptixDenoiserParams* params = new OptixDenoiserParams();
+    OptixDenoiserOptions* options = new OptixDenoiserOptions();
+    OptixDenoiserModelKind modelKind = OPTIX_DENOISER_MODEL_KIND_AOV;
+    options->inputKind = OPTIX_DENOISER_INPUT_RGB_ALBEDO_NORMAL;
+
+    uint32_t scratch_size = 0;
+    uint32_t state_size = 0;
+    const uint64_t frame_size = noisy.width() * noisy.height();
+
+    OptixImage2D inputs[3] = {};
+    OptixImage2D output;
+
+    //TODO check result
+    OptixResult result = optixDenoiserCreate(context, options, denoiser); 
+    result = optixDenoiserSetModel(denoiser, modelKind, nullptr, 0);
+    result = optixDenoiserComputeMemoryResources(denoiser, noisy.width(), noisy.height(), sizes);
+    scratch_size = static_cast<uint32_t>(sizes->withoutOverlapScratchSizeInBytes / sizeof(float));
+
+    ek::Array<Float> int_float = ek::zero<Float>(1);
+    ek::Array<Float> scratch_float = ek::zero<Float>(scratch_size);
+    ek::Array<Float> state_float = ek::zero<Float>(sizes->stateSizeInBytes / sizeof(float));
+    ek::Array<Float> noisy_data = ek::zero<Float>(frame_size);
+    ek::Array<Float> normals_data = ek::zero<Float>(frame_size);
+    ek::Array<Float> albedo_data = ek::zero<Float>(frame_size);
+    ek::Array<Float> output_data = ek::zero<Float>(frame_size);
+    ek::eval(int_float);
+    ek::eval(scratch_float);
+    ek::eval(state_float);
+    ek::eval(noisy_data);
+    ek::eval(normals_data);
+    ek::eval(albedo_data);
+    ek::eval(output_data);
+    CUdeviceptr intensity = (CUdeviceptr) int_float.data();
+    CUdeviceptr scratch = (CUdeviceptr) scratch_float.data();
+    CUdeviceptr state = (CUdeviceptr) state_float.data();
+
+    inputs[0].data = noisy.data();
+    inputs[0].width = noisy.width();
+    inputs[0].height = noisy.height();
+    inputs[0].format = OPTIX_PIXEL_FORMAT_FLOAT4;
+    inputs[0].rowStrideInBytes = noisy.width() * 4 * sizeof(Float);
+    inputs[0].pixelStrideInBytes = 4 * sizeof(Float);
+
+    unsigned int nb_channels = 1;
+    if(albedo!= nullptr) {
+        inputs[1].data = (void*) albedo->data();
+        inputs[1].width = albedo->width();
+        inputs[1].height = albedo->height();
+        inputs[1].format = OPTIX_PIXEL_FORMAT_FLOAT4;
+        inputs[1].rowStrideInBytes = albedo->width() * 4 * sizeof(Float);
+        inputs[1].pixelStrideInBytes = 4 * sizeof(Float);
+        nb_channels++;
+    }
+    if(normals != nullptr) {
+        inputs[2].data = (void*) normals->data();
+        inputs[2].width = normals->width();
+        inputs[2].height = normals->height();
+        inputs[2].format = OPTIX_PIXEL_FORMAT_FLOAT4;
+        inputs[2].rowStrideInBytes = normals->width() * 4 * sizeof(Float);
+        inputs[2].pixelStrideInBytes = 4 * sizeof(Float);
+        nb_channels++;
+    }
+
+    output.data = output_data.data();
+    output.width = noisy.width();
+    output.height = noisy.height();
+    output.format = OPTIX_PIXEL_FORMAT_FLOAT4;
+    output.rowStrideInBytes = noisy.width() * 4 * sizeof(Float);
+    output.pixelStrideInBytes = 4 * sizeof(Float);
+
+    result = optixDenoiserSetup(denoiser, 0, noisy.width(), noisy.height(), state, state_size, scratch, scratch_size);
+
+    params->denoiseAlpha = 0;
+    params->hdrIntensity = intensity;
+    params->blendFactor  = 0.0f;
+
+    result = optixDenoiserComputeIntensity(denoiser, 0, inputs, intensity, scratch, scratch_size); 
+    result = optixDenoiserInvoke(denoiser, 0, params, state, state_size, inputs, nb_channels, 0, 0, &output, scratch, scratch_size);
+    if(result != 0)
+        return;
+    
+    Float* data_ptr = (Float*) noisy.data();
+    Float* output_ptr = (Float*) output.data;
+    for(size_t i = 0 ; i < frame_size ; ++i)
+        data_ptr[i] = output_ptr[i];
+
+    optixDenoiserDestroy(denoiser);
+    delete options;
+    delete params;
+    delete sizes;
+    delete denoiser;
 }
 
+template <typename Float>
 void denoise (Bitmap& noisy) {
-    denoise(noisy, nullptr, nullptr);
+    denoise<Float>(noisy, nullptr, nullptr);
 }
 
 NAMESPACE_END(mitsuba)

--- a/include/mitsuba/render/denoiser.h
+++ b/include/mitsuba/render/denoiser.h
@@ -6,140 +6,107 @@
 #include <enoki-jit/optix.h>
 #include <enoki/array.h>
 #include <iostream>
+#include <exception>
+
+#define optix_check(call) if(call != 0) {std::cerr << "Optix call failed" << std::endl; return Float(0.0);}                  
 
 NAMESPACE_BEGIN(mitsuba)
 
 template <typename Float>
-void denoise (Bitmap& noisy, const Bitmap* albedo, const Bitmap* normals) {
-    std::cout << "In denoiser " << std::endl;
-    OptixDeviceContext context = jit_optix_context();
-    if(context == nullptr)
-        std::cout << "null context" << std::endl;
+Float denoise (const Bitmap& noisy, Bitmap* albedo, Bitmap* normals) {
+    if constexpr (ek::is_array_v<Float>) {
+        // std::cout << "In denoiser " << std::endl;
+        OptixDeviceContext context = jit_optix_context();
 
-    OptixDenoiser denoiser = nullptr;//new OptixDenoiser();   
-    OptixDenoiserSizes sizes = {};// = new OptixDenoiserSizes();   
-    OptixDenoiserParams params = {};// = new OptixDenoiserParams();   
-    OptixDenoiserOptions options = {};// = new OptixDenoiserOptions();
-    // OptixDenoiser* denoiser = (OptixDenoiser*) jit_malloc(AllocType::Device, sizeof(OptixDenoiser));   
-    // OptixDenoiserSizes* sizes = (OptixDenoiserSizes*) jit_malloc(AllocType::Device, sizeof(OptixDenoiserSizes));   
-    // OptixDenoiserParams* params = (OptixDenoiserParams*) jit_malloc(AllocType::Device, sizeof(OptixDenoiserParams));   
-    // OptixDenoiserOptions* options = (OptixDenoiserOptions*) jit_malloc(AllocType::Device, sizeof(OptixDenoiserOptions));    
-    OptixDenoiserModelKind modelKind = OPTIX_DENOISER_MODEL_KIND_AOV;
-    options.inputKind = OPTIX_DENOISER_INPUT_RGB_ALBEDO_NORMAL;
+        OptixDenoiser denoiser = nullptr;  
+        OptixDenoiserSizes sizes = {};
+        OptixDenoiserParams params = {};
+        OptixDenoiserOptions options = {};
+        OptixDenoiserModelKind modelKind = albedo == nullptr ? OPTIX_DENOISER_MODEL_KIND_HDR : OPTIX_DENOISER_MODEL_KIND_AOV;
+        options.inputKind = albedo == nullptr ? OPTIX_DENOISER_INPUT_RGB : OPTIX_DENOISER_INPUT_RGB_ALBEDO_NORMAL;
 
-    std::cout << "vars created" << std::endl;
+        uint32_t scratch_size = 0;
+        uint32_t state_size = 0;
+        const uint64_t frame_size = noisy.pixel_count();
 
-    uint32_t scratch_size = 0;
-    uint32_t state_size = 0;
-    const uint64_t frame_size = noisy.width() * noisy.height();
+        OptixImage2D inputs[3] = {};
+        OptixImage2D output;
 
-    OptixImage2D inputs[3] = {};
-    OptixImage2D output;
+        optix_check(optixDenoiserCreate(context, &options, &denoiser)); 
+        optix_check(optixDenoiserSetModel(denoiser, modelKind, nullptr, 0));
+        optix_check(optixDenoiserComputeMemoryResources(denoiser, noisy.width(), noisy.height(), &sizes));
+        scratch_size = static_cast<uint32_t>(sizes.withoutOverlapScratchSizeInBytes);
+        state_size = static_cast<uint32_t>(sizes.stateSizeInBytes);
 
-    //TODO check result
-    std::cout << "Creating denoiser " << context << std::endl;
-    OptixResult result = optixDenoiserCreate(context, &options, &denoiser); 
-    std::cout << "Denoiser created " << std::endl;
-    result = optixDenoiserSetModel(denoiser, modelKind, nullptr, 0);
-    std::cout << "Model set" << std::endl;
-    result = optixDenoiserComputeMemoryResources(denoiser, noisy.width(), noisy.height(), &sizes);
-    std::cout << "Mem computed" << std::endl;
-    scratch_size = static_cast<uint32_t>(sizes.withoutOverlapScratchSizeInBytes);
-    std::cout << "Scratch size set" << std::endl;
+        Float intensity_float = ek::zero<Float>(1);
+        Float scratch_float = ek::zero<Float>(scratch_size);
+        Float state_float = ek::zero<Float>(state_size);
+        Float output_data = ek::zero<Float>(frame_size * noisy.channel_count());
+        ek::eval(intensity_float);
+        ek::eval(scratch_float);
+        ek::eval(state_float);
+        ek::eval(output_data);
 
-    ek::Array<Float> int_float = ek::zero<Float>(1);
-    ek::Array<Float> scratch_float = ek::zero<Float>(scratch_size);
-    ek::Array<Float> state_float = ek::zero<Float>(sizes.stateSizeInBytes);
-    ek::Array<Float> noisy_data = ek::zero<Float>(frame_size);
-    ek::Array<Float> normals_data = ek::zero<Float>(frame_size);
-    ek::Array<Float> albedo_data = ek::zero<Float>(frame_size);
-    ek::Array<Float> output_data = ek::zero<Float>(frame_size);
-    ek::eval(int_float);
-    ek::eval(scratch_float);
-    ek::eval(state_float);
-    ek::eval(noisy_data);
-    ek::eval(normals_data);
-    ek::eval(albedo_data);
-    ek::eval(output_data);
-    CUdeviceptr intensity = (CUdeviceptr) int_float.data();
-    CUdeviceptr scratch = (CUdeviceptr) scratch_float.data();
-    CUdeviceptr state = (CUdeviceptr) state_float.data();
-    std::cout << "CUdeviceptr set" << std::endl;
+        CUdeviceptr intensity = 0;
+        CUdeviceptr scratch = 0;
+        CUdeviceptr state = 0;
+        intensity = intensity_float.data();
+        scratch = scratch_float.data();
+        state = state_float.data();
+        output.data = output_data.data();
 
-    inputs[0].data = noisy.data();
-    inputs[0].width = noisy.width();
-    inputs[0].height = noisy.height();
-    inputs[0].format = OPTIX_PIXEL_FORMAT_FLOAT4;
-    inputs[0].rowStrideInBytes = noisy.width() * 4 * sizeof(Float);
-    inputs[0].pixelStrideInBytes = 4 * sizeof(Float);
+        output.width = noisy.width();
+        output.height = noisy.height();
+        output.format = OPTIX_PIXEL_FORMAT_FLOAT4;
+        output.rowStrideInBytes = noisy.width() * 4 * sizeof(Float);
+        output.pixelStrideInBytes = 4 * sizeof(Float);
+        DynamicBuffer<Float> noisy_data = ek::load<DynamicBuffer<Float>>(noisy.data(), noisy.pixel_count() * noisy.channel_count());
+        inputs[0].data = noisy_data.data();
+        inputs[0].width = noisy.width();
+        inputs[0].height = noisy.height();
+        inputs[0].format = OPTIX_PIXEL_FORMAT_FLOAT4;
+        inputs[0].rowStrideInBytes = noisy.width() * 4 * sizeof(Float);
+        inputs[0].pixelStrideInBytes = 4 * sizeof(Float);
 
-    unsigned int nb_channels = 1;
-    if(albedo != nullptr) {
-        inputs[1].data = (void*) albedo->data();
-        inputs[1].width = albedo->width();
-        inputs[1].height = albedo->height();
-        inputs[1].format = OPTIX_PIXEL_FORMAT_FLOAT4;
-        inputs[1].rowStrideInBytes = albedo->width() * 4 * sizeof(Float);
-        inputs[1].pixelStrideInBytes = 4 * sizeof(Float);
-        nb_channels++;
+        unsigned int nb_channels = 1;
+        if(albedo != nullptr) {
+
+            DynamicBuffer<Float> albedo_data = ek::load<DynamicBuffer<Float>>(albedo->data(), albedo->pixel_count() * albedo->channel_count());
+            inputs[1].data = albedo_data.data();
+            inputs[1].width = albedo->width();
+            inputs[1].height = albedo->height();
+            inputs[1].format = OPTIX_PIXEL_FORMAT_FLOAT4;
+            inputs[1].rowStrideInBytes = albedo->width() * 4 * sizeof(Float);
+            inputs[1].pixelStrideInBytes = 4 * sizeof(Float);
+            nb_channels++;
+        }
+        if(normals != nullptr) {
+            DynamicBuffer<Float> normals_data = ek::load<DynamicBuffer<Float>>(normals->data(), normals->pixel_count() * normals->channel_count());
+            inputs[2].data = normals_data.data();
+            inputs[2].width = normals->width();
+            inputs[2].height = normals->height();
+            inputs[2].format = OPTIX_PIXEL_FORMAT_FLOAT4;
+            inputs[2].rowStrideInBytes = normals->width() * 4 * sizeof(Float);
+            inputs[2].pixelStrideInBytes = 4 * sizeof(Float);
+            nb_channels++;
+        }
+
+        optix_check(optixDenoiserSetup(denoiser, 0, noisy.width(), noisy.height(), state, state_size, scratch, scratch_size));
+        optix_check(optixDenoiserComputeIntensity(denoiser, 0, inputs, intensity, scratch, scratch_size)); 
+        optix_check(optixDenoiserInvoke(denoiser, 0, &params, state, state_size, inputs, nb_channels, 
+                                        0, 0, &output, scratch, scratch_size));
+
+        Float denoised_data = ek::map<Float>(output.data, noisy.pixel_count() * noisy.channel_count());
+
+        optix_check(optixDenoiserDestroy(denoiser));
+        return denoised_data;
     }
-    if(normals != nullptr) {
-        inputs[2].data = (void*) normals->data();
-        inputs[2].width = normals->width();
-        inputs[2].height = normals->height();
-        inputs[2].format = OPTIX_PIXEL_FORMAT_FLOAT4;
-        inputs[2].rowStrideInBytes = normals->width() * 4 * sizeof(Float);
-        inputs[2].pixelStrideInBytes = 4 * sizeof(Float);
-        nb_channels++;
-    }
-    std::cout << "inputs set" << std::endl;
-
-    output.data = output_data.data();
-    output.width = noisy.width();
-    output.height = noisy.height();
-    output.format = OPTIX_PIXEL_FORMAT_FLOAT4;
-    output.rowStrideInBytes = noisy.width() * 4 * sizeof(Float);
-    output.pixelStrideInBytes = 4 * sizeof(Float);
-
-    std::cout << "outputs set" << std::endl;
-
-    result = optixDenoiserSetup(denoiser, 0, noisy.width(), noisy.height(), state, state_size, scratch, scratch_size);
-
-    std::cout << "denoiser setup" << std::endl;
- 
-    params.denoiseAlpha = 0;
-    params.hdrIntensity = intensity;
-    params.blendFactor  = 0.0f;
-
-    result = optixDenoiserComputeIntensity(denoiser, 0, inputs, intensity, scratch, scratch_size); 
-
-    std::cout << "intensity computed" << std::endl;
-
-    result = optixDenoiserInvoke(denoiser, 0, &params, state, state_size, inputs, nb_channels, 0, 0, &output, scratch, scratch_size);
-
-    std::cout << "invoked" << std::endl;
-    
-    Float* data_ptr = (Float*) noisy.data();
-    Float* output_ptr = (Float*) output.data;
-    for(size_t i = 0 ; i < frame_size ; ++i)
-        data_ptr[i] = output_ptr[i];
-    
-    std::cout << "data copied" << std::endl;
-
-    optixDenoiserDestroy(denoiser);
-
-    std::cout << "denoiser destroyed" << std::endl;
-
-    std::cout << "result : " << (int) result << std::endl;
-    // delete options;
-    // delete params;
-    // delete sizes;
-    // delete denoiser;
+    return Float(0.0);
 }
 
 template <typename Float>
-void denoise (Bitmap& noisy) {
-    denoise<Float>(noisy, nullptr, nullptr);
+Float denoise (const Bitmap& noisy) {
+    return denoise<Float>(noisy, nullptr, nullptr);
 }
 
 NAMESPACE_END(mitsuba)

--- a/include/mitsuba/render/optix_api.h
+++ b/include/mitsuba/render/optix_api.h
@@ -226,20 +226,20 @@ struct OptixShaderBindingTable {
 /// Various sizes related to the denoiser.
 ///
 /// \see #optixDenoiserComputeMemoryResources()
-typedef struct OptixDenoiserSizes
+struct OptixDenoiserSizes
 {
     size_t       stateSizeInBytes;
     size_t       withOverlapScratchSizeInBytes;
     size_t       withoutOverlapScratchSizeInBytes;
     unsigned int overlapWindowSizeInPixels;
-} OptixDenoiserSizes;
+};
 
 /// Various parameters used by the denoiser
 ///
 /// \see #optixDenoiserInvoke()
 /// \see #optixDenoiserComputeIntensity()
 /// \see #optixDenoiserComputeAverageColor()
-typedef struct OptixDenoiserParams
+struct OptixDenoiserParams
 {
     /// if set to nonzero value, denoise alpha channel (if present) in first inputLayer image
     unsigned int denoiseAlpha;
@@ -260,7 +260,7 @@ typedef struct OptixDenoiserParams
     /// points to three floats. with the default (null pointer) denoised results will not be
     /// optimal.
     CUdeviceptr  hdrAverageColor;
-} OptixDenoiserParams;
+};
 
 /// Input kinds used by the denoiser.
 ///
@@ -268,17 +268,17 @@ typedef struct OptixDenoiserParams
 /// Albedo values must be in the range [0..1] (values less than zero will be clamped to zero).
 /// The normals must be transformed into screen space. The z component is not used.
 /// \see #OptixDenoiserOptions::inputKind
-typedef enum OptixDenoiserInputKind
+enum OptixDenoiserInputKind
 {
     OPTIX_DENOISER_INPUT_RGB               = 0x2301,
     OPTIX_DENOISER_INPUT_RGB_ALBEDO        = 0x2302,
     OPTIX_DENOISER_INPUT_RGB_ALBEDO_NORMAL = 0x2303,
-} OptixDenoiserInputKind;
+};
 
 /// Model kind used by the denoiser.
 ///
 /// \see #optixDenoiserSetModel()
-typedef enum OptixDenoiserModelKind
+enum OptixDenoiserModelKind
 {
     /// Use the model provided by the associated pointer.  See the programming guide for a
     /// description of how to format the data.
@@ -293,21 +293,21 @@ typedef enum OptixDenoiserModelKind
     /// Use the built-in model appropriate for high dynamic range input and support for AOVs
     OPTIX_DENOISER_MODEL_KIND_AOV = 0x2324,
 
-} OptixDenoiserModelKind;
+};
 
 /// Options used by the denoiser
 ///
 /// \see #optixDenoiserCreate()
-typedef struct OptixDenoiserOptions
+struct OptixDenoiserOptions
 {
     /// The kind of denoiser input.
     OptixDenoiserInputKind inputKind;
-} OptixDenoiserOptions;
+};
 
 /// Pixel formats used by the denoiser.
 ///
 /// \see #OptixImage2D::format
-typedef enum OptixPixelFormat
+enum OptixPixelFormat
 {
     OPTIX_PIXEL_FORMAT_HALF3  = 0x2201,  ///< three halfs, RGB
     OPTIX_PIXEL_FORMAT_HALF4  = 0x2202,  ///< four halfs, RGBA
@@ -315,12 +315,12 @@ typedef enum OptixPixelFormat
     OPTIX_PIXEL_FORMAT_FLOAT4 = 0x2204,  ///< four floats, RGBA
     OPTIX_PIXEL_FORMAT_UCHAR3 = 0x2205,  ///< three unsigned chars, RGB
     OPTIX_PIXEL_FORMAT_UCHAR4 = 0x2206   ///< four unsigned chars, RGBA
-} OptixPixelFormat;
+};
 
 /// Image descriptor used by the denoiser.
 ///
 /// \see #optixDenoiserInvoke(), #optixDenoiserComputeIntensity()
-typedef struct OptixImage2D
+struct OptixImage2D
 {
     /// Pointer to the actual pixel data.
     CUdeviceptr data;
@@ -335,7 +335,7 @@ typedef struct OptixImage2D
     unsigned int pixelStrideInBytes;
     /// Pixel format.
     OptixPixelFormat format;
-} OptixImage2D;
+};
 
 // =====================================================
 //             Commonly used OptiX functions

--- a/include/mitsuba/render/optix_api.h
+++ b/include/mitsuba/render/optix_api.h
@@ -25,6 +25,8 @@ using OptixAccelPropertyType = int;
 using OptixProgramGroupKind  = int;
 using OptixDeviceContext     = void*;
 
+using OptixDenoiser          = void*;
+
 // =====================================================
 //            Commonly used OptiX constants
 // =====================================================
@@ -221,6 +223,120 @@ struct OptixShaderBindingTable {
     unsigned int callablesRecordCount;
 };
 
+/// Various sizes related to the denoiser.
+///
+/// \see #optixDenoiserComputeMemoryResources()
+typedef struct OptixDenoiserSizes
+{
+    size_t       stateSizeInBytes;
+    size_t       withOverlapScratchSizeInBytes;
+    size_t       withoutOverlapScratchSizeInBytes;
+    unsigned int overlapWindowSizeInPixels;
+} OptixDenoiserSizes;
+
+/// Various parameters used by the denoiser
+///
+/// \see #optixDenoiserInvoke()
+/// \see #optixDenoiserComputeIntensity()
+/// \see #optixDenoiserComputeAverageColor()
+typedef struct OptixDenoiserParams
+{
+    /// if set to nonzero value, denoise alpha channel (if present) in first inputLayer image
+    unsigned int denoiseAlpha;
+
+    /// average log intensity of input image (default null pointer). points to a single float.
+    /// with the default (null pointer) denoised results will not be optimal for very dark or
+    /// bright input images.
+    CUdeviceptr  hdrIntensity;
+
+    /// blend factor.
+    /// If set to 0 the output is 100% of the denoised input. If set to 1, the output is 100% of
+    /// the unmodified input. Values between 0 and 1 will linearly interpolate between the denoised
+    /// and unmodified input.
+    float        blendFactor;
+
+    /// this parameter is used when the OPTIX_DENOISER_MODEL_KIND_AOV model kind is set.
+    /// average log color of input image, separate for RGB channels (default null pointer).
+    /// points to three floats. with the default (null pointer) denoised results will not be
+    /// optimal.
+    CUdeviceptr  hdrAverageColor;
+} OptixDenoiserParams;
+
+/// Input kinds used by the denoiser.
+///
+/// RGB(A) values less than zero will be clamped to zero.
+/// Albedo values must be in the range [0..1] (values less than zero will be clamped to zero).
+/// The normals must be transformed into screen space. The z component is not used.
+/// \see #OptixDenoiserOptions::inputKind
+typedef enum OptixDenoiserInputKind
+{
+    OPTIX_DENOISER_INPUT_RGB               = 0x2301,
+    OPTIX_DENOISER_INPUT_RGB_ALBEDO        = 0x2302,
+    OPTIX_DENOISER_INPUT_RGB_ALBEDO_NORMAL = 0x2303,
+} OptixDenoiserInputKind;
+
+/// Model kind used by the denoiser.
+///
+/// \see #optixDenoiserSetModel()
+typedef enum OptixDenoiserModelKind
+{
+    /// Use the model provided by the associated pointer.  See the programming guide for a
+    /// description of how to format the data.
+    OPTIX_DENOISER_MODEL_KIND_USER = 0x2321,
+
+    /// Use the built-in model appropriate for low dynamic range input.
+    OPTIX_DENOISER_MODEL_KIND_LDR = 0x2322,
+
+    /// Use the built-in model appropriate for high dynamic range input.
+    OPTIX_DENOISER_MODEL_KIND_HDR = 0x2323,
+
+    /// Use the built-in model appropriate for high dynamic range input and support for AOVs
+    OPTIX_DENOISER_MODEL_KIND_AOV = 0x2324,
+
+} OptixDenoiserModelKind;
+
+/// Options used by the denoiser
+///
+/// \see #optixDenoiserCreate()
+typedef struct OptixDenoiserOptions
+{
+    /// The kind of denoiser input.
+    OptixDenoiserInputKind inputKind;
+} OptixDenoiserOptions;
+
+/// Pixel formats used by the denoiser.
+///
+/// \see #OptixImage2D::format
+typedef enum OptixPixelFormat
+{
+    OPTIX_PIXEL_FORMAT_HALF3  = 0x2201,  ///< three halfs, RGB
+    OPTIX_PIXEL_FORMAT_HALF4  = 0x2202,  ///< four halfs, RGBA
+    OPTIX_PIXEL_FORMAT_FLOAT3 = 0x2203,  ///< three floats, RGB
+    OPTIX_PIXEL_FORMAT_FLOAT4 = 0x2204,  ///< four floats, RGBA
+    OPTIX_PIXEL_FORMAT_UCHAR3 = 0x2205,  ///< three unsigned chars, RGB
+    OPTIX_PIXEL_FORMAT_UCHAR4 = 0x2206   ///< four unsigned chars, RGBA
+} OptixPixelFormat;
+
+/// Image descriptor used by the denoiser.
+///
+/// \see #optixDenoiserInvoke(), #optixDenoiserComputeIntensity()
+typedef struct OptixImage2D
+{
+    /// Pointer to the actual pixel data.
+    CUdeviceptr data;
+    /// Width of the image (in pixels)
+    unsigned int width;
+    /// Height of the image (in pixels)
+    unsigned int height;
+    /// Stride between subsequent rows of the image (in bytes).
+    unsigned int rowStrideInBytes;
+    /// Stride between subsequent pixels of the image (in bytes).
+    /// For now, only 0 or the value that corresponds to a dense packing of pixels (no gaps) is supported.
+    unsigned int pixelStrideInBytes;
+    /// Pixel format.
+    OptixPixelFormat format;
+} OptixImage2D;
+
 // =====================================================
 //             Commonly used OptiX functions
 // =====================================================
@@ -248,6 +364,14 @@ D(optixProgramGroupDestroy, OptixProgramGroup);
 D(optixSbtRecordPackHeader, OptixProgramGroup, void *);
 D(optixAccelCompact, OptixDeviceContext, CUstream, OptixTraversableHandle,
   CUdeviceptr, size_t, OptixTraversableHandle *);
+D(optixDenoiserCreate, OptixDeviceContext, const OptixDenoiserOptions*, OptixDenoiser*);
+D(optixDenoiserSetModel, OptixDenoiser, OptixDenoiserModelKind, void*, size_t);
+D(optixDenoiserComputeMemoryResources, const OptixDenoiser, unsigned int, unsigned int, OptixDenoiserSizes*);
+D(optixDenoiserSetup, OptixDenoiser, CUstream, unsigned int, unsigned int, CUdeviceptr, size_t, CUdeviceptr, size_t);
+D(optixDenoiserComputeIntensity, OptixDenoiser, CUstream, const OptixImage2D* inputImage, CUdeviceptr, CUdeviceptr, size_t);
+D(optixDenoiserInvoke, OptixDenoiser, CUstream, const OptixDenoiserParams*, CUdeviceptr, size_t, const OptixImage2D*, 
+  unsigned int, unsigned int, unsigned int, const OptixImage2D*, CUdeviceptr, size_t);
+D(optixDenoiserDestroy, OptixDenoiser);
 
 #undef D
 

--- a/src/bsdfs/diffuse.cpp
+++ b/src/bsdfs/diffuse.cpp
@@ -160,6 +160,11 @@ public:
     void traverse(TraversalCallback *callback) override {
         callback->put_object("reflectance", m_reflectance.get());
     }
+ 
+    /// Return the diffuse reflectance value (if any)
+    Spectrum get_diffuse_reflectance(const SurfaceInteraction3f &si, Mask active) const override {
+        return m_reflectance->eval(si, active);
+    }
 
     std::string to_string() const override {
         std::ostringstream oss;

--- a/src/bsdfs/plastic.cpp
+++ b/src/bsdfs/plastic.cpp
@@ -337,6 +337,11 @@ public:
 
         if (m_specular_reflectance)
             callback->put_object("specular_reflectance", m_specular_reflectance.get());
+    }   
+    
+    /// Return the diffuse reflectance value (if any)
+    Spectrum get_diffuse_reflectance(const SurfaceInteraction3f &si, Mask active) const override {
+        return m_diffuse_reflectance->eval(si, active);
     }
 
     std::string to_string() const override {

--- a/src/bsdfs/roughplastic.cpp
+++ b/src/bsdfs/roughplastic.cpp
@@ -479,6 +479,11 @@ public:
                  m_internal_reflectance);
     }
 
+    /// Return the diffuse reflectance value (if any)
+    Spectrum get_diffuse_reflectance(const SurfaceInteraction3f &si, Mask active) const override {
+        return m_diffuse_reflectance->eval(si, active);
+    }
+
     std::string to_string() const override {
         std::ostringstream oss;
         oss << "RoughPlastic[" << std::endl

--- a/src/librender/bsdf.cpp
+++ b/src/librender/bsdf.cpp
@@ -21,6 +21,13 @@ MTS_VARIANT Spectrum BSDF<Float, Spectrum>::eval_null_transmission(
     return 0.f;
 }
 
+MTS_VARIANT Spectrum BSDF<Float, Spectrum>::get_diffuse_reflectance(
+    const SurfaceInteraction3f &si, Mask active) const {
+    Vector3f placeholder = Vector3f(0.0f, 0.0f, 1.0f);
+    BSDFContext ctx;
+    return eval(ctx, si, placeholder, active) * 3.14159265358979323846; //M_PI
+}
+
 template <typename Index>
 std::string type_mask_to_string(Index type_mask) {
     std::ostringstream oss;

--- a/src/librender/optix_api.cpp
+++ b/src/librender/optix_api.cpp
@@ -25,6 +25,13 @@ void optix_initialize() {
     L(optixProgramGroupCreate);
     L(optixProgramGroupDestroy)
     L(optixSbtRecordPackHeader);
+    L(optixDenoiserCreate);
+    L(optixDenoiserSetModel);
+    L(optixDenoiserComputeMemoryResources);
+    L(optixDenoiserSetup);
+    L(optixDenoiserComputeIntensity);
+    L(optixDenoiserInvoke);
+    L(optixDenoiserDestroy);
 
     #undef L
 }

--- a/src/librender/python/CMakeLists.txt
+++ b/src/librender/python/CMakeLists.txt
@@ -9,6 +9,7 @@ foreach (MTS_VARIANT ${MTS_VARIANTS})
     THIN_LTO OPT_SIZE
     main_v.cpp
     bsdf_v.cpp
+    denoiser_v.cpp
     emitter_v.cpp
     endpoint_v.cpp
     film_v.cpp

--- a/src/librender/python/bsdf_v.cpp
+++ b/src/librender/python/bsdf_v.cpp
@@ -59,6 +59,11 @@ public:
         PYBIND11_OVERRIDE_PURE(Return, BSDF, eval_pdf, ctx, si, wo, active);
     }
 
+    Spectrum get_diffuse_reflectance(const SurfaceInteraction3f &si,
+              Mask active) const override {
+        PYBIND11_OVERRIDE_PURE(Spectrum, BSDF, get_diffuse_reflectance, si, active);
+    }
+
     std::string to_string() const override {
         PYBIND11_OVERRIDE_PURE(std::string, BSDF, to_string,);
     }
@@ -95,6 +100,10 @@ template <typename Ptr, typename Cls> void bind_bsdf_generic(Cls &cls) {
              [](Ptr bsdf, const SurfaceInteraction3f &si, Mask active) {
                  return bsdf->eval_null_transmission(si, active);
              }, "si"_a, "active"_a = true, D(BSDF, eval_null_transmission))
+        .def("get_diffuse_reflectance",
+             [](Ptr bsdf, const SurfaceInteraction3f &si, Mask active) {
+                 return bsdf->get_diffuse_reflectance(si, active);
+             }, "si"_a, "active"_a = true)
         .def("flags", [](Ptr bsdf) { return bsdf->flags(); }, D(BSDF, flags))
         .def("needs_differentials",
              [](Ptr bsdf) { return bsdf->needs_differentials(); },

--- a/src/librender/python/denoiser_v.cpp
+++ b/src/librender/python/denoiser_v.cpp
@@ -4,9 +4,9 @@
 MTS_PY_EXPORT(denoiser) {
     MTS_PY_IMPORT_TYPES()
     m.def("denoise",
-        py::overload_cast<Bitmap &>(&denoise),
+        py::overload_cast<Bitmap &>(&denoise<Float>),
         "noisy"_a, D(denoise))
     .def("denoise",
-        py::overload_cast<Bitmap &, const Bitmap *, const Bitmap *>(&denoise),
+        py::overload_cast<Bitmap &, const Bitmap *, const Bitmap *>(&denoise<Float>),
         "noisy"_a, "albedo"_a, "normals"_a, D(denoise, 2));
 }

--- a/src/librender/python/denoiser_v.cpp
+++ b/src/librender/python/denoiser_v.cpp
@@ -1,0 +1,12 @@
+#include <mitsuba/render/denoiser.h>
+#include <mitsuba/python/python.h>
+
+MTS_PY_EXPORT(denoiser) {
+    MTS_PY_IMPORT_TYPES()
+    m.def("denoise",
+        py::overload_cast<Bitmap &>(&denoise),
+        "noisy"_a, D(denoise))
+    .def("denoise",
+        py::overload_cast<Bitmap &, const Bitmap *, const Bitmap *>(&denoise),
+        "noisy"_a, "albedo"_a, "normals"_a, D(denoise, 2));
+}

--- a/src/librender/python/denoiser_v.cpp
+++ b/src/librender/python/denoiser_v.cpp
@@ -4,9 +4,9 @@
 MTS_PY_EXPORT(denoiser) {
     MTS_PY_IMPORT_TYPES()
     m.def("denoise",
-        py::overload_cast<Bitmap &>(&denoise<Float>),
+        py::overload_cast<const Bitmap &>(&denoise<Float>),
         "noisy"_a, D(denoise))
     .def("denoise",
-        py::overload_cast<Bitmap &, const Bitmap *, const Bitmap *>(&denoise<Float>),
+        py::overload_cast<const Bitmap &, Bitmap *, Bitmap *>(&denoise<Float>),
         "noisy"_a, "albedo"_a, "normals"_a, D(denoise, 2));
 }

--- a/src/librender/python/main_v.cpp
+++ b/src/librender/python/main_v.cpp
@@ -50,6 +50,7 @@ static py::object caster(Object *o) {
 
 MTS_PY_DECLARE(BSDFSample);
 MTS_PY_DECLARE(BSDF);
+MTS_PY_DECLARE(denoise);
 MTS_PY_DECLARE(Emitter);
 MTS_PY_DECLARE(Endpoint);
 MTS_PY_DECLARE(Film);
@@ -98,6 +99,7 @@ PYBIND11_MODULE(MODULE_NAME, m) {
     MTS_PY_IMPORT(DirectionSample);
     MTS_PY_IMPORT(BSDFSample);
     MTS_PY_IMPORT(BSDF);
+    MTS_PY_IMPORT(denoise);
     MTS_PY_IMPORT(Film);
     MTS_PY_IMPORT(fresnel);
     MTS_PY_IMPORT(ImageBlock);

--- a/src/librender/python/main_v.cpp
+++ b/src/librender/python/main_v.cpp
@@ -50,7 +50,7 @@ static py::object caster(Object *o) {
 
 MTS_PY_DECLARE(BSDFSample);
 MTS_PY_DECLARE(BSDF);
-MTS_PY_DECLARE(denoise);
+MTS_PY_DECLARE(denoiser);
 MTS_PY_DECLARE(Emitter);
 MTS_PY_DECLARE(Endpoint);
 MTS_PY_DECLARE(Film);
@@ -99,7 +99,7 @@ PYBIND11_MODULE(MODULE_NAME, m) {
     MTS_PY_IMPORT(DirectionSample);
     MTS_PY_IMPORT(BSDFSample);
     MTS_PY_IMPORT(BSDF);
-    MTS_PY_IMPORT(denoise);
+    MTS_PY_IMPORT(denoiser);
     MTS_PY_IMPORT(Film);
     MTS_PY_IMPORT(fresnel);
     MTS_PY_IMPORT(ImageBlock);

--- a/src/librender/shape.cpp
+++ b/src/librender/shape.cpp
@@ -184,7 +184,7 @@ static void embree_intersect_packet(int *valid, void *geometryUserPtr,
     using Ray3fP   = Ray<Point<FloatP, 3>, Spectrum>;
     using UInt32P  = ek::uint32_array_t<FloatP>;
 
-    using Float32  = ek::float32_array_t<Float>;
+    // using Float32  = ek::float32_array_t<Float>;
     using Float32P = ek::Packet<ek::scalar_t<Float32>, N>;
 
     const Shape* shape = (const Shape*) geometryUserPtr;


### PR DESCRIPTION

## Description

Integration of Optix Denoiser into Mitsuba2 and corresponding python bindings. Initial work, needs polishing

## Checklist:

- [ ] My code follows the [style guidelines](https://mitsuba2.readthedocs.io/en/latest/src/developer_guide/intro.html#introduction) of this project
- [x] My changes generate no new warnings
- [x] My code also compiles for `cuda_*` and `llvm_*` variants. If you can't test this, please leave below
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 2 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba2/blob/master/LICENSE)