### PR TITLE
Tests: replace usage of `np.random.seed`

### DIFF
--- a/src/conftest.py
+++ b/src/conftest.py
@@ -30,6 +30,12 @@ def gc_collect():
     gc.collect()
 
 
+@pytest.fixture
+def np_rng():
+    import numpy as np
+    return np.random.default_rng(seed=12345)
+
+
 @pytest.hookimpl(hookwrapper=True)
 def pytest_runtest_makereport(item, call):
     outcome = yield

--- a/src/libcore/tests/test_bitmap.py
+++ b/src/libcore/tests/test_bitmap.py
@@ -128,20 +128,19 @@ def test_premultiply_alpha(variant_scalar_rgb, tmpdir):
     assert np.allclose(b3, [1.0, 0.0, 0.0, 1.0, 0.0, 2, 0.0, 0.5, 0.0, 0.0, 0.0, 0.0])
 
 
-def test_read_write_jpeg(variant_scalar_rgb, tmpdir):
+def test_read_write_jpeg(variant_scalar_rgb, tmpdir, np_rng):
     from mitsuba.core import Bitmap, Struct
-    np.random.seed(12345)
     tmp_file = os.path.join(str(tmpdir), "out.jpg")
 
     b = Bitmap(Bitmap.PixelFormat.Y, Struct.Type.UInt8, [10, 10])
-    ref = np.uint8(np.random.random((10, 10))*255)
+    ref = np.uint8(np_rng.random((10, 10))*255)
     np.array(b, copy=False)[:] = ref[..., np.newaxis]
     b.write(tmp_file, quality=50)
     b2 = Bitmap(tmp_file)
     assert np.sum(np.abs(np.float32(np.array(b2)[:, :, 0])-ref)) / (10*10*255) < 0.07
 
     b = Bitmap(Bitmap.PixelFormat.RGB, Struct.Type.UInt8, [10, 10])
-    ref = np.uint8(np.random.random((10, 10, 3))*255)
+    ref = np.uint8(np_rng.random((10, 10, 3))*255)
     np.array(b, copy=False)[:] = ref
     b.write(tmp_file, quality=100)
     b2 = Bitmap(tmp_file)
@@ -150,20 +149,19 @@ def test_read_write_jpeg(variant_scalar_rgb, tmpdir):
     os.remove(tmp_file)
 
 
-def test_read_write_png(variant_scalar_rgb, tmpdir):
+def test_read_write_png(variant_scalar_rgb, tmpdir, np_rng):
     from mitsuba.core import Bitmap, Struct
-    np.random.seed(12345)
     tmp_file = os.path.join(str(tmpdir), "out.png")
 
     b = Bitmap(Bitmap.PixelFormat.Y, Struct.Type.UInt8, [10, 10])
-    ref = np.uint8(np.random.random((10, 10))*255)
+    ref = np.uint8(np_rng.random((10, 10))*255)
     np.array(b, copy=False)[:] = ref[..., np.newaxis]
     b.write(tmp_file)
     b2 = Bitmap(tmp_file)
     assert np.sum(np.abs(np.float32(np.array(b2)[:, :, 0])-ref)) == 0
 
     b = Bitmap(Bitmap.PixelFormat.RGBA, Struct.Type.UInt8, [10, 10])
-    ref = np.uint8(np.random.random((10, 10, 4))*255)
+    ref = np.uint8(np_rng.random((10, 10, 4))*255)
     np.array(b, copy=False)[:] = ref
     b.write(tmp_file)
     b2 = Bitmap(tmp_file)
@@ -172,12 +170,11 @@ def test_read_write_png(variant_scalar_rgb, tmpdir):
     os.remove(tmp_file)
 
 
-def test_read_write_hdr(variant_scalar_rgb, tmpdir):
+def test_read_write_hdr(variant_scalar_rgb, tmpdir, np_rng):
     from mitsuba.core import Bitmap, Struct
-    np.random.seed(12345)
 
     b = Bitmap(Bitmap.PixelFormat.RGB, Struct.Type.Float32, [10, 20])
-    ref = np.float32(np.random.random((20, 10, 3)))
+    ref = np.float32(np_rng.random((20, 10, 3)))
     np.array(b, copy=False)[:] = ref[...]
     tmp_file = os.path.join(str(tmpdir), "out.hdr")
     b.write(tmp_file)
@@ -186,12 +183,11 @@ def test_read_write_hdr(variant_scalar_rgb, tmpdir):
     os.remove(tmp_file)
 
 
-def test_read_write_pfm(variant_scalar_rgb, tmpdir):
+def test_read_write_pfm(variant_scalar_rgb, tmpdir, np_rng):
     from mitsuba.core import Bitmap, Struct
-    np.random.seed(12345)
 
     b = Bitmap(Bitmap.PixelFormat.RGB, Struct.Type.Float32, [10, 20])
-    ref = np.float32(np.random.random((20, 10, 3)))
+    ref = np.float32(np_rng.random((20, 10, 3)))
     np.array(b, copy=False)[:] = ref[...]
     tmp_file = os.path.join(str(tmpdir), "out.pfm")
     b.write(tmp_file)
@@ -200,12 +196,11 @@ def test_read_write_pfm(variant_scalar_rgb, tmpdir):
     os.remove(tmp_file)
 
 
-def test_read_write_ppm(variant_scalar_rgb, tmpdir):
+def test_read_write_ppm(variant_scalar_rgb, tmpdir, np_rng):
     from mitsuba.core import Bitmap, Struct
-    np.random.seed(12345)
 
     b = Bitmap(Bitmap.PixelFormat.RGB, Struct.Type.UInt8, [10, 20])
-    ref = np.uint8(np.random.random((20, 10, 3))*255)
+    ref = np.uint8(np_rng.random((20, 10, 3))*255)
     np.array(b, copy=False)[:] = ref[...]
     tmp_file = os.path.join(str(tmpdir), "out.ppm")
     b.write(tmp_file)

--- a/src/libcore/tests/test_distr_2d.py
+++ b/src/libcore/tests/test_distr_2d.py
@@ -101,20 +101,20 @@ def test03_forward_inverse_nd(variant_scalar_rgb, warp, normalize):
 
     cls = getattr(mitsuba.core, warp)
     ndim = int(warp[-1]) + 2
-    np.random.seed(all_warps.index(warp))
+    rng = np.random.default_rng(seed=all_warps.index(warp))
 
     for i in range(10):
-        shape = np.random.randint(2, 8, ndim)
+        shape = rng.integers(2, 8, ndim)
         param_res = [
-            sorted(np.random.rand(s)) for s in shape[:-2]
+            sorted(rng.random(s)) for s in shape[:-2]
         ]
-        values = np.random.rand(*shape) * 10
+        values = rng.random(shape) * 10
         if i == 9:
             values = np.ones(shape)
         instance = cls(values, param_res, normalize=normalize)
 
         for j in range(10):
-            p_i = Vector2f(np.random.rand(2))
+            p_i = Vector2f(rng.random(2))
             p_o, pdf = instance.sample(p_i)
             assert ek.allclose(pdf, instance.eval(p_o), atol=1e-4)
             p_i_2, pdf2 = instance.invert(p_o)
@@ -134,17 +134,17 @@ def test04_chi2(variants_vec_backends_once, warp, attempt):
 
     cls = getattr(mitsuba.core, warp)
     ndim = int(warp[-1]) + 2
-    np.random.seed(all_warps.index(warp) * 10 + attempt)
+    rng = np.random.default_rng(seed=all_warps.index(warp) * 10 + attempt)
 
-    shape = np.random.randint(2, 8, ndim)
+    shape = rng.integers(2, 8, ndim)
     param_res = [
-        sorted(np.random.rand(s)) for s in shape[:-2]
+        sorted(rng.random(s)) for s in shape[:-2]
     ]
 
     if attempt == 9:
         values = np.ones(shape)
     else:
-        values = np.random.rand(*shape) * 10
+        values = rng.random(shape) * 10
 
     instance = cls(values, param_res)
 
@@ -153,7 +153,7 @@ def test04_chi2(variants_vec_backends_once, warp, attempt):
             ek.lerp(
                 param_res[i][0],
                 param_res[i][-1],
-                np.random.rand()
+                rng.random()
             ) for i in range(0, ndim - 2)
         ]
 

--- a/src/libcore/tests/test_transform.py
+++ b/src/libcore/tests/test_transform.py
@@ -42,8 +42,8 @@ def test01_basics(variants_all_backends_once):
         )
 
 
-def test02_inverse(variant_scalar_rgb):
-    from mitsuba.core import Transform4f, Matrix4f
+def test02_inverse(variant_scalar_rgb, np_rng):
+    from mitsuba.core import Transform4f
 
     p = [1, 2, 3]
     def check_inverse(tr, expected):
@@ -98,7 +98,7 @@ def test02_inverse(variant_scalar_rgb):
     check_inverse(trafo, la.inv(expected))
 
     for i in range(10):
-        mtx = np.random.random((4, 4))
+        mtx = np_rng.random((4, 4))
         inv_ref = la.inv(mtx)
 
         trafo = Transform4f(mtx)
@@ -107,7 +107,7 @@ def test02_inverse(variant_scalar_rgb):
         assert ek.allclose(trafo.matrix, mtx, atol=1e-4)
         assert la.norm(inv_ref-inv_val, 'fro') / la.norm(inv_val, 'fro') < 5e-4
 
-        p = np.random.random((3,))
+        p = np_rng.random((3,))
         res = trafo.inverse() @ (trafo @ p)
         assert la.norm(res - p, 2) < 5e-3
 

--- a/src/librender/tests/test_imageblock.py
+++ b/src/librender/tests/test_imageblock.py
@@ -74,7 +74,7 @@ def test02_put_image_block(variant_scalar_rgb):
         im.put(im2)
         check_value(im, (i+1) * ref)
 
-def test03_put_values_basic(variant_scalar_rgb):
+def test03_put_values_basic(variant_scalar_rgb, np_rng):
     from mitsuba.core.xml import load_string
     from mitsuba.render import ImageBlock
 
@@ -90,7 +90,7 @@ def test03_put_values_basic(variant_scalar_rgb):
     ref = np.zeros(shape=(im.height() + 2 * border, im.width() + 2 * border, 3 + 1 + 1))
     for i in range(border, im.height() + border):
         for j in range(border, im.width() + border):
-            rgb = np.random.uniform(size=(3,))
+            rgb = np_rng.uniform(size=(3,))
             ref[i, j, :3] = rgb
             ref[i, j,  3] = 1  # Alpha
             ref[i, j,  4] = 1  # Weight
@@ -101,7 +101,7 @@ def test03_put_values_basic(variant_scalar_rgb):
     check_value(im, ref, atol=1e-6)
 
 
-def test04_put_vec_basic(variants_vec_rgb):
+def test04_put_vec_basic(variants_vec_rgb, np_rng):
     from mitsuba.core.xml import load_string
     from mitsuba.render import ImageBlock
 
@@ -117,7 +117,7 @@ def test04_put_vec_basic(variants_vec_rgb):
     im.clear()
 
     n = 29
-    positions = np.random.uniform(size=(n, 2))
+    positions = np_rng.uniform(size=(n, 2))
 
     positions[:, 0] = np.floor(positions[:, 0] * (im.width()-1)).astype(int)
     positions[:, 1] = np.floor(positions[:, 1] * (im.height()-1)).astype(int)
@@ -142,7 +142,7 @@ def test04_put_vec_basic(variants_vec_rgb):
     check_value(im, ref, atol=1e-6)
 
 
-def test05_put_with_filter(variants_vec_rgb):
+def test05_put_with_filter(variants_vec_rgb, np_rng):
     from mitsuba.core import float_dtype
     from mitsuba.core.xml import load_string as load_string_vec
     from mitsuba.render import ImageBlock as ImageBlockV
@@ -176,7 +176,7 @@ def test05_put_with_filter(variants_vec_rgb):
         [0, 1], [2, 5], [4, 1], [0, 11], [5, 4]
     ], dtype=float_dtype)
     n = positions.shape[0]
-    positions += np.random.uniform(size=positions.shape, low=0, high=0.95)
+    positions += np_rng.uniform(size=positions.shape, low=0, high=0.95)
 
     rgb = np.arange(n * 3).reshape((n, 3)) * 10
     alphas = np.ones(shape=(n,))
@@ -227,7 +227,7 @@ def test05_put_with_filter(variants_vec_rgb):
     check_value(im2, ref, atol=1e-6)
 
 
-def test06_put_values_basic(variant_scalar_spectral):
+def test06_put_values_basic(variant_scalar_spectral, np_rng):
     from mitsuba.core import MTS_WAVELENGTH_SAMPLES, spectrum_to_srgb
     from mitsuba.core.xml import load_string
     from mitsuba.render import ImageBlock
@@ -245,8 +245,8 @@ def test06_put_values_basic(variant_scalar_spectral):
                           3 + 1 + 1))
     for i in range(border, im.height() + border):
         for j in range(border, im.width() + border):
-            wavelengths = np.random.uniform(size=(MTS_WAVELENGTH_SAMPLES,), low=350, high=750)
-            spectrum = np.random.uniform(size=(MTS_WAVELENGTH_SAMPLES,))
+            wavelengths = np_rng.uniform(size=(MTS_WAVELENGTH_SAMPLES,), low=350, high=750)
+            spectrum = np_rng.uniform(size=(MTS_WAVELENGTH_SAMPLES,))
             ref[i, j, :3] = spectrum_to_srgb(spectrum, wavelengths)
             ref[i, j,  3] = 1  # Alpha
             ref[i, j,  4] = 1  # Weight

--- a/src/librender/tests/test_records.py
+++ b/src/librender/tests/test_records.py
@@ -118,15 +118,14 @@ def test04_direction_sample_construction_single(variant_scalar_rgb):
     assert ek.allclose(record.d, d)
 
 
-def test05_direction_sample_construction_vec(variants_vec_backends_once):
+def test05_direction_sample_construction_vec(variants_vec_backends_once, np_rng):
     from mitsuba.render import DirectionSample3f, SurfaceInteraction3f
     import numpy as np
 
-    np.random.seed(12345)
     refs = np.array([[0.0, 0.5, 0.7],
                      [1.0, 1.5, 0.2],
                      [-1.3, 0.0, 99.1]])
-    its = refs + np.random.uniform(size=refs.shape)
+    its = refs + np_rng.uniform(size=refs.shape)
     directions = its - refs
     directions /= np.expand_dims(np.linalg.norm(directions, axis=1), 0).T
 

--- a/src/librender/tests/test_spectra.py
+++ b/src/librender/tests/test_spectra.py
@@ -44,7 +44,7 @@ def test03_blackbody(variant_scalar_spectral):
                        [0, 10997.9, 11812, 0])
 
 
-def test04_srgb_d65(variant_scalar_spectral):
+def test04_srgb_d65(variant_scalar_spectral, np_rng):
     """srgb_d65 emitters should evaluate to the product of D65 and sRGB spectra,
     with intensity factored out when evaluating the sRGB model."""
 
@@ -55,9 +55,8 @@ def test04_srgb_d65(variant_scalar_spectral):
     import numpy as np
 
 
-    np.random.seed(12345)
     wavelengths = np.linspace(300, 800, MTS_WAVELENGTH_SAMPLES)
-    wavelengths += (10 * np.random.uniform(size=wavelengths.shape)).astype(int)
+    wavelengths += (10 * np_rng.uniform(size=wavelengths.shape)).astype(int)
     d65 = load_string("<spectrum version='2.0.0' type='d65'/>").expand()[0]
 
     ps = PositionSample3f()

--- a/src/librender/tests/test_volumegrid.py
+++ b/src/librender/tests/test_volumegrid.py
@@ -5,10 +5,10 @@ import enoki as ek
 import numpy as np
 import os
 
-def test01_numpy_conversion(variant_scalar_rgb):
+def test01_numpy_conversion(variant_scalar_rgb, np_rng):
     from mitsuba.render import VolumeGrid
 
-    a = np.random.rand(4, 8, 16, 3).astype(np.float32)
+    a = np_rng.random((4, 8, 16, 3)).astype(np.float32)
     grid = VolumeGrid(a)
     assert np.allclose(a, np.array(grid))
     assert np.allclose(np.max(a), grid.max())
@@ -23,11 +23,11 @@ def test01_numpy_conversion(variant_scalar_rgb):
     assert np.allclose(a.shape[3], grid.channel_count())
 
 
-def test02_read_write(variant_scalar_rgb, tmpdir):
+def test02_read_write(variant_scalar_rgb, tmpdir, np_rng):
     from mitsuba.render import VolumeGrid
 
     tmp_file = os.path.join(str(tmpdir), "out.vol")
-    grid = np.random.rand(4, 8, 16, 3).astype(np.float32)
+    grid = np_rng.random((4, 8, 16, 3)).astype(np.float32)
     VolumeGrid(grid).write(tmp_file)
     loaded = VolumeGrid(tmp_file)
     assert np.allclose(np.array(loaded), grid)

--- a/src/python/python/test/util.py
+++ b/src/python/python/test/util.py
@@ -124,8 +124,8 @@ def check_vectorization(kernel, arg_dims = [], width = 125, atol=1e-6, modes=['l
         arg_dims = [1 if t == float else t.Size for t in args_types]
 
     # Construct random argument arrays
-    np.random.seed(0)
-    args_np = [np.random.random(width) if d == 1 else np.random.random((width, d)) for d in arg_dims]
+    rng = np.random.default_rng(seed=0)
+    args_np = [rng.random(width) if d == 1 else rng.random((width, d)) for d in arg_dims]
 
     # Evaluate non-vectorized kernel
     from mitsuba.core import Float, Vector2f, Vector3f

--- a/src/sensors/tests/test_irradiancemeter.py
+++ b/src/sensors/tests/test_irradiancemeter.py
@@ -48,7 +48,7 @@ def test_construct(variant_scalar_rgb):
     ("center", "radius"),
     [([2.0, 5.0, 8.3], 2.0), ([0.0, 0.0, 0.0], 1.0), ([1.0, 4.0, 0.0], 5.0)]
 )
-def test_sampling(variant_scalar_rgb, center, radius):
+def test_sampling(variant_scalar_rgb, center, radius, np_rng):
     """We construct an irradiance meter attached to a sphere and assert that
     sampled rays originate at the sphere's surface
     """
@@ -60,9 +60,9 @@ def test_sampling(variant_scalar_rgb, center, radius):
     sensor = sphere.sensor()
     num_samples = 100
 
-    wav_samples = np.random.rand(num_samples)
-    pos_samples = np.random.rand(num_samples, 2)
-    dir_samples = np.random.rand(num_samples, 2)
+    wav_samples = np_rng.random((num_samples,))
+    pos_samples = np_rng.random((num_samples, 2))
+    dir_samples = np_rng.random((num_samples, 2))
 
     for i in range(num_samples):
         ray = sensor.sample_ray_differential(
@@ -82,7 +82,7 @@ def constant_emitter_dict(radiance):
 
 
 @pytest.mark.parametrize("radiance", [2.04, 1.0, 0.0])
-def test_incoming_flux(variant_scalar_rgb, radiance):
+def test_incoming_flux(variant_scalar_rgb, radiance, np_rng):
     """
     We test the recorded power density of the irradiance meter, by creating a simple scene:
     The irradiance meter is attached to a sphere with unit radius at the coordinate origin
@@ -107,9 +107,9 @@ def test_incoming_flux(variant_scalar_rgb, radiance):
     power_density_cum = 0.0
     num_samples = 100
 
-    wav_samples = np.random.rand(num_samples)
-    pos_samples = np.random.rand(num_samples, 2)
-    dir_samples = np.random.rand(num_samples, 2)
+    wav_samples = np_rng.random((num_samples,))
+    pos_samples = np_rng.random((num_samples, 2))
+    dir_samples = np_rng.random((num_samples, 2))
 
     for i in range(num_samples):
         ray, weight = sensor.sample_ray_differential(

--- a/src/textures/tests/test_bitmap.py
+++ b/src/textures/tests/test_bitmap.py
@@ -32,7 +32,7 @@ def test01_sample_position(variants_vec_backends_once, filter_type, wrap_mode):
 
 
 @fresolver_append_path
-def test02_eval_grad(variant_scalar_rgb):
+def test02_eval_grad(variant_scalar_rgb, np_rng):
     # Tests evaluating the texture gradient under different rotation
     from mitsuba.render import SurfaceInteraction3f
     from mitsuba.core.xml import load_string
@@ -41,7 +41,7 @@ def test02_eval_grad(variant_scalar_rgb):
     import enoki as ek
     delta = 1e-4
     si = SurfaceInteraction3f()
-    for u01 in np.random.rand(10, 1):
+    for u01 in np_rng.random((10, 1)):
         angle = 360.0*u01[0]
         bitmap = load_string("""
         <texture type="bitmap" version="2.0.0">
@@ -50,7 +50,7 @@ def test02_eval_grad(variant_scalar_rgb):
                 <rotate angle="%f"/>
             </transform>
         </texture>""" % angle).expand()[0]
-        for uv in np.random.rand(10, 2):
+        for uv in np_rng.random((10, 2)):
             si.uv = Vector2f(uv)
             f = bitmap.eval_1(si)
             si.uv = uv + Vector2f(delta, 0)


### PR DESCRIPTION
- Replace with a `Generator` object, as suggested by the NumPy documentation.
- Created a PyTest fixture to easily get a seeded NumPy RNG object.