### PR TITLE
Fix film crop in JIT modes

### DIFF
--- a/src/librender/integrator.cpp
+++ b/src/librender/integrator.cpp
@@ -170,6 +170,7 @@ SamplingIntegrator<Float, Spectrum>::render(Scene *scene,
                                                film->reconstruction_filter(),
                                                false, false, false, false);
         block->clear();
+        block->set_offset(film->crop_offset());
         Vector2f pos = Vector2f(Float(idx % uint32_t(film_size[0])),
                                 Float(idx / uint32_t(film_size[0])));
         std::vector<Float> aovs(channels.size());
@@ -177,7 +178,7 @@ SamplingIntegrator<Float, Spectrum>::render(Scene *scene,
         Timer timer;
         for (size_t i = 0; i < n_passes; i++) {
             render_sample(scene, sensor, sampler, block, aovs.data(),
-                          pos, diff_scale_factor);
+                          pos + film->crop_offset(), diff_scale_factor);
             sampler->schedule_state();
 
             if (n_passes > 1) {


### PR DESCRIPTION
Fixes crashing and invalid block data in JIT variants in scenes with sensor cropping, e.g.,

```xml
<?xml version="1.0" encoding="utf-8"?>
<scene version="0.5.0">
​
    <shape type="sphere" name="area_emitter">
        <transform name="toWorld">
            <scale x="1000" y="1000" z="1000"/>
            <translate x="0" y="0" z="4000"/>
        </transform>
        <emitter type="area">
            <spectrum name="radiance" value="10"/>
        </emitter>
    </shape>
​
    <bsdf type="diffuse" id="test_bsdf">
        <texture type="checkerboard" name="reflectance">
            <spectrum name="color0" value="0.5"/>
            <spectrum name="color1" value="1"/>
            <!-- <float name="uscale" value="1"/>
            <float name="vscale" value="1"/>
            <float name="voffset" value="$checkerboardSpacingOffset"/> -->
        </texture>
    </bsdf>
​
	<integrator type="volpath">
		<integer name="maxDepth" value="2"/>
		<integer name="rrDepth" value="2"/>
	</integrator>
​
    <sensor type="perspective" id="camera">
		<float name="nearClip" value="1"/>
		<float name="farClip" value="5000"/>
        <string name="fovAxis" value="x"/>
​
		<transform name="toWorld">
			<lookat target="0, 0, 0" origin="0, 0, 2000" up="0, 1, 0"/>
		</transform>
​
		<sampler type="independent">
			<integer name="sampleCount" value="1024"/>
		</sampler>
​
        <float name="fov" value="3"/>
        <film type="hdrfilm">
			<integer name="height" value="200"/>
			<integer name="width" value="200"/>
            <integer name="crop_offset_x" value="50"/>
			<integer name="crop_offset_y" value="50"/>
            <integer name="crop_width" value="100"/>
			<integer name="crop_height" value="100"/>
			<rfilter type="box"/>
			<boolean name="banner" value="false"/>
		</film>
	</sensor>
​
    <shape type="rectangle">
        <transform name="toWorld">
            <scale x="40" y="40" z="1"/>
            <translate x="0" y="0" z="0"/>
            <!--<rotate x="1" y="1" z="0" angle="-45"/>-->
        </transform>
		<ref id="test_bsdf"/>
	</shape>
​
</scene>
```