### PR TITLE
Sort XML parameters before replacing

### DIFF
--- a/src/libcore/xml.cpp
+++ b/src/libcore/xml.cpp
@@ -439,6 +439,10 @@ static std::pair<std::string, std::string> parse_xml(XMLSource &src, XMLParseCon
                                                      bool within_spectrum = false) {
     try {
         if (!param.empty()) {
+            std::sort(param.begin(), param.end(),
+                [](const auto &a, const auto &b) -> bool {
+                    return a.first.length() > b.first.length();
+                });
             for (auto attr: node.attributes()) {
                 std::string value = attr.value();
                 if (value.find('$') == std::string::npos)


### PR DESCRIPTION
Fixes the following bug:

```python
mitsuba.core.xml.load_string("""<scene version="2.0.0">

<default name="test" value="1.0" />
<default name="testing" value="2.0" />

<spectrum value="$testing" />

</scene>""")
```

```
RuntimeError: ​[xml.cpp:225] Error while loading "<string>" (at line 6, col 2): could not parse constant spectrum "1.0ing".
```