### PR TITLE
Append path to FileResolver in megakernel tests

### DIFF
--- a/src/librender/tests/test_megakernel.py
+++ b/src/librender/tests/test_megakernel.py
@@ -2,6 +2,9 @@ import enoki as ek
 import mitsuba
 import pytest
 
+from mitsuba.python.test.util import fresolver_append_path
+
+
 def write_kernels(*args, output_dir='kernels', scene_fname=None):
     import os
     import json
@@ -27,13 +30,14 @@ def write_kernels(*args, output_dir='kernels', scene_fname=None):
 
 
 @pytest.mark.parametrize('integrator_name', ['rb', 'path'])
+@fresolver_append_path
 def test01_kernel_launches_path(variants_vec_rgb, integrator_name):
     """
     Tests that forward rendering launches the correct number of kernels
     """
     from mitsuba.core import xml
 
-    scene = xml.load_file('../resources/data/scenes/cbox/cbox.xml')
+    scene = xml.load_file('resources/data/scenes/cbox/cbox.xml')
     film_size = scene.sensors()[0].film().crop_size()
     spp = 2
 
@@ -86,8 +90,9 @@ def test01_kernel_launches_path(variants_vec_rgb, integrator_name):
 
 
 @pytest.mark.parametrize('scene_fname', [
-    '../resources/data/scenes/cbox/cbox.xml',
-    '../resources/data/tests/scenes/various_emitters/test_various_emitters.xml'])
+    'resources/data/scenes/cbox/cbox.xml',
+    'resources/data/tests/scenes/various_emitters/test_various_emitters.xml'])
+@fresolver_append_path
 def test02_kernel_launches_ptracer(variants_vec_rgb, scene_fname):
     """
     Tests that forward rendering launches the correct number of kernels
@@ -152,6 +157,7 @@ def test02_kernel_launches_ptracer(variants_vec_rgb, scene_fname):
     assert history_3[2]['size'] == film_wavefront_size
 
 
+@fresolver_append_path
 def test03_kernel_launches_optimization(variants_all_ad_rgb):
     """
     Check the history of kernel launches during a simple optimization loop
@@ -160,7 +166,7 @@ def test03_kernel_launches_optimization(variants_all_ad_rgb):
     from mitsuba.core import xml, Color3f
     from mitsuba.python.util import traverse
 
-    scene = xml.load_file('../resources/data/scenes/cbox/cbox.xml')
+    scene = xml.load_file('resources/data/scenes/cbox/cbox.xml')
     film_size = scene.sensors()[0].film().crop_size()
     spp = 4
 


### PR DESCRIPTION
## Description

A small fix to make it possible to run `pytest test_megakernels.py` from the project root directory.

## Testing

N/A.

## Checklist

- [x] My code follows the [style guidelines](https://mitsuba2.readthedocs.io/en/latest/src/developer_guide/intro.html#introduction) of this project
- [x] My changes generate no new warnings
- [x] My code also compiles for `cuda_*` and `llvm_*` variants. If you can't test this, please leave below
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 2 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba2/blob/master/LICENSE)