### PR TITLE
Print bbox of grids

### DIFF
--- a/src/volumes/grid.cpp
+++ b/src/volumes/grid.cpp
@@ -237,7 +237,7 @@ protected:
 template <typename Float, typename Spectrum, uint32_t Channels, bool Raw>
 class GridVolumeImpl final : public Volume<Float, Spectrum> {
 public:
-    MTS_IMPORT_BASE(Volume, update_bbox, m_to_local)
+    MTS_IMPORT_BASE(Volume, update_bbox, m_to_local, m_bbox)
     MTS_IMPORT_TYPES()
 
     GridVolumeImpl(const Properties &props,
@@ -501,6 +501,7 @@ public:
         std::ostringstream oss;
         oss << "GridVolume[" << std::endl
             << "  to_local = " << m_to_local << "," << std::endl
+            << "  bbox = " << string::indent(m_bbox) << "," << std::endl
             << "  dimensions = " << resolution() << "," << std::endl
             << "  max = " << m_max << "," << std::endl
             << "  channels = " << m_data.shape()[3] << std::endl


### PR DESCRIPTION
## Description

When debugging scenes that include volumes its very useful to know the bounding box of a gridvolume in order to place a corresponding shape correctly arround it.

## Testing

Cosmetic change, no testing needed.

## Checklist:

*Please make sure to complete this checklist before requesting a review.*

- [ ] My code follows the [style guidelines](https://mitsuba2.readthedocs.io/en/latest/src/developer_guide/intro.html#introduction) of this project
- [x] My changes generate no new warnings
- [x] My code also compiles for `cuda_*` and `llvm_*` variants. If you can't test this, please leave below
- [ ] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 2 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba2/blob/master/LICENSE)