### PR TITLE
Particle tracer fixes

### DIFF
--- a/src/emitters/area.cpp
+++ b/src/emitters/area.cpp
@@ -92,11 +92,13 @@ public:
         SurfaceInteraction3f si(ps, ek::zero<Wavelength>());
         auto [wavelength, wav_weight] =
             sample_wavelengths(si, wavelength_sample, active);
+        si.time = time;
+        si.wavelengths = wavelength;
 
         // Note: some terms cancelled out with `warp::square_to_cosine_hemisphere_pdf`.
-        Spectrum weight = 2.f * pos_weight * wav_weight * ek::Pi<ScalarFloat>;
+        Spectrum weight = pos_weight * wav_weight * ek::Pi<ScalarFloat>;
 
-        return { Ray3f(ps.p, Frame3f(ps.n).to_world(local), time, wavelength),
+        return { si.spawn_ray(si.to_world(local)),
                  depolarizer<Spectrum>(weight) & active };
     }
 


### PR DESCRIPTION
The lack or ray origin offset resulted in almost exactly 50%
of the rays to intersect when leaving the shape, which was then
corrected for by an incorrect 2x factor.

- [x] Identify and fix brightness issue from #42 
- [ ] If possible, fix shading normals issue from #42
- [ ] Update render test references
- [ ] Check if other emitters need ray offsets
- [ ] Fix test failures from #41 