### PR TITLE
[Bug] Fixed direct loading of rgb/spectrum using load_dict()

### DIFF
--- a/src/libcore/python/spectrum_v.cpp
+++ b/src/libcore/python/spectrum_v.cpp
@@ -62,4 +62,7 @@ MTS_PY_EXPORT(Spectrum) {
 
     m.def("unpolarized_spectrum", [](const Spectrum &s) { return unpolarized_spectrum(s); }, "");
     m.def("depolarizer", [](const Spectrum &s) { return depolarizer(s); }, "");
+
+    m.def("spectrum_list_to_srgb", &spectrum_list_to_srgb<ScalarFloat>,
+          "wavelengths"_a, "values"_a, "bounded"_a=true);
 }

--- a/src/libcore/python/xml_v.cpp
+++ b/src/libcore/python/xml_v.cpp
@@ -107,12 +107,82 @@ void expand_and_set_object(Properties &props, const std::string &name, const ref
 }
 
 template <typename Float, typename Spectrum>
+ref<Object> create_texture_from(const py::dict &dict, bool within_emitter) {
+    // Treat nested dictionary differently when their type is "rgb" or "spectrum"
+    ref<Object> obj;
+    std::string type = get_type(dict);
+    if (type == "rgb") {
+        if (dict.size() != 2) {
+            Throw("'rgb' dictionary should always contain 2 entries "
+                    "('type' and 'value'), got %u.", dict.size());
+        }
+        // Read info from the dictionary
+        Properties::Color3f color(0.f);
+        for (auto& [k2, value2] : dict) {
+            std::string key2 = k2.template cast<std::string>();
+            if (key2 == "value")
+                color = value2.template cast<Properties::Color3f>();
+            else if (key2 != "type")
+                Throw("Unexpected key in rgb dictionary: %s", key2);
+        }
+        // Update the properties struct
+        obj = mitsuba::xml::detail::create_texture_from_rgb(
+                "rgb", color, GET_VARIANT(), within_emitter);
+    } else if (type == "spectrum") {
+        if (dict.size() != 2) {
+            Throw("'spectrum' dictionary should always contain 2 "
+                    "entries ('type' and 'value'), got %u.", dict.size());
+        }
+        // Read info from the dictionary
+        Properties::Float const_value(1.f);
+        std::vector<Properties::Float> wavelengths;
+        std::vector<Properties::Float> values;
+        for (auto& [k2, value2] : dict) {
+            std::string key2 = k2.template cast<std::string>();
+            if (key2 == "filename") {
+                spectrum_from_file(value2.template cast<std::string>(), wavelengths, values);
+            } else if (key2 == "value") {
+                if (py::isinstance<py::float_>(value2) ||
+                    py::isinstance<py::int_>(value2)) {
+                    const_value = value2.template cast<Properties::Float>();
+                } else if (py::isinstance<py::list>(value2)) {
+                    py::list list = value2.template cast<py::list>();
+                    wavelengths.resize(list.size());
+                    values.resize(list.size());
+                    for (size_t i = 0; i < list.size(); ++i) {
+                        auto pair = list[i].template cast<py::tuple>();
+                        wavelengths[i] = pair[0].template cast<Properties::Float>();
+                        values[i]      = pair[1].template cast<Properties::Float>();
+                    }
+                } else {
+                    Throw("Unexpected value type in 'spectrum' dictionary: %s", value2);
+                }
+            } else if (key2 != "type") {
+                Throw("Unexpected key in spectrum dictionary: %s", key2);
+            }
+        }
+        // Update the properties struct
+        obj = mitsuba::xml::detail::create_texture_from_spectrum(
+                "spectrum", const_value, wavelengths, values, GET_VARIANT(),
+                within_emitter, is_spectral_v<Spectrum>,
+                is_monochromatic_v<Spectrum>);
+    }
+
+    return obj;
+}
+
+template <typename Float, typename Spectrum>
 ref<Object> load_dict(const std::string &dict_key, const py::dict &dict,
                       std::map<std::string, ref<Object>> &instances) {
     MTS_IMPORT_CORE_TYPES()
     using ScalarArray3f = ek::Array<ScalarFloat, 3>;
 
     std::string type = get_type(dict);
+
+    if (type == "spectrum" || type == "rgb") {
+        return create_texture_from<Float, Spectrum>(dict, false);
+    }
+
     bool is_scene = (type == "scene");
 
     const Class *class_;
@@ -147,68 +217,9 @@ ref<Object> load_dict(const std::string &dict_key, const py::dict &dict,
         if (py::isinstance<py::dict>(value)) {
             py::dict dict2 = value.template cast<py::dict>();
             std::string type2 = get_type(dict2);
-
-            // Treat nested dictionary differently when their type is "rgb" or "spectrum"
-            if (type2 == "rgb") {
-                if (dict2.size() != 2) {
-                    Throw("'rgb' dictionary should always contain 2 entries "
-                          "('type' and 'value'), got %u.", dict2.size());
-                }
-                // Read info from the dictionary
-                Properties::Color3f color(0.f);
-                for (auto& [k2, value2] : dict2) {
-                    std::string key2 = k2.template cast<std::string>();
-                    if (key2 == "value")
-                        color = value2.template cast<Properties::Color3f>();
-                    else if (key2 != "type")
-                        Throw("Unexpected key in rgb dictionary: %s", key2);
-                }
-                // Update the properties struct
-                ref<Object> obj = mitsuba::xml::detail::create_texture_from_rgb(
-                    key, color, GET_VARIANT(), within_emitter);
-                props.set_object(key, obj);
-                continue;
-            }
-            if (type2 == "spectrum") {
-                if (dict2.size() != 2) {
-                    Throw("'spectrum' dictionary should always contain 2 "
-                          "entries ('type' and 'value'), got %u.", dict2.size());
-                }
-                // Read info from the dictionary
-                Properties::Float const_value(1.f);
-                std::vector<Properties::Float> wavelengths;
-                std::vector<Properties::Float> values;
-                for (auto& [k2, value2] : dict2) {
-                    std::string key2 = k2.template cast<std::string>();
-                    if (key2 == "filename") {
-                        spectrum_from_file(value2.template cast<std::string>(), wavelengths, values);
-                    } else if (key2 == "value") {
-                        if (py::isinstance<py::float_>(value2) ||
-                            py::isinstance<py::int_>(value2)) {
-                            const_value = value2.template cast<Properties::Float>();
-                        } else if (py::isinstance<py::list>(value2)) {
-                            py::list list = value2.template cast<py::list>();
-                            wavelengths.resize(list.size());
-                            values.resize(list.size());
-                            for (size_t i = 0; i < list.size(); ++i) {
-                                auto pair = list[i].template cast<py::tuple>();
-                                wavelengths[i] = pair[0].template cast<Properties::Float>();
-                                values[i]      = pair[1].template cast<Properties::Float>();
-                            }
-                        } else {
-                            Throw("Unexpected value type in 'spectrum' dictionary: %s", value2);
-                        }
-                    } else if (key2 != "type") {
-                        Throw("Unexpected key in spectrum dictionary: %s", key2);
-                    }
-                }
-                // Update the properties struct
-                ref<Object> obj =
-                    mitsuba::xml::detail::create_texture_from_spectrum(
-                        key, const_value, wavelengths, values, GET_VARIANT(),
-                        within_emitter, is_spectral_v<Spectrum>,
-                        is_monochromatic_v<Spectrum>);
-                props.set_object(key, obj);
+            
+            if (type2 == "spectrum" || type2 == "rgb") {
+                props.set_object(key, create_texture_from<Float, Spectrum>(dict2, within_emitter));
                 continue;
             }
 


### PR DESCRIPTION
## Description

This PR only refactor the logic behind `load_dict()` function in Python.  Given the previous state, if you want to load only `spectrum` or `rgb` (without a scene or parent plugin) it generates an exception. 
The solution is to move the specific code that handles these types before calling `PluginManager` with a non existent plugin name.

Fixes # (issue)

## Testing

Local testing in my machine.

## Checklist:

- [ ] My code follows the [style guidelines](https://mitsuba2.readthedocs.io/en/latest/src/developer_guide/intro.html#introduction) of this project
- [x] My changes generate no new warnings
- [x] My code also compiles for `cuda_*` and `llvm_*` variants. If you can't test this, please leave below
- [ ] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 2 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba2/blob/master/LICENSE)