### PR TITLE
Accelerated PDF integration for the Chi^2 test

### DIFF
--- a/src/bsdfs/tests/test_pplastic.py
+++ b/src/bsdfs/tests/test_pplastic.py
@@ -16,6 +16,7 @@ def test01_chi2_smooth(variants_vec_backends_once_rgb):
         pdf_func=pdf_func,
         sample_dim=3,
         res=201,
+        ires=16,
         seed=2
     )
 

--- a/src/bsdfs/tests/test_rough_conductor.py
+++ b/src/bsdfs/tests/test_rough_conductor.py
@@ -14,8 +14,8 @@ def test01_chi2_smooth(variants_vec_backends_once_rgb):
         sample_func=sample_func,
         pdf_func=pdf_func,
         sample_dim=3,
-        res=151,
-        ires=8
+        res=150,
+        ires=16
     )
 
     assert chi2.run()
@@ -35,7 +35,7 @@ def test02_chi2_aniso_beckmann_all(variants_vec_backends_once_rgb):
         sample_func=sample_func,
         pdf_func=pdf_func,
         sample_dim=3,
-        ires=8
+        ires=16
     )
 
     assert chi2.run()

--- a/src/bsdfs/tests/test_rough_plastic.py
+++ b/src/bsdfs/tests/test_rough_plastic.py
@@ -16,6 +16,7 @@ def test01_chi2_smooth(variants_vec_backends_once_rgb):
         sample_func=sample_func,
         pdf_func=pdf_func,
         sample_dim=3,
+        ires=16,
         res=201
     )
 

--- a/src/librender/tests/test_microfacet.py
+++ b/src/librender/tests/test_microfacet.py
@@ -327,9 +327,8 @@ def test06_chi2(variants_vec_backends_once, md_type_name, alpha, sample_visible,
         sample_func=lambda *args: sample_func(*(list(args) + [angle])),
         pdf_func=lambda *args: pdf_func(*(list(args) + [angle])),
         sample_dim=2,
-        res=203,
-        ires=10,
-        seed=10
+        res=128,
+        ires=32
     )
 
     assert chi2.run()


### PR DESCRIPTION
The previous implementation of the Chi^2 test was written for a much
older version of Enoki, using behavior that is no longer reasonable for
Enoki-JIT. It evaluated the PDF function many (ires * ires) times to
evaluate a trapezoid quadrature rule per cell. With recent versions of
Enoki(-JIT), this can generate incredibly large kernels (e.g. when
ires >= 32) containing thousands of inlined function calls.

This commit adapts the implementation so that the equivalent calculation
takes place with a single PDF evaluation.

It also changes the plotting in case of failures so that the color
scale is anchored at zero (offsets could produce very confusing plots).
