### PR TITLE
[Bug] Fix bitmap texture mirrored wrapping

### DIFF
--- a/src/textures/bitmap.cpp
+++ b/src/textures/bitmap.cpp
@@ -410,9 +410,12 @@ public:
         if (m_wrap_mode == WrapMode::Clamp) {
             return clamp(value, 0, res - 1);
         } else {
+            // In a N-wide texture, pixel positions from -N to -1 should have
+            // div == 0, however at pixel -N we have -1. This also appears at
+            // -2N,-3N,.. all negative positions are therefore shifted by 1.
             T value_shift_neg = ek::select(value < 0, value + 1, value);
             T div = T(m_inv_resolution_x(value_shift_neg.x()),
-                       m_inv_resolution_y(value_shift_neg.y()));
+                      m_inv_resolution_y(value_shift_neg.y()));
 
             T mod = value - div * res;
 

--- a/src/textures/tests/test_bitmap.py
+++ b/src/textures/tests/test_bitmap.py
@@ -77,10 +77,10 @@ def test03_wrap(variants_vec_backends_once_rgb, wrap_mode):
     def eval_ranges(range_x, range_y):
         xv, yv = ek.meshgrid(range_x, range_y)
 
-        siv = SurfaceInteraction3f()
-        siv.uv = [xv, yv]
+        si = ek.zero(SurfaceInteraction3f)
+        si.uv = [xv, yv]
 
-        return bitmap.eval_3(siv)
+        return bitmap.eval_3(si)
 
     axis_res = 20
 


### PR DESCRIPTION
## Description

A fix is introduced for a bug in the `BitmapTextureImpl` class where the `Mirror` `WrapMode` was not wrapping correctly for the last pixel in each axis when using negative UV coordinates.

## Testing

A new test was added that checks all wrapping modes (not just `Mirror`).