### PR TITLE
Fixed import of load_string

### DIFF
--- a/src/bsdfs/tests/test_polarizer.py
+++ b/src/bsdfs/tests/test_polarizer.py
@@ -3,7 +3,8 @@ import pytest
 import drjit as dr
 
 def test01_create(variant_scalar_mono_polarized):
-    from mitsuba.render import load_string, BSDFFlags
+    from mitsuba.core import load_string
+    from mitsuba.render import BSDFFlags
 
     b = load_string("<bsdf version='2.0.0' type='polarizer'></bsdf>")
     assert b is not None


### PR DESCRIPTION
Bugfix for python import in pytest.

## Description

In the test `src/bsdfs/tests/test_polarizer.py::test01_create`, `load_string` was being imported from `mitsuba.render` when it should be loaded from `mitsuba.core` (like the other tests). This bugfix addresses that.

## Testing
I reran the test and previously it was failing due to missing import, and now it passes.

## Checklist:

- [x] My code follows the [style guidelines](https://mitsuba2.readthedocs.io/en/latest/src/developer_guide/intro.html#introduction) of this project
- [x] My changes generate no new warnings
- [x] My code also compiles for `cuda_*` and `llvm_*` variants. If you can't test this, please leave below
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 2 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba2/blob/master/LICENSE)