### PR TITLE
Fix transform indentation in grid volume plugin repr

### DIFF
--- a/src/volumes/grid.cpp
+++ b/src/volumes/grid.cpp
@@ -337,7 +337,7 @@ public:
     std::string to_string() const override {
         std::ostringstream oss;
         oss << "GridVolume[" << std::endl
-            << "  to_local = " << m_to_local << "," << std::endl
+            << "  to_local = " << string::indent(m_to_local, 13) << "," << std::endl
             << "  bbox = " << string::indent(m_bbox) << "," << std::endl
             << "  dimensions = " << resolution() << "," << std::endl
             << "  max = " << m_max << "," << std::endl


### PR DESCRIPTION
## Description

This PR fixes the indentation of the string representation of the `to_world` field of the `gridvolume` plugin.

## Checklist:

- [x] My code follows the [style guidelines](https://mitsuba2.readthedocs.io/en/latest/src/developer_guide/intro.html#introduction) of this project
- [x] My changes generate no new warnings
- [x] My code also compiles for `cuda_*` and `llvm_*` variants. If you can't test this, please leave below
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 2 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba2/blob/master/LICENSE)