### PR TITLE
Add missing backslash for TeX symbol in docstring

### DIFF
--- a/src/python/python/ad/integrators/common.py
+++ b/src/python/python/ad/integrators/common.py
@@ -14,7 +14,7 @@ class ADIntegrator(mi.SamplingIntegrator):
      * - max_depth
        - |int|
        - Specifies the longest path depth in the generated output image (where -1
-         corresponds to :math:`\infty`). A value of |1| will only render directly
+         corresponds to :math:`\\infty`). A value of |1| will only render directly
          visible light sources. |2| will lead to single-bounce (direct-only)
          illumination, and so on. (Default: |-1|)
      * - rr_depth


### PR DESCRIPTION
## Description

This commit adds an escaping backslash to a TeX symbol in a docstring. In cases which I have a hard time reproducing (I detected that as I was writing tests for high-level components in Eradiate), Mitsuba imports raise a `SyntaxError` which I can trace to this docstring.

## Checklist

- [x] My code follows the [style guidelines](https://mitsuba2.readthedocs.io/en/latest/src/developer_guide/intro.html#introduction) of this project
- [x] My changes generate no new warnings
- [x] My code also compiles for `cuda_*` and `llvm_*` variants. If you can't test this, please leave below
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 2 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba2/blob/master/LICENSE)