### PR TITLE
Automatically expand top-level node in load_string/load_file/load_dict

### DIFF
--- a/include/mitsuba/core/xml.h
+++ b/include/mitsuba/core/xml.h
@@ -30,17 +30,19 @@ using ParameterList = std::vector<std::pair<std::string, std::string>>;
  *     When Mitsuba updates scene to a newer version, should the
  *     updated XML file be written back to disk?
  */
-extern MI_EXPORT_LIB ref<Object> load_file(const fs::path &path,
-                                             const std::string &variant,
-                                             ParameterList parameters = ParameterList(),
-                                             bool update_scene = false,
-                                             bool parallel = true);
+extern MI_EXPORT_LIB std::vector<ref<Object>> load_file(
+                                        const fs::path &path,
+                                        const std::string &variant,
+                                        ParameterList parameters = ParameterList(),
+                                        bool update_scene = false,
+                                        bool parallel = true);
 
 /// Load a Mitsuba scene from an XML string
-extern MI_EXPORT_LIB ref<Object> load_string(const std::string &string,
-                                               const std::string &variant,
-                                               ParameterList parameters = ParameterList(),
-                                               bool parallel = true);
+extern MI_EXPORT_LIB std::vector<ref<Object>> load_string(
+                                        const std::string &string,
+                                        const std::string &variant,
+                                        ParameterList parameters = ParameterList(),
+                                        bool parallel = true);
 
 
 
@@ -62,6 +64,10 @@ extern MI_EXPORT_LIB ref<Object> create_texture_from_spectrum(
                                         bool within_emitter,
                                         bool is_spectral_mode,
                                         bool is_monochromatic_mode);
+
+/// Expands a node (if it does not expand it is wrapped into a std::vector)
+extern MI_EXPORT_LIB std::vector<ref<Object>> expand_node(
+                                        const ref<Object> &top_node);
 NAMESPACE_END(detail)
 
 NAMESPACE_END(xml)

--- a/src/core/python/xml_v.cpp
+++ b/src/core/python/xml_v.cpp
@@ -12,10 +12,27 @@ extern Caster cast_object;
 
 // Forward declaration
 template <typename Float, typename Spectrum>
-ref<Object> load_dict(const std::string& dict_key, const py::dict& dict, std::map<std::string, ref<Object>> &instances);
+std::vector<ref<Object>> load_dict(
+        const std::string &dict_key, 
+        const py::dict &dict,
+        std::map<std::string, ref<Object>> &instances
+);
 
 /// Shorthand notation for accessing the MI_VARIANT string
 #define GET_VARIANT() mitsuba::detail::get_variant<Float, Spectrum>()
+
+/// Depending on whether or not the input vector has size 1, returns the first
+/// and only element of the vector or the entire vector as a list
+MI_INLINE py::object single_object_or_list(std::vector<ref<Object>> &objects) {
+    if (objects.size() == 1)
+        return cast_object(objects[0]);
+
+    py::list l;
+    for (ref<Object> &obj : objects)
+        l.append(cast_object(obj));
+
+    return static_cast<py::object>(l);
+}
 
 MI_PY_EXPORT(xml) {
     MI_PY_IMPORT_TYPES()
@@ -33,7 +50,11 @@ MI_PY_EXPORT(xml) {
             }
 
             py::gil_scoped_release release;
-            return cast_object(xml::load_file(name, GET_VARIANT(), param, update_scene, parallel));
+
+            std::vector<ref<Object>> objects = xml::load_file(
+                name, GET_VARIANT(), param, update_scene, parallel);
+
+            return single_object_or_list(objects);
         },
         "path"_a, "update_scene"_a = false, "parallel"_a = !dr::is_jit_array_v<Float>,
         D(xml, load_file));
@@ -41,7 +62,6 @@ MI_PY_EXPORT(xml) {
     m.def(
         "load_string",
         [](const std::string &name, bool parallel, py::kwargs kwargs) {
-
             xml::ParameterList param;
             if (kwargs) {
                 for (auto [k, v] : kwargs)
@@ -52,7 +72,11 @@ MI_PY_EXPORT(xml) {
             }
 
             py::gil_scoped_release release;
-            return cast_object(xml::load_string(name, GET_VARIANT(), param, parallel));
+
+            std::vector<ref<Object>> objects = xml::load_string(
+                name, GET_VARIANT(), param, parallel);
+
+            return single_object_or_list(objects);
         },
         "string"_a, "parallel"_a = !dr::is_jit_array_v<Float>,
         D(xml, load_string));
@@ -61,12 +85,17 @@ MI_PY_EXPORT(xml) {
         "load_dict",
         [](const py::dict dict) {
             std::map<std::string, ref<Object>> instances;
-            auto obj = cast_object(load_dict<Float, Spectrum>("", dict, instances));
+            std::vector<ref<Object>> objects =
+                load_dict<Float, Spectrum>("", dict, instances);
+
+            py::object out = single_object_or_list(objects);
+
             if constexpr (dr::is_jit_array_v<Float>) {
                 dr::eval();
                 dr::sync_thread();
             }
-            return obj;
+
+            return out;
         },
         "dict"_a,
         R"doc(Load a Mitsuba scene or object from an Python dictionary
@@ -172,16 +201,17 @@ ref<Object> create_texture_from(const py::dict &dict, bool within_emitter) {
 }
 
 template <typename Float, typename Spectrum>
-ref<Object> load_dict(const std::string &dict_key, const py::dict &dict,
-                      std::map<std::string, ref<Object>> &instances) {
+std::vector<ref<Object>> load_dict(const std::string &dict_key,
+                                   const py::dict &dict,
+                                   std::map<std::string,
+                                   ref<Object>> &instances) {
     MI_IMPORT_CORE_TYPES()
     using ScalarArray3f = dr::Array<ScalarFloat, 3>;
 
     std::string type = get_type(dict);
 
-    if (type == "spectrum" || type == "rgb") {
-        return create_texture_from<Float, Spectrum>(dict, false);
-    }
+    if (type == "spectrum" || type == "rgb")
+        return { create_texture_from<Float, Spectrum>(dict, false) };
 
     bool is_scene = (type == "scene");
 
@@ -245,22 +275,32 @@ ref<Object> load_dict(const std::string &dict_key, const py::dict &dict,
             }
 
             // Load the dictionary recursively
-            ref<Object> obj = load_dict<Float, Spectrum>(key, dict2, instances);
-            expand_and_set_object(props, key, obj);
+            std::vector<ref<Object>> objects = load_dict<Float, Spectrum>(key, dict2, instances);
+            size_t n_objects = objects.size();
+            int ctr = 0;
 
-            // Add instanced object to the instance map for later references
-            if (is_scene) {
-                // An object can be referenced using its key
-                if (instances.count(key) != 0)
-                    Throw("%s has duplicate id: %s", key, key);
-                instances[key] = obj;
+            for (auto &obj : objects) {
+                if (n_objects > 1) {
+                    props.set_object(key + "_" + std::to_string(ctr++), obj);
+                } else {
+                    props.set_object(key, obj);
+                }
 
-                // An object can also be referenced using its "id" if it has one
-                std::string id = obj->id();
-                if (!id.empty() && id != key) {
-                    if (instances.count(id) != 0)
-                        Throw("%s has duplicate id: %s", key, id);
-                    instances[id] = obj;
+                // Add instanced object to the instance map for later references
+                if (is_scene) {
+                    // An object can be referenced using its key
+                    if (instances.count(key) != 0)
+                        Throw("%s has duplicate id: %s", key, key);
+                    instances[key] = obj;
+
+                    // An object can also be referenced using its "id" if it has
+                    // one
+                    std::string id = obj->id();
+                    if (!id.empty() && id != key) {
+                        if (instances.count(id) != 0)
+                            Throw("%s has duplicate id: %s", key, id);
+                        instances[id] = obj;
+                    }
                 }
             }
 
@@ -295,7 +335,7 @@ ref<Object> load_dict(const std::string &dict_key, const py::dict &dict,
     if (!props.unqueried().empty())
         Throw("Unreferenced property \"%s\" in plugin of type \"%s\"!", props.unqueried()[0], type);
 
-    return obj;
+    return mitsuba::xml::detail::expand_node(obj);
 }
 
 #undef SET_PROPS

--- a/src/core/tests/test_dict.py
+++ b/src/core/tests/test_dict.py
@@ -440,18 +440,12 @@ def test10_dict_expand_nested_object(variant_scalar_spectral):
 
     assert str(b0) == str(b1)
 
-    # Check that root object isn't expanded
+    # Check that root object is expanded
     spectrum = mi.load_dict({
             "type" : "d65",
     })
-    assert len(spectrum.expand()) == 1
-
-    # But we should be able to use this object in another dict, and it will be expanded
-    b3 = mi.load_dict({
-        "type" : "diffuse",
-        "reflectance" : spectrum
-    })
-    assert str(b0) == str(b3)
+    assert len(spectrum.expand()) == 0
+    assert spectrum.class_().name() == "RegularSpectrum"
 
     # Object should be expanded when used through a reference
     scene = mi.load_dict({

--- a/src/mitsuba/mitsuba.cpp
+++ b/src/mitsuba/mitsuba.cpp
@@ -359,11 +359,15 @@ int main(int argc, char *argv[]) {
                 filename = arg_output->as_string();
 
             // Try and parse a scene from the passed file.
-            ref<Object> parsed =
+            std::vector<ref<Object>> parsed =
                 xml::load_file(arg_extra->as_string(), mode, params,
                                *arg_update, parallel_loading);
 
-            MI_INVOKE_VARIANT(mode, render, parsed.get(), sensor_i, filename);
+            if (parsed.size() != 1)
+                Throw("Root element of the input file is expanded into "
+                      "multiple objects, only a single object is expected!");
+
+            MI_INVOKE_VARIANT(mode, render, parsed[0].get(), sensor_i, filename);
             arg_extra = arg_extra->next();
         }
     } catch (const std::exception &e) {

--- a/src/render/tests/test_spectra.py
+++ b/src/render/tests/test_spectra.py
@@ -17,7 +17,7 @@ def test02_d65(variant_scalar_spectral):
     """d65: Spot check the model in a few places, the chi^2 test will ensure
     that sampling works."""
 
-    d65 = mi.load_dict({ "type" : "d65" }).expand()[0]
+    d65 = mi.load_dict({ "type" : "d65" })
     ps = mi.PositionSample3f()
 
     assert dr.allclose(d65.eval(mi.SurfaceInteraction3f(ps, [350, 456, 700, 840])),
@@ -45,7 +45,7 @@ def test04_srgb_d65(variant_scalar_spectral, np_rng):
 
     wavelengths = np.linspace(300, 800, mi.MI_WAVELENGTH_SAMPLES)
     wavelengths += (10 * np_rng.uniform(size=wavelengths.shape)).astype(int)
-    d65 = mi.load_dict({ "type" : "d65" }).expand()[0]
+    d65 = mi.load_dict({ "type" : "d65" })
 
     ps = mi.PositionSample3f()
     d65_eval = d65.eval(mi.SurfaceInteraction3f(ps, wavelengths))

--- a/src/sensors/tests/test_distant.py
+++ b/src/sensors/tests/test_distant.py
@@ -32,7 +32,7 @@ def sensor_dict(target=None, direction=None):
 
 
 def make_sensor(d):
-    return mi.load_dict(d).expand()[0]
+    return mi.load_dict(d)
 
 
 def test_construct(variant_scalar_rgb):

--- a/src/spectra/d65.cpp
+++ b/src/spectra/d65.cpp
@@ -35,11 +35,13 @@ D65 spectrum (:monosp:`d65`)
  * - scale
    - |float|
    - Optional scaling factor applied to the emitted spectrum. (Default: 1.0)
-   - |exposed|
 
 The CIE Standard Illuminant D65 corresponds roughly to the average midday light in Europe,
 also called a daylight illuminant. It is the default emission spectrum used for light sources
 in all spectral rendering modes.
+
+This plugin, once instantiated, will usually automatically be converted into a
+`spectrum-regular`_ instance.
 
 .. tabs::
     .. code-tab:: xml
@@ -74,10 +76,6 @@ public:
            sRGB yields a pixel value of (1, 1, 1) */
         m_scale = props.get<ScalarFloat>("scale", 1.f);
         m_scale *= 1.f / 10568.f;
-    }
-
-    void traverse(TraversalCallback *callback) override {
-        callback->put_parameter("scale", m_scale, +ParamFlags::NonDifferentiable);
     }
 
     std::vector<ref<Object>> expand() const override {


### PR DESCRIPTION
## Description

This PR changes the way `load_string()`, `load_file` and `load_dict` instantiate Mitsuba plugins. Each one of these functions, now automatically expands (call to `Object::expand()`) the top-level/root node of their input.

In Python, when the root node is expanded into a single item, the item is returned directly rather than in a list of size 1. In C++, these functions always return a `std::vector` of the root node's expansion.