### PR TITLE
Fix string representation of `homogeneous` and `constvolume` plugins

### DIFF
--- a/src/media/homogeneous.cpp
+++ b/src/media/homogeneous.cpp
@@ -185,9 +185,9 @@ public:
     std::string to_string() const override {
         std::ostringstream oss;
         oss << "HomogeneousMedium[" << std::endl
-            << "  albedo  = " << string::indent(m_albedo) << std::endl
-            << "  sigma_t = " << string::indent(m_sigmat) << std::endl
-            << "  scale   = " << string::indent(m_scale)  << std::endl
+            << "  albedo = " << string::indent(m_albedo) << "," << std::endl
+            << "  sigma_t = " << string::indent(m_sigmat) << "," << std::endl
+            << "  scale = " << string::indent(m_scale)  << std::endl
             << "]";
         return oss.str();
     }

--- a/src/volumes/const.cpp
+++ b/src/volumes/const.cpp
@@ -86,8 +86,8 @@ public:
     std::string to_string() const override {
         std::ostringstream oss;
         oss << "ConstVolume[" << std::endl
-            << "  to_local = " << m_to_local << "," << std::endl
-            << "  value = " << m_value << std::endl
+            << "  to_local = " << string::indent(m_to_local, 13) << "," << std::endl
+            << "  value = " << string::indent(m_value, 4) << std::endl
             << "]";
         return oss.str();
     }


### PR DESCRIPTION
## Description

This PR fixes missing indentation and commas in the string representation of the `homogeneous` and `constvolume` plugins.

## Checklist:

- [x] My code follows the [style guidelines](https://mitsuba2.readthedocs.io/en/latest/src/developer_guide/intro.html#introduction) of this project
- [x] My changes generate no new warnings
- [x] My code also compiles for `cuda_*` and `llvm_*` variants. If you can't test this, please leave below
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 2 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba2/blob/master/LICENSE)