### PR TITLE
Updated docstrings of blend plugins

### DIFF
--- a/src/bsdfs/blendbsdf.cpp
+++ b/src/bsdfs/blendbsdf.cpp
@@ -35,6 +35,8 @@ Blended material (:monosp:`blendbsdf`)
 This plugin implements a *blend* material, which represents
 linear combinations of two BSDF instances. Any surface scattering model in Mitsuba 3 (be it smooth,
 rough, reflecting, or transmitting) can be mixed with others in this manner to synthesize new models.
+The association of nested BSDF plugins with the two positions in the interpolation is based on the 
+alphanumeric order of their identifiers.
 
 The following XML snippet describes the material shown above:
 

--- a/src/phase/blendphase.cpp
+++ b/src/phase/blendphase.cpp
@@ -33,22 +33,31 @@ combinations of two phase function instances. Any phase function in Mitsuba 3
 manner. This is of particular interest when mixing components in a participating
 medium (*e.g.* accounting for the presence of aerosols in a Rayleigh-scattering
 atmosphere).
+The association of nested Phase plugins with the two positions in the 
+interpolation is based on the alphanumeric order of their identifiers.
 
 .. tabs::
     .. code-tab:: xml
 
         <phase type="blendphase">
             <float name="weight" value="0.5"/>
-            <phase type="isotropic" />
-            <phase type="hg">
+            <phase name="phase_0" type="isotropic" />
+            <phase name="phase_1" type="hg">
                 <float name="g" value="0.2"/>
             </phase>
         </phase>
 
     .. code-tab:: python
 
-        'type': 'hg',
-        'g': 0.1
+        'type': 'blendphase',
+        'weight': 0.5,
+        'phase_0': {
+            'type': 'isotropic'
+        },
+        'phase_1': {
+            'type': 'hg',
+            'g': 0.2
+        }
 
 */
 


### PR DESCRIPTION
## Description

This PR introduces changes to the docstrings of the `blendphase` and `blendbsdf` plugins. It is now clarified that the nested plugins will be sorted according to the alphanumerical order of their identifiers.
Additionally I updated the code snippets of the `blendphase` plugin.

Fixes #106 

## Testing

This PR affects only docstrings.

## Checklist:

- [x] My code follows the [style guidelines](https://mitsuba2.readthedocs.io/en/latest/src/developer_guide/intro.html#introduction) of this project
- [x] My changes generate no new warnings
- [x] My code also compiles for `cuda_*` and `llvm_*` variants. If you can't test this, please leave below
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 3 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba2/blob/master/LICENSE)