### PR TITLE
[Feature] Add conversion from XML scene to list of `Properties`

### DIFF
--- a/include/mitsuba/core/xml.h
+++ b/include/mitsuba/core/xml.h
@@ -69,6 +69,13 @@ extern MI_EXPORT_LIB ref<Object> create_texture_from_spectrum(
 /// Expands a node (if it does not expand it is wrapped into a std::vector)
 extern MI_EXPORT_LIB std::vector<ref<Object>> expand_node(
                                         const ref<Object> &top_node);
+
+/// Read a Mitsuba XML file and return a list of pairs containing the
+/// name of the plugin and the corresponding populated Properties object
+extern MI_EXPORT_LIB std::vector<std::pair<std::string, Properties>> xml_to_properties(
+                                        const fs::path &path,
+                                        const std::string &variant);
+       
 NAMESPACE_END(detail)
 
 NAMESPACE_END(xml)

--- a/src/core/python/xml_v.cpp
+++ b/src/core/python/xml_v.cpp
@@ -104,6 +104,16 @@ Parameter ``dict``:
     Python dictionary containing the object description
 
 )doc");
+
+    m.def(
+        "xml_to_props",
+        [](const std::string &path) {
+            py::gil_scoped_release release;
+
+            return xml::detail::xml_to_properties(path, GET_VARIANT());
+        },
+        "path"_a,
+        R"doc(Get the names and properties of the objects described in a Mitsuba XML file)doc");
 }
 
 // Helper function to find a value of "type" in a Python dictionary

--- a/src/core/tests/test_xml.py
+++ b/src/core/tests/test_xml.py
@@ -306,3 +306,86 @@ def test24_properties_duplicated(variant_scalar_rgb):
                             </bsdf>
                         </scene>""")
     e.match(err_str)
+
+
+def test25_xml_to_props_invalid_file(variant_scalar_rgb):
+    with pytest.raises(Exception) as e:
+        mi.xml_to_props('')
+    e.match('file does not exist')
+
+
+@fresolver_append_path
+def test26_xml_to_props_empty_scene(variant_scalar_rgb, tmp_path):
+    filepath = str(tmp_path / 'test_xml-test26_output.xml')
+    print(f"Output temporary file: {filepath}")
+
+    scene_dict = {
+        'type': 'scene',
+    }
+    mi.xml.dict_to_xml(scene_dict, filepath)
+
+    props = mi.xml_to_props(filepath)
+    assert len(props) == 1
+
+    class_name, properties = props[0]
+    assert class_name == 'Scene'
+    assert properties.plugin_name() == 'scene'
+    assert len(properties.property_names()) == 0
+
+
+@fresolver_append_path
+def test27_xml_to_props_named_references(variant_scalar_rgb, tmp_path):
+    filepath = str(tmp_path / 'test_xml-test27_output.xml')
+    print(f"Output temporary file: {filepath}")
+
+    scene_dict = {
+        'type': 'scene',
+        'light':{
+            'type': 'point',
+        }
+    }
+    mi.xml.dict_to_xml(scene_dict, filepath)
+
+    props = mi.xml_to_props(filepath)
+    assert len(props) == 2
+
+    has_scene = False
+    for cls, prop in props:
+        if cls == 'Scene':
+            has_scene = True
+            assert len(prop.named_references()) == 1
+            _, ref_id = prop.named_references()[0]
+            has_ref_id = False
+            for cls, prop in props:
+                if prop.id() == ref_id:
+                    has_ref_id = True
+                    assert prop.plugin_name() == 'point'
+            assert has_ref_id
+    assert has_scene
+
+
+@fresolver_append_path
+def test28_xml_to_props_property_args(variant_scalar_rgb, tmp_path):
+    filepath = str(tmp_path / 'test_xml-test28_output.xml')
+    print(f"Output temporary file: {filepath}")
+
+    scene_dict = {
+        'type': 'scene',
+        'sphere': {
+            'type': 'sphere',
+            'center' : [0, 0, -10],
+            'radius' : 10.0,
+        }
+    }
+    mi.xml.dict_to_xml(scene_dict, filepath)
+
+    props = mi.xml_to_props(filepath)
+    assert len(props) == 2
+
+    has_sphere = False
+    for _, prop in props:
+        if prop.plugin_name() == 'sphere':
+            has_sphere = True
+            assert dr.allclose(prop['center'], [0, 0, -10])
+            assert prop['radius'] == 10.0
+    assert has_sphere

--- a/src/python/__init__.py
+++ b/src/python/__init__.py
@@ -347,6 +347,7 @@ del MitsubaVariantModule
 del typing, types
 del threading
 del os
-del config
+if config in locals():
+    del config
 del MI_VARIANTS
 del variant, submodule, name, reload


### PR DESCRIPTION
## Description

As part of the scene import feature for the [mitsuba-blender](https://github.com/mitsuba-renderer/mitsuba2-blender/tree/sp-addon) project, we need to extract object parameters (shapes, bsdfs, etc...) from an XML scene file. Currently, the importer parses the file and instantiates the objects, which consequently prevents us to access to all of their properties.

These new changes add a function that returns a list of pairs with the first element being the name of the described plugin object and the second element being the properties of that object.

## Testing

We test the failure case where the specified file does not exist as well as a few simple XML files that verify that:
1. Objects report the correct class names
2. Property arguments are correctly converted
3. Named references point to valid objects

## Checklist:

- [x] My code follows the [style guidelines](https://mitsuba2.readthedocs.io/en/latest/src/developer_guide/intro.html#introduction) of this project
- [x] My changes generate no new warnings
- [x] My code also compiles for `cuda_*` and `llvm_*` variants. If you can't test this, please leave below
- [x] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 3 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba2/blob/master/LICENSE)

## Note:

This PR only implements the logic with input files (not Python dictionaries or strings). Moreover, it duplicates the logic already implemented in `load_file`. It would perhaps be preferable to separate the `load_file` logic into two separate functions. The first would do a similar job as `xml_to_prop` and the second would be the instantiation logic of Mitsuba objects. This would lead to less code reuse and a cleaner overall structure.