### PR TITLE
Docs: Add newlines to cmake commands

### DIFF
--- a/docs/src/developer_guide/compiling.rst
+++ b/docs/src/developer_guide/compiling.rst
@@ -152,7 +152,8 @@ inside the :monosp:`mitsuba3` root directory:
     # Create a directory where build products are stored
     mkdir build
     cd build
-    cmake -GNinja .. ninja
+    cmake -GNinja .. 
+    ninja
 
 
 **Tested version**
@@ -236,7 +237,10 @@ Now, compilation should be as simple as running the following from inside the
 
 .. code-block:: bash
 
-    mkdir build cd build cmake -GNinja .. ninja
+    mkdir build 
+    cd build 
+    cmake -GNinja .. 
+    ninja
 
 
 **Tested version**


### PR DESCRIPTION
Added some newlines to cmake commands for compiling Mitsuba on Linux and MacOS.