### PR TITLE
Fix error in ParamFlags docstring

### DIFF
--- a/include/mitsuba/core/object.h
+++ b/include/mitsuba/core/object.h
@@ -273,7 +273,7 @@ private:
  * introduce discontinuities in the Monte Carlo simulation.
  */
 enum class ParamFlags : uint32_t {
-    /// Tracking gradients w.r.t. this parameter is not allowed
+    /// Tracking gradients w.r.t. this parameter is allowed
     Differentiable = 0x0,
 
     /// Tracking gradients w.r.t. this parameter is not allowed


### PR DESCRIPTION
This PR just fixes a small but maybe confusing error in the ParamFlags docstring. Obviously the `Differentiable` flag means that tracking gradients is allowed.