### PR TITLE
Module lookup TLS fixes

### DIFF
--- a/src/python/__init__.py
+++ b/src/python/__init__.py
@@ -264,7 +264,11 @@ class MitsubaModule(types.ModuleType):
                 result[v] = sys.modules[f'mitsuba.{v}']
 
         # Add this lookup to the cache
-        _tls.cache[(variant, submodule, key)] = result
+        cache = getattr(_tls, 'cache', None)
+        if cache is None:
+            cache = {}
+            _tls.cache = cache
+        cache[(variant, submodule, key)] = result
 
         return result
 

--- a/src/python/__init__.py
+++ b/src/python/__init__.py
@@ -236,6 +236,7 @@ class MitsubaModule(types.ModuleType):
             from .config import MI_DEFAULT_VARIANT
             if MI_DEFAULT_VARIANT != '':
                 self.set_variant(MI_DEFAULT_VARIANT)
+                variant = MI_DEFAULT_VARIANT
             else:
                 raise ImportError('Before importing any packages, you must '
                                   'specify the desired variant of Mitsuba '


### PR DESCRIPTION
Bugfix, Bug

## Description

This PR fixes crashes when using mitsuba in additional worker threads, where the module lookup cache and default variant stored in TLS are not correctly recreated / set.

## Testing

Minimal repro (tested with Python 3.8 on Ubuntu 20.04.4 LTS):
```python
import mitsuba as mi
import drjit as dr

import threading
import matplotlib.pyplot as plt

mi.set_variant('scalar_rgb') # remove for default variant repro

class RenderThread(threading.Thread):
    def __init__(self, scene, env):
        super().__init__(name='RenderThread')
        self.env = env
        self.scene = scene

    def run(self):
        mi.set_variant('scalar_rgb') # remove for default variant repro
        with mi.ScopedSetThreadEnvironment(self.env):
            self.img = mi.render(self.scene)

scene_desc = mi.cornell_box()
scene = mi.load_dict(mi.cornell_box())
render_thread = RenderThread(scene, mi.ThreadEnvironment())
render_thread.start()

render_thread.join()
plt.imshow(render_thread.img)
plt.show()
```

## Checklist:

- [x] My code follows the [style guidelines](https://mitsuba2.readthedocs.io/en/latest/src/developer_guide/intro.html#introduction) of this project
- [x] My changes generate no new warnings
- [x] My code also compiles for `cuda_*` and `llvm_*` variants. If you can't test this, please leave below
- ~[ ] I have commented my code~
- ~[ ] I have made corresponding changes to the documentation~
- ~[ ] I have added tests that prove my fix is effective or that my feature works~
- [x] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 3 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba2/blob/master/LICENSE)