### PR TITLE
perspective: Fix string repr indentation

### DIFF
--- a/src/sensors/perspective.cpp
+++ b/src/sensors/perspective.cpp
@@ -391,7 +391,7 @@ public:
             << "  resolution = " << m_resolution << "," << std::endl
             << "  shutter_open = " << m_shutter_open << "," << std::endl
             << "  shutter_open_time = " << m_shutter_open_time << "," << std::endl
-            << "  to_world = " << indent(m_to_world) << std::endl
+            << "  to_world = " << indent(m_to_world, 13) << std::endl
             << "]";
         return oss.str();
     }


### PR DESCRIPTION
## Description

This PR fixes the indentation of the `to_world` param in the string representation of the `perspective` plugin.

Before:
```
PerspectiveCamera[
  ...
  to_world = [[1, 0, 0, 0],
   [0, 1, 0, 0],
   [0, 0, 1, 0],
   [0, 0, 0, 1]]
]
```

After:
```
PerspectiveCamera[
  ...
  to_world = [[1, 0, 0, 0],
              [0, 1, 0, 0],
              [0, 0, 1, 0],
              [0, 0, 0, 1]]
]
```

## Checklist:

- [x] My code follows the [style guidelines](https://mitsuba2.readthedocs.io/en/latest/src/developer_guide/intro.html#introduction) of this project
- [x] My changes generate no new warnings
- [x] My code also compiles for `cuda_*` and `llvm_*` variants. If you can't test this, please leave below
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 3 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba2/blob/master/LICENSE)