### PR TITLE
Minor typo fixes

### DIFF
--- a/include/mitsuba/render/bsdf.h
+++ b/include/mitsuba/render/bsdf.h
@@ -307,9 +307,9 @@ public:
      *            and other information. The contents are undefined if sampling
      *            failed.
      *
-     *     value: The BSDF value (multiplied by the cosine foreshortening
-     *            factor when a non-delta component is sampled). A zero
-     *            spectrum indicates that sampling failed.
+     *     value: The BSDF value divided by the probability (multiplied by the
+     *            cosine foreshortening factor when a non-delta component is
+     *            sampled). A zero spectrum indicates that sampling failed.
      */
     virtual std::pair<BSDFSample3f, Spectrum>
     sample(const BSDFContext &ctx,

--- a/src/spectra/blackbody.cpp
+++ b/src/spectra/blackbody.cpp
@@ -8,8 +8,8 @@ NAMESPACE_BEGIN(mitsuba)
 
 .. _spectrum-blackbody:
 
-sRGB D65 spectrum (:monosp:`blackbody`)
----------------------------------------
+Blackbody spectrum (:monosp:`blackbody`)
+----------------------------------------
 
 .. pluginparameters::
 


### PR DESCRIPTION
This PR fixes minor typos.

* `BSDF.sample()`: Align docstring description and params
* `blackbody`: Fix plugin doc title