### PR TITLE
Documentation fixes

### DIFF
--- a/docs/references.bib
+++ b/docs/references.bib
@@ -25,13 +25,10 @@
   year = {2016},
 }
 
-@article{kensler1967correlated,
-  title={Correlated multi-jittered sampling},
-  author={Kensler, Andrew},
-  journal={Mathematical Physics and applied mathematics},
-  volume={7},
-  pages={86--112},
-  year={1967}
+@inproceedings{Kensler2013CorrelatedMS,
+  title={Correlated Multi-Jittered Sampling},
+  author={Andrew E. Kensler},
+  year={2013}
 }
 
 @article {Kollig2002Efficient,

--- a/docs/src/plugin_reference.rst
+++ b/docs/src/plugin_reference.rst
@@ -98,3 +98,12 @@ then it can be instantiated e.g. as follows:
                 'filename': 'cute.jpg'
             }
         }
+
+Flags
+^^^^^^
+
+Each parameter optionally has flags that are listed in the last column.
+These flags indicate whether the parameter is differentiable or not, or whether it introduces
+discontinuities and thus needs special treatment.
+
+See :py:class:`mitsuba.ParamFlags` for their documentation.

--- a/src/samplers/multijitter.cpp
+++ b/src/samplers/multijitter.cpp
@@ -27,7 +27,7 @@ Correlated Multi-Jittered sampler (:monosp:`multijitter`)
    - |bool|
    - Adds additional random jitter withing the substratum (Default: True)
 
-This plugin implements the methods introduced in Pixar's tech memo :cite:`kensler1967correlated`.
+This plugin implements the methods introduced in Pixar's tech memo :cite:`Kensler2013CorrelatedMS`.
 
 Unlike the previously described stratified sampler, multi-jittered sample patterns produce samples
 that are well stratified in 2D but also well stratified when projected onto one dimension. This can


### PR DESCRIPTION
Some smaller improvements for the documentation:

1. When reading the `multijitter` plugin documentation I stumbled upon an odd reference ("from Pixar" vs 1967). It seems like Google Scholar had a parsing issue there, and took an old Sobel reference that is _in the pdf_  as the publication venue.

2. I was missing the introduction of the "Flags" column for the plugin parameters. The hover feature is nice, but I still feel this topic is a bit sparsely covered. Also couldn't find any tutorials / guides sections that would shed some light on it either.
Feel free to extend this.

Disclaimer: As I have no means of building the docs myself at the moment, I would advice for a manual check before merging this. I'm not too familiar with the reST syntax. 