### PR TITLE
Changed amazon bucket links in gallery.rst to use https

### DIFF
--- a/docs/src/gallery.rst
+++ b/docs/src/gallery.rst
@@ -15,7 +15,7 @@ Simple scenes
 
 .. grid:: 3
 
-    .. grid-item-card:: `🅱️ <https://benedikt-bitterli.me/resources/>`_ `Cornell Box <http://rgl.s3.eu-central-1.amazonaws.com/scenes/cornell-box.zip>`_
+    .. grid-item-card:: `🅱️ <https://benedikt-bitterli.me/resources/>`_ `Cornell Box <https://rgl.s3.eu-central-1.amazonaws.com/scenes/cornell-box.zip>`_
         :class-title: sd-text-center sd-font-weight-bold
         :class-body: sd-text-center
 
@@ -23,7 +23,7 @@ Simple scenes
             :height: 90
             :align: center
 
-    .. grid-item-card:: `Material preview <http://rgl.s3.eu-central-1.amazonaws.com/scenes/matpreview.zip>`_
+    .. grid-item-card:: `Material preview <https://rgl.s3.eu-central-1.amazonaws.com/scenes/matpreview.zip>`_
         :class-title: sd-text-center sd-font-weight-bold
         :class-body: sd-text-center
 
@@ -31,7 +31,7 @@ Simple scenes
             :height: 90
             :align: center
 
-    .. grid-item-card:: `🅱️ <https://benedikt-bitterli.me/resources/>`_ `Veach bidir <http://rgl.s3.eu-central-1.amazonaws.com/scenes/veach-bidir.zip>`_
+    .. grid-item-card:: `🅱️ <https://benedikt-bitterli.me/resources/>`_ `Veach bidir <https://rgl.s3.eu-central-1.amazonaws.com/scenes/veach-bidir.zip>`_
         :class-title: sd-text-center sd-font-weight-bold
         :class-body: sd-text-center
 
@@ -41,7 +41,7 @@ Simple scenes
 
         by `Benedikt Bitterli <https://benedikt-bitterli.me/>`_
 
-    .. grid-item-card:: `🅱️ <https://benedikt-bitterli.me/resources/>`_ `Veach MIS <http://rgl.s3.eu-central-1.amazonaws.com/scenes/veach-mis.zip>`_
+    .. grid-item-card:: `🅱️ <https://benedikt-bitterli.me/resources/>`_ `Veach MIS <https://rgl.s3.eu-central-1.amazonaws.com/scenes/veach-mis.zip>`_
         :class-title: sd-text-center sd-font-weight-bold
         :class-body: sd-text-center
 
@@ -51,7 +51,7 @@ Simple scenes
 
         by `Benedikt Bitterli <https://benedikt-bitterli.me/>`_
 
-    .. grid-item-card:: `🅱️ <https://benedikt-bitterli.me/resources/>`_ `Veach Ajar <http://rgl.s3.eu-central-1.amazonaws.com/scenes/veach-ajar.zip>`_
+    .. grid-item-card:: `🅱️ <https://benedikt-bitterli.me/resources/>`_ `Veach Ajar <https://rgl.s3.eu-central-1.amazonaws.com/scenes/veach-ajar.zip>`_
         :class-title: sd-text-center sd-font-weight-bold
         :class-body: sd-text-center
 
@@ -61,7 +61,7 @@ Simple scenes
 
         by `Benedikt Bitterli <https://benedikt-bitterli.me/>`_
 
-    .. grid-item-card:: `🅱️ <https://benedikt-bitterli.me/resources/>`_ `Volumetric caustics <http://rgl.s3.eu-central-1.amazonaws.com/scenes/volumetric-caustic.zip>`_
+    .. grid-item-card:: `🅱️ <https://benedikt-bitterli.me/resources/>`_ `Volumetric caustics <https://rgl.s3.eu-central-1.amazonaws.com/scenes/volumetric-caustic.zip>`_
         :class-title: sd-text-center sd-font-weight-bold
         :class-body: sd-text-center
 
@@ -77,7 +77,7 @@ Single object
 
 .. grid:: 3
 
-    .. grid-item-card:: `🅱️ <https://benedikt-bitterli.me/resources/>`_ `Pontiac GTO 67 <http://rgl.s3.eu-central-1.amazonaws.com/scenes/car.zip>`_
+    .. grid-item-card:: `🅱️ <https://benedikt-bitterli.me/resources/>`_ `Pontiac GTO 67 <https://rgl.s3.eu-central-1.amazonaws.com/scenes/car.zip>`_
         :class-title: sd-text-center sd-font-weight-bold
         :class-body: sd-text-center
 
@@ -87,7 +87,7 @@ Single object
 
         by `thecali <http://www.blendswap.com/users/view/thecali>`_
 
-    .. grid-item-card:: `🅱️ <https://benedikt-bitterli.me/resources/>`_ `Old vintage car <http://rgl.s3.eu-central-1.amazonaws.com/scenes/car2.zip>`_
+    .. grid-item-card:: `🅱️ <https://benedikt-bitterli.me/resources/>`_ `Old vintage car <https://rgl.s3.eu-central-1.amazonaws.com/scenes/car2.zip>`_
         :class-title: sd-text-center sd-font-weight-bold
         :class-body: sd-text-center
 
@@ -97,7 +97,7 @@ Single object
 
         by `piopis <http://www.blendswap.com/users/view/piopis>`_
 
-    .. grid-item-card:: `🅱️ <https://benedikt-bitterli.me/resources/>`_ `Coffee Maker <http://rgl.s3.eu-central-1.amazonaws.com/scenes/coffee.zip>`_
+    .. grid-item-card:: `🅱️ <https://benedikt-bitterli.me/resources/>`_ `Coffee Maker <https://rgl.s3.eu-central-1.amazonaws.com/scenes/coffee.zip>`_
         :class-title: sd-text-center sd-font-weight-bold
         :class-body: sd-text-center
 
@@ -107,7 +107,7 @@ Single object
 
         by `cekuhnen <http://www.blendswap.com/user/cekuhnen>`_
 
-    .. grid-item-card:: `🅱️ <https://benedikt-bitterli.me/resources/>`_ `Dragon <http://rgl.s3.eu-central-1.amazonaws.com/scenes/dragon.zip>`_
+    .. grid-item-card:: `🅱️ <https://benedikt-bitterli.me/resources/>`_ `Dragon <https://rgl.s3.eu-central-1.amazonaws.com/scenes/dragon.zip>`_
         :class-title: sd-text-center sd-font-weight-bold
         :class-body: sd-text-center
 
@@ -117,7 +117,7 @@ Single object
 
         by `Delatronic <http://www.blendswap.com/user/Delatronic>`_
 
-    .. grid-item-card:: `🅱️ <https://benedikt-bitterli.me/resources/>`_ `Spaceship <http://rgl.s3.eu-central-1.amazonaws.com/scenes/spaceship.zip>`_
+    .. grid-item-card:: `🅱️ <https://benedikt-bitterli.me/resources/>`_ `Spaceship <https://rgl.s3.eu-central-1.amazonaws.com/scenes/spaceship.zip>`_
         :class-title: sd-text-center sd-font-weight-bold
         :class-body: sd-text-center
 
@@ -127,7 +127,7 @@ Single object
 
         by `thecali <http://www.blendswap.com/user/thecali>`_
 
-    .. grid-item-card:: `🅱️ <https://benedikt-bitterli.me/resources/>`_ `Lamp <http://rgl.s3.eu-central-1.amazonaws.com/scenes/lamp.zip>`_
+    .. grid-item-card:: `🅱️ <https://benedikt-bitterli.me/resources/>`_ `Lamp <https://rgl.s3.eu-central-1.amazonaws.com/scenes/lamp.zip>`_
         :class-title: sd-text-center sd-font-weight-bold
         :class-body: sd-text-center
 
@@ -137,7 +137,7 @@ Single object
 
         by `UP3D <http://www.blendswap.com/users/view/UP3D>`_
 
-    .. grid-item-card:: `🅱️ <https://benedikt-bitterli.me/resources/>`_ `Teapot <http://rgl.s3.eu-central-1.amazonaws.com/scenes/teapot.zip>`_
+    .. grid-item-card:: `🅱️ <https://benedikt-bitterli.me/resources/>`_ `Teapot <https://rgl.s3.eu-central-1.amazonaws.com/scenes/teapot.zip>`_
         :class-title: sd-text-center sd-font-weight-bold
         :class-body: sd-text-center
 
@@ -147,7 +147,7 @@ Single object
 
         by `Benedikt Bitterli <https://benedikt-bitterli.me/>`_
 
-    .. grid-item-card:: `🅱️ <https://benedikt-bitterli.me/resources/>`_ `Teapot full <http://rgl.s3.eu-central-1.amazonaws.com/scenes/teapot-full.zip>`_
+    .. grid-item-card:: `🅱️ <https://benedikt-bitterli.me/resources/>`_ `Teapot full <https://rgl.s3.eu-central-1.amazonaws.com/scenes/teapot-full.zip>`_
         :class-title: sd-text-center sd-font-weight-bold
         :class-body: sd-text-center
 
@@ -158,7 +158,7 @@ Single object
         by `Benedikt Bitterli <https://benedikt-bitterli.me/>`_
 
 
-    .. grid-item-card:: `Lego Bulldozer <http://rgl.s3.eu-central-1.amazonaws.com/scenes/lego.zip>`_
+    .. grid-item-card:: `Lego Bulldozer <https://rgl.s3.eu-central-1.amazonaws.com/scenes/lego.zip>`_
         :class-title: sd-text-center sd-font-weight-bold
         :class-body: sd-text-center
 
@@ -168,7 +168,7 @@ Single object
 
         by `Heinzelnisse <https://www.blendswap.com/profile/88652>`_
 
-    .. grid-item-card:: `Sci-Fi Rover <http://rgl.s3.eu-central-1.amazonaws.com/scenes/rover.zip>`_
+    .. grid-item-card:: `Sci-Fi Rover <https://rgl.s3.eu-central-1.amazonaws.com/scenes/rover.zip>`_
         :class-title: sd-text-center sd-font-weight-bold
         :class-body: sd-text-center
 
@@ -185,7 +185,7 @@ Architecture
 
 .. grid:: 3
 
-    .. grid-item-card:: `🅱️ <https://benedikt-bitterli.me/resources/>`_ `Bathroom <http://rgl.s3.eu-central-1.amazonaws.com/scenes/bathroom.zip>`_
+    .. grid-item-card:: `🅱️ <https://benedikt-bitterli.me/resources/>`_ `Bathroom <https://rgl.s3.eu-central-1.amazonaws.com/scenes/bathroom.zip>`_
         :class-title: sd-text-center sd-font-weight-bold
         :class-body: sd-text-center
 
@@ -195,7 +195,7 @@ Architecture
 
         by `Mareck <http://www.blendswap.com/users/view/Mareck>`_
 
-    .. grid-item-card:: `🅱️ <https://benedikt-bitterli.me/resources/>`_ `Salle de bain <http://rgl.s3.eu-central-1.amazonaws.com/scenes/bathroom2.zip>`_
+    .. grid-item-card:: `🅱️ <https://benedikt-bitterli.me/resources/>`_ `Salle de bain <https://rgl.s3.eu-central-1.amazonaws.com/scenes/bathroom2.zip>`_
         :class-title: sd-text-center sd-font-weight-bold
         :class-body: sd-text-center
 
@@ -205,7 +205,7 @@ Architecture
 
         by `nacimus <http://www.blendswap.com/users/view/nacimus>`_
 
-    .. grid-item-card:: `🅱️ <https://benedikt-bitterli.me/resources/>`_ `Bedroom <http://rgl.s3.eu-central-1.amazonaws.com/scenes/bedroom.zip>`_
+    .. grid-item-card:: `🅱️ <https://benedikt-bitterli.me/resources/>`_ `Bedroom <https://rgl.s3.eu-central-1.amazonaws.com/scenes/bedroom.zip>`_
         :class-title: sd-text-center sd-font-weight-bold
         :class-body: sd-text-center
 
@@ -215,7 +215,7 @@ Architecture
 
         by `SlykDrako <http://www.blendswap.com/user/SlykDrako>`_
 
-    .. grid-item-card:: `🅱️ <https://benedikt-bitterli.me/resources/>`_ `Japanese Classroom <http://rgl.s3.eu-central-1.amazonaws.com/scenes/classroom.zip>`_
+    .. grid-item-card:: `🅱️ <https://benedikt-bitterli.me/resources/>`_ `Japanese Classroom <https://rgl.s3.eu-central-1.amazonaws.com/scenes/classroom.zip>`_
         :class-title: sd-text-center sd-font-weight-bold
         :class-body: sd-text-center
 
@@ -225,7 +225,7 @@ Architecture
 
         by `NovaZeeke <http://www.blendswap.com/users/view/NovaZeeke>`_
 
-    .. grid-item-card:: `🅱️ <https://benedikt-bitterli.me/resources/>`_ `The Breakfast Room <http://rgl.s3.eu-central-1.amazonaws.com/scenes/dining-room.zip>`_
+    .. grid-item-card:: `🅱️ <https://benedikt-bitterli.me/resources/>`_ `The Breakfast Room <https://rgl.s3.eu-central-1.amazonaws.com/scenes/dining-room.zip>`_
         :class-title: sd-text-center sd-font-weight-bold
         :class-body: sd-text-center
 
@@ -235,7 +235,7 @@ Architecture
 
         by `Wig42 <http://www.blendswap.com/users/view/Wig42>`_
 
-    .. grid-item-card:: `🅱️ <https://benedikt-bitterli.me/resources/>`_ `Country Kitchen <http://rgl.s3.eu-central-1.amazonaws.com/scenes/kitchen.zip>`_
+    .. grid-item-card:: `🅱️ <https://benedikt-bitterli.me/resources/>`_ `Country Kitchen <https://rgl.s3.eu-central-1.amazonaws.com/scenes/kitchen.zip>`_
         :class-title: sd-text-center sd-font-weight-bold
         :class-body: sd-text-center
 
@@ -245,7 +245,7 @@ Architecture
 
         by `Jay-Artist <http://www.blendswap.com/user/Jay-Artist>`_
 
-    .. grid-item-card:: `🅱️ <https://benedikt-bitterli.me/resources/>`_ `Grey & White Room <http://rgl.s3.eu-central-1.amazonaws.com/scenes/living-room.zip>`_
+    .. grid-item-card:: `🅱️ <https://benedikt-bitterli.me/resources/>`_ `Grey & White Room <https://rgl.s3.eu-central-1.amazonaws.com/scenes/living-room.zip>`_
         :class-title: sd-text-center sd-font-weight-bold
         :class-body: sd-text-center
 
@@ -255,7 +255,7 @@ Architecture
 
         by `Wig42 <http://www.blendswap.com/users/view/Wig42>`_
 
-    .. grid-item-card:: `🅱️ <https://benedikt-bitterli.me/resources/>`_ `The White Room <http://rgl.s3.eu-central-1.amazonaws.com/scenes/living-room-2.zip>`_
+    .. grid-item-card:: `🅱️ <https://benedikt-bitterli.me/resources/>`_ `The White Room <https://rgl.s3.eu-central-1.amazonaws.com/scenes/living-room-2.zip>`_
         :class-title: sd-text-center sd-font-weight-bold
         :class-body: sd-text-center
 
@@ -265,7 +265,7 @@ Architecture
 
         by `Jay-Artist <http://www.blendswap.com/user/Jay-Artist>`_
 
-    .. grid-item-card:: `🅱️ <https://benedikt-bitterli.me/resources/>`_ `Modern Living Room <http://rgl.s3.eu-central-1.amazonaws.com/scenes/living-room-3.zip>`_
+    .. grid-item-card:: `🅱️ <https://benedikt-bitterli.me/resources/>`_ `Modern Living Room <https://rgl.s3.eu-central-1.amazonaws.com/scenes/living-room-3.zip>`_
         :class-title: sd-text-center sd-font-weight-bold
         :class-body: sd-text-center
 
@@ -275,7 +275,7 @@ Architecture
 
         by `Wig42 <http://www.blendswap.com/users/view/Wig42>`_
 
-    .. grid-item-card:: `🅱️ <https://benedikt-bitterli.me/resources/>`_ `Wooden Staircase <http://rgl.s3.eu-central-1.amazonaws.com/scenes/staircase.zip>`_
+    .. grid-item-card:: `🅱️ <https://benedikt-bitterli.me/resources/>`_ `Wooden Staircase <https://rgl.s3.eu-central-1.amazonaws.com/scenes/staircase.zip>`_
         :class-title: sd-text-center sd-font-weight-bold
         :class-body: sd-text-center
 
@@ -285,7 +285,7 @@ Architecture
 
         by `Wig42 <http://www.blendswap.com/users/view/Wig42>`_
 
-    .. grid-item-card:: `🅱️ <https://benedikt-bitterli.me/resources/>`_ `Modern Hall <http://rgl.s3.eu-central-1.amazonaws.com/scenes/staircase2.zip>`_
+    .. grid-item-card:: `🅱️ <https://benedikt-bitterli.me/resources/>`_ `Modern Hall <https://rgl.s3.eu-central-1.amazonaws.com/scenes/staircase2.zip>`_
         :class-title: sd-text-center sd-font-weight-bold
         :class-body: sd-text-center
 
@@ -295,7 +295,7 @@ Architecture
 
         by `NewSee2l035 <http://www.blendswap.com/user/NewSee2l035>`_
 
-    .. grid-item-card:: `🅱️ <https://benedikt-bitterli.me/resources/>`_ `Glass of water <http://rgl.s3.eu-central-1.amazonaws.com/scenes/glass-of-water.zip>`_
+    .. grid-item-card:: `🅱️ <https://benedikt-bitterli.me/resources/>`_ `Glass of water <https://rgl.s3.eu-central-1.amazonaws.com/scenes/glass-of-water.zip>`_
         :class-title: sd-text-center sd-font-weight-bold
         :class-body: sd-text-center
 
@@ -305,7 +305,7 @@ Architecture
 
         by `aXel <http://www.blendswap.com/user/aXel>`_
 
-    .. grid-item-card:: `🅱️ <https://benedikt-bitterli.me/resources/>`_ `Victorian Style House <http://rgl.s3.eu-central-1.amazonaws.com/scenes/house.zip>`_
+    .. grid-item-card:: `🅱️ <https://benedikt-bitterli.me/resources/>`_ `Victorian Style House <https://rgl.s3.eu-central-1.amazonaws.com/scenes/house.zip>`_
         :class-title: sd-text-center sd-font-weight-bold
         :class-body: sd-text-center
 
@@ -321,7 +321,7 @@ Documentation banners
 
 .. grid:: 3
 
-    .. grid-item-card:: `Banner 1 <http://rgl.s3.eu-central-1.amazonaws.com/scenes/banner_01.zip>`_
+    .. grid-item-card:: `Banner 1 <https://rgl.s3.eu-central-1.amazonaws.com/scenes/banner_01.zip>`_
         :class-title: sd-text-center sd-font-weight-bold
         :class-body: sd-text-center
 
@@ -329,7 +329,7 @@ Documentation banners
             :height: 90
             :align: center
 
-    .. grid-item-card:: `Banner 2 <http://rgl.s3.eu-central-1.amazonaws.com/scenes/banner_02.zip>`_
+    .. grid-item-card:: `Banner 2 <https://rgl.s3.eu-central-1.amazonaws.com/scenes/banner_02.zip>`_
         :class-title: sd-text-center sd-font-weight-bold
         :class-body: sd-text-center
 
@@ -337,7 +337,7 @@ Documentation banners
             :height: 90
             :align: center
 
-    .. grid-item-card:: `Banner 3 <http://rgl.s3.eu-central-1.amazonaws.com/scenes/banner_03.zip>`_
+    .. grid-item-card:: `Banner 3 <https://rgl.s3.eu-central-1.amazonaws.com/scenes/banner_03.zip>`_
         :class-title: sd-text-center sd-font-weight-bold
         :class-body: sd-text-center
 
@@ -345,7 +345,7 @@ Documentation banners
             :height: 90
             :align: center
 
-    .. grid-item-card:: `Banner 4 <http://rgl.s3.eu-central-1.amazonaws.com/scenes/banner_04.zip>`_
+    .. grid-item-card:: `Banner 4 <https://rgl.s3.eu-central-1.amazonaws.com/scenes/banner_04.zip>`_
         :class-title: sd-text-center sd-font-weight-bold
         :class-body: sd-text-center
 
@@ -353,7 +353,7 @@ Documentation banners
             :height: 90
             :align: center
 
-    .. grid-item-card:: `Banner 5 <http://rgl.s3.eu-central-1.amazonaws.com/scenes/banner_05.zip>`_
+    .. grid-item-card:: `Banner 5 <https://rgl.s3.eu-central-1.amazonaws.com/scenes/banner_05.zip>`_
         :class-title: sd-text-center sd-font-weight-bold
         :class-body: sd-text-center
 
@@ -361,7 +361,7 @@ Documentation banners
             :height: 90
             :align: center
 
-    .. grid-item-card:: `Banner 6 <http://rgl.s3.eu-central-1.amazonaws.com/scenes/banner_06.zip>`_
+    .. grid-item-card:: `Banner 6 <https://rgl.s3.eu-central-1.amazonaws.com/scenes/banner_06.zip>`_
         :class-title: sd-text-center sd-font-weight-bold
         :class-body: sd-text-center
 
@@ -369,7 +369,7 @@ Documentation banners
             :height: 90
             :align: center
 
-    .. grid-item-card:: `Banner 7 <http://rgl.s3.eu-central-1.amazonaws.com/scenes/banner_07.zip>`_
+    .. grid-item-card:: `Banner 7 <https://rgl.s3.eu-central-1.amazonaws.com/scenes/banner_07.zip>`_
         :class-title: sd-text-center sd-font-weight-bold
         :class-body: sd-text-center
 


### PR DESCRIPTION
Links to the example models in the documentation don't use encryption.

bug, documentation

## Description

Some modern browsers such as Chrome reject downloads from non-encrypted sources. Changing the `http` part of the download links to `https` fixes this issue.


## Testing

No tests were added

## Checklist:

- [x] My code follows the [style guidelines](https://mitsuba2.readthedocs.io/en/latest/src/developer_guide/intro.html#introduction) of this project - Does not apply
- [ ] My changes generate no new warnings
- [ ] My code also compiles for `cuda_*` and `llvm_*` variants. If you can't test this, please leave below
- [ ] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 3 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba2/blob/master/LICENSE)