### PR TITLE
replace "=" with ":" in python dictionary examples

### DIFF
--- a/docs/src/plugin_reference/section_emitters.rst
+++ b/docs/src/plugin_reference/section_emitters.rst
@@ -71,9 +71,9 @@ These are specified as children of the corresponding ``<shape>`` element:
 
         # .. scene contents ..
 
-        'type'='sphere',
+        'type': 'sphere',
         'emitter': {
-            'type'='area',
+            'type': 'area',
             'radiance': {
                 'type': 'spectrum',
                 'value': 1.0,

--- a/src/emitters/area.cpp
+++ b/src/emitters/area.cpp
@@ -44,9 +44,9 @@ emitter shape and specify an :monosp:`area` instance as its child:
 
     .. code-tab:: python
 
-        'type'='sphere',
+        'type': 'sphere',
         'emitter': {
-            'type'='area',
+            'type': 'area',
             'radiance': {
                 'type': 'spectrum',
                 'value': 1.0,

--- a/src/emitters/constant.cpp
+++ b/src/emitters/constant.cpp
@@ -38,7 +38,7 @@ geometry that uses basic (e.g. diffuse) materials.
 
     .. code-tab:: python
 
-        'type'='constant',
+        'type': 'constant',
         'radiance': {
             'type': 'spectrum',
             'value': 1.0,

--- a/src/emitters/directional.cpp
+++ b/src/emitters/directional.cpp
@@ -48,7 +48,7 @@ radiates in the direction of the positive Z axis, i.e. :math:`(0, 0, 1)`.
 
     .. code-tab:: python
 
-        'type'='directional',
+        'type': 'directional',
         'direction': [1.0, 0.0, 0.0],
         'irradiance': {
             'type': 'spectrum',

--- a/src/emitters/directionalarea.cpp
+++ b/src/emitters/directionalarea.cpp
@@ -41,9 +41,9 @@ Similar to an area light, but emitting only in the normal direction.
 
     .. code-tab:: python
 
-        'type'='sphere',
+        'type': 'sphere',
         'emitter': {
-            'type'='directionalarea',
+            'type': 'directionalarea',
             'radiance': {
                 'type': 'spectrum',
                 'value': 1.0,

--- a/src/emitters/envmap.cpp
+++ b/src/emitters/envmap.cpp
@@ -83,7 +83,7 @@ High quality free light probes are available on
 
     .. code-tab:: python
 
-        'type'='envmap',
+        'type': 'envmap',
         'filename': 'textures/museum.exr'
 
  */

--- a/src/emitters/point.cpp
+++ b/src/emitters/point.cpp
@@ -47,7 +47,7 @@ uniformly radiates illumination into all directions.
 
     .. code-tab:: python
 
-        'type'='point',
+        'type': 'point',
         'position': [0.0, 5.0, 0.0],
         'intensity': {
             'type': 'spectrum',

--- a/src/emitters/projector.cpp
+++ b/src/emitters/projector.cpp
@@ -101,7 +101,7 @@ operation remains efficient even if only a single pixel is turned on.
 
     .. code-tab:: python
 
-        'type'='projector',
+        'type': 'projector',
         'irradiance': {
             'type': 'spectrum',
             'value': 1.0,

--- a/src/emitters/spot.cpp
+++ b/src/emitters/spot.cpp
@@ -57,7 +57,7 @@ using the lookat tag, e.g.:
 
     .. code-tab:: python
 
-        'type'='spot',
+        'type': 'spot',
         'to_world': mi.ScalarTransform4f.lookat(
             origin=[1, 1, 1],
             target=[1, 2, 1],

--- a/src/samplers/independent.cpp
+++ b/src/samplers/independent.cpp
@@ -59,7 +59,7 @@ on the order of the machine epsilon (:math:`6\cdot 10^{-8}`) in single precision
 
     .. code-tab:: python
 
-        'type'='independent',
+        'type': 'independent',
         'sample_count': '64'
 
  */

--- a/src/samplers/ldsampler.cpp
+++ b/src/samplers/ldsampler.cpp
@@ -66,7 +66,7 @@ which is a quality criterion on their spatial distribution.
 
     .. code-tab:: python
 
-        'type'='ldsampler',
+        'type': 'ldsampler',
         'sample_count': '64'
 
  */

--- a/src/samplers/multijitter.cpp
+++ b/src/samplers/multijitter.cpp
@@ -67,7 +67,7 @@ columns and the rows.
 
     .. code-tab:: python
 
-        'type'='multijitter',
+        'type': 'multijitter',
         'sample_count': '64'
 
  */

--- a/src/samplers/orthogonal.cpp
+++ b/src/samplers/orthogonal.cpp
@@ -71,7 +71,7 @@ stratification of 2D projections of those samples wouldn't be ensured anymore.
 
     .. code-tab:: python
 
-        'type'='orthogonal',
+        'type': 'orthogonal',
         'sample_count': '4'
 
  */

--- a/src/samplers/stratified.cpp
+++ b/src/samplers/stratified.cpp
@@ -58,7 +58,7 @@ the independent sampler, as well as better convergence.
 
     .. code-tab:: python
 
-        'type'='stratified',
+        'type': 'stratified',
         'sample_count': '4'
 
  */

--- a/src/sensors/irradiancemeter.cpp
+++ b/src/sensors/irradiancemeter.cpp
@@ -45,7 +45,7 @@ simply instantiate the desired sensor shape and specify an
 
     .. code-tab:: python
 
-        'type'='sphere',
+        'type': 'sphere',
         'sensor': {
             'type': 'irradiancemeter'
             'film': {

--- a/src/sensors/orthographic.cpp
+++ b/src/sensors/orthographic.cpp
@@ -66,7 +66,7 @@ The exact camera position and orientation is most easily expressed using the
 
     .. code-tab:: python
 
-        'type'='orthographic',
+        'type': 'orthographic',
         'to_world': mi.ScalarTransform4f.lookat(
             origin=[1, 1, 1],
             target=[1, 2, 1],

--- a/src/sensors/perspective.cpp
+++ b/src/sensors/perspective.cpp
@@ -109,7 +109,7 @@ The exact camera position and orientation is most easily expressed using the
 
     .. code-tab:: python
 
-        'type'='perspective',
+        'type': 'perspective',
         'fov': 45,
         'to_world': mi.ScalarTransform4f.lookat(
             origin=[1, 1, 1],

--- a/src/sensors/thinlens.cpp
+++ b/src/sensors/thinlens.cpp
@@ -121,7 +121,7 @@ The exact camera position and orientation is most easily expressed using the
 
     .. code-tab:: python
 
-        'type'='thinlens',
+        'type': 'thinlens',
         'fov': 45,
         'to_world': mi.ScalarTransform4f.lookat(
             origin=[1, 1, 1],


### PR DESCRIPTION
documentation

## Description

In the `python` examples, dictionaries were incorrectly specified with `=` signs. This fixes that.

## Testing

I haven't actually changed any of the code.

## Checklist:

- [X] My code follows the [style guidelines](https://mitsuba2.readthedocs.io/en/latest/src/developer_guide/intro.html#introduction) of this project
- [X] My changes generate no new warnings
- [ ] My code also compiles for `cuda_*` and `llvm_*` variants. If you can't test this, please leave below
- [ ] I have commented my code
- [X] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I cleaned the commit history and removed any "Merge" commits
- [X] I give permission that the Mitsuba 3 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba2/blob/master/LICENSE)