### PR TITLE
Fix flag combination issue

### DIFF
--- a/src/mitsuba/mitsuba.cpp
+++ b/src/mitsuba/mitsuba.cpp
@@ -242,7 +242,6 @@ int main(int argc, char *argv[]) {
                 thread_count = 1;
             }
         }
-        Thread::set_thread_count(thread_count);
 
         while (arg_define && *arg_define) {
             std::string value = arg_define->as_string();
@@ -256,6 +255,22 @@ int main(int argc, char *argv[]) {
         mode = (*arg_mode ? arg_mode->as_string() : MI_DEFAULT_VARIANT);
         bool cuda = string::starts_with(mode, "cuda_");
         bool llvm = string::starts_with(mode, "llvm_");
+
+
+        /*
+         * Ugly workaround for the issue:
+         * pool_set_size with count = 0 AND
+         * cuda rendering makes optix init
+         * fail.
+         * */
+        if( cuda ){
+            if( thread_count == 1 )
+                Thread::set_thread_count( 2 );
+            else
+                Thread::set_thread_count(thread_count);
+        }else{
+            Thread::set_thread_count(thread_count);
+        }
 
 #if defined(MI_ENABLE_CUDA)
         if (cuda)


### PR DESCRIPTION
*Please add the labels (e.g. bug, feature, ..) corresponding to this PR*

## Description

When running mitsuba3 like this:

`./mitsuba3/build/mitsuba -t 1 -m cuda_rgb mitsuba3/resources/data/scenes/cbox/cbox-rgb.xml  -o test`

I get this error:

```
Caught a critical exception: [xml.cpp:1117] Error while loading "scenes/biconvex/cbox_biconvex_test.xml" (near line 1, col 1): could not instantiate scene plugin of type "scene": 
[xml.cpp:1117]   [scene_optix.inl:177] Optix configuration initialization failed! The OptiX module compilation did not complete succesfully. The module's compilation state is: 0x2360
```

Specifying -t 1 and -m cuda_rgb is not a valid combination per se (setting a CPU thread count + GPU rendering makes no sense!) BUT - when this is accidentally input it makes for some head scratching...

The problem is caused by `pool_set_size` in thread.cpp:

```
void Thread::set_thread_count(size_t count) {
    global_thread_count = count;
    // Main thread counts as one thread
    pool_set_size(nullptr, (uint32_t) (count - 1));
}
```

..when this function is called with count = 1, and rendering with any cuda* backend, then optix initialisation fails. E.g. -t = 2 works:

`./mitsuba3/build/mitsuba -t 2 -m cuda_rgb mitsuba3/resources/data/scenes/cbox/cbox-rgb.xml  -o test`

I do not expect this to be a good fix for the issue. But it does show what is happening. So maybe some option checking would be more suited?