### PR TITLE
Fix an if direction when loading .obj files and ignoring their normals.

### DIFF
--- a/src/shapes/obj.cpp
+++ b/src/shapes/obj.cpp
@@ -226,7 +226,7 @@ public:
                 m_bbox.expand(p);
                 vertices.push_back(p);
             } else if (cur[0] == 'v' && cur[1] == 'n' && (cur[2] == ' ' || cur[2] == '\t')) {
-                if (!m_face_normals) {
+                if (m_face_normals) {
                     cur += 3;
                     // Vertex normal
                     InputNormal3f n;


### PR DESCRIPTION
## Description

6941c0834a5be9ba5a208849f96fdfe664f9fa28 addressed my issue #191 but the introduced `if` was in the wrong direction: it would actually ignore the `vn` directives when `m_face_normals`. This PR flips that switch.

## Testing

None so far, I am not familiar enough with the codebase :(

## Checklist

<!-- Please make sure to complete this checklist before requesting a review. -->

- [x] My code follows the [style guidelines](https://mitsuba.readthedocs.io/en/latest/src/developer_guide.html#coding-style) of this project
- [x] My changes generate no new warnings
- [ ] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 3 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba/blob/master/LICENSE)