### PR TITLE
Parser should raise exception when kwarg is not used

### DIFF
--- a/include/mitsuba/core/string.h
+++ b/include/mitsuba/core/string.h
@@ -124,13 +124,16 @@ std::string indent(const T *value, size_t amount = 2) {
     return indent((const T2 *) value, amount);
 }
 
-inline void replace_inplace(std::string &str, const std::string &source,
+inline bool replace_inplace(std::string &str, const std::string &source,
                             const std::string &target) {
     size_t pos = 0;
+    bool found = false;
     while ((pos = str.find(source, pos)) != std::string::npos) {
+        found = true;
         str.replace(pos, source.length(), target);
         pos += target.length();
     }
+    return found;
 }
 
 /// Remove leading and trailing characters

--- a/include/mitsuba/core/xml.h
+++ b/include/mitsuba/core/xml.h
@@ -11,7 +11,7 @@ NAMESPACE_BEGIN(mitsuba)
 NAMESPACE_BEGIN(xml)
 
 /// Used to pass key=value pairs to the parser
-using ParameterList = std::vector<std::pair<std::string, std::string>>;
+using ParameterList = std::vector<std::tuple<std::string, std::string, bool>>;
 
 /**
  * Load a Mitsuba scene from an XML file
@@ -75,7 +75,7 @@ extern MI_EXPORT_LIB std::vector<ref<Object>> expand_node(
 extern MI_EXPORT_LIB std::vector<std::pair<std::string, Properties>> xml_to_properties(
                                         const fs::path &path,
                                         const std::string &variant);
-       
+
 NAMESPACE_END(detail)
 
 NAMESPACE_END(xml)

--- a/src/core/python/xml_v.cpp
+++ b/src/core/python/xml_v.cpp
@@ -45,7 +45,8 @@ MI_PY_EXPORT(xml) {
                 for (auto [k, v] : kwargs)
                     param.emplace_back(
                         (std::string) py::str(k),
-                        (std::string) py::str(v)
+                        (std::string) py::str(v),
+                        false
                     );
             }
 
@@ -67,7 +68,8 @@ MI_PY_EXPORT(xml) {
                 for (auto [k, v] : kwargs)
                     param.emplace_back(
                         (std::string) py::str(k),
-                        (std::string) py::str(v)
+                        (std::string) py::str(v),
+                        false
                     );
             }
 

--- a/src/core/tests/test_xml.py
+++ b/src/core/tests/test_xml.py
@@ -389,3 +389,25 @@ def test28_xml_to_props_property_args(variant_scalar_rgb, tmp_path):
             assert dr.allclose(prop['center'], [0, 0, -10])
             assert prop['radius'] == 10.0
     assert has_sphere
+
+
+def test29_xml_kwargs(variant_scalar_rgb):
+    mi.load_string("""<scene version="3.0.0">
+                            <bsdf type="$bsdf"/>
+                      </scene>""", bsdf='diffuse')
+
+    with pytest.raises(RuntimeError) as e:
+        mi.load_string("""<scene version="3.0.0">
+                            <bsdf type="$bsdf"/>
+                        </scene>""", bsdf='diffuse', emitter='area')
+    e.match('Unused parameter "emitter"')
+
+
+def test30_invalid_parameter_name(variant_scalar_rgb):
+    with pytest.raises(Exception) as e:
+        mi.load_string("""
+        <scene version="3.0.0">
+            <default name="test_2," value="2"/>
+        </scene>
+        """)
+    e.match('Invalid character in parameter name')

--- a/src/mitsuba/mitsuba.cpp
+++ b/src/mitsuba/mitsuba.cpp
@@ -249,8 +249,7 @@ int main(int argc, char *argv[]) {
             auto sep = value.find('=');
             if (sep == std::string::npos)
                 Throw("-D/--define: expect key=value pair!");
-            params.push_back(std::make_pair(value.substr(0, sep),
-                                            value.substr(sep+1)));
+            params.emplace_back(value.substr(0, sep), value.substr(sep+1), false);
             arg_define = arg_define->next();
         }
         mode = (*arg_mode ? arg_mode->as_string() : MI_DEFAULT_VARIANT);


### PR DESCRIPTION
This PR adds a check on keyword parameters passed to the parser to make sure those are used at least once. The previous behavior is too error prone.