### PR TITLE
rfilter.h: Include <limits>

### DIFF
--- a/include/mitsuba/core/rfilter.h
+++ b/include/mitsuba/core/rfilter.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <limits>
 #include <mitsuba/core/object.h>
 #include <mitsuba/core/math.h>
 #include <mitsuba/core/logger.h>


### PR DESCRIPTION
This file uses `std::numeric_limits`, so should include the standard <limits> header.

<!-- Please add the labels (e.g. bug fix, feature, ..) corresponding to this PR -->

## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes # (issue)

## Testing

<!-- Please describe the tests that you added to verify your changes. -->

## Checklist

<!-- Please make sure to complete this checklist before requesting a review. -->

- [ ] My code follows the [style guidelines](https://mitsuba.readthedocs.io/en/latest/src/developer_guide.html#coding-style) of this project
- [ ] My changes generate no new warnings
- [ ] My code also compiles for `cuda_*` and `llvm_*` variants. If you can't test this, please leave below
- [ ] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I cleaned the commit history and removed any "Merge" commits
- [ ] I give permission that the Mitsuba 3 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba/blob/master/LICENSE)