### PR TITLE
Differentiable shape `to_world` parameter

### DIFF
--- a/include/mitsuba/python/docstr.h
+++ b/include/mitsuba/python/docstr.h
@@ -6789,8 +6789,6 @@ static const char *__doc_mitsuba_ShapeGroup_m_shapes = R"doc()doc";
 
 static const char *__doc_mitsuba_ShapeGroup_m_shapes_registry_ids = R"doc()doc";
 
-static const char *__doc_mitsuba_ShapeGroup_optix_accel_ready = R"doc()doc";
-
 static const char *__doc_mitsuba_ShapeGroup_optix_build_gas = R"doc(Build OptiX geometry acceleration structures)doc";
 
 static const char *__doc_mitsuba_ShapeGroup_optix_fill_hitgroup_records = R"doc()doc";

--- a/include/mitsuba/render/shape.h
+++ b/include/mitsuba/render/shape.h
@@ -534,8 +534,9 @@ public:
     // Mark that shape as an instance
     void mark_as_instance() { m_is_instance = true; }
 
-    /// The \c Scene class needs access to \c Shape::m_dirty
+    /// The \c Scene and \c ShapeGroup class needs access to \c Shape::m_dirty
     friend class Scene<Float, Spectrum>;
+    friend class ShapeGroup<Float, Spectrum>;
 
     /// Return whether any shape's parameters require gradients (default return false)
     virtual bool parameters_grad_enabled() const;

--- a/include/mitsuba/render/shape.h
+++ b/include/mitsuba/render/shape.h
@@ -353,8 +353,7 @@ public:
      *
      * This function maps a 2D UV value to a surface interaction data
      * structure. Its behavior is only well-defined in regions where this
-     * mapping is bijective. Only the mesh data structure currently implements
-     * this interface via ray tracing, others are to follow later.
+     * mapping is bijective.
      * The default implementation throws.
      */
     virtual SurfaceInteraction3f eval_parameterization(const Point2f &uv,

--- a/include/mitsuba/render/shape.h
+++ b/include/mitsuba/render/shape.h
@@ -572,7 +572,7 @@ protected:
     void* m_optix_data_ptr = nullptr;
 #endif
 
-private:
+protected:
     /// True if the shape's geometry has changed
     bool m_dirty = true;
 };

--- a/include/mitsuba/render/shapegroup.h
+++ b/include/mitsuba/render/shapegroup.h
@@ -70,7 +70,7 @@ public:
                                      const OptixProgramGroup *program_groups) override;
 
     /// Build OptiX geometry acceleration structures
-    void optix_build_gas(const OptixDeviceContext& context) override;
+    void optix_build_gas(const OptixDeviceContext& context);
 #endif
 
     MI_DECLARE_CLASS()

--- a/src/core/python/xml_v.cpp
+++ b/src/core/python/xml_v.cpp
@@ -266,7 +266,7 @@ std::vector<ref<Object>> load_dict(const std::string &dict_key,
             }
 
             // Nested dict with type == "ref" specify a reference to another
-            // object previously instanciated
+            // object previously instantiated
             if (type2 == "ref") {
                 if (is_scene)
                     Throw("Reference found at the scene level: %s", key);

--- a/src/python/python/util.py
+++ b/src/python/python/util.py
@@ -93,7 +93,7 @@ class SceneParameters(Mapping):
         type_length = int(max([len(type(v).__name__) for k, v in self.properties.items()]))
         param_list = '\n'
         param_list += '  ' + '-' * (name_length + 53) + '\n'
-        param_list += f"  {'Name':{name_length}}  {'Flags':7}  {'Type':type_length} {'Parent'}\n"
+        param_list += f"  {'Name':{name_length}}  {'Flags':7}  {'Type':{type_length}} {'Parent'}\n"
         param_list += '  ' + '-' * (name_length + 53) + '\n'
         for k, v in self.properties.items():
             value, value_type, node, flags = v

--- a/src/python/python/util.py
+++ b/src/python/python/util.py
@@ -90,9 +90,10 @@ class SceneParameters(Mapping):
         if len(self) == 0:
             return f'SceneParameters[]'
         name_length = int(max([len(k) for k in self.properties.keys()]) + 2)
+        type_length = int(max([len(type(v).__name__) for k, v in self.properties.items()]))
         param_list = '\n'
         param_list += '  ' + '-' * (name_length + 53) + '\n'
-        param_list += f"  {'Name':{name_length}}  {'Flags':7}  {'Type':15} {'Parent'}\n"
+        param_list += f"  {'Name':{name_length}}  {'Flags':7}  {'Type':type_length} {'Parent'}\n"
         param_list += '  ' + '-' * (name_length + 53) + '\n'
         for k, v in self.properties.items():
             value, value_type, node, flags = v
@@ -106,7 +107,7 @@ class SceneParameters(Mapping):
             if (flags & mi.ParamFlags.Discontinuous) != 0:
                 flags_str += ', D'
 
-            param_list += f'  {k:{name_length}}  {flags_str:7}  {type(value).__name__:15} {node.class_().name()}\n'
+            param_list += f'  {k:{name_length}}  {flags_str:7}  {type(value).__name__:{type_length}} {node.class_().name()}\n'
         return f'SceneParameters[{param_list}]'
 
     def __iter__(self):

--- a/src/render/scene.cpp
+++ b/src/render/scene.cpp
@@ -301,9 +301,17 @@ MI_VARIANT void Scene<Float, Spectrum>::parameters_changed(const std::vector<std
 
     bool accel_is_dirty = false;
     for (auto &s : m_shapes) {
-        accel_is_dirty = s->dirty();
-        if (accel_is_dirty)
+        if (s->dirty()) {
+            accel_is_dirty = true;
             break;
+        }
+    }
+
+    for (auto &s : m_shapegroups) {
+        if (s->dirty()) {
+            accel_is_dirty = true;
+            break;
+        }
     }
 
     if (accel_is_dirty) {
@@ -352,9 +360,10 @@ MI_VARIANT void Scene<Float, Spectrum>::static_accel_shutdown() {
 }
 
 MI_VARIANT void Scene<Float, Spectrum>::clear_shapes_dirty() {
-    for (auto &s : m_shapes) {
+    for (auto &s : m_shapes)
         s->m_dirty = false;
-    }
+    for (auto &s : m_shapegroups)
+        s->m_dirty = false;
 }
 
 MI_VARIANT void Scene<Float, Spectrum>::static_accel_initialization_cpu() { }

--- a/src/render/shapegroup.cpp
+++ b/src/render/shapegroup.cpp
@@ -14,7 +14,7 @@ MI_VARIANT ShapeGroup<Float, Spectrum>::ShapeGroup(const Properties &props) {
     m_has_meshes = false;
     m_has_others = false;
 
-    // Add children to the underlying datastructure
+    // Add children to the underlying data structure
     for (auto &kv : props.objects()) {
         const Class *c_class = kv.second->class_();
         if (c_class->name() == "Instance") {
@@ -71,7 +71,7 @@ MI_VARIANT ShapeGroup<Float, Spectrum>::ShapeGroup(const Properties &props) {
 MI_VARIANT ShapeGroup<Float, Spectrum>::~ShapeGroup() {
 #if defined(MI_ENABLE_EMBREE)
     if constexpr (!dr::is_cuda_v<Float>) {
-        // Ensure all raytracing kernels are terminated before releasing the scene
+        // Ensure all ray tracing kernels are terminated before releasing the scene
         if constexpr (dr::is_llvm_v<Float>)
             dr::sync_thread();
 
@@ -80,49 +80,27 @@ MI_VARIANT ShapeGroup<Float, Spectrum>::~ShapeGroup() {
 #endif
 }
 
-#if defined(MI_ENABLE_EMBREE)
-MI_VARIANT RTCGeometry ShapeGroup<Float, Spectrum>::embree_geometry(RTCDevice device) {
-    DRJIT_MARK_USED(device);
-    if constexpr (!dr::is_cuda_v<Float>) {
-        // Construct the BVH only once
-        if (m_embree_scene == nullptr) {
-            m_embree_scene = rtcNewScene(device);
-            for (auto shape : m_shapes) {
-                RTCGeometry geom = shape->embree_geometry(device);
-                rtcAttachGeometry(m_embree_scene, geom);
-                rtcReleaseGeometry(geom);
-            }
-
-            // Ensure shape data pointers are finished evaluating before building
-            if constexpr (dr::is_llvm_v<Float>)
-                dr::sync_thread();
-
-            rtcCommitScene(m_embree_scene);
-        }
-
-        RTCGeometry instance = rtcNewGeometry(device, RTC_GEOMETRY_TYPE_INSTANCE);
-        rtcSetGeometryInstancedScene(instance, m_embree_scene);
-        return instance;
-    } else {
-        Throw("embree_geometry() should only be called in CPU mode.");
+MI_VARIANT void ShapeGroup<Float, Spectrum>::traverse(TraversalCallback *callback) {
+    for (auto s : m_shapes) {
+        std::string id = s->id();
+        if (id.empty() || string::starts_with(id, "_unnamed_"))
+            id = s->class_()->name();
+        callback->put_object(id, s.get(), +ParamFlags::Differentiable);
     }
 }
-#else
-MI_VARIANT
-std::tuple<typename ShapeGroup<Float, Spectrum>::ScalarFloat,
-           typename ShapeGroup<Float, Spectrum>::ScalarPoint2f,
-           typename ShapeGroup<Float, Spectrum>::ScalarUInt32,
-           typename ShapeGroup<Float, Spectrum>::ScalarUInt32>
-ShapeGroup<Float, Spectrum>::ray_intersect_preliminary_scalar(const ScalarRay3f &ray) const {
-    auto pi = m_kdtree->template ray_intersect_scalar<false>(ray);
-    return { pi.t, pi.prim_uv, pi.shape_index, pi.prim_index };
+
+MI_VARIANT void ShapeGroup<Float, Spectrum>::parameters_changed(const std::vector<std::string> &/*keys*/) {
+    if constexpr (!dr::is_cuda_v<Float>) {
+        for (auto &s : m_shapes) {
+            if (s->dirty()) {
+                m_dirty = true;
+                break;
+            }
+        }
+    }
+    Base::parameters_changed();
 }
 
-MI_VARIANT
-bool ShapeGroup<Float, Spectrum>::ray_test_scalar(const ScalarRay3f &ray) const {
-    return m_kdtree->template ray_intersect_scalar<true>(ray).is_valid();
-}
-#endif
 
 MI_VARIANT typename ShapeGroup<Float, Spectrum>::SurfaceInteraction3f
 ShapeGroup<Float, Spectrum>::compute_surface_interaction(const Ray3f &ray,
@@ -178,7 +156,79 @@ MI_VARIANT void ShapeGroup<Float, Spectrum>::optix_fill_hitgroup_records(std::ve
     fill_hitgroup_records(m_shapes, hitgroup_records, program_groups);
 }
 
+MI_VARIANT void ShapeGroup<Float, Spectrum>::optix_build_gas(const OptixDeviceContext& context) {
+    if (dirty()) {
+        build_gas(context, m_shapes, m_accel);
+        for (auto &s : m_shapes)
+            s->m_dirty = false;
+    }
+}
 #endif
+
+#if defined(MI_ENABLE_EMBREE)
+MI_VARIANT RTCGeometry ShapeGroup<Float, Spectrum>::embree_geometry(RTCDevice device) {
+    DRJIT_MARK_USED(device);
+    if constexpr (!dr::is_cuda_v<Float>) {
+        if (dirty()) {
+            if (m_embree_scene == nullptr)
+                m_embree_scene = rtcNewScene(device);
+
+            for (int geo : m_embree_geometries)
+                rtcDetachGeometry(m_embree_scene, geo);
+            m_embree_geometries.clear();
+
+            for (Shape *shape : m_shapes) {
+                RTCGeometry geom = shape->embree_geometry(embree_device);
+                m_embree_geometries.push_back(rtcAttachGeometry(m_embree_scene, geom));
+                rtcReleaseGeometry(geom);
+            }
+
+            // Ensure shape data pointers are finished evaluating before building
+            if constexpr (dr::is_llvm_v<Float>)
+                dr::sync_thread();
+
+            rtcCommitScene(m_embree_scene);
+
+            for (auto &s : m_shapes)
+                s->m_dirty = false;
+
+            // This method is called once per instance, hence make sure we only
+            // rebuild the BVH once per update.
+            m_dirty = false;
+        }
+
+        RTCGeometry instance = rtcNewGeometry(device, RTC_GEOMETRY_TYPE_INSTANCE);
+        rtcSetGeometryInstancedScene(instance, m_embree_scene);
+        return instance;
+    } else {
+        Throw("embree_geometry() should only be called in CPU mode.");
+    }
+}
+#endif
+
+#if !defined(MI_ENABLE_EMBREE)
+MI_VARIANT
+std::tuple<typename ShapeGroup<Float, Spectrum>::ScalarFloat,
+           typename ShapeGroup<Float, Spectrum>::ScalarPoint2f,
+           typename ShapeGroup<Float, Spectrum>::ScalarUInt32,
+           typename ShapeGroup<Float, Spectrum>::ScalarUInt32>
+ShapeGroup<Float, Spectrum>::ray_intersect_preliminary_scalar(const ScalarRay3f &ray) const {
+    auto pi = m_kdtree->template ray_intersect_scalar<false>(ray);
+    return { pi.t, pi.prim_uv, pi.shape_index, pi.prim_index };
+}
+
+MI_VARIANT
+bool ShapeGroup<Float, Spectrum>::ray_test_scalar(const ScalarRay3f &ray) const {
+    return m_kdtree->template ray_intersect_scalar<true>(ray).is_valid();
+}
+#endif
+
+MI_VARIANT bool ShapeGroup<Float, Spectrum>::parameters_grad_enabled() const {
+    for (auto s : m_shapes)
+        if (s->parameters_grad_enabled())
+            return true;
+    return false;
+}
 
 MI_VARIANT std::string ShapeGroup<Float, Spectrum>::to_string() const {
     std::ostringstream oss;

--- a/src/render/shapegroup.cpp
+++ b/src/render/shapegroup.cpp
@@ -169,7 +169,7 @@ MI_VARIANT void ShapeGroup<Float, Spectrum>::optix_build_gas(const OptixDeviceCo
 MI_VARIANT RTCGeometry ShapeGroup<Float, Spectrum>::embree_geometry(RTCDevice device) {
     DRJIT_MARK_USED(device);
     if constexpr (!dr::is_cuda_v<Float>) {
-        if (dirty()) {
+        if (m_dirty) {
             if (m_embree_scene == nullptr)
                 m_embree_scene = rtcNewScene(device);
 
@@ -177,8 +177,8 @@ MI_VARIANT RTCGeometry ShapeGroup<Float, Spectrum>::embree_geometry(RTCDevice de
                 rtcDetachGeometry(m_embree_scene, geo);
             m_embree_geometries.clear();
 
-            for (Shape *shape : m_shapes) {
-                RTCGeometry geom = shape->embree_geometry(embree_device);
+            for (auto &s : m_shapes) {
+                RTCGeometry geom = s->embree_geometry(device);
                 m_embree_geometries.push_back(rtcAttachGeometry(m_embree_scene, geom));
                 rtcReleaseGeometry(geom);
             }

--- a/src/sensors/orthographic.cpp
+++ b/src/sensors/orthographic.cpp
@@ -48,7 +48,7 @@ the XY-plane facing along the positive Z direction. Transformed versions
 can be instantiated e.g. as follows:
 
 The exact camera position and orientation is most easily expressed using the
-:monosp:`lookat` tag, i.e.:
+:monosp:`look_at` tag, i.e.:
 
 .. tabs::
     .. code-tab:: xml
@@ -60,14 +60,14 @@ The exact camera position and orientation is most easily expressed using the
 
                 <!-- Move and rotate the camera so that looks from (1, 1, 1) to (1, 2, 1)
                     and the direction (0, 0, 1) points "up" in the output image -->
-                <lookat origin="1, 1, 1" target="1, 2, 1" up="0, 0, 1"/>
+                <look_at origin="1, 1, 1" target="1, 2, 1" up="0, 0, 1"/>
             </transform>
         </sensor>
 
     .. code-tab:: python
 
         'type': 'orthographic',
-        'to_world': mi.ScalarTransform4f.lookat(
+        'to_world': mi.ScalarTransform4f.look_at(
             origin=[1, 1, 1],
             target=[1, 2, 1],
             up=[0, 0, 1]

--- a/src/sensors/perspective.cpp
+++ b/src/sensors/perspective.cpp
@@ -90,7 +90,7 @@ Alternatively, it is also possible to specify a field of view in degrees
 along a given axis (see the :monosp:`fov` and :monosp:`fov_axis` parameters).
 
 The exact camera position and orientation is most easily expressed using the
-:monosp:`lookat` tag, i.e.:
+:monosp:`look_at` tag, i.e.:
 
 .. tabs::
     .. code-tab:: xml
@@ -101,7 +101,7 @@ The exact camera position and orientation is most easily expressed using the
             <transform name="to_world">
                 <!-- Move and rotate the camera so that looks from (1, 1, 1) to (1, 2, 1)
                     and the direction (0, 0, 1) points "up" in the output image -->
-                <lookat origin="1, 1, 1" target="1, 2, 1" up="0, 0, 1"/>
+                <look_at origin="1, 1, 1" target="1, 2, 1" up="0, 0, 1"/>
             </transform>
             <!-- film -->
             <!-- sampler -->
@@ -111,7 +111,7 @@ The exact camera position and orientation is most easily expressed using the
 
         'type': 'perspective',
         'fov': 45,
-        'to_world': mi.ScalarTransform4f.lookat(
+        'to_world': mi.ScalarTransform4f.look_at(
             origin=[1, 1, 1],
             target=[1, 2, 1],
             up=[0, 0, 1]

--- a/src/shapes/cylinder.cpp
+++ b/src/shapes/cylinder.cpp
@@ -422,7 +422,6 @@ public:
         bool detach_shape = has_flag(ray_flags, RayFlags::DetachShape);
         bool follow_shape = has_flag(ray_flags, RayFlags::FollowShape);
 
-        const Point3f& length = m_length.value();
         const Float& radius = m_radius.value();
         const Transform4f& to_world = m_to_world.value();
         const Transform4f& to_object = m_to_object.value();
@@ -430,7 +429,7 @@ public:
         /* If necessary, temporally suspend gradient tracking for all shape
         parameters to construct a surface interaction completely detach from
         the shape. */
-        dr::suspend_grad<Float> scope(detach_shape, length, radius, to_world, to_object);
+        dr::suspend_grad<Float> scope(detach_shape, radius, to_world, to_object);
 
         SurfaceInteraction3f si = dr::zeros<SurfaceInteraction3f>();
 
@@ -486,7 +485,7 @@ public:
         si.sh_frame.n = si.n;
 
         if (likely(need_dn_duv)) {
-            si.dn_du = si.dp_du / (m_radius.value() * (m_flip_normals ? -1.f : 1.f));
+            si.dn_du = si.dp_du / (radius * (m_flip_normals ? -1.f : 1.f));
             si.dn_dv = Vector3f(0.f);
         }
 

--- a/src/shapes/instance.cpp
+++ b/src/shapes/instance.cpp
@@ -37,7 +37,7 @@ details on how to create instances, refer to the :ref:`shape-shapegroup` plugin.
         :width: 100%
         :align: center
 
-    The Stanford bunny loaded a single time and instanciated 1365 times (equivalent to 100 million
+    The Stanford bunny loaded a single time and instantiated 1365 times (equivalent to 100 million
     triangles)
 
 .. warning::
@@ -52,7 +52,7 @@ details on how to create instances, refer to the :ref:`shape-shapegroup` plugin.
 template <typename Float, typename Spectrum>
 class Instance final: public Shape<Float, Spectrum> {
 public:
-    MI_IMPORT_BASE(Shape, m_id, m_to_world, m_to_object)
+    MI_IMPORT_BASE(Shape, m_id, m_to_world, m_to_object, mark_dirty)
     MI_IMPORT_TYPES(BSDF)
 
     using typename Base::ScalarSize;
@@ -77,14 +77,15 @@ public:
     }
 
     void traverse(TraversalCallback *callback) override {
-        callback->put_parameter("to_world", *m_to_world.ptr(), +ParamFlags::NonDifferentiable);
-        Base::traverse(callback);
+        callback->put_parameter("to_world", *m_to_world.ptr(), +ParamFlags::Differentiable | ParamFlags::Discontinuous);
     }
 
     void parameters_changed(const std::vector<std::string> &keys) override {
         if (keys.empty() || string::contains(keys, "to_world")) {
             // Update the scalar value of the matrix
             m_to_world = m_to_world.value();
+            m_to_object = m_to_world.value().inverse();
+            mark_dirty();
         }
         Base::parameters_changed();
     }
@@ -148,38 +149,84 @@ public:
                                                      Mask active) const override {
         MI_MASK_ARGUMENT(active);
 
+        const Transform4f& to_world  = m_to_world.value();
+        const Transform4f& to_object = m_to_object.value();
+
+        constexpr bool IsDiff = dr::is_diff_v<Float>;
+        bool grad_enabled = dr::grad_enabled(to_world);
+
+        if constexpr (IsDiff) {
+            if (grad_enabled && m_shapegroup->parameters_grad_enabled())
+                Throw("Cannot differentiate instance parameters and shapegroup "
+                      "internal parameters at the same time!");
+        }
+
         // Nested instancing is not supported
         if (recursion_depth > 0)
             return dr::zeros<SurfaceInteraction3f>();
 
-        SurfaceInteraction3f si = m_shapegroup->compute_surface_interaction(
-            m_to_object.value().transform_affine(ray), pi, ray_flags, recursion_depth, active);
+        bool detach_shape = has_flag(ray_flags, RayFlags::DetachShape);
+        bool follow_shape = has_flag(ray_flags, RayFlags::FollowShape);
 
-        si.p = m_to_world.value().transform_affine(si.p);
-        si.n = dr::normalize(m_to_world.value().transform_affine(si.n));
+        /* If necessary, temporally suspend gradient tracking for all shape
+           parameters to construct a surface interaction completely detach from
+           the shape. */
+        dr::suspend_grad<Float> scope(detach_shape, to_world, to_object);
 
-        if (likely(has_flag(ray_flags, RayFlags::ShadingFrame))) {
-            si.sh_frame.n = dr::normalize(m_to_world.value().transform_affine(si.sh_frame.n));
-            si.initialize_sh_frame();
+        SurfaceInteraction3f si;
+        {
+            /* Temporally suspend gradient tracking when `to_world` need to be
+               differentiated as the various terms of `si` will be recomputed
+               to account for the motion of `si` already. */
+            dr::suspend_grad<Float> scope(grad_enabled);
+            si = m_shapegroup->compute_surface_interaction(
+                to_object.transform_affine(ray), pi, ray_flags,
+                recursion_depth, active);
         }
 
+        // Hit point `si.p` is only attached to the surface motion
+        si.p = to_world.transform_affine(si.p);
+        si.n = dr::normalize(dr::detach(to_world).transform_affine(si.n));
+        if (likely(has_flag(ray_flags, RayFlags::ShadingFrame)))
+            si.sh_frame.n = dr::normalize(dr::detach(to_world).transform_affine(si.sh_frame.n));
+
+        if constexpr (IsDiff) {
+            if (follow_shape && grad_enabled) {
+                /* Recompute si.t in a differential manner as the distance
+                   between the ray origin and the hit point following the moving
+                   surface. */
+                si.t = dr::sqrt(dr::squared_norm(si.p - ray.o) / dr::squared_norm(ray.d));
+            } else if (!follow_shape && grad_enabled) {
+                /* Differential recomputation of the intersection of the ray
+                   with the moving plane tangent to the hit point. In this
+                   scenario, it is important that `si.p` stays along the ray as
+                   the surface moves. */
+                si.t = (dr::dot(si.n, si.p) - dr::dot(si.n, ray.o)) / dr::dot(si.n, ray.d);
+                si.p = ray(si.t);
+                // TODO what can we do about the normals? Take into account curvature?
+                // TODO si.uv should be attached but we don't know about the underlying parameterization
+            }
+        }
+
+        if (likely(has_flag(ray_flags, RayFlags::ShadingFrame)))
+            si.initialize_sh_frame();
+
         if (likely(has_flag(ray_flags, RayFlags::dPdUV))) {
-            si.dp_du = m_to_world.value().transform_affine(si.dp_du);
-            si.dp_dv = m_to_world.value().transform_affine(si.dp_dv);
+            si.dp_du = to_world.transform_affine(si.dp_du);
+            si.dp_dv = to_world.transform_affine(si.dp_dv);
         }
 
         if (has_flag(ray_flags, RayFlags::dNGdUV) || has_flag(ray_flags, RayFlags::dNSdUV)) {
             Normal3f n = has_flag(ray_flags, RayFlags::dNGdUV) ? si.n : si.sh_frame.n;
 
             // Determine the length of the transformed normal before it was re-normalized
-            Normal3f tn = m_to_world.value().transform_affine(
-                dr::normalize(m_to_object.value().transform_affine(n)));
+            Normal3f tn = to_world.transform_affine(dr::normalize(to_object.transform_affine(n)));
             Float inv_len = dr::rcp(dr::norm(tn));
             tn *= inv_len;
 
             // Apply transform to dn_du and dn_dv
-            si.dn_du = m_to_world.value().transform_affine(Normal3f(si.dn_du)) * inv_len;
-            si.dn_dv = m_to_world.value().transform_affine(Normal3f(si.dn_dv)) * inv_len;
+            si.dn_du = to_world.transform_affine(Normal3f(si.dn_du)) * inv_len;
+            si.dn_dv = to_world.transform_affine(Normal3f(si.dn_dv)) * inv_len;
 
             si.dn_du -= tn * dr::dot(tn, si.dn_du);
             si.dn_dv -= tn * dr::dot(tn, si.dn_dv);
@@ -232,6 +279,10 @@ public:
         /* no op */
     }
 #endif
+
+    bool parameters_grad_enabled() const override {
+        return dr::grad_enabled(m_to_world) | m_shapegroup->parameters_grad_enabled();
+    }
 
     MI_DECLARE_CLASS()
 private:

--- a/src/shapes/shapegroup.cpp
+++ b/src/shapes/shapegroup.cpp
@@ -79,7 +79,7 @@ where only a few distinct types of trees have to be kept in memory. An example i
         # Instantiate the shape group without any kind of transformation
         'first_instance': {
             'type': 'instance',
-            'shapegroup: {
+            'shapegroup': {
                 'type': 'ref',
                 'id': 'my_shape_group'
             }
@@ -88,7 +88,7 @@ where only a few distinct types of trees have to be kept in memory. An example i
         # Create instance of the shape group, but rotated, scaled, and translated
         'second_instance': {
             'to_world': mi.ScalarTransform4f.rotate([1, 0, 0], 45).scale([1.5, 1.5, 1.5]).translate([0, 10, 0])
-            'shapegroup: {
+            'shapegroup': {
                 'type': 'ref',
                 'id': 'my_shape_group'
             }

--- a/src/shapes/sphere.cpp
+++ b/src/shapes/sphere.cpp
@@ -161,7 +161,7 @@ public:
 
     void traverse(TraversalCallback *callback) override {
         Base::traverse(callback);
-        callback->put_parameter("to_world", *m_to_world.ptr(), +ParamFlags::Differentiable);
+        callback->put_parameter("to_world", *m_to_world.ptr(), +ParamFlags::Differentiable | ParamFlags::Discontinuous);
     }
 
     void parameters_changed(const std::vector<std::string> &keys) override {

--- a/src/shapes/sphere.cpp
+++ b/src/shapes/sphere.cpp
@@ -338,10 +338,9 @@ public:
     ray_intersect_preliminary_impl(const Ray3fP &ray,
                                    dr::mask_t<FloatP> active) const {
         MI_MASK_ARGUMENT(active);
-        using Value = std::conditional_t<dr::is_cuda_v<FloatP> ||
-                                dr::is_diff_v<Float>,
-                            dr::float32_array_t<FloatP>,
-                            dr::float64_array_t<FloatP>>;
+        using Value = std::conditional_t<dr::is_cuda_v<FloatP> || dr::is_diff_v<Float>,
+                                         dr::float32_array_t<FloatP>,
+                                         dr::float64_array_t<FloatP>>;
         using Value3 = Vector<Value, 3>;
 
         using ScalarValue  = dr::scalar_t<Value>;
@@ -388,10 +387,9 @@ public:
                                      dr::mask_t<FloatP> active) const {
         MI_MASK_ARGUMENT(active);
 
-        using Value = std::conditional_t<dr::is_cuda_v<FloatP> ||
-                                              dr::is_diff_v<Float>,
-                                          dr::float32_array_t<FloatP>,
-                                          dr::float64_array_t<FloatP>>;
+        using Value = std::conditional_t<dr::is_cuda_v<FloatP> || dr::is_diff_v<Float>,
+                                         dr::float32_array_t<FloatP>,
+                                         dr::float64_array_t<FloatP>>;
         using Value3 = Vector<Value, 3>;
         using ScalarValue  = dr::scalar_t<Value>;
         using ScalarValue3 = Vector<ScalarValue, 3>;

--- a/src/shapes/sphere.cpp
+++ b/src/shapes/sphere.cpp
@@ -463,12 +463,12 @@ public:
         Point3f local;
         if constexpr (IsDiff) {
             if (follow_shape) {
-                /* FollowShape glues the interaction point with the sphere,
-                   therefore to also needs to account for a possible differential
-                   rotation in to_world. we first compute a detached intersection
-                   point in local space and transform it back in world space to
-                   get a point rigidly attached to the sphere attached point,
-                   including translation, scaling and rotation */
+                /* FollowShape glues the interaction point with the shape.
+                   Therefore, to also account for a possible differential motion
+                   of the shape, we first compute a detached intersection point
+                   in local space and transform it back in world space to get a
+                   point rigidly attached to the shape's motion, including
+                   translation, scaling and rotation. */
                 Normal3f n = dr::normalize(ray(pi.t) - center);
                 local = to_object.transform_affine(dr::fmadd(n, radius, center));
                 /* With FollowShape the local position should always be static as
@@ -528,7 +528,6 @@ public:
 
         if (m_flip_normals)
             si.sh_frame.n = -si.sh_frame.n;
-
         si.n = si.sh_frame.n;
 
         if (need_dn_duv) {

--- a/src/shapes/sphere.cpp
+++ b/src/shapes/sphere.cpp
@@ -145,12 +145,12 @@ public:
         m_radius = dr::norm(m_to_world.value().transform_affine(Vector3f(1.f, 0.f, 0.f)));
         m_center = m_to_world.value().transform_affine(Point3f(0.f));
 
-        if (m_radius.scalar() <= 0.f) {
+        if (S[0][0] <= 0.f) {
             m_radius = dr::abs(m_radius.value());
             m_flip_normals = !m_flip_normals;
         }
 
-        // Reconstruct the to_world transform with uniform scaling and no shear
+        // Compute the to_object transformation with uniform scaling and no shear
         m_to_object = m_to_world.value().inverse();
 
         m_inv_surface_area = dr::rcp(surface_area());

--- a/src/shapes/tests/test_cylinder.py
+++ b/src/shapes/tests/test_cylinder.py
@@ -180,3 +180,79 @@ def test06_differentiable_surface_interaction_ray_backward(variant_cuda_ad_rgb):
     si = pi.compute_surface_interaction(ray)
     dr.backward(si.t)
     assert dr.allclose(dr.grad(ray.o), [0, -1, 0])
+
+
+def test07_differentiable_surface_interaction_ray_forward(variants_all_ad_rgb):
+    shape = mi.load_dict({'type' : 'cylinder'})
+    params = mi.traverse(shape)
+
+    # Test 01: When the cylinder is inflating, the point hitting the center will
+    #          move back along the ray. The normal isn't changing nor the UVs.
+
+    ray = mi.Ray3f(mi.Vector3f(0, 2, 0.5), mi.Vector3f(0, -1, 0))
+
+    theta = mi.Float(0)
+    dr.enable_grad(theta)
+    params['to_world'] = mi.Transform4f.scale([1 + theta, 1 + theta, 1])
+    params.update()
+    si = shape.ray_intersect(ray, mi.RayFlags.All)
+
+    dr.forward(theta)
+
+    assert dr.allclose(dr.grad(si.t), -1)
+    assert dr.allclose(dr.grad(si.p), [0, 1, 0])
+    assert dr.allclose(dr.grad(si.n), 0, atol=1e-6)
+    assert dr.allclose(dr.grad(si.uv), 0)
+
+    # Test 02: With FollowShape, an intersection point at a translating cylinder
+    #          should move with the cylinder. The normal and the UVs should be static.
+
+    ray = mi.Ray3f(mi.Vector3f(0, 2, 0.5), mi.Vector3f(0, -1, 0))
+
+    theta = mi.Float(0.0)
+    dr.enable_grad(theta)
+    params['to_world'] = mi.Transform4f.translate([0, 0, theta])
+    params.update()
+    si = shape.ray_intersect(ray, mi.RayFlags.All | mi.RayFlags.FollowShape)
+
+    dr.forward(theta)
+
+    assert dr.allclose(dr.grad(si.p), [0.0, 0.0, 1.0])
+    assert dr.allclose(dr.grad(si.n), 0.0)
+    assert dr.allclose(dr.grad(si.uv), 0.0)
+
+    # Test 03: With FollowShape, an intersection point and normal at a rotating
+    #          cylinder should follow the rotation speed along the tangent
+    #          direction. The UVs should be static.
+
+    ray = mi.Ray3f(mi.Vector3f(0, 2, 0.5), mi.Vector3f(0, -1, 0))
+
+    theta = mi.Float(0.0)
+    dr.enable_grad(theta)
+    params['to_world'] = mi.Transform4f.rotate([0, 0, 1], 90 * theta)
+    params.update()
+    si = shape.ray_intersect(ray, mi.RayFlags.All | mi.RayFlags.FollowShape)
+
+    dr.forward(theta)
+
+    assert dr.allclose(dr.grad(si.p), [-dr.pi / 2.0, 0.0, 0.0])
+    assert dr.allclose(dr.grad(si.n), [-dr.pi / 2.0, 0.0, 0.0])
+    assert dr.allclose(dr.grad(si.uv), 0.0)
+
+    # Test 04: Without FollowShape, a cylinder that is only rotating shouldn't
+    #          produce any gradients for the intersection point and normal, but
+    #          for the UVs.
+
+    ray = mi.Ray3f(mi.Vector3f(0, 2, 0.5), mi.Vector3f(0, -1, 0))
+
+    theta = mi.Float(0.0)
+    dr.enable_grad(theta)
+    params['to_world'] = mi.Transform4f.rotate([0, 0, 1], 90 * theta)
+    params.update()
+    si = shape.ray_intersect(ray, mi.RayFlags.All)
+
+    dr.forward(theta)
+
+    assert dr.allclose(dr.grad(si.p), 0.0)
+    assert dr.allclose(dr.grad(si.n), 0.0)
+    assert dr.allclose(dr.grad(si.uv), [-0.25, 0.0])

--- a/src/shapes/tests/test_sphere.py
+++ b/src/shapes/tests/test_sphere.py
@@ -221,6 +221,24 @@ def test08_differentiable_surface_interaction_ray_forward_follow_shape(variants_
     shape = mi.load_dict({'type' : 'sphere'})
     params = mi.traverse(shape)
 
+    # Test 00: With DetachShape and no moving rays, the output shouldn't produce
+    #          any gradients.
+
+    ray = mi.Ray3f(mi.Vector3f(0, 0, -2), mi.Vector3f(0, 0, 1))
+
+    theta = mi.Float(0)
+    dr.enable_grad(theta)
+    params['to_world'] = mi.Transform4f.scale(1 + theta)
+    params.update()
+    si = shape.ray_intersect(ray, mi.RayFlags.All | mi.RayFlags.DetachShape)
+
+    dr.forward(theta)
+
+    assert dr.allclose(dr.grad(si.p), 0.0)
+    assert dr.allclose(dr.grad(si.t), 0.0)
+    assert dr.allclose(dr.grad(si.n), 0.0)
+    assert dr.allclose(dr.grad(si.uv), 0.0)
+
     # Test 01: When the sphere is inflating, the point hitting the center will
     #          move back along the ray. The normal isn't changing nor the UVs.
 

--- a/src/shapes/tests/test_sphere.py
+++ b/src/shapes/tests/test_sphere.py
@@ -129,10 +129,10 @@ def test05_sample_direct(variant_scalar_rgb):
         for xi_2 in dr.linspace(Float, 1e-3, 1 - 1e-3, 10):
             sample = sphere.sample_direction(it, [xi_2, 1 - xi_1])
             d = sample_cone([xi_1, xi_2], cos_cone_angle)
-            its = sphere.ray_intersect(mi.Ray3f(it.p, d))
+            si = sphere.ray_intersect(mi.Ray3f(it.p, d))
             assert dr.allclose(d, sample.d, atol=1e-5, rtol=1e-5)
-            assert dr.allclose(its.t, sample.dist, atol=1e-5, rtol=1e-5)
-            assert dr.allclose(its.p, sample.p, atol=1e-5, rtol=1e-5)
+            assert dr.allclose(si.t, sample.dist, atol=1e-5, rtol=1e-5)
+            assert dr.allclose(si.p, sample.p, atol=1e-5, rtol=1e-5)
 
 
 def test06_differentiable_surface_interaction_ray_forward(variants_all_ad_rgb):
@@ -217,7 +217,85 @@ def test07_differentiable_surface_interaction_ray_backward(variants_all_ad_rgb):
     assert dr.allclose(dr.grad(ray.o), [0, 0, -1])
 
 
-def test08_si_singularity(variants_all_rgb):
+def test08_differentiable_surface_interaction_ray_forward_follow_shape(variants_all_ad_rgb):
+    shape = mi.load_dict({'type' : 'sphere'})
+    params = mi.traverse(shape)
+
+    # Test 01: When the sphere is inflating, the point hitting the center will
+    #          move back along the ray. The normal isn't changing nor the UVs.
+
+    ray = mi.Ray3f(mi.Vector3f(0, 0, -2), mi.Vector3f(0, 0, 1))
+
+    theta = mi.Float(0)
+    dr.enable_grad(theta)
+    params['to_world'] = mi.Transform4f.scale(1 + theta)
+    params.update()
+    si = shape.ray_intersect(ray, mi.RayFlags.All)
+
+    dr.forward(theta)
+
+    assert dr.allclose(dr.grad(si.t), -1)
+    assert dr.allclose(dr.grad(si.p), [0, 0, -1])
+    assert dr.allclose(dr.grad(si.n), 0)
+    assert dr.allclose(dr.grad(si.uv), 0)
+
+    # Test 02: With FollowShape, an intersection point at the pole of a translating
+    #          sphere should move with the pole. The normal and the UVs should be static.
+
+    ray = mi.Ray3f(mi.Vector3f(0.0, 0.0, -2.0), mi.Vector3f(0.0, 0.0, 1.0))
+
+    theta = mi.Float(0.0)
+    dr.enable_grad(theta)
+    params['to_world'] = mi.Transform4f.translate([theta, 0.0, 0.0])
+    params.update()
+    si = shape.ray_intersect(ray, mi.RayFlags.All | mi.RayFlags.FollowShape)
+
+    dr.forward(theta)
+
+    assert dr.allclose(dr.grad(si.p), [1.0, 0.0, 0.0])
+    assert dr.allclose(dr.grad(si.n), 0.0)
+    assert dr.allclose(dr.grad(si.uv), 0.0)
+
+    # Test 03: With FollowShape, an intersection point and normal at the pole of
+    #          a rotating sphere should follow the rotation speed along the
+    #          tangent direction. The UVs should be static.
+
+    ray = mi.Ray3f(mi.Vector3f(0.0, 0.0, -2.0), mi.Vector3f(0.0, 0.0, 1.0))
+
+    theta = mi.Float(0.0)
+    dr.enable_grad(theta)
+    params['to_world'] = mi.Transform4f.rotate([0, 1, 0], 90 * theta)
+    params.update()
+    si = shape.ray_intersect(ray, mi.RayFlags.All | mi.RayFlags.FollowShape)
+
+    dr.forward(theta)
+
+    assert dr.allclose(dr.grad(si.p), [-dr.pi / 2.0, 0.0, 0.0])
+    assert dr.allclose(dr.grad(si.n), [-dr.pi / 2.0, 0.0, 0.0])
+    assert dr.allclose(dr.grad(si.uv), 0.0)
+
+    # Test 04: Without FollowShape, a sphere that is only rotating shouldn't
+    #          produce any gradients for the intersection point and normal, but
+    #          for the UVs.
+
+    ray = mi.Ray3f(mi.Vector3f(0.0, -2.0, 0.0), mi.Vector3f(0.0, 1.0, 0.0))
+
+    theta = mi.Float(0.0)
+    dr.enable_grad(theta)
+    params['to_world'] = mi.Transform4f.rotate([1, 0, 0], 90 * theta)
+    params.update()
+    si = shape.ray_intersect(ray, mi.RayFlags.All)
+
+    dr.forward(theta)
+
+    assert dr.allclose(dr.grad(si.p), 0.0)
+    assert dr.allclose(dr.grad(si.n), 0.0)
+    assert dr.allclose(dr.grad(si.uv), [0.0, -0.5])
+
+
+
+
+def test09_si_singularity(variants_all_rgb):
     scene = mi.load_dict({"type" : "scene", 's': { 'type': 'sphere' }})
     ray = mi.Ray3f([0, 0, -1], [0, 0, 1])
 


### PR DESCRIPTION
## Description

This PR attempts to enable the computation of gradients for the `to_world` parameter of the `sphere` analytical shape plugin.

The following changes are necessary to achieve this:
- Make the parameters update and state recomputation differentiable (e.g. when recomputing `m_radius`, `m_center`)
- Add support for the `DetachShape` and `FollowShape` flags in the `compute_surface_interaction` method.

This PR also implements `Sphere::eval_parameterization()` for texture sphere emitters.
