### PR TITLE
OptiX 7.4 denoiser

### DIFF
--- a/docs/docs_api/conf.py
+++ b/docs/docs_api/conf.py
@@ -80,7 +80,8 @@ extensions.append('sphinx.ext.autodoc')
 # autodoc_typehints = 'description'
 
 autodoc_default_options = {
-    'members': True
+    'members': True,
+    'special-members': '__call__',
 }
 
 autoclass_content = 'both'
@@ -198,6 +199,7 @@ api_doc_structure = {
               r'mitsuba.Color([\w]+)',
               r'mitsuba.Ray([\w]+)'],
     'Constants': [r'mitsuba.MI_([\w]+)', r'mitsuba.is_([\w]+)', 'mitsuba.DEBUG'],
+    'Denoiser': ['mitsuba.OptixDenoiser'],
     'BSDF': [r'mitsuba.BSDF([\w]*)', 'mitsuba.TransportMode',
              r'mitsuba.Microfacet([\w]+)'],
     'Integrator': [r'mitsuba.(.*)Integrator([\w]*)', 'mitsuba.ad.common.mis_weight'],
@@ -217,7 +219,8 @@ api_doc_structure = {
                r'mitsuba.([\w]+)Interaction([\w]+)',
                r'mitsuba.([\w]+)Intersection([\w]+)', ],
     'Spectrum': [r'mitsuba.spectrum_([\w]+)', r'mitsuba.srgb_([\w]+)',
-                 r'mitsuba.cie1931([\w]+)', 'mitsuba.xyz_to_srgb',
+                 r'mitsuba.cie1931([\w]+)', 'mitsuba.cie_d65',
+                 'mitsuba.xyz_to_srgb',
                  'mitsuba.pdf_rgb_spectrum', 'mitsuba.luminance',
                  'mitsuba.eval_reflectance', 'mitsuba.linear_rgb_rec',
                  'mitsuba.sample_rgb_spectrum'],

--- a/docs/docs_api/list_api.rst
+++ b/docs/docs_api/list_api.rst
@@ -1,7 +1,5 @@
 .. autoclass:: mitsuba.AdjointIntegrator
 
-.. autoclass:: mitsuba.AnimatedTransform
-
 .. autoclass:: mitsuba.Appender
 
 .. autoclass:: mitsuba.ArgParser
@@ -136,9 +134,13 @@
 
 .. autofunction:: mitsuba.MI_AUTHORS
 
+.. autofunction:: mitsuba.MI_CIE_D65_NORMALIZATION
+
 .. autofunction:: mitsuba.MI_CIE_MAX
 
 .. autofunction:: mitsuba.MI_CIE_MIN
+
+.. autofunction:: mitsuba.MI_CIE_Y_NORMALIZATION
 
 .. autofunction:: mitsuba.MI_ENABLE_CUDA
 
@@ -211,6 +213,8 @@
 .. autoclass:: mitsuba.Object
 
 .. autoclass:: mitsuba.ObjectPtr
+
+.. autoclass:: mitsuba.OptixDenoiser
 
 .. autoclass:: mitsuba.PCG32
 
@@ -570,6 +574,8 @@
 
 .. autofunction:: mitsuba.cie1931_y
 
+.. autofunction:: mitsuba.cie_d65
+
 .. autofunction:: mitsuba.coordinate_system
 
 .. autofunction:: mitsuba.cornell_box
@@ -672,9 +678,13 @@
 
 .. autofunction:: mitsuba.mueller.diattenuator
 
+.. autofunction:: mitsuba.mueller.left_circular_polarizer
+
 .. autofunction:: mitsuba.mueller.linear_polarizer
 
 .. autofunction:: mitsuba.mueller.linear_retarder
+
+.. autofunction:: mitsuba.mueller.right_circular_polarizer
 
 .. autofunction:: mitsuba.mueller.rotate_mueller_basis
 

--- a/docs/generated/extracted_rst_api.rst
+++ b/docs/generated/extracted_rst_api.rst
@@ -39,80 +39,6 @@
         Returns → None:
             *no description available*
 
-.. py:class:: mitsuba.AnimatedTransform
-
-    Base class: :py:obj:`mitsuba.Object`
-
-    Encapsulates an animated 4x4 homogeneous coordinate transformation
-
-    The animation is stored as keyframe animation with linear segments.
-    The implementation performs a polar decomposition of each keyframe
-    into a 3x3 scale/shear matrix, a rotation quaternion, and a
-    translation vector. These will all be interpolated independently at
-    eval time.
-
-
-    .. py:method:: __init__(self)
-
-    .. py:method:: __init__(self, arg0)
-
-        Parameter ``arg0`` (:py:obj:`mitsuba.ScalarTransform4f`):
-            *no description available*
-
-    .. py:method:: mitsuba.AnimatedTransform.append(overloaded)
-
-
-        .. py:method:: append(self, arg0, arg1)
-
-            Append a keyframe to the current animated transform
-
-            Parameter ``arg0`` (float):
-                *no description available*
-
-            Parameter ``arg1`` (:py:obj:`mitsuba.ScalarTransform4f`):
-                *no description available*
-
-        .. py:method:: append(self, arg0)
-
-            Parameter ``arg0`` (:py:obj:`mitsuba.AnimatedTransform.Keyframe`):
-                *no description available*
-
-    .. py:method:: mitsuba.AnimatedTransform.eval(self, time, unused=True)
-
-        Compatibility wrapper, which strips the mask argument and invokes
-        eval()
-
-        Parameter ``time`` (drjit.llvm.ad.Float):
-            *no description available*
-
-        Parameter ``unused`` (drjit.llvm.ad.Bool):
-            *no description available*
-
-        Returns → :py:obj:`mitsuba.Transform4f`:
-            *no description available*
-
-    .. py:method:: mitsuba.AnimatedTransform.has_scale(self)
-
-        Determine whether the transformation involves any kind of scaling
-
-        Returns → bool:
-            *no description available*
-
-    .. py:method:: mitsuba.AnimatedTransform.size(self)
-
-        Return the number of keyframes
-
-        Returns → int:
-            *no description available*
-
-    .. py:method:: mitsuba.AnimatedTransform.translation_bounds(self)
-
-        Return an axis-aligned box bounding the amount of translation
-        throughout the animation sequence
-
-        Returns → :py:obj:`mitsuba.ScalarBoundingBox3f`:
-            *no description available*
-
 .. py:class:: mitsuba.Appender
 
     Base class: :py:obj:`mitsuba.Object`
@@ -410,6 +336,17 @@
 
             Returns → int:
                 *no description available*
+
+    .. py:method:: mitsuba.BSDF.get_diffuse_reflectance(self, si, active=True)
+
+        Parameter ``si`` (:py:obj:`mitsuba.SurfaceInteraction3f`):
+            *no description available*
+
+        Parameter ``active`` (drjit.llvm.ad.Bool):
+            Mask to specify active lanes.
+
+        Returns → :py:obj:`mitsuba.Color3f`:
+            *no description available*
 
     .. py:method:: mitsuba.BSDF.id(self)
 
@@ -831,6 +768,17 @@
         Returns → :py:obj:`mitsuba.BSDFPtr`:
             *no description available*
 
+    .. py:method:: mitsuba.BSDFPtr.get_diffuse_reflectance(self, si, active=True)
+
+        Parameter ``si`` (:py:obj:`mitsuba.SurfaceInteraction3f`):
+            *no description available*
+
+        Parameter ``active`` (drjit.llvm.ad.Bool):
+            Mask to specify active lanes.
+
+        Returns → :py:obj:`mitsuba.Color3f`:
+            *no description available*
+
     .. py:method:: mitsuba.BSDFPtr.label_(self)
 
         Returns → str:
@@ -1126,7 +1074,7 @@
 
         Members:
 
-        .. py:data:: None
+        .. py:data:: Empty
 
             No transformation (default)
 
@@ -1407,7 +1355,7 @@
     .. py:method:: mitsuba.Bitmap.convert(overloaded)
 
 
-        .. py:method:: convert(self, pixel_format=None, component_format=None, srgb_gamma=None, alpha_transform=<AlphaTransform., None)
+        .. py:method:: convert(self, pixel_format=None, component_format=None, srgb_gamma=None, alpha_transform=<AlphaTransform., Empty)
 
             Convert the bitmap into another pixel and/or component format
 
@@ -1463,7 +1411,7 @@
             Parameter ``alpha_transform`` (:py:obj:`mitsuba.Bitmap.AlphaTransform`):
                 *no description available*
 
-            Parameter ``None`` (0>):
+            Parameter ``Empty`` (0>):
                 *no description available*
 
             Returns → :py:obj:`mitsuba.Bitmap`:
@@ -3670,6 +3618,11 @@
         Returns → float:
             *no description available*
 
+    .. py:method:: mitsuba.ContinuousDistribution.max(self)
+
+        Returns → float:
+            *no description available*
+
     .. py:method:: mitsuba.ContinuousDistribution.normalization(self)
 
         Return the normalization factor (i.e. the inverse of sum())
@@ -3740,7 +3693,7 @@
 
 .. py:data:: mitsuba.DEBUG
     :type: bool
-    :value: True
+    :value: False
 
 .. py:class:: mitsuba.DefaultFormatter
 
@@ -5018,6 +4971,12 @@
     To avoid lock-related bottlenecks when rendering with many cores,
     rendering threads first store results in an "image block", which is
     then committed to the film using the put() method.
+
+    .. py:method:: __init__(self, props)
+
+        Parameter ``props`` (:py:obj:`mitsuba.Properties`):
+            *no description available*
+
 
     .. py:method:: mitsuba.Film.bitmap(self, raw=False)
 
@@ -7853,8 +7812,7 @@
     can also be queried via the read() method, in which case the
     reconstruction filter is used to compute suitable interpolation
     weights. This is feature is useful for differentiable rendering, where
-    we one needs to evaluate the reverse-mode derivative of the put()
-    method.
+    one needs to evaluate the reverse-mode derivative of the put() method.
 
 
     .. py:method:: __init__(self, size, offset, channel_count, rfilter=None, border=False, normalize=False, coalesce=True, warn_negative=False, warn_invalid=False)
@@ -10038,6 +9996,11 @@
         Returns → float:
             *no description available*
 
+    .. py:method:: mitsuba.IrregularContinuousDistribution.max(self)
+
+        Returns → float:
+            *no description available*
+
     .. py:method:: mitsuba.IrregularContinuousDistribution.nodes(self)
 
         Return the nodes of the underlying discretization
@@ -10309,6 +10272,14 @@
 
 .. py:class:: mitsuba.Loop
 
+    .. py:method:: mitsuba.Loop.__call__(self, arg0)
+
+        Parameter ``arg0`` (drjit.llvm.ad.Bool):
+            *no description available*
+
+        Returns → bool:
+            *no description available*
+
     .. py:method:: mitsuba.Loop.init(self)
 
         Returns → None:
@@ -10342,6 +10313,10 @@
     :type: str
     :value: Realistic Graphics Lab, EPFL
 
+.. py:data:: mitsuba.MI_CIE_D65_NORMALIZATION
+    :type: float
+    :value: 0.010101273599490354
+
 .. py:data:: mitsuba.MI_CIE_MAX
     :type: float
     :value: 830.0
@@ -10349,6 +10324,10 @@
 .. py:data:: mitsuba.MI_CIE_MIN
     :type: float
     :value: 360.0
+
+.. py:data:: mitsuba.MI_CIE_Y_NORMALIZATION
+    :type: float
+    :value: 0.009367658735689113
 
 .. py:data:: mitsuba.MI_ENABLE_CUDA
     :type: bool
@@ -10364,7 +10343,7 @@
 
 .. py:data:: mitsuba.MI_VERSION
     :type: str
-    :value: 3.0.1
+    :value: 3.0.2
 
 .. py:data:: mitsuba.MI_VERSION_MAJOR
     :type: int
@@ -10376,7 +10355,7 @@
 
 .. py:data:: mitsuba.MI_VERSION_PATCH
     :type: int
-    :value: 1
+    :value: 2
 
 .. py:data:: mitsuba.MI_YEAR
     :type: str
@@ -11634,7 +11613,7 @@
     .. py:method:: mitsuba.MediumInteraction3f.mint
         :property:
 
-        mint used when sampling the given distance "t".
+        mint used when sampling the given distance ``t``
 
     .. py:method:: mitsuba.MediumInteraction3f.sh_frame
         :property:
@@ -12026,13 +12005,7 @@
 
     1. __init__(self: :py:obj:`mitsuba.llvm_ad_rgb.Mesh`, props: :py:obj:`mitsuba.llvm_ad_rgb.Properties`) -> None
 
-    2. __init__(self: :py:obj:`mitsuba.llvm_ad_rgb.Mesh`, name: str, vertex_count: int, face_count: int, props: :py:obj:`mitsuba.llvm_ad_rgb.Properties` = Properties[
-      plugin_name = "",
-      id = "",
-      elements = {
-      }
-    ]
-    , has_vertex_normals: bool = False, has_vertex_texcoords: bool = False) -> None
+    2. __init__(self: :py:obj:`mitsuba.llvm_ad_rgb.Mesh`, name: str, vertex_count: int, face_count: int, props: :py:obj:`mitsuba.llvm_ad_rgb.Properties` = Properties(), has_vertex_normals: bool = False, has_vertex_texcoords: bool = False) -> None
 
     Create a new mesh with the given vertex and face data structures
 
@@ -12694,6 +12667,151 @@
     .. py:method:: mitsuba.ObjectPtr.zero_
 
         (arg0: int) -> :py:obj:`mitsuba.llvm_ad_rgb.ObjectPtr`
+
+.. py:class:: mitsuba.OptixDenoiser
+
+    Base class: :py:obj:`mitsuba.Object`
+
+    Wrapper for the OptiX AI denoiser
+
+    The OptiX AI denoiser is wrapped in this object such that it can work
+    directly with Mitsuba types and its conventions.
+
+    The denoiser works best when applied to noisy renderings that were
+    produced with a Film which used the `box` ReconstructionFilter. With a
+    filter that spans multiple pixels, the denoiser might identify some
+    local variance as a feature of the scene and will not denoise it.
+
+    .. py:method:: __init__(self, input_size, albedo=False, normals=False, temporal=False)
+
+        Constructs an OptiX denoiser
+        
+        Parameter ``input_size`` (:py:obj:`mitsuba.ScalarVector2u`):
+            Resolution of noisy images that will be fed to the denoiser.
+        
+        Parameter ``albedo`` (bool):
+            Whether or not albedo information will also be given to the
+            denoiser.
+        
+        Parameter ``normals`` (bool):
+            Whether or not shading normals information will also be given to
+            the Denoiser.
+        
+        Returns:
+            A callable object which will apply the OptiX denoiser.
+
+        Parameter ``temporal`` (bool):
+            *no description available*
+
+        
+    .. py:method:: mitsuba.OptixDenoiser.__call__(overloaded)
+
+
+        .. py:method:: __call__(self, noisy, denoise_alpha=True, albedo=[], normals=[], to_sensor=Transform4f(), flow=[], previous_denoised=[])
+
+            Apply denoiser on inputs which are TensorXf objects.
+
+            Parameter ``noisy`` (drjit.llvm.ad.TensorXf):
+                The noisy input. (tensor shape: (width, height, 3 | 4))
+
+            Parameter ``denoise_alpha`` (bool):
+                Whether or not the alpha channel (if specified in the noisy input)
+                should be denoised too. This parameter is optional, by default it
+                is true.
+
+            Parameter ``albedo`` (drjit.llvm.ad.TensorXf):
+                Albedo information of the noisy rendering. This parameter is
+                optional unless the OptixDenoiser was built with albedo support.
+                (tensor shape: (width, height, 3))
+
+            Parameter ``normals`` (drjit.llvm.ad.TensorXf):
+                Shading normal information of the noisy rendering. The normals
+                must be in the coordinate frame of the sensor which was used to
+                render the noisy input. This parameter is optional unless the
+                OptixDenoiser was built with normals support. (tensor shape:
+                (width, height, 3))
+
+            Parameter ``to_sensor`` (:py:obj:`mitsuba.Transform4f`):
+                A Transform4f which is applied to the ``normals`` parameter before
+                denoising. This should be used to tranform the normals into the
+                correct coordinate frame. This parameter is optional, by default
+                no transformation is applied.
+
+            Parameter ``flow`` (drjit.llvm.ad.TensorXf):
+                With temporal denoising, this parameter is the optical flow
+                between the previous frame and the current one. It should capture
+                the 2D motion of each individual pixel. When this parameter is
+                unknown, it can been set to a zero-initialized TensorXf of the
+                correct size and still produce convincing results. This parameter
+                is optional unless the OptixDenoiser was built with temporal
+                denoising support. (tensor shape: (width, height, 2))
+
+            Parameter ``previous_denoised`` (drjit.llvm.ad.TensorXf):
+                With temporal denoising, the previous denoised frame should be
+                passed here. For the very first frame, the OptiX documentation
+                recommends passing the noisy input for this argument. This
+                parameter is optional unless the OptixDenoiser was built with
+                temporal denoising support. (tensor shape: (width, height, 3 | 4))
+
+            Returns → drjit.llvm.ad.TensorXf:
+                The denoised input.
+
+        .. py:method:: __call__(self, noisy, denoise_alpha=True, albedo_ch='', normals_ch='', to_sensor=Transform4f(), flow_ch='', previous_denoised_ch='', noisy_ch='<root>')
+
+            Apply denoiser on inputs which are Bitmap objects.
+
+            Parameter ``noisy`` (:py:obj:`mitsuba.Bitmap`):
+                The noisy input. When passing additional information like albedo
+                or normals to the denoiser, this Bitmap object must be a
+                MultiChannel bitmap.
+
+            Parameter ``denoise_alpha`` (bool):
+                Whether or not the alpha channel (if specified in the noisy input)
+                should be denoised too. This parameter is optional, by default it
+                is true.
+
+            Parameter ``albedo_ch`` (str):
+                The name of the channel in the ``noisy`` parameter which contains
+                the albedo information of the noisy rendering. This parameter is
+                optional unless the OptixDenoiser was built with albedo support.
+
+            Parameter ``normals_ch`` (str):
+                The name of the channel in the ``noisy`` parameter which contains
+                the shading normal information of the noisy rendering. The normals
+                must be in the coordinate frame of the sensor which was used to
+                render the noisy input. This parameter is optional unless the
+                OptixDenoiser was built with normals support.
+
+            Parameter ``to_sensor`` (:py:obj:`mitsuba.Transform4f`):
+                A Transform4f which is applied to the ``normals`` parameter before
+                denoising. This should be used to tranform the normals into the
+                correct coordinate frame. This parameter is optional, by default
+                no transformation is applied.
+
+            Parameter ``flow_ch`` (str):
+                With temporal denoising, this parameter is name of the channel in
+                the ``noisy`` parameter which contains the optical flow between
+                the previous frame and the current one. It should capture the 2D
+                motion of each individual pixel. When this parameter is unknown,
+                it can been set to a zero-initialized TensorXf of the correct size
+                and still produce convincing results. This parameter is optional
+                unless the OptixDenoiser was built with temporal denoising
+                support.
+
+            Parameter ``previous_denoised_ch`` (str):
+                With temporal denoising, this parameter is name of the channel in
+                the ``noisy`` parameter which contains the previous denoised
+                frame. For the very first frame, the OptiX documentation
+                recommends passing the noisy input for this argument. This
+                parameter is optional unless the OptixDenoiser was built with
+                temporal denoising support.
+
+            Parameter ``noisy_ch`` (str):
+                The name of the channel in the ``noisy`` parameter which contains
+                the shading normal information of the noisy rendering.
+
+            Returns → :py:obj:`mitsuba.Bitmap`:
+                The denoised input.
 
 .. py:class:: mitsuba.PCG32
 
@@ -13571,8 +13689,6 @@
 
             Transform
 
-            AnimatedTransform
-
             Color
 
             String
@@ -13591,20 +13707,6 @@
 
     .. py:method:: mitsuba.Properties.Type.name
         :property:
-
-    .. py:method:: mitsuba.Properties.animated_transform(self, arg0, arg1)
-
-        Retrieve an animated transformation (use default value if no entry
-        exists)
-
-        Parameter ``arg0`` (str):
-            *no description available*
-
-        Parameter ``arg1`` (mitsuba::AnimatedTransform):
-            *no description available*
-
-        Returns → object:
-            *no description available*
 
     .. py:method:: mitsuba.Properties.copy_attribute(self, arg0, arg1, arg2)
 
@@ -13945,6 +14047,16 @@
         Parameter ``maxt`` (drjit.llvm.ad.Float):
             *no description available*
 
+    .. py:method:: mitsuba.Ray2f.__call__(self, t)
+
+        Return the position of a point along the ray
+
+        Parameter ``t`` (drjit.llvm.ad.Float):
+            *no description available*
+
+        Returns → :py:obj:`mitsuba.Point2f`:
+            *no description available*
+
     .. py:method:: mitsuba.Ray2f.assign(self, arg0)
 
         Parameter ``arg0`` (:py:obj:`mitsuba.Ray2f`):
@@ -14030,6 +14142,16 @@
             *no description available*
 
         Parameter ``maxt`` (drjit.llvm.ad.Float):
+            *no description available*
+
+    .. py:method:: mitsuba.Ray3f.__call__(self, t)
+
+        Return the position of a point along the ray
+
+        Parameter ``t`` (drjit.llvm.ad.Float):
+            *no description available*
+
+        Returns → :py:obj:`mitsuba.Point3f`:
             *no description available*
 
     .. py:method:: mitsuba.Ray3f.assign(self, arg0)
@@ -14255,18 +14377,18 @@
         Returns → Tuple[float, float]:
             *no description available*
 
-    .. py:method:: mitsuba.Resampler.resample(self, self, source, source_stride, target_stride, channels)
+    .. py:method:: mitsuba.Resampler.resample(self, source, source_stride, target, target_stride, channels)
 
         Resample a multi-channel array and clamp the results to a specified
         valid range
 
-        Parameter ``source`` (int):
+        Parameter ``source`` (numpy.ndarray[numpy.float32]):
             Source array of samples
 
-        Parameter ``target``:
+        Parameter ``target`` (numpy.ndarray[numpy.float32]):
             Target array of samples
 
-        Parameter ``source_stride`` (numpy.ndarray[numpy.float32]):
+        Parameter ``source_stride`` (int):
             Stride of samples in the source array. A value of '1' implies that
             they are densely packed.
 
@@ -16802,25 +16924,81 @@
         Returns → bool:
             *no description available*
 
-    .. py:method:: mitsuba.Sensor.sample_ray_differential(self, time, sample1, sample2, sample3, active=True)
+    .. py:method:: mitsuba.Sensor.sample_ray_differential(overloaded)
 
-        Parameter ``time`` (drjit.llvm.ad.Float):
-            *no description available*
 
-        Parameter ``sample1`` (drjit.llvm.ad.Float):
-            *no description available*
+        .. py:method:: sample_ray_differential(self, time, sample1, sample2, sample3, active=True)
 
-        Parameter ``sample2`` (:py:obj:`mitsuba.Point2f`):
-            *no description available*
+            Parameter ``time`` (drjit.llvm.ad.Float):
+                *no description available*
 
-        Parameter ``sample3`` (:py:obj:`mitsuba.Point2f`):
-            *no description available*
+            Parameter ``sample1`` (drjit.llvm.ad.Float):
+                *no description available*
 
-        Parameter ``active`` (drjit.llvm.ad.Bool):
-            Mask to specify active lanes.
+            Parameter ``sample2`` (:py:obj:`mitsuba.Point2f`):
+                *no description available*
 
-        Returns → Tuple[:py:obj:`mitsuba.RayDifferential3f`, :py:obj:`mitsuba.Color3f`]:
-            *no description available*
+            Parameter ``sample3`` (:py:obj:`mitsuba.Point2f`):
+                *no description available*
+
+            Parameter ``active`` (drjit.llvm.ad.Bool):
+                Mask to specify active lanes.
+
+            Returns → Tuple[:py:obj:`mitsuba.RayDifferential3f`, :py:obj:`mitsuba.Color3f`]:
+                *no description available*
+
+        .. py:method:: sample_ray_differential(self, arg0, arg1, arg2, arg3, arg4)
+
+            Importance sample a ray differential proportional to the sensor's
+            sensitivity profile.
+
+            The sensor profile is a six-dimensional quantity that depends on time,
+            wavelength, surface position, and direction. This function takes a
+            given time value and five uniformly distributed samples on the
+            interval [0, 1] and warps them so that the returned ray the profile.
+            Any discrepancies between ideal and actual sampled profile are
+            absorbed into a spectral importance weight that is returned along with
+            the ray.
+
+            In contrast to Endpoint::sample_ray(), this function returns
+            differentials with respect to the X and Y axis in screen space.
+
+            Parameter ``time``:
+                The scene time associated with the ray_differential to be sampled
+
+            Parameter ``sample1``:
+                A uniformly distributed 1D value that is used to sample the
+                spectral dimension of the sensitivity profile.
+
+            Parameter ``sample2``:
+                This argument corresponds to the sample position in fractional
+                pixel coordinates relative to the crop window of the underlying
+                film.
+
+            Parameter ``sample3``:
+                A uniformly distributed sample on the domain ``[0,1]^2``. This
+                argument determines the position on the aperture of the sensor.
+                This argument is ignored if ``needs_sample_3() == false``.
+
+            Returns → Tuple[:py:obj:`mitsuba.RayDifferential3f`, :py:obj:`mitsuba.Color3f`]:
+                The sampled ray differential and (potentially spectrally varying)
+                importance weights. The latter account for the difference between
+                the sensor profile and the actual used sampling density function.
+
+            Parameter ``arg0`` (drjit.llvm.ad.Float):
+                *no description available*
+
+            Parameter ``arg1`` (drjit.llvm.ad.Float):
+                *no description available*
+
+            Parameter ``arg2`` (:py:obj:`mitsuba.Point2f`):
+                *no description available*
+
+            Parameter ``arg3`` (:py:obj:`mitsuba.Point2f`):
+                *no description available*
+
+            Parameter ``arg4`` (drjit.llvm.ad.Bool):
+                *no description available*
 
     .. py:method:: mitsuba.Sensor.sampler(self)
 
@@ -18613,6 +18791,10 @@
 
         Members:
 
+        .. py:data:: Empty
+
+            No flags set (default value)
+
         .. py:data:: Normalized
 
             Specifies whether an integer field encodes a normalized value in the
@@ -18707,7 +18889,7 @@
         Returns → int:
             *no description available*
 
-    .. py:method:: mitsuba.Struct.append(self, name, type, flags=<Flags.???: 0>, default=0.0)
+    .. py:method:: mitsuba.Struct.append(self, name, type, flags=<Flags., Empty, default=0.0)
 
         Append a new field to the ``Struct``; determines size and offset
         automatically
@@ -18719,6 +18901,9 @@
             *no description available*
 
         Parameter ``flags`` (int):
+            *no description available*
+
+        Parameter ``Empty`` (0>):
             *no description available*
 
         Parameter ``default`` (float):
@@ -24962,6 +25147,12 @@
 
     Abstract base class for 3D volumes.
 
+    .. py:method:: __init__(self, props)
+
+        Parameter ``props`` (:py:obj:`mitsuba.Properties`):
+            *no description available*
+
+
     .. py:method:: mitsuba.Volume.bbox(self)
 
         Returns the bounding box of the volume
@@ -26239,6 +26430,18 @@
     Returns → drjit.llvm.ad.Float:
         *no description available*
 
+.. py:function:: mitsuba.cie_d65(wavelength)
+
+    Evaluate the CIE D65 illuminant spectrum given a wavelength in
+    nanometers, normalized to ensures that it integrates to a luminance of
+    1.0.
+
+    Parameter ``wavelength`` (drjit.llvm.ad.Float):
+        *no description available*
+
+    Returns → drjit.llvm.ad.Float:
+        *no description available*
+
 .. py:function:: mitsuba.coordinate_system(n)
 
     Complete the set {a} to an orthonormal basis {a, b, c}
@@ -27143,6 +27346,27 @@
         Returns → drjit::Matrix<:py:obj:`mitsuba.Color`:
             *no description available*
 
+.. py:function:: mitsuba.mueller.left_circular_polarizer(overloaded)
+
+
+    .. py:function:: left_circular_polarizer()
+
+        Constructs the Mueller matrix of a (left) circular polarizer.
+
+        "Polarized Light and Optical Systems" by Chipman et al. Table 6.2
+
+        Returns → drjit.llvm.ad.Matrix4f:
+            *no description available*
+
+    .. py:function:: left_circular_polarizer()
+
+        Constructs the Mueller matrix of a (left) circular polarizer.
+
+        "Polarized Light and Optical Systems" by Chipman et al. Table 6.2
+
+        Returns → drjit::Matrix<:py:obj:`mitsuba.Color`:
+            *no description available*
+
 .. py:function:: mitsuba.mueller.linear_polarizer(overloaded)
 
 
@@ -27211,6 +27435,27 @@
 
         Parameter ``phase`` (:py:obj:`mitsuba.Color3f`):
             The phase difference between the fast and slow axis
+
+        Returns → drjit::Matrix<:py:obj:`mitsuba.Color`:
+            *no description available*
+
+.. py:function:: mitsuba.mueller.right_circular_polarizer(overloaded)
+
+
+    .. py:function:: right_circular_polarizer()
+
+        Constructs the Mueller matrix of a (right) circular polarizer.
+
+        "Polarized Light and Optical Systems" by Chipman et al. Table 6.2
+
+        Returns → drjit.llvm.ad.Matrix4f:
+            *no description available*
+
+    .. py:function:: right_circular_polarizer()
+
+        Constructs the Mueller matrix of a (right) circular polarizer.
+
+        "Polarized Light and Optical Systems" by Chipman et al. Table 6.2
 
         Returns → drjit::Matrix<:py:obj:`mitsuba.Color`:
             *no description available*
@@ -28463,7 +28708,7 @@
     Returns → Tuple[List[float], List[float]]:
         *no description available*
 
-.. py:function:: mitsuba.spectrum_list_to_srgb(wavelengths, values, bounded=True)
+.. py:function:: mitsuba.spectrum_list_to_srgb(wavelengths, values, bounded=True, d65=False)
 
     Parameter ``wavelengths`` (List[float]):
         *no description available*
@@ -28472,6 +28717,9 @@
         *no description available*
 
     Parameter ``bounded`` (bool):
+        *no description available*
+
+    Parameter ``d65`` (bool):
         *no description available*
 
     Returns → :py:obj:`mitsuba.ScalarColor3f`:

--- a/docs/generated/mitsuba_api.rst
+++ b/docs/generated/mitsuba_api.rst
@@ -2,332 +2,332 @@ Core
 ----
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 28036
-  :end-line: 28132
+  :start-line: 28281
+  :end-line: 28377
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 28419
-  :end-line: 28427
+  :start-line: 28664
+  :end-line: 28672
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 29101
-  :end-line: 29107
+  :start-line: 29349
+  :end-line: 29355
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 29029
-  :end-line: 29041
+  :start-line: 29277
+  :end-line: 29289
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 16687
-  :end-line: 16773
+  :start-line: 16809
+  :end-line: 16895
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 29108
-  :end-line: 29114
+  :start-line: 29356
+  :end-line: 29362
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 28411
-  :end-line: 28418
+  :start-line: 28656
+  :end-line: 28663
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 162
-  :end-line: 233
+  :start-line: 88
+  :end-line: 159
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 234
-  :end-line: 251
+  :start-line: 160
+  :end-line: 177
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 3744
-  :end-line: 3825
+  :start-line: 3697
+  :end-line: 3778
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 4184
-  :end-line: 4195
+  :start-line: 4137
+  :end-line: 4148
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 4949
-  :end-line: 5009
+  :start-line: 4902
+  :end-line: 4962
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 11985
-  :end-line: 12019
+  :start-line: 11964
+  :end-line: 11998
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 17965
-  :end-line: 18467
+  :start-line: 18143
+  :end-line: 18645
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 18468
-  :end-line: 18499
+  :start-line: 18646
+  :end-line: 18677
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 25195
-  :end-line: 25250
+  :start-line: 25386
+  :end-line: 25441
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 4889
-  :end-line: 4948
+  :start-line: 4842
+  :end-line: 4901
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 7112
-  :end-line: 7146
+  :start-line: 7071
+  :end-line: 7105
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 10112
-  :end-line: 10122
+  :start-line: 10075
+  :end-line: 10085
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 10309
-  :end-line: 10339
+  :start-line: 10272
+  :end-line: 10310
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 11888
-  :end-line: 11984
+  :start-line: 11867
+  :end-line: 11963
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 12816
-  :end-line: 12848
+  :start-line: 12934
+  :end-line: 12966
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 13237
-  :end-line: 13267
+  :start-line: 13355
+  :end-line: 13385
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 16774
-  :end-line: 16784
+  :start-line: 16896
+  :end-line: 16906
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 17909
-  :end-line: 17964
+  :start-line: 18087
+  :end-line: 18142
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 18500
-  :end-line: 18826
+  :start-line: 18678
+  :end-line: 19011
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 18827
-  :end-line: 18923
+  :start-line: 19012
+  :end-line: 19108
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 22289
-  :end-line: 22542
+  :start-line: 22474
+  :end-line: 22727
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 22543
-  :end-line: 22550
+  :start-line: 22728
+  :end-line: 22735
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 22551
-  :end-line: 22578
+  :start-line: 22736
+  :end-line: 22763
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 26283
-  :end-line: 26296
+  :start-line: 26486
+  :end-line: 26499
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 26297
-  :end-line: 26309
-
-------------
-
-.. include:: generated/extracted_rst_api.rst
-  :start-line: 26310
-  :end-line: 26316
-
-------------
-
-.. include:: generated/extracted_rst_api.rst
-  :start-line: 26317
-  :end-line: 26331
-
-------------
-
-.. include:: generated/extracted_rst_api.rst
-  :start-line: 26332
-  :end-line: 26341
-
-------------
-
-.. include:: generated/extracted_rst_api.rst
-  :start-line: 26342
-  :end-line: 26353
-
-------------
-
-.. include:: generated/extracted_rst_api.rst
-  :start-line: 26354
-  :end-line: 26363
-
-------------
-
-.. include:: generated/extracted_rst_api.rst
-  :start-line: 26364
-  :end-line: 26374
-
-------------
-
-.. include:: generated/extracted_rst_api.rst
-  :start-line: 26375
-  :end-line: 26482
-
-------------
-
-.. include:: generated/extracted_rst_api.rst
-  :start-line: 26483
-  :end-line: 26486
-
-------------
-
-.. include:: generated/extracted_rst_api.rst
-  :start-line: 26487
-  :end-line: 26497
-
-------------
-
-.. include:: generated/extracted_rst_api.rst
-  :start-line: 26498
+  :start-line: 26500
   :end-line: 26512
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 26613
-  :end-line: 26716
+  :start-line: 26513
+  :end-line: 26519
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 27907
-  :end-line: 27917
+  :start-line: 26520
+  :end-line: 26534
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 27918
-  :end-line: 27928
+  :start-line: 26535
+  :end-line: 26544
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 27929
-  :end-line: 27939
+  :start-line: 26545
+  :end-line: 26556
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 27940
-  :end-line: 27950
+  :start-line: 26557
+  :end-line: 26566
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 27951
-  :end-line: 27961
+  :start-line: 26567
+  :end-line: 26577
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 27962
-  :end-line: 27972
+  :start-line: 26578
+  :end-line: 26685
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 27973
-  :end-line: 27983
+  :start-line: 26686
+  :end-line: 26689
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 27984
-  :end-line: 27994
+  :start-line: 26690
+  :end-line: 26700
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 27995
-  :end-line: 28013
+  :start-line: 26701
+  :end-line: 26715
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 28014
-  :end-line: 28024
+  :start-line: 26816
+  :end-line: 26919
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 28025
-  :end-line: 28035
+  :start-line: 28152
+  :end-line: 28162
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 23445
-  :end-line: 23489
+  :start-line: 28163
+  :end-line: 28173
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 28174
+  :end-line: 28184
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 28185
+  :end-line: 28195
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 28196
+  :end-line: 28206
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 28207
+  :end-line: 28217
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 28218
+  :end-line: 28228
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 28229
+  :end-line: 28239
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 28240
+  :end-line: 28258
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 28259
+  :end-line: 28269
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 28270
+  :end-line: 28280
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 23630
+  :end-line: 23674
 
 ------------
 
@@ -335,25 +335,211 @@ Parsing
 -------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 26744
-  :end-line: 26753
+  :start-line: 26947
+  :end-line: 26956
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 26754
-  :end-line: 26778
+  :start-line: 26957
+  :end-line: 26981
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 26779
-  :end-line: 26791
+  :start-line: 26982
+  :end-line: 26994
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 29673
+  :start-line: 29921
+  :end-line: 29931
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 29932
+  :end-line: 29941
+
+------------
+
+Object
+------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 12415
+  :end-line: 12563
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 12564
+  :end-line: 12669
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 3430
+  :end-line: 3476
+
+------------
+
+Properties
+----------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 13641
+  :end-line: 13870
+
+------------
+
+Bitmap
+------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 986
+  :end-line: 1713
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 1714
+  :end-line: 1776
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 14333
+  :end-line: 14447
+
+------------
+
+Warp
+----
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 29363
+  :end-line: 29375
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 29376
+  :end-line: 29397
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 29398
+  :end-line: 29407
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 29408
+  :end-line: 29428
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 29429
+  :end-line: 29448
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 29449
+  :end-line: 29458
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 29459
+  :end-line: 29474
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 29475
+  :end-line: 29487
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 29488
+  :end-line: 29500
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 29501
+  :end-line: 29534
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 29535
+  :end-line: 29554
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 29555
+  :end-line: 29565
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 29566
+  :end-line: 29575
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 29576
+  :end-line: 29595
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 29596
+  :end-line: 29614
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 29615
+  :end-line: 29625
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 29626
+  :end-line: 29633
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 29634
+  :end-line: 29643
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 29644
+  :end-line: 29653
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 29654
+  :end-line: 29670
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 29671
   :end-line: 29683
 
 ------------
@@ -364,315 +550,129 @@ Parsing
 
 ------------
 
-Object
-------
-
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 12442
-  :end-line: 12590
+  :start-line: 29694
+  :end-line: 29703
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 12591
-  :end-line: 12696
+  :start-line: 29704
+  :end-line: 29713
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 3482
-  :end-line: 3528
-
-------------
-
-Properties
-----------
-
-.. include:: generated/extracted_rst_api.rst
-  :start-line: 13523
-  :end-line: 13768
-
-------------
-
-Bitmap
-------
-
-.. include:: generated/extracted_rst_api.rst
-  :start-line: 1038
-  :end-line: 1765
+  :start-line: 29714
+  :end-line: 29723
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 1766
-  :end-line: 1828
+  :start-line: 29724
+  :end-line: 29734
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 14211
-  :end-line: 14325
-
-------------
-
-Warp
-----
-
-.. include:: generated/extracted_rst_api.rst
-  :start-line: 29115
-  :end-line: 29127
+  :start-line: 29735
+  :end-line: 29744
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 29128
-  :end-line: 29149
+  :start-line: 29745
+  :end-line: 29755
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 29150
-  :end-line: 29159
+  :start-line: 29756
+  :end-line: 29765
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 29160
-  :end-line: 29180
+  :start-line: 29766
+  :end-line: 29776
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 29181
-  :end-line: 29200
+  :start-line: 29777
+  :end-line: 29787
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 29201
-  :end-line: 29210
+  :start-line: 29788
+  :end-line: 29797
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 29211
-  :end-line: 29226
+  :start-line: 29798
+  :end-line: 29811
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 29227
-  :end-line: 29239
+  :start-line: 29812
+  :end-line: 29824
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 29240
-  :end-line: 29252
+  :start-line: 29825
+  :end-line: 29834
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 29253
-  :end-line: 29286
+  :start-line: 29835
+  :end-line: 29844
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 29287
-  :end-line: 29306
+  :start-line: 29845
+  :end-line: 29857
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 29307
-  :end-line: 29317
+  :start-line: 29858
+  :end-line: 29867
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 29318
-  :end-line: 29327
+  :start-line: 29868
+  :end-line: 29877
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 29328
-  :end-line: 29347
+  :start-line: 29878
+  :end-line: 29887
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 29348
-  :end-line: 29366
+  :start-line: 29888
+  :end-line: 29897
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 29367
-  :end-line: 29377
+  :start-line: 29898
+  :end-line: 29907
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 29378
-  :end-line: 29385
-
-------------
-
-.. include:: generated/extracted_rst_api.rst
-  :start-line: 29386
-  :end-line: 29395
-
-------------
-
-.. include:: generated/extracted_rst_api.rst
-  :start-line: 29396
-  :end-line: 29405
-
-------------
-
-.. include:: generated/extracted_rst_api.rst
-  :start-line: 29406
-  :end-line: 29422
-
-------------
-
-.. include:: generated/extracted_rst_api.rst
-  :start-line: 29423
-  :end-line: 29435
-
-------------
-
-.. include:: generated/extracted_rst_api.rst
-  :start-line: 29436
-  :end-line: 29445
-
-------------
-
-.. include:: generated/extracted_rst_api.rst
-  :start-line: 29446
-  :end-line: 29455
-
-------------
-
-.. include:: generated/extracted_rst_api.rst
-  :start-line: 29456
-  :end-line: 29465
-
-------------
-
-.. include:: generated/extracted_rst_api.rst
-  :start-line: 29466
-  :end-line: 29475
-
-------------
-
-.. include:: generated/extracted_rst_api.rst
-  :start-line: 29476
-  :end-line: 29486
-
-------------
-
-.. include:: generated/extracted_rst_api.rst
-  :start-line: 29487
-  :end-line: 29496
-
-------------
-
-.. include:: generated/extracted_rst_api.rst
-  :start-line: 29497
-  :end-line: 29507
-
-------------
-
-.. include:: generated/extracted_rst_api.rst
-  :start-line: 29508
-  :end-line: 29517
-
-------------
-
-.. include:: generated/extracted_rst_api.rst
-  :start-line: 29518
-  :end-line: 29528
-
-------------
-
-.. include:: generated/extracted_rst_api.rst
-  :start-line: 29529
-  :end-line: 29539
-
-------------
-
-.. include:: generated/extracted_rst_api.rst
-  :start-line: 29540
-  :end-line: 29549
-
-------------
-
-.. include:: generated/extracted_rst_api.rst
-  :start-line: 29550
-  :end-line: 29563
-
-------------
-
-.. include:: generated/extracted_rst_api.rst
-  :start-line: 29564
-  :end-line: 29576
-
-------------
-
-.. include:: generated/extracted_rst_api.rst
-  :start-line: 29577
-  :end-line: 29586
-
-------------
-
-.. include:: generated/extracted_rst_api.rst
-  :start-line: 29587
-  :end-line: 29596
-
-------------
-
-.. include:: generated/extracted_rst_api.rst
-  :start-line: 29597
-  :end-line: 29609
-
-------------
-
-.. include:: generated/extracted_rst_api.rst
-  :start-line: 29610
-  :end-line: 29619
-
-------------
-
-.. include:: generated/extracted_rst_api.rst
-  :start-line: 29620
-  :end-line: 29629
-
-------------
-
-.. include:: generated/extracted_rst_api.rst
-  :start-line: 29630
-  :end-line: 29639
-
-------------
-
-.. include:: generated/extracted_rst_api.rst
-  :start-line: 29640
-  :end-line: 29649
-
-------------
-
-.. include:: generated/extracted_rst_api.rst
-  :start-line: 29650
-  :end-line: 29659
-
-------------
-
-.. include:: generated/extracted_rst_api.rst
-  :start-line: 29660
-  :end-line: 29672
+  :start-line: 29908
+  :end-line: 29920
 
 ------------
 
@@ -680,104 +680,104 @@ Distributions
 -------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 3541
-  :end-line: 3735
+  :start-line: 3489
+  :end-line: 3688
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 3940
-  :end-line: 4148
+  :start-line: 3893
+  :end-line: 4101
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 4149
-  :end-line: 4183
+  :start-line: 4102
+  :end-line: 4136
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 9908
-  :end-line: 10111
+  :start-line: 9866
+  :end-line: 10074
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 12179
-  :end-line: 12401
+  :start-line: 12152
+  :end-line: 12374
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 7354
-  :end-line: 7472
+  :start-line: 7313
+  :end-line: 7431
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 7473
-  :end-line: 7591
+  :start-line: 7432
+  :end-line: 7550
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 7592
-  :end-line: 7710
+  :start-line: 7551
+  :end-line: 7669
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 7711
-  :end-line: 7829
+  :start-line: 7670
+  :end-line: 7788
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 10384
-  :end-line: 10508
+  :start-line: 10363
+  :end-line: 10487
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 10509
-  :end-line: 10633
+  :start-line: 10488
+  :end-line: 10612
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 10634
-  :end-line: 10758
+  :start-line: 10613
+  :end-line: 10737
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 10759
-  :end-line: 10883
+  :start-line: 10738
+  :end-line: 10862
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 10884
-  :end-line: 11008
+  :start-line: 10863
+  :end-line: 10987
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 11009
-  :end-line: 11133
+  :start-line: 10988
+  :end-line: 11112
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 11134
-  :end-line: 11258
+  :start-line: 11113
+  :end-line: 11237
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 11259
-  :end-line: 11383
+  :start-line: 11238
+  :end-line: 11362
 
 ------------
 
@@ -785,254 +785,254 @@ Math
 ----
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 26817
-  :end-line: 26820
+  :start-line: 27020
+  :end-line: 27023
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 26821
-  :end-line: 26824
+  :start-line: 27024
+  :end-line: 27027
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 26825
-  :end-line: 26858
+  :start-line: 27028
+  :end-line: 27061
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 26859
-  :end-line: 26900
+  :start-line: 27062
+  :end-line: 27103
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 26901
-  :end-line: 26910
+  :start-line: 27104
+  :end-line: 27113
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 26911
-  :end-line: 26942
+  :start-line: 27114
+  :end-line: 27145
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 26943
-  :end-line: 26956
+  :start-line: 27146
+  :end-line: 27159
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 26957
-  :end-line: 26969
+  :start-line: 27160
+  :end-line: 27172
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 26970
-  :end-line: 26979
+  :start-line: 27173
+  :end-line: 27182
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 26980
-  :end-line: 26987
+  :start-line: 27183
+  :end-line: 27190
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 26988
-  :end-line: 26995
+  :start-line: 27191
+  :end-line: 27198
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 26996
-  :end-line: 27003
+  :start-line: 27199
+  :end-line: 27206
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 27004
-  :end-line: 27011
+  :start-line: 27207
+  :end-line: 27214
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 27012
-  :end-line: 27015
+  :start-line: 27215
+  :end-line: 27218
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 27016
-  :end-line: 27025
+  :start-line: 27219
+  :end-line: 27228
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 27026
-  :end-line: 27041
+  :start-line: 27229
+  :end-line: 27244
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 27042
-  :end-line: 27051
+  :start-line: 27245
+  :end-line: 27254
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 27052
-  :end-line: 27065
+  :start-line: 27255
+  :end-line: 27268
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 28500
-  :end-line: 28583
+  :start-line: 28748
+  :end-line: 28831
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 28584
-  :end-line: 28634
+  :start-line: 28832
+  :end-line: 28882
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 28635
-  :end-line: 28658
+  :start-line: 28883
+  :end-line: 28906
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 28659
-  :end-line: 28682
+  :start-line: 28907
+  :end-line: 28930
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 28683
-  :end-line: 28706
+  :start-line: 28931
+  :end-line: 28954
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 28707
-  :end-line: 28786
+  :start-line: 28955
+  :end-line: 29034
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 28787
-  :end-line: 28854
+  :start-line: 29035
+  :end-line: 29102
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 28855
-  :end-line: 28913
+  :start-line: 29103
+  :end-line: 29161
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 28914
-  :end-line: 28983
+  :start-line: 29162
+  :end-line: 29231
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 27731
-  :end-line: 27743
+  :start-line: 27976
+  :end-line: 27988
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 27744
-  :end-line: 27761
+  :start-line: 27989
+  :end-line: 28006
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 27762
-  :end-line: 27779
+  :start-line: 28007
+  :end-line: 28024
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 27780
-  :end-line: 27801
+  :start-line: 28025
+  :end-line: 28046
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 27802
-  :end-line: 27825
+  :start-line: 28047
+  :end-line: 28070
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 13798
-  :end-line: 13887
+  :start-line: 13900
+  :end-line: 13989
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 27826
-  :end-line: 27838
+  :start-line: 28071
+  :end-line: 28083
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 26241
-  :end-line: 26250
+  :start-line: 26444
+  :end-line: 26453
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 27839
-  :end-line: 27864
+  :start-line: 28084
+  :end-line: 28109
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 27865
-  :end-line: 27906
+  :start-line: 28110
+  :end-line: 28151
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 26513
-  :end-line: 26540
+  :start-line: 26716
+  :end-line: 26743
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 26541
-  :end-line: 26561
+  :start-line: 26744
+  :end-line: 26764
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 26562
-  :end-line: 26575
+  :start-line: 26765
+  :end-line: 26778
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 26576
-  :end-line: 26612
+  :start-line: 26779
+  :end-line: 26815
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 27705
-  :end-line: 27730
+  :start-line: 27950
+  :end-line: 27975
 
 ------------
 
@@ -1040,56 +1040,56 @@ Random
 ------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 28168
-  :end-line: 28214
+  :start-line: 28413
+  :end-line: 28459
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 28215
-  :end-line: 28261
+  :start-line: 28460
+  :end-line: 28506
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 28262
-  :end-line: 28312
+  :start-line: 28507
+  :end-line: 28557
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 28313
-  :end-line: 28361
+  :start-line: 28558
+  :end-line: 28606
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 28362
-  :end-line: 28410
+  :start-line: 28607
+  :end-line: 28655
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 12697
-  :end-line: 12815
+  :start-line: 12815
+  :end-line: 12933
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 27640
-  :end-line: 27668
+  :start-line: 27885
+  :end-line: 27913
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 27669
-  :end-line: 27704
+  :start-line: 27914
+  :end-line: 27949
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 28428
-  :end-line: 28440
+  :start-line: 28673
+  :end-line: 28685
 
 ------------
 
@@ -1097,20 +1097,20 @@ Log
 ---
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 10123
-  :end-line: 10157
+  :start-line: 10086
+  :end-line: 10120
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 10158
-  :end-line: 10308
+  :start-line: 10121
+  :end-line: 10271
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 115
-  :end-line: 161
+  :start-line: 41
+  :end-line: 87
 
 ------------
 
@@ -1118,878 +1118,872 @@ Types
 -----
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 14575
-  :end-line: 14875
+  :start-line: 14697
+  :end-line: 14997
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 14876
-  :end-line: 15196
+  :start-line: 14998
+  :end-line: 15318
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 15197
-  :end-line: 15269
+  :start-line: 15319
+  :end-line: 15391
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 15270
-  :end-line: 15271
+  :start-line: 15392
+  :end-line: 15393
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 15272
-  :end-line: 15273
+  :start-line: 15394
+  :end-line: 15395
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 15274
-  :end-line: 15275
+  :start-line: 15396
+  :end-line: 15397
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 15276
-  :end-line: 15277
+  :start-line: 15398
+  :end-line: 15399
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 15278
-  :end-line: 15279
+  :start-line: 15400
+  :end-line: 15401
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 15280
-  :end-line: 15281
+  :start-line: 15402
+  :end-line: 15403
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 15282
-  :end-line: 15283
+  :start-line: 15404
+  :end-line: 15405
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 15284
-  :end-line: 15285
+  :start-line: 15406
+  :end-line: 15407
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 15286
-  :end-line: 15287
+  :start-line: 15408
+  :end-line: 15409
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 15288
-  :end-line: 15289
+  :start-line: 15410
+  :end-line: 15411
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 15290
-  :end-line: 15291
+  :start-line: 15412
+  :end-line: 15413
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 15292
-  :end-line: 15293
+  :start-line: 15414
+  :end-line: 15415
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 15294
-  :end-line: 15295
+  :start-line: 15416
+  :end-line: 15417
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 15296
-  :end-line: 15297
+  :start-line: 15418
+  :end-line: 15419
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 15298
-  :end-line: 15299
+  :start-line: 15420
+  :end-line: 15421
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 15300
-  :end-line: 15301
+  :start-line: 15422
+  :end-line: 15423
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 15302
-  :end-line: 15303
+  :start-line: 15424
+  :end-line: 15425
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 15304
-  :end-line: 15305
+  :start-line: 15426
+  :end-line: 15427
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 15306
-  :end-line: 15307
+  :start-line: 15428
+  :end-line: 15429
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 15308
-  :end-line: 15309
+  :start-line: 15430
+  :end-line: 15431
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 15310
-  :end-line: 15311
+  :start-line: 15432
+  :end-line: 15433
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 15312
-  :end-line: 15313
+  :start-line: 15434
+  :end-line: 15435
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 15314
-  :end-line: 15315
+  :start-line: 15436
+  :end-line: 15437
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 15316
-  :end-line: 15317
+  :start-line: 15438
+  :end-line: 15439
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 15318
-  :end-line: 15319
+  :start-line: 15440
+  :end-line: 15441
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 15320
-  :end-line: 15321
+  :start-line: 15442
+  :end-line: 15443
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 15322
-  :end-line: 15323
+  :start-line: 15444
+  :end-line: 15445
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 15324
-  :end-line: 15325
+  :start-line: 15446
+  :end-line: 15447
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 15326
-  :end-line: 15475
+  :start-line: 15448
+  :end-line: 15597
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 15476
-  :end-line: 15625
+  :start-line: 15598
+  :end-line: 15747
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 15626
-  :end-line: 15882
+  :start-line: 15748
+  :end-line: 16004
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 15883
-  :end-line: 16139
+  :start-line: 16005
+  :end-line: 16261
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 16140
-  :end-line: 16141
+  :start-line: 16262
+  :end-line: 16263
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 16142
-  :end-line: 16143
+  :start-line: 16264
+  :end-line: 16265
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 16144
-  :end-line: 16145
+  :start-line: 16266
+  :end-line: 16267
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 16146
-  :end-line: 16147
+  :start-line: 16268
+  :end-line: 16269
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 16148
-  :end-line: 16149
+  :start-line: 16270
+  :end-line: 16271
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 16150
-  :end-line: 16151
+  :start-line: 16272
+  :end-line: 16273
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 16152
-  :end-line: 16153
+  :start-line: 16274
+  :end-line: 16275
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 16154
-  :end-line: 16155
+  :start-line: 16276
+  :end-line: 16277
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 16156
-  :end-line: 16157
+  :start-line: 16278
+  :end-line: 16279
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 16158
-  :end-line: 16159
+  :start-line: 16280
+  :end-line: 16281
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 16160
-  :end-line: 16161
+  :start-line: 16282
+  :end-line: 16283
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 16162
-  :end-line: 16163
+  :start-line: 16284
+  :end-line: 16285
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 16164
-  :end-line: 16165
+  :start-line: 16286
+  :end-line: 16287
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 16166
-  :end-line: 16167
+  :start-line: 16288
+  :end-line: 16289
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 16168
-  :end-line: 16169
+  :start-line: 16290
+  :end-line: 16291
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 16170
-  :end-line: 16171
+  :start-line: 16292
+  :end-line: 16293
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 16172
-  :end-line: 16173
+  :start-line: 16294
+  :end-line: 16295
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 16174
-  :end-line: 16175
+  :start-line: 16296
+  :end-line: 16297
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 16176
-  :end-line: 16177
+  :start-line: 16298
+  :end-line: 16299
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 16178
-  :end-line: 16179
+  :start-line: 16300
+  :end-line: 16301
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 1829
-  :end-line: 2130
+  :start-line: 1777
+  :end-line: 2078
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 23490
-  :end-line: 24228
+  :start-line: 23675
+  :end-line: 24413
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 24229
-  :end-line: 24917
+  :start-line: 24414
+  :end-line: 25102
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 8154
-  :end-line: 8834
+  :start-line: 8112
+  :end-line: 8792
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 8835
-  :end-line: 9515
+  :start-line: 8793
+  :end-line: 9473
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 9516
-  :end-line: 9796
+  :start-line: 9474
+  :end-line: 9754
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 9797
-  :end-line: 9907
+  :start-line: 9755
+  :end-line: 9865
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 5272
-  :end-line: 6191
+  :start-line: 5231
+  :end-line: 6150
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 6192
-  :end-line: 7111
+  :start-line: 6151
+  :end-line: 7070
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 19225
-  :end-line: 19367
+  :start-line: 19410
+  :end-line: 19552
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 19368
-  :end-line: 19870
+  :start-line: 19553
+  :end-line: 20055
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 19871
-  :end-line: 20263
+  :start-line: 20056
+  :end-line: 20448
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 20264
-  :end-line: 20656
+  :start-line: 20449
+  :end-line: 20841
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 20657
-  :end-line: 21049
+  :start-line: 20842
+  :end-line: 21234
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 21050
-  :end-line: 21442
+  :start-line: 21235
+  :end-line: 21627
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 24918
-  :end-line: 24919
+  :start-line: 25103
+  :end-line: 25104
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 24920
-  :end-line: 24921
+  :start-line: 25105
+  :end-line: 25106
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 24922
-  :end-line: 24923
+  :start-line: 25107
+  :end-line: 25108
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 24924
-  :end-line: 24925
+  :start-line: 25109
+  :end-line: 25110
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 24926
-  :end-line: 24927
+  :start-line: 25111
+  :end-line: 25112
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 24928
-  :end-line: 24929
+  :start-line: 25113
+  :end-line: 25114
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 24930
-  :end-line: 24931
+  :start-line: 25115
+  :end-line: 25116
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 24932
-  :end-line: 24933
+  :start-line: 25117
+  :end-line: 25118
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 24934
-  :end-line: 24935
+  :start-line: 25119
+  :end-line: 25120
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 24936
-  :end-line: 24937
+  :start-line: 25121
+  :end-line: 25122
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 24938
-  :end-line: 24939
+  :start-line: 25123
+  :end-line: 25124
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 24940
-  :end-line: 24941
+  :start-line: 25125
+  :end-line: 25126
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 24942
-  :end-line: 24943
+  :start-line: 25127
+  :end-line: 25128
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 24944
-  :end-line: 24945
+  :start-line: 25129
+  :end-line: 25130
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 24946
-  :end-line: 24947
+  :start-line: 25131
+  :end-line: 25132
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 24948
-  :end-line: 24949
+  :start-line: 25133
+  :end-line: 25134
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 24950
-  :end-line: 24951
+  :start-line: 25135
+  :end-line: 25136
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 24952
-  :end-line: 24953
+  :start-line: 25137
+  :end-line: 25138
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 24954
-  :end-line: 24955
+  :start-line: 25139
+  :end-line: 25140
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 24956
-  :end-line: 24957
+  :start-line: 25141
+  :end-line: 25142
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 13268
-  :end-line: 13269
+  :start-line: 13386
+  :end-line: 13387
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 13270
-  :end-line: 13271
+  :start-line: 13388
+  :end-line: 13389
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 13272
-  :end-line: 13273
+  :start-line: 13390
+  :end-line: 13391
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 13274
-  :end-line: 13275
+  :start-line: 13392
+  :end-line: 13393
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 13276
-  :end-line: 13277
+  :start-line: 13394
+  :end-line: 13395
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 13278
-  :end-line: 13279
+  :start-line: 13396
+  :end-line: 13397
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 13280
-  :end-line: 13281
+  :start-line: 13398
+  :end-line: 13399
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 13282
-  :end-line: 13283
+  :start-line: 13400
+  :end-line: 13401
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 13284
-  :end-line: 13285
+  :start-line: 13402
+  :end-line: 13403
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 13286
-  :end-line: 13287
+  :start-line: 13404
+  :end-line: 13405
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 13288
-  :end-line: 13289
+  :start-line: 13406
+  :end-line: 13407
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 13290
-  :end-line: 13291
+  :start-line: 13408
+  :end-line: 13409
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 13292
-  :end-line: 13293
+  :start-line: 13410
+  :end-line: 13411
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 13294
-  :end-line: 13295
+  :start-line: 13412
+  :end-line: 13413
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 13296
-  :end-line: 13297
+  :start-line: 13414
+  :end-line: 13415
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 13298
-  :end-line: 13299
+  :start-line: 13416
+  :end-line: 13417
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 13300
-  :end-line: 13301
+  :start-line: 13418
+  :end-line: 13419
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 13302
-  :end-line: 13303
+  :start-line: 13420
+  :end-line: 13421
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 13304
-  :end-line: 13305
+  :start-line: 13422
+  :end-line: 13423
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 13306
-  :end-line: 13307
+  :start-line: 13424
+  :end-line: 13425
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 12438
-  :end-line: 12439
+  :start-line: 12411
+  :end-line: 12412
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 12440
-  :end-line: 12441
+  :start-line: 12413
+  :end-line: 12414
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 11384
-  :end-line: 11412
+  :start-line: 11363
+  :end-line: 11391
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 11413
-  :end-line: 11449
+  :start-line: 11392
+  :end-line: 11428
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 11450
-  :end-line: 11478
+  :start-line: 11429
+  :end-line: 11457
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 13769
-  :end-line: 13797
+  :start-line: 13871
+  :end-line: 13899
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 21680
-  :end-line: 21882
+  :start-line: 21865
+  :end-line: 22067
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 21883
-  :end-line: 22085
+  :start-line: 22068
+  :end-line: 22270
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 22086
-  :end-line: 22288
+  :start-line: 22271
+  :end-line: 22473
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 2131
-  :end-line: 2431
+  :start-line: 2079
+  :end-line: 2379
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 2432
-  :end-line: 2752
+  :start-line: 2380
+  :end-line: 2700
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 2753
-  :end-line: 2825
+  :start-line: 2701
+  :end-line: 2773
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 22579
-  :end-line: 22735
+  :start-line: 22764
+  :end-line: 22920
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 22736
-  :end-line: 22892
+  :start-line: 22921
+  :end-line: 23077
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 22893
-  :end-line: 23156
+  :start-line: 23078
+  :end-line: 23341
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 23157
-  :end-line: 23420
+  :start-line: 23342
+  :end-line: 23605
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 2826
-  :end-line: 2868
+  :start-line: 2774
+  :end-line: 2816
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 2869
-  :end-line: 2911
+  :start-line: 2817
+  :end-line: 2859
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 2912
-  :end-line: 3032
+  :start-line: 2860
+  :end-line: 2980
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 3033
-  :end-line: 3153
+  :start-line: 2981
+  :end-line: 3101
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 3154
-  :end-line: 3196
+  :start-line: 3102
+  :end-line: 3144
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 3197
-  :end-line: 3239
+  :start-line: 3145
+  :end-line: 3187
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 3240
-  :end-line: 3360
+  :start-line: 3188
+  :end-line: 3308
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 3361
-  :end-line: 3481
+  :start-line: 3309
+  :end-line: 3429
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 41
-  :end-line: 114
+  :start-line: 7106
+  :end-line: 7312
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 7147
-  :end-line: 7353
+  :start-line: 3477
+  :end-line: 3478
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 3529
-  :end-line: 3530
+  :start-line: 3479
+  :end-line: 3480
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 3531
-  :end-line: 3532
+  :start-line: 3481
+  :end-line: 3482
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 3533
-  :end-line: 3534
+  :start-line: 3483
+  :end-line: 3484
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 3535
-  :end-line: 3536
+  :start-line: 3485
+  :end-line: 3486
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 3537
-  :end-line: 3538
+  :start-line: 3487
+  :end-line: 3488
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 3539
-  :end-line: 3540
+  :start-line: 13990
+  :end-line: 14086
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 13888
-  :end-line: 13974
+  :start-line: 14087
+  :end-line: 14183
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 13975
-  :end-line: 14061
+  :start-line: 14184
+  :end-line: 14232
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 14062
-  :end-line: 14110
-
-------------
-
-.. include:: generated/extracted_rst_api.rst
-  :start-line: 14111
-  :end-line: 14147
+  :start-line: 14233
+  :end-line: 14269
 
 ------------
 
@@ -1997,98 +1991,119 @@ Constants
 ---------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 10340
-  :end-line: 10343
+  :start-line: 10311
+  :end-line: 10314
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 10344
-  :end-line: 10347
+  :start-line: 10315
+  :end-line: 10318
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 10348
-  :end-line: 10351
+  :start-line: 10319
+  :end-line: 10322
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 10352
-  :end-line: 10355
+  :start-line: 10323
+  :end-line: 10326
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 10356
-  :end-line: 10359
+  :start-line: 10327
+  :end-line: 10330
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 10360
-  :end-line: 10363
+  :start-line: 10331
+  :end-line: 10334
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 10364
-  :end-line: 10367
+  :start-line: 10335
+  :end-line: 10338
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 10368
-  :end-line: 10371
+  :start-line: 10339
+  :end-line: 10342
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 10372
-  :end-line: 10375
+  :start-line: 10343
+  :end-line: 10346
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 10376
-  :end-line: 10379
+  :start-line: 10347
+  :end-line: 10350
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 10380
-  :end-line: 10383
+  :start-line: 10351
+  :end-line: 10354
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 26717
-  :end-line: 26720
+  :start-line: 10355
+  :end-line: 10358
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 26721
-  :end-line: 26724
+  :start-line: 10359
+  :end-line: 10362
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 26725
-  :end-line: 26728
+  :start-line: 26920
+  :end-line: 26923
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 26729
-  :end-line: 26732
+  :start-line: 26924
+  :end-line: 26927
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 3740
-  :end-line: 3743
+  :start-line: 26928
+  :end-line: 26931
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 26932
+  :end-line: 26935
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 3693
+  :end-line: 3696
+
+------------
+
+Denoiser
+--------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 12670
+  :end-line: 12814
 
 ------------
 
@@ -2096,50 +2111,50 @@ BSDF
 ----
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 252
-  :end-line: 508
+  :start-line: 178
+  :end-line: 445
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 509
-  :end-line: 578
+  :start-line: 446
+  :end-line: 515
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 579
-  :end-line: 683
+  :start-line: 516
+  :end-line: 620
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 684
-  :end-line: 976
+  :start-line: 621
+  :end-line: 924
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 977
-  :end-line: 1037
+  :start-line: 925
+  :end-line: 985
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 23421
-  :end-line: 23444
+  :start-line: 23606
+  :end-line: 23629
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 12179
-  :end-line: 12401
+  :start-line: 12152
+  :end-line: 12374
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 12402
-  :end-line: 12425
+  :start-line: 12375
+  :end-line: 12398
 
 ------------
 
@@ -2153,44 +2168,44 @@ Integrator
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 3736
-  :end-line: 3739
+  :start-line: 3689
+  :end-line: 3692
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 9516
-  :end-line: 9796
+  :start-line: 9474
+  :end-line: 9754
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 12426
-  :end-line: 12437
+  :start-line: 12399
+  :end-line: 12410
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 14510
-  :end-line: 14574
+  :start-line: 14632
+  :end-line: 14696
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 25393
-  :end-line: 25825
+  :start-line: 25584
+  :end-line: 26016
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 25826
-  :end-line: 25977
+  :start-line: 26017
+  :end-line: 26168
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 25978
-  :end-line: 25982
+  :start-line: 26169
+  :end-line: 26173
 
 ------------
 
@@ -2198,8 +2213,8 @@ Endpoint
 --------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 4565
-  :end-line: 4888
+  :start-line: 4518
+  :end-line: 4841
 
 ------------
 
@@ -2207,20 +2222,20 @@ Emitter
 -------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 4196
-  :end-line: 4216
+  :start-line: 4149
+  :end-line: 4169
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 4217
-  :end-line: 4260
+  :start-line: 4170
+  :end-line: 4213
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 4261
-  :end-line: 4564
+  :start-line: 4214
+  :end-line: 4517
 
 ------------
 
@@ -2228,26 +2243,26 @@ Sensor
 ------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 16785
-  :end-line: 16849
+  :start-line: 16907
+  :end-line: 17027
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 16850
-  :end-line: 17118
+  :start-line: 17028
+  :end-line: 17296
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 13485
-  :end-line: 13522
+  :start-line: 13603
+  :end-line: 13640
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 27598
-  :end-line: 27610
+  :start-line: 27843
+  :end-line: 27855
 
 ------------
 
@@ -2255,38 +2270,38 @@ Medium
 ------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 11479
-  :end-line: 11603
+  :start-line: 11458
+  :end-line: 11582
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 11604
-  :end-line: 11667
+  :start-line: 11583
+  :end-line: 11646
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 11668
-  :end-line: 11887
+  :start-line: 11647
+  :end-line: 11866
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 12976
-  :end-line: 12994
+  :start-line: 13094
+  :end-line: 13112
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 12995
-  :end-line: 13030
+  :start-line: 13113
+  :end-line: 13148
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 13031
-  :end-line: 13236
+  :start-line: 13149
+  :end-line: 13354
 
 ------------
 
@@ -2294,20 +2309,20 @@ Shape
 -----
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 17119
-  :end-line: 17555
+  :start-line: 17297
+  :end-line: 17733
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 17556
-  :end-line: 17908
+  :start-line: 17734
+  :end-line: 18086
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 12020
-  :end-line: 12178
+  :start-line: 11999
+  :end-line: 12151
 
 ------------
 
@@ -2315,8 +2330,8 @@ Texture
 -------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 21443
-  :end-line: 21679
+  :start-line: 21628
+  :end-line: 21864
 
 ------------
 
@@ -2324,14 +2339,14 @@ Volume
 ------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 24958
-  :end-line: 25094
+  :start-line: 25143
+  :end-line: 25285
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 25095
-  :end-line: 25194
+  :start-line: 25286
+  :end-line: 25385
 
 ------------
 
@@ -2339,26 +2354,26 @@ PhaseFunction
 -------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 12849
-  :end-line: 12975
+  :start-line: 12967
+  :end-line: 13093
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 12976
-  :end-line: 12994
+  :start-line: 13094
+  :end-line: 13112
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 12995
-  :end-line: 13030
+  :start-line: 13113
+  :end-line: 13148
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 13031
-  :end-line: 13236
+  :start-line: 13149
+  :end-line: 13354
 
 ------------
 
@@ -2366,20 +2381,20 @@ Film
 ----
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 5010
-  :end-line: 5197
+  :start-line: 4963
+  :end-line: 5156
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 5198
-  :end-line: 5230
+  :start-line: 5157
+  :end-line: 5189
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 7830
-  :end-line: 8153
+  :start-line: 7789
+  :end-line: 8111
 
 ------------
 
@@ -2387,20 +2402,20 @@ Filter
 ------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 1766
-  :end-line: 1828
+  :start-line: 1714
+  :end-line: 1776
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 5231
-  :end-line: 5271
+  :start-line: 5190
+  :end-line: 5230
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 14148
-  :end-line: 14210
+  :start-line: 14270
+  :end-line: 14332
 
 ------------
 
@@ -2408,8 +2423,8 @@ Sampler
 -------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 14326
-  :end-line: 14509
+  :start-line: 14448
+  :end-line: 14631
 
 ------------
 
@@ -2417,14 +2432,14 @@ Scene
 -----
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 16180
-  :end-line: 16686
+  :start-line: 16302
+  :end-line: 16808
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 26251
-  :end-line: 26254
+  :start-line: 26454
+  :end-line: 26457
 
 ------------
 
@@ -2432,32 +2447,32 @@ Record
 ------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 13308
-  :end-line: 13386
+  :start-line: 13426
+  :end-line: 13504
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 3826
-  :end-line: 3939
+  :start-line: 3779
+  :end-line: 3892
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 11604
-  :end-line: 11667
+  :start-line: 11583
+  :end-line: 11646
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 18924
-  :end-line: 19224
+  :start-line: 19109
+  :end-line: 19409
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 13387
-  :end-line: 13484
+  :start-line: 13505
+  :end-line: 13602
 
 ------------
 
@@ -2465,92 +2480,98 @@ Spectrum
 --------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 28441
-  :end-line: 28464
+  :start-line: 28686
+  :end-line: 28709
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 28465
-  :end-line: 28478
+  :start-line: 28710
+  :end-line: 28726
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 28479
-  :end-line: 28499
+  :start-line: 28727
+  :end-line: 28747
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 28984
-  :end-line: 28994
+  :start-line: 29232
+  :end-line: 29242
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 28995
-  :end-line: 29007
+  :start-line: 29243
+  :end-line: 29255
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 29008
-  :end-line: 29015
+  :start-line: 29256
+  :end-line: 29263
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 29016
-  :end-line: 29028
+  :start-line: 29264
+  :end-line: 29276
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 26219
-  :end-line: 26229
+  :start-line: 26410
+  :end-line: 26420
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 26230
-  :end-line: 26240
+  :start-line: 26421
+  :end-line: 26431
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 29694
-  :end-line: 29707
+  :start-line: 26432
+  :end-line: 26443
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 27611
-  :end-line: 27639
+  :start-line: 29942
+  :end-line: 29955
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 26792
-  :end-line: 26816
+  :start-line: 27856
+  :end-line: 27884
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 26263
-  :end-line: 26282
+  :start-line: 26995
+  :end-line: 27019
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 26733
-  :end-line: 26743
+  :start-line: 26466
+  :end-line: 26485
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 28133
-  :end-line: 28167
+  :start-line: 26936
+  :end-line: 26946
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 28378
+  :end-line: 28412
 
 ------------
 
@@ -2558,104 +2579,116 @@ Polarization
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 27066
-  :end-line: 27088
+  :start-line: 27269
+  :end-line: 27291
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 27089
-  :end-line: 27111
+  :start-line: 27292
+  :end-line: 27314
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 27112
-  :end-line: 27144
+  :start-line: 27315
+  :end-line: 27347
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 27145
-  :end-line: 27175
+  :start-line: 27348
+  :end-line: 27368
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 27176
-  :end-line: 27216
+  :start-line: 27369
+  :end-line: 27399
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 27217
-  :end-line: 27299
+  :start-line: 27400
+  :end-line: 27440
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 27300
-  :end-line: 27360
+  :start-line: 27441
+  :end-line: 27461
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 27361
-  :end-line: 27390
+  :start-line: 27462
+  :end-line: 27544
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 27391
-  :end-line: 27420
+  :start-line: 27545
+  :end-line: 27605
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 27421
-  :end-line: 27451
+  :start-line: 27606
+  :end-line: 27635
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 27452
-  :end-line: 27492
+  :start-line: 27636
+  :end-line: 27665
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 27493
-  :end-line: 27529
+  :start-line: 27666
+  :end-line: 27696
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 27530
-  :end-line: 27566
+  :start-line: 27697
+  :end-line: 27737
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 27567
-  :end-line: 27586
+  :start-line: 27738
+  :end-line: 27774
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 27587
-  :end-line: 27597
+  :start-line: 27775
+  :end-line: 27811
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 26255
-  :end-line: 26262
+  :start-line: 27812
+  :end-line: 27831
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 29042
-  :end-line: 29049
+  :start-line: 27832
+  :end-line: 27842
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 26458
+  :end-line: 26465
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 29290
+  :end-line: 29297
 
 ------------
 
@@ -2663,38 +2696,38 @@ Util
 ----
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 29050
-  :end-line: 29054
+  :start-line: 29298
+  :end-line: 29302
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 29055
-  :end-line: 29061
+  :start-line: 29303
+  :end-line: 29309
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 29062
-  :end-line: 29074
+  :start-line: 29310
+  :end-line: 29322
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 29075
-  :end-line: 29088
+  :start-line: 29323
+  :end-line: 29336
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 29089
-  :end-line: 29096
+  :start-line: 29337
+  :end-line: 29344
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 29097
-  :end-line: 29100
+  :start-line: 29345
+  :end-line: 29348
 
 ------------
 
@@ -2702,56 +2735,56 @@ Chi2
 ----
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 26057
-  :end-line: 26069
+  :start-line: 26248
+  :end-line: 26260
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 26070
-  :end-line: 26173
+  :start-line: 26261
+  :end-line: 26364
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 26174
-  :end-line: 26183
+  :start-line: 26365
+  :end-line: 26374
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 26184
-  :end-line: 26187
+  :start-line: 26375
+  :end-line: 26378
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 26188
-  :end-line: 26192
+  :start-line: 26379
+  :end-line: 26383
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 26193
-  :end-line: 26205
+  :start-line: 26384
+  :end-line: 26396
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 26206
-  :end-line: 26209
+  :start-line: 26397
+  :end-line: 26400
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 26210
-  :end-line: 26214
+  :start-line: 26401
+  :end-line: 26405
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 26215
-  :end-line: 26218
+  :start-line: 26406
+  :end-line: 26409
 
 ------------
 
@@ -2759,26 +2792,26 @@ Autodiff
 --------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 25251
-  :end-line: 25311
+  :start-line: 25442
+  :end-line: 25502
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 25312
-  :end-line: 25342
+  :start-line: 25503
+  :end-line: 25533
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 25343
-  :end-line: 25392
+  :start-line: 25534
+  :end-line: 25583
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 25983
-  :end-line: 26056
+  :start-line: 26174
+  :end-line: 26247
 
 ------------
 

--- a/include/mitsuba/python/docstr.h
+++ b/include/mitsuba/python/docstr.h
@@ -4749,7 +4749,16 @@ static const char *__doc_mitsuba_OptixAccelData_meshes = R"doc()doc";
 
 static const char *__doc_mitsuba_OptixAccelData_others = R"doc()doc";
 
-static const char *__doc_mitsuba_OptixDenoiser = R"doc(OptiX Denoiser)doc";
+static const char *__doc_mitsuba_OptixDenoiser =
+R"doc(Wrapper for the OptiX AI denoiser
+
+The OptiX AI denoiser is wrapped in this object such that it can work
+directly with Mitsuba types and its conventions.
+
+The denoiser works best when applied to noisy renderings that were
+produced with a Film which used the `box` ReconstructionFilter. With a
+filter that spans multiple pixels, the denoiser might identify some
+local variance as a feature of the scene and will not denoise it.)doc";
 
 static const char *__doc_mitsuba_OptixDenoiser_2 = R"doc()doc";
 
@@ -4759,7 +4768,24 @@ static const char *__doc_mitsuba_OptixDenoiser_4 = R"doc()doc";
 
 static const char *__doc_mitsuba_OptixDenoiser_5 = R"doc()doc";
 
-static const char *__doc_mitsuba_OptixDenoiser_OptixDenoiser = R"doc()doc";
+static const char *__doc_mitsuba_OptixDenoiser_OptixDenoiser =
+R"doc(Constructs an OptiX denoiser
+
+Parameter ``input_size``:
+    Resolution of noisy images that will be fed to the denoiser.
+
+Parameter ``albedo``:
+    Whether or not albedo information will also be given to the
+    denoiser.
+
+Parameter ``normals``:
+    Whether or not shading normals information will also be given to
+    the Denoiser.
+
+Returns:
+    A callable object which will apply the OptiX denoiser.)doc";
+
+static const char *__doc_mitsuba_OptixDenoiser_OptixDenoiser_2 = R"doc()doc";
 
 static const char *__doc_mitsuba_OptixDenoiser_class = R"doc()doc";
 
@@ -4771,8 +4797,6 @@ static const char *__doc_mitsuba_OptixDenoiser_m_input_size = R"doc()doc";
 
 static const char *__doc_mitsuba_OptixDenoiser_m_options = R"doc()doc";
 
-static const char *__doc_mitsuba_OptixDenoiser_m_output_data = R"doc()doc";
-
 static const char *__doc_mitsuba_OptixDenoiser_m_scratch = R"doc()doc";
 
 static const char *__doc_mitsuba_OptixDenoiser_m_scratch_size = R"doc()doc";
@@ -4783,11 +4807,115 @@ static const char *__doc_mitsuba_OptixDenoiser_m_state_size = R"doc()doc";
 
 static const char *__doc_mitsuba_OptixDenoiser_m_temporal = R"doc()doc";
 
-static const char *__doc_mitsuba_OptixDenoiser_operator_call = R"doc()doc";
+static const char *__doc_mitsuba_OptixDenoiser_operator_assign = R"doc()doc";
 
-static const char *__doc_mitsuba_OptixDenoiser_operator_call_2 = R"doc()doc";
+static const char *__doc_mitsuba_OptixDenoiser_operator_call =
+R"doc(Apply denoiser on inputs which are TensorXf objects.
+
+Parameter ``noisy``:
+    The noisy input. (tensor shape: (width, height, 3 | 4))
+
+Parameter ``denoise_alpha``:
+    Whether or not the alpha channel (if specified in the noisy input)
+    should be denoised too. This parameter is optional, by default it
+    is true.
+
+Parameter ``albedo``:
+    Albedo information of the noisy rendering. This parameter is
+    optional unless the OptixDenoiser was built with albedo support.
+    (tensor shape: (width, height, 3))
+
+Parameter ``normals``:
+    Shading normal information of the noisy rendering. The normals
+    must be in the coordinate frame of the sensor which was used to
+    render the noisy input. This parameter is optional unless the
+    OptixDenoiser was built with normals support. (tensor shape:
+    (width, height, 3))
+
+Parameter ``to_sensor``:
+    A Transform4f which is applied to the ``normals`` parameter before
+    denoising. This should be used to tranform the normals into the
+    correct coordinate frame. This parameter is optional, by default
+    no transformation is applied.
+
+Parameter ``flow``:
+    With temporal denoising, this parameter is the optical flow
+    between the previous frame and the current one. It should capture
+    the 2D motion of each individual pixel. When this parameter is
+    unknown, it can been set to a zero-initialized TensorXf of the
+    correct size and still produce convincing results. This parameter
+    is optional unless the OptixDenoiser was built with temporal
+    denoising support. (tensor shape: (width, height, 2))
+
+Parameter ``previous_denoised``:
+    With temporal denoising, the previous denoised frame should be
+    passed here. For the very first frame, the OptiX documentation
+    recommends passing the noisy input for this argument. This
+    parameter is optional unless the OptixDenoiser was built with
+    temporal denoising support. (tensor shape: (width, height, 3 | 4))
+
+Returns:
+    The denoised input.)doc";
+
+static const char *__doc_mitsuba_OptixDenoiser_operator_call_2 =
+R"doc(Apply denoiser on inputs which are Bitmap objects.
+
+Parameter ``noisy``:
+    The noisy input. When passing additional information like albedo
+    or normals to the denoiser, this Bitmap object must be a
+    MultiChannel bitmap.
+
+Parameter ``denoise_alpha``:
+    Whether or not the alpha channel (if specified in the noisy input)
+    should be denoised too. This parameter is optional, by default it
+    is true.
+
+Parameter ``albedo_ch``:
+    The name of the channel in the ``noisy`` parameter which contains
+    the albedo information of the noisy rendering. This parameter is
+    optional unless the OptixDenoiser was built with albedo support.
+
+Parameter ``normals_ch``:
+    The name of the channel in the ``noisy`` parameter which contains
+    the shading normal information of the noisy rendering. The normals
+    must be in the coordinate frame of the sensor which was used to
+    render the noisy input. This parameter is optional unless the
+    OptixDenoiser was built with normals support.
+
+Parameter ``to_sensor``:
+    A Transform4f which is applied to the ``normals`` parameter before
+    denoising. This should be used to tranform the normals into the
+    correct coordinate frame. This parameter is optional, by default
+    no transformation is applied.
+
+Parameter ``flow_ch``:
+    With temporal denoising, this parameter is name of the channel in
+    the ``noisy`` parameter which contains the optical flow between
+    the previous frame and the current one. It should capture the 2D
+    motion of each individual pixel. When this parameter is unknown,
+    it can been set to a zero-initialized TensorXf of the correct size
+    and still produce convincing results. This parameter is optional
+    unless the OptixDenoiser was built with temporal denoising
+    support.
+
+Parameter ``previous_denoised_ch``:
+    With temporal denoising, this parameter is name of the channel in
+    the ``noisy`` parameter which contains the previous denoised
+    frame. For the very first frame, the OptiX documentation
+    recommends passing the noisy input for this argument. This
+    parameter is optional unless the OptixDenoiser was built with
+    temporal denoising support.
+
+Parameter ``noisy_ch``:
+    The name of the channel in the ``noisy`` parameter which contains
+    the shading normal information of the noisy rendering.
+
+Returns:
+    The denoised input.)doc";
 
 static const char *__doc_mitsuba_OptixDenoiser_to_string = R"doc()doc";
+
+static const char *__doc_mitsuba_OptixDenoiser_validate_input = R"doc(Helper function to validate tensor sizes)doc";
 
 static const char *__doc_mitsuba_PCG32Sampler =
 R"doc(Interface for sampler plugins based on the PCG32 random number
@@ -9935,6 +10063,20 @@ recurrence)doc";
 static const char *__doc_mitsuba_math_legendre_pd_diff = R"doc(Evaluate the function legendre_pd(l+1, x) - legendre_pd(l-1, x))doc";
 
 static const char *__doc_mitsuba_math_log2i_ceil = R"doc(Ceiling of base-2 logarithm)doc";
+
+static const char *__doc_mitsuba_math_middle =
+R"doc(This function computes a suitable middle point for use in the bisect()
+function
+
+To mitigate the issue of varying density of floating point numbers on
+the number line, the floats are reinterpreted as unsigned integers. As
+long as sign of both numbers is the same, this maps the floats to the
+evenly spaced set of integers. The middle of these integers ensures
+that the space of numbers is halved on each iteration of the
+bisection.
+
+Note that this strategy does not work if the numbers have different
+sign. In this case the function always returns 0.0 as the middle.)doc";
 
 static const char *__doc_mitsuba_math_modulo = R"doc(Always-positive modulo function)doc";
 

--- a/include/mitsuba/python/docstr.h
+++ b/include/mitsuba/python/docstr.h
@@ -749,6 +749,8 @@ Parameter ``si``:
 Parameter ``wo``:
     The outgoing direction)doc";
 
+static const char *__doc_mitsuba_BSDF_eval_diffuse_reflectance = R"doc(Return the diffuse reflectance value)doc";
+
 static const char *__doc_mitsuba_BSDF_eval_null_transmission =
 R"doc(Evaluate un-scattered transmission component of the BSDF
 
@@ -797,8 +799,6 @@ Parameter ``wo``:
 static const char *__doc_mitsuba_BSDF_flags = R"doc(Flags for all components combined.)doc";
 
 static const char *__doc_mitsuba_BSDF_flags_2 = R"doc(Flags for a specific component of this BSDF.)doc";
-
-static const char *__doc_mitsuba_BSDF_get_diffuse_reflectance = R"doc(Return the diffuse reflectance value (if any))doc";
 
 static const char *__doc_mitsuba_BSDF_id = R"doc(Return a string identifier)doc";
 

--- a/include/mitsuba/python/docstr.h
+++ b/include/mitsuba/python/docstr.h
@@ -113,11 +113,73 @@ static const char *__doc_OptixBuildInputTriangleArray_vertexStrideInBytes = R"do
 
 static const char *__doc_OptixBuildInput_type = R"doc()doc";
 
+static const char *__doc_OptixDenoiserGuideLayer = R"doc()doc";
+
+static const char *__doc_OptixDenoiserGuideLayer_albedo = R"doc()doc";
+
+static const char *__doc_OptixDenoiserGuideLayer_flow = R"doc()doc";
+
+static const char *__doc_OptixDenoiserGuideLayer_normal = R"doc()doc";
+
+static const char *__doc_OptixDenoiserLayer = R"doc()doc";
+
+static const char *__doc_OptixDenoiserLayer_input = R"doc()doc";
+
+static const char *__doc_OptixDenoiserLayer_output = R"doc()doc";
+
+static const char *__doc_OptixDenoiserLayer_previousOutput = R"doc()doc";
+
+static const char *__doc_OptixDenoiserModelKind = R"doc()doc";
+
+static const char *__doc_OptixDenoiserModelKind_OPTIX_DENOISER_MODEL_KIND_HDR = R"doc()doc";
+
+static const char *__doc_OptixDenoiserModelKind_OPTIX_DENOISER_MODEL_KIND_TEMPORAL = R"doc()doc";
+
+static const char *__doc_OptixDenoiserOptions = R"doc()doc";
+
+static const char *__doc_OptixDenoiserOptions_guideAlbedo = R"doc()doc";
+
+static const char *__doc_OptixDenoiserOptions_guideNormal = R"doc()doc";
+
+static const char *__doc_OptixDenoiserParams = R"doc()doc";
+
+static const char *__doc_OptixDenoiserParams_blendFactor = R"doc()doc";
+
+static const char *__doc_OptixDenoiserParams_denoiseAlpha = R"doc()doc";
+
+static const char *__doc_OptixDenoiserParams_hdrAverageColor = R"doc()doc";
+
+static const char *__doc_OptixDenoiserParams_hdrIntensity = R"doc()doc";
+
+static const char *__doc_OptixDenoiserSizes = R"doc()doc";
+
+static const char *__doc_OptixDenoiserSizes_overlapWindowSizeInPixels = R"doc()doc";
+
+static const char *__doc_OptixDenoiserSizes_stateSizeInBytes = R"doc()doc";
+
+static const char *__doc_OptixDenoiserSizes_withOverlapScratchSizeInBytes = R"doc()doc";
+
+static const char *__doc_OptixDenoiserSizes_withoutOverlapScratchSizeInBytes = R"doc()doc";
+
 static const char *__doc_OptixHitGroupData = R"doc(Stores information about a Shape on the Optix side)doc";
 
 static const char *__doc_OptixHitGroupData_data = R"doc(Pointer to the memory region of Shape data (e.g. ``OptixSphereData`` ))doc";
 
 static const char *__doc_OptixHitGroupData_shape_registry_id = R"doc(Shape id in Dr.Jit's pointer registry)doc";
+
+static const char *__doc_OptixImage2D = R"doc()doc";
+
+static const char *__doc_OptixImage2D_data = R"doc()doc";
+
+static const char *__doc_OptixImage2D_format = R"doc()doc";
+
+static const char *__doc_OptixImage2D_height = R"doc()doc";
+
+static const char *__doc_OptixImage2D_pixelStrideInBytes = R"doc()doc";
+
+static const char *__doc_OptixImage2D_rowStrideInBytes = R"doc()doc";
+
+static const char *__doc_OptixImage2D_width = R"doc()doc";
 
 static const char *__doc_OptixInstance = R"doc()doc";
 
@@ -182,6 +244,24 @@ static const char *__doc_OptixPipelineCompileOptions_traversableGraphFlags = R"d
 static const char *__doc_OptixPipelineCompileOptions_usesMotionBlur = R"doc()doc";
 
 static const char *__doc_OptixPipelineCompileOptions_usesPrimitiveTypeFlags = R"doc()doc";
+
+static const char *__doc_OptixPixelFormat = R"doc()doc";
+
+static const char *__doc_OptixPixelFormat_OPTIX_PIXEL_FORMAT_FLOAT2 = R"doc()doc";
+
+static const char *__doc_OptixPixelFormat_OPTIX_PIXEL_FORMAT_FLOAT3 = R"doc()doc";
+
+static const char *__doc_OptixPixelFormat_OPTIX_PIXEL_FORMAT_FLOAT4 = R"doc()doc";
+
+static const char *__doc_OptixPixelFormat_OPTIX_PIXEL_FORMAT_HALF2 = R"doc()doc";
+
+static const char *__doc_OptixPixelFormat_OPTIX_PIXEL_FORMAT_HALF3 = R"doc()doc";
+
+static const char *__doc_OptixPixelFormat_OPTIX_PIXEL_FORMAT_HALF4 = R"doc()doc";
+
+static const char *__doc_OptixPixelFormat_OPTIX_PIXEL_FORMAT_UCHAR3 = R"doc()doc";
+
+static const char *__doc_OptixPixelFormat_OPTIX_PIXEL_FORMAT_UCHAR4 = R"doc()doc";
 
 static const char *__doc_OptixProgramGroupDesc = R"doc()doc";
 
@@ -713,6 +793,8 @@ Parameter ``wo``:
 static const char *__doc_mitsuba_BSDF_flags = R"doc(Flags for all components combined.)doc";
 
 static const char *__doc_mitsuba_BSDF_flags_2 = R"doc(Flags for a specific component of this BSDF.)doc";
+
+static const char *__doc_mitsuba_BSDF_get_diffuse_reflectance = R"doc(Return the diffuse reflectance value (if any))doc";
 
 static const char *__doc_mitsuba_BSDF_id = R"doc(Return a string identifier)doc";
 
@@ -1783,6 +1865,52 @@ static const char *__doc_mitsuba_DefaultFormatter_set_has_date = R"doc(Should da
 static const char *__doc_mitsuba_DefaultFormatter_set_has_log_level = R"doc(Should log level information be included? The default is yes.)doc";
 
 static const char *__doc_mitsuba_DefaultFormatter_set_has_thread = R"doc(Should thread information be included? The default is yes.)doc";
+
+static const char *__doc_mitsuba_Denoiser = R"doc(OptiX Denoiser)doc";
+
+static const char *__doc_mitsuba_Denoiser_2 = R"doc()doc";
+
+static const char *__doc_mitsuba_Denoiser_3 = R"doc()doc";
+
+static const char *__doc_mitsuba_Denoiser_4 = R"doc()doc";
+
+static const char *__doc_mitsuba_Denoiser_Denoiser = R"doc()doc";
+
+static const char *__doc_mitsuba_Denoiser_class = R"doc()doc";
+
+static const char *__doc_mitsuba_Denoiser_denoise = R"doc()doc";
+
+static const char *__doc_mitsuba_Denoiser_denoise1 = R"doc()doc";
+
+static const char *__doc_mitsuba_Denoiser_m_albedo_data = R"doc()doc";
+
+static const char *__doc_mitsuba_Denoiser_m_denoiser = R"doc()doc";
+
+static const char *__doc_mitsuba_Denoiser_m_flow_data = R"doc()doc";
+
+static const char *__doc_mitsuba_Denoiser_m_hdr_intensity = R"doc()doc";
+
+static const char *__doc_mitsuba_Denoiser_m_input_data = R"doc()doc";
+
+static const char *__doc_mitsuba_Denoiser_m_normal_data = R"doc()doc";
+
+static const char *__doc_mitsuba_Denoiser_m_options = R"doc()doc";
+
+static const char *__doc_mitsuba_Denoiser_m_output_data = R"doc()doc";
+
+static const char *__doc_mitsuba_Denoiser_m_previous_output_data = R"doc()doc";
+
+static const char *__doc_mitsuba_Denoiser_m_scratch = R"doc()doc";
+
+static const char *__doc_mitsuba_Denoiser_m_scratch_size = R"doc()doc";
+
+static const char *__doc_mitsuba_Denoiser_m_state = R"doc()doc";
+
+static const char *__doc_mitsuba_Denoiser_m_state_size = R"doc()doc";
+
+static const char *__doc_mitsuba_Denoiser_m_temporal = R"doc()doc";
+
+static const char *__doc_mitsuba_Denoiser_to_string = R"doc()doc";
 
 static const char *__doc_mitsuba_DirectionSample =
 R"doc(Record for solid-angle based area sampling techniques

--- a/include/mitsuba/python/docstr.h
+++ b/include/mitsuba/python/docstr.h
@@ -345,6 +345,8 @@ static const char *__doc_mitsuba_AdjointIntegrator_3 = R"doc()doc";
 
 static const char *__doc_mitsuba_AdjointIntegrator_4 = R"doc()doc";
 
+static const char *__doc_mitsuba_AdjointIntegrator_5 = R"doc()doc";
+
 static const char *__doc_mitsuba_AdjointIntegrator_AdjointIntegrator = R"doc(Create an integrator)doc";
 
 static const char *__doc_mitsuba_AdjointIntegrator_class = R"doc()doc";
@@ -567,6 +569,8 @@ static const char *__doc_mitsuba_BSDF_2 = R"doc()doc";
 static const char *__doc_mitsuba_BSDF_3 = R"doc()doc";
 
 static const char *__doc_mitsuba_BSDF_4 = R"doc()doc";
+
+static const char *__doc_mitsuba_BSDF_5 = R"doc()doc";
 
 static const char *__doc_mitsuba_BSDFContext =
 R"doc(Context data structure for BSDF evaluation and sampling
@@ -1866,44 +1870,6 @@ static const char *__doc_mitsuba_DefaultFormatter_set_has_log_level = R"doc(Shou
 
 static const char *__doc_mitsuba_DefaultFormatter_set_has_thread = R"doc(Should thread information be included? The default is yes.)doc";
 
-static const char *__doc_mitsuba_Denoiser = R"doc(OptiX Denoiser)doc";
-
-static const char *__doc_mitsuba_Denoiser_2 = R"doc()doc";
-
-static const char *__doc_mitsuba_Denoiser_3 = R"doc()doc";
-
-static const char *__doc_mitsuba_Denoiser_4 = R"doc()doc";
-
-static const char *__doc_mitsuba_Denoiser_Denoiser = R"doc()doc";
-
-static const char *__doc_mitsuba_Denoiser_class = R"doc()doc";
-
-static const char *__doc_mitsuba_Denoiser_denoise = R"doc()doc";
-
-static const char *__doc_mitsuba_Denoiser_denoise_2 = R"doc()doc";
-
-static const char *__doc_mitsuba_Denoiser_m_denoiser = R"doc()doc";
-
-static const char *__doc_mitsuba_Denoiser_m_hdr_intensity = R"doc()doc";
-
-static const char *__doc_mitsuba_Denoiser_m_input_size = R"doc()doc";
-
-static const char *__doc_mitsuba_Denoiser_m_options = R"doc()doc";
-
-static const char *__doc_mitsuba_Denoiser_m_output_data = R"doc()doc";
-
-static const char *__doc_mitsuba_Denoiser_m_scratch = R"doc()doc";
-
-static const char *__doc_mitsuba_Denoiser_m_scratch_size = R"doc()doc";
-
-static const char *__doc_mitsuba_Denoiser_m_state = R"doc()doc";
-
-static const char *__doc_mitsuba_Denoiser_m_state_size = R"doc()doc";
-
-static const char *__doc_mitsuba_Denoiser_m_temporal = R"doc()doc";
-
-static const char *__doc_mitsuba_Denoiser_to_string = R"doc()doc";
-
 static const char *__doc_mitsuba_DirectionSample =
 R"doc(Record for solid-angle based area sampling techniques
 
@@ -2271,6 +2237,8 @@ static const char *__doc_mitsuba_Emitter_3 = R"doc()doc";
 
 static const char *__doc_mitsuba_Emitter_4 = R"doc()doc";
 
+static const char *__doc_mitsuba_Emitter_5 = R"doc()doc";
+
 static const char *__doc_mitsuba_EmitterFlags =
 R"doc(This list of flags is used to classify the different types of
 emitters.)doc";
@@ -2357,6 +2325,8 @@ static const char *__doc_mitsuba_Endpoint_2 = R"doc()doc";
 static const char *__doc_mitsuba_Endpoint_3 = R"doc()doc";
 
 static const char *__doc_mitsuba_Endpoint_4 = R"doc()doc";
+
+static const char *__doc_mitsuba_Endpoint_5 = R"doc()doc";
 
 static const char *__doc_mitsuba_Endpoint_Endpoint = R"doc()doc";
 
@@ -2765,6 +2735,8 @@ static const char *__doc_mitsuba_Film_2 = R"doc()doc";
 static const char *__doc_mitsuba_Film_3 = R"doc()doc";
 
 static const char *__doc_mitsuba_Film_4 = R"doc()doc";
+
+static const char *__doc_mitsuba_Film_5 = R"doc()doc";
 
 static const char *__doc_mitsuba_FilmFlags = R"doc(This list of flags is used to classify the different types of films.)doc";
 
@@ -3215,6 +3187,8 @@ static const char *__doc_mitsuba_ImageBlock_3 = R"doc()doc";
 
 static const char *__doc_mitsuba_ImageBlock_4 = R"doc()doc";
 
+static const char *__doc_mitsuba_ImageBlock_5 = R"doc()doc";
+
 static const char *__doc_mitsuba_ImageBlock_ImageBlock =
 R"doc(Construct a zero-initialized image block with the desired shape and
 channel count
@@ -3449,6 +3423,8 @@ static const char *__doc_mitsuba_Integrator_2 = R"doc()doc";
 static const char *__doc_mitsuba_Integrator_3 = R"doc()doc";
 
 static const char *__doc_mitsuba_Integrator_4 = R"doc()doc";
+
+static const char *__doc_mitsuba_Integrator_5 = R"doc()doc";
 
 static const char *__doc_mitsuba_Integrator_Integrator = R"doc(Create an integrator)doc";
 
@@ -3936,6 +3912,8 @@ static const char *__doc_mitsuba_Medium_3 = R"doc()doc";
 
 static const char *__doc_mitsuba_Medium_4 = R"doc()doc";
 
+static const char *__doc_mitsuba_Medium_5 = R"doc()doc";
+
 static const char *__doc_mitsuba_MediumInteraction = R"doc(Stores information related to a medium scattering interaction)doc";
 
 static const char *__doc_mitsuba_MediumInteraction_MediumInteraction = R"doc()doc";
@@ -4214,6 +4192,8 @@ static const char *__doc_mitsuba_Mesh_2 = R"doc()doc";
 static const char *__doc_mitsuba_Mesh_3 = R"doc()doc";
 
 static const char *__doc_mitsuba_Mesh_4 = R"doc()doc";
+
+static const char *__doc_mitsuba_Mesh_5 = R"doc()doc";
 
 static const char *__doc_mitsuba_Mesh_Mesh = R"doc(Create a new mesh with the given vertex and face data structures)doc";
 
@@ -4617,6 +4597,8 @@ static const char *__doc_mitsuba_MonteCarloIntegrator_3 = R"doc()doc";
 
 static const char *__doc_mitsuba_MonteCarloIntegrator_4 = R"doc()doc";
 
+static const char *__doc_mitsuba_MonteCarloIntegrator_5 = R"doc()doc";
+
 static const char *__doc_mitsuba_MonteCarloIntegrator_MonteCarloIntegrator = R"doc(Create an integrator)doc";
 
 static const char *__doc_mitsuba_MonteCarloIntegrator_class = R"doc()doc";
@@ -4767,6 +4749,46 @@ static const char *__doc_mitsuba_OptixAccelData_meshes = R"doc()doc";
 
 static const char *__doc_mitsuba_OptixAccelData_others = R"doc()doc";
 
+static const char *__doc_mitsuba_OptixDenoiser = R"doc(OptiX Denoiser)doc";
+
+static const char *__doc_mitsuba_OptixDenoiser_2 = R"doc()doc";
+
+static const char *__doc_mitsuba_OptixDenoiser_3 = R"doc()doc";
+
+static const char *__doc_mitsuba_OptixDenoiser_4 = R"doc()doc";
+
+static const char *__doc_mitsuba_OptixDenoiser_5 = R"doc()doc";
+
+static const char *__doc_mitsuba_OptixDenoiser_OptixDenoiser = R"doc()doc";
+
+static const char *__doc_mitsuba_OptixDenoiser_class = R"doc()doc";
+
+static const char *__doc_mitsuba_OptixDenoiser_m_denoiser = R"doc()doc";
+
+static const char *__doc_mitsuba_OptixDenoiser_m_hdr_intensity = R"doc()doc";
+
+static const char *__doc_mitsuba_OptixDenoiser_m_input_size = R"doc()doc";
+
+static const char *__doc_mitsuba_OptixDenoiser_m_options = R"doc()doc";
+
+static const char *__doc_mitsuba_OptixDenoiser_m_output_data = R"doc()doc";
+
+static const char *__doc_mitsuba_OptixDenoiser_m_scratch = R"doc()doc";
+
+static const char *__doc_mitsuba_OptixDenoiser_m_scratch_size = R"doc()doc";
+
+static const char *__doc_mitsuba_OptixDenoiser_m_state = R"doc()doc";
+
+static const char *__doc_mitsuba_OptixDenoiser_m_state_size = R"doc()doc";
+
+static const char *__doc_mitsuba_OptixDenoiser_m_temporal = R"doc()doc";
+
+static const char *__doc_mitsuba_OptixDenoiser_operator_call = R"doc()doc";
+
+static const char *__doc_mitsuba_OptixDenoiser_operator_call_2 = R"doc()doc";
+
+static const char *__doc_mitsuba_OptixDenoiser_to_string = R"doc()doc";
+
 static const char *__doc_mitsuba_PCG32Sampler =
 R"doc(Interface for sampler plugins based on the PCG32 random number
 generator)doc";
@@ -4776,6 +4798,8 @@ static const char *__doc_mitsuba_PCG32Sampler_2 = R"doc()doc";
 static const char *__doc_mitsuba_PCG32Sampler_3 = R"doc()doc";
 
 static const char *__doc_mitsuba_PCG32Sampler_4 = R"doc()doc";
+
+static const char *__doc_mitsuba_PCG32Sampler_5 = R"doc()doc";
 
 static const char *__doc_mitsuba_PCG32Sampler_PCG32Sampler = R"doc()doc";
 
@@ -4814,6 +4838,8 @@ static const char *__doc_mitsuba_PhaseFunction_2 = R"doc()doc";
 static const char *__doc_mitsuba_PhaseFunction_3 = R"doc()doc";
 
 static const char *__doc_mitsuba_PhaseFunction_4 = R"doc()doc";
+
+static const char *__doc_mitsuba_PhaseFunction_5 = R"doc()doc";
 
 static const char *__doc_mitsuba_PhaseFunctionContext = R"doc()doc";
 
@@ -5270,6 +5296,8 @@ static const char *__doc_mitsuba_ProjectiveCamera_2 = R"doc()doc";
 static const char *__doc_mitsuba_ProjectiveCamera_3 = R"doc()doc";
 
 static const char *__doc_mitsuba_ProjectiveCamera_4 = R"doc()doc";
+
+static const char *__doc_mitsuba_ProjectiveCamera_5 = R"doc()doc";
 
 static const char *__doc_mitsuba_ProjectiveCamera_ProjectiveCamera = R"doc()doc";
 
@@ -5735,6 +5763,8 @@ static const char *__doc_mitsuba_ReconstructionFilter_3 = R"doc()doc";
 
 static const char *__doc_mitsuba_ReconstructionFilter_4 = R"doc()doc";
 
+static const char *__doc_mitsuba_ReconstructionFilter_5 = R"doc()doc";
+
 static const char *__doc_mitsuba_ReconstructionFilter_ReconstructionFilter = R"doc(Create a new reconstruction filter)doc";
 
 static const char *__doc_mitsuba_ReconstructionFilter_border_size = R"doc(Return the block border size required when rendering with this filter)doc";
@@ -5907,6 +5937,8 @@ static const char *__doc_mitsuba_Sampler_3 = R"doc()doc";
 
 static const char *__doc_mitsuba_Sampler_4 = R"doc()doc";
 
+static const char *__doc_mitsuba_Sampler_5 = R"doc()doc";
+
 static const char *__doc_mitsuba_Sampler_Sampler = R"doc()doc";
 
 static const char *__doc_mitsuba_Sampler_Sampler_2 = R"doc(Copy state to a new sampler object)doc";
@@ -6000,6 +6032,8 @@ static const char *__doc_mitsuba_SamplingIntegrator_3 = R"doc()doc";
 
 static const char *__doc_mitsuba_SamplingIntegrator_4 = R"doc()doc";
 
+static const char *__doc_mitsuba_SamplingIntegrator_5 = R"doc()doc";
+
 static const char *__doc_mitsuba_SamplingIntegrator_SamplingIntegrator = R"doc(//! @})doc";
 
 static const char *__doc_mitsuba_SamplingIntegrator_class = R"doc()doc";
@@ -6088,6 +6122,8 @@ static const char *__doc_mitsuba_Scene_2 = R"doc()doc";
 static const char *__doc_mitsuba_Scene_3 = R"doc()doc";
 
 static const char *__doc_mitsuba_Scene_4 = R"doc()doc";
+
+static const char *__doc_mitsuba_Scene_5 = R"doc()doc";
 
 static const char *__doc_mitsuba_Scene_Scene = R"doc(Instantiate a scene from a Properties object)doc";
 
@@ -6588,6 +6624,8 @@ static const char *__doc_mitsuba_Sensor_3 = R"doc()doc";
 
 static const char *__doc_mitsuba_Sensor_4 = R"doc()doc";
 
+static const char *__doc_mitsuba_Sensor_5 = R"doc()doc";
+
 static const char *__doc_mitsuba_Sensor_Sensor = R"doc()doc";
 
 static const char *__doc_mitsuba_Sensor_class = R"doc()doc";
@@ -6716,6 +6754,8 @@ static const char *__doc_mitsuba_Shape_3 = R"doc()doc";
 
 static const char *__doc_mitsuba_Shape_4 = R"doc()doc";
 
+static const char *__doc_mitsuba_Shape_5 = R"doc()doc";
+
 static const char *__doc_mitsuba_ShapeGroup = R"doc()doc";
 
 static const char *__doc_mitsuba_ShapeGroup_2 = R"doc()doc";
@@ -6723,6 +6763,8 @@ static const char *__doc_mitsuba_ShapeGroup_2 = R"doc()doc";
 static const char *__doc_mitsuba_ShapeGroup_3 = R"doc()doc";
 
 static const char *__doc_mitsuba_ShapeGroup_4 = R"doc()doc";
+
+static const char *__doc_mitsuba_ShapeGroup_5 = R"doc()doc";
 
 static const char *__doc_mitsuba_ShapeGroup_ShapeGroup = R"doc()doc";
 
@@ -6777,6 +6819,8 @@ static const char *__doc_mitsuba_ShapeKDTree_2 = R"doc()doc";
 static const char *__doc_mitsuba_ShapeKDTree_3 = R"doc()doc";
 
 static const char *__doc_mitsuba_ShapeKDTree_4 = R"doc()doc";
+
+static const char *__doc_mitsuba_ShapeKDTree_5 = R"doc()doc";
 
 static const char *__doc_mitsuba_ShapeKDTree_ShapeKDTree =
 R"doc(Create an empty kd-tree and take build-related parameters from
@@ -8431,6 +8475,8 @@ static const char *__doc_mitsuba_Texture_3 = R"doc()doc";
 
 static const char *__doc_mitsuba_Texture_4 = R"doc()doc";
 
+static const char *__doc_mitsuba_Texture_5 = R"doc()doc";
+
 static const char *__doc_mitsuba_Texture_D65 = R"doc(Convenience function returning the standard D65 illuminant)doc";
 
 static const char *__doc_mitsuba_Texture_D65_2 =
@@ -8956,6 +9002,8 @@ static const char *__doc_mitsuba_Volume_3 = R"doc()doc";
 
 static const char *__doc_mitsuba_Volume_4 = R"doc()doc";
 
+static const char *__doc_mitsuba_Volume_5 = R"doc()doc";
+
 static const char *__doc_mitsuba_VolumeGrid = R"doc()doc";
 
 static const char *__doc_mitsuba_VolumeGrid_2 = R"doc()doc";
@@ -8963,6 +9011,8 @@ static const char *__doc_mitsuba_VolumeGrid_2 = R"doc()doc";
 static const char *__doc_mitsuba_VolumeGrid_3 = R"doc()doc";
 
 static const char *__doc_mitsuba_VolumeGrid_4 = R"doc()doc";
+
+static const char *__doc_mitsuba_VolumeGrid_5 = R"doc()doc";
 
 static const char *__doc_mitsuba_VolumeGrid_VolumeGrid =
 R"doc(Load a VolumeGrid from a given filename

--- a/include/mitsuba/python/docstr.h
+++ b/include/mitsuba/python/docstr.h
@@ -1880,25 +1880,17 @@ static const char *__doc_mitsuba_Denoiser_class = R"doc()doc";
 
 static const char *__doc_mitsuba_Denoiser_denoise = R"doc()doc";
 
-static const char *__doc_mitsuba_Denoiser_denoise1 = R"doc()doc";
-
-static const char *__doc_mitsuba_Denoiser_m_albedo_data = R"doc()doc";
+static const char *__doc_mitsuba_Denoiser_denoise_2 = R"doc()doc";
 
 static const char *__doc_mitsuba_Denoiser_m_denoiser = R"doc()doc";
 
-static const char *__doc_mitsuba_Denoiser_m_flow_data = R"doc()doc";
-
 static const char *__doc_mitsuba_Denoiser_m_hdr_intensity = R"doc()doc";
 
-static const char *__doc_mitsuba_Denoiser_m_input_data = R"doc()doc";
-
-static const char *__doc_mitsuba_Denoiser_m_normal_data = R"doc()doc";
+static const char *__doc_mitsuba_Denoiser_m_input_size = R"doc()doc";
 
 static const char *__doc_mitsuba_Denoiser_m_options = R"doc()doc";
 
 static const char *__doc_mitsuba_Denoiser_m_output_data = R"doc()doc";
-
-static const char *__doc_mitsuba_Denoiser_m_previous_output_data = R"doc()doc";
 
 static const char *__doc_mitsuba_Denoiser_m_scratch = R"doc()doc";
 
@@ -3215,8 +3207,7 @@ In addition to receiving samples via the put() method, the image block
 can also be queried via the read() method, in which case the
 reconstruction filter is used to compute suitable interpolation
 weights. This is feature is useful for differentiable rendering, where
-we one needs to evaluate the reverse-mode derivative of the put()
-method.)doc";
+one needs to evaluate the reverse-mode derivative of the put() method.)doc";
 
 static const char *__doc_mitsuba_ImageBlock_2 = R"doc()doc";
 

--- a/include/mitsuba/render/bsdf.h
+++ b/include/mitsuba/render/bsdf.h
@@ -462,6 +462,9 @@ public:
     /// Set a string identifier
     void set_id(const std::string& id) override { m_id = id; };
 
+    /// Return the diffuse reflectance value (if any)
+    virtual Spectrum get_diffuse_reflectance(const SurfaceInteraction3f &si, Mask active = true) const;
+
     /// Return a human-readable representation of the BSDF
     std::string to_string() const override = 0;
 
@@ -541,6 +544,7 @@ DRJIT_VCALL_TEMPLATE_BEGIN(mitsuba::BSDF)
     DRJIT_VCALL_METHOD(eval_null_transmission)
     DRJIT_VCALL_METHOD(pdf)
     DRJIT_VCALL_METHOD(eval_pdf)
+    DRJIT_VCALL_METHOD(get_diffuse_reflectance)
     DRJIT_VCALL_GETTER(flags, uint32_t)
     auto needs_differentials() const {
         return has_flag(flags(), mitsuba::BSDFFlags::NeedsDifferentials);

--- a/include/mitsuba/render/bsdf.h
+++ b/include/mitsuba/render/bsdf.h
@@ -463,7 +463,8 @@ public:
     void set_id(const std::string& id) override { m_id = id; };
 
     /// Return the diffuse reflectance value (if any)
-    virtual Spectrum get_diffuse_reflectance(const SurfaceInteraction3f &si, Mask active = true) const;
+    virtual Spectrum get_diffuse_reflectance(const SurfaceInteraction3f &si,
+                                             Mask active = true) const;
 
     /// Return a human-readable representation of the BSDF
     std::string to_string() const override = 0;

--- a/include/mitsuba/render/bsdf.h
+++ b/include/mitsuba/render/bsdf.h
@@ -462,9 +462,22 @@ public:
     /// Set a string identifier
     void set_id(const std::string& id) override { m_id = id; };
 
-    /// Return the diffuse reflectance value (if any)
-    virtual Spectrum get_diffuse_reflectance(const SurfaceInteraction3f &si,
-                                             Mask active = true) const;
+    /**
+     * \brief Evaluate the diffuse reflectance
+     *
+     * This method approximates the total diffuse reflectance for a given
+     * direction. For some materials, an exact value can be computed
+     * inexpensively.
+     * When this is not possible, the value is approximated by
+     * evaluating the BSDF for a normal outgoing direction and returning this
+     * value multiplied by pi. This is the default behaviour of this method.
+     *
+     * \param si
+     *     A surface interaction data structure describing the underlying
+     *     surface position.
+     */
+    virtual Spectrum eval_diffuse_reflectance(const SurfaceInteraction3f &si,
+                                              Mask active = true) const;
 
     /// Return a human-readable representation of the BSDF
     std::string to_string() const override = 0;
@@ -545,7 +558,7 @@ DRJIT_VCALL_TEMPLATE_BEGIN(mitsuba::BSDF)
     DRJIT_VCALL_METHOD(eval_null_transmission)
     DRJIT_VCALL_METHOD(pdf)
     DRJIT_VCALL_METHOD(eval_pdf)
-    DRJIT_VCALL_METHOD(get_diffuse_reflectance)
+    DRJIT_VCALL_METHOD(eval_diffuse_reflectance)
     DRJIT_VCALL_GETTER(flags, uint32_t)
     auto needs_differentials() const {
         return has_flag(flags(), mitsuba::BSDFFlags::NeedsDifferentials);

--- a/include/mitsuba/render/denoiser.h
+++ b/include/mitsuba/render/denoiser.h
@@ -1,0 +1,128 @@
+// #prsagma once
+
+#include <mitsuba/core/bitmap.h>
+#include <mitsuba/core/platform.h>
+#include <mitsuba/render/optix_api.h>
+#include <enoki-jit/optix.h>
+#include <enoki/array.h>
+#include <iostream>
+#include <exception>
+
+#define optix_check(call) if(call != 0) {std::cerr << "Optix call failed" << std::endl; return Float(0.0);}                  
+
+NAMESPACE_BEGIN(mitsuba)
+
+template <typename Float>
+Float denoise(const Bitmap& noisy, Bitmap* albedo, Bitmap* normals) {
+    if constexpr (ek::is_array_v<Float>) {
+        OptixDeviceContext context = jit_optix_context();
+
+        OptixDenoiser denoiser = nullptr;  
+        OptixDenoiserSizes sizes = {};
+        OptixDenoiserParams params = {};
+        OptixDenoiserOptions options = {};
+        OptixDenoiserModelKind modelKind = albedo == nullptr ? OPTIX_DENOISER_MODEL_KIND_HDR : OPTIX_DENOISER_MODEL_KIND_AOV;
+        options.inputKind = albedo == nullptr ? OPTIX_DENOISER_INPUT_RGB : OPTIX_DENOISER_INPUT_RGB_ALBEDO_NORMAL;
+
+        uint32_t scratch_size = 0;
+        uint32_t state_size = 0;
+
+        OptixImage2D inputs[3] = {};
+        OptixImage2D output;
+
+        optix_check(optixDenoiserCreate(context, &options, &denoiser)); 
+        optix_check(optixDenoiserSetModel(denoiser, modelKind, nullptr, 0));
+        optix_check(optixDenoiserComputeMemoryResources(denoiser, noisy.width(), noisy.height(), &sizes));
+        scratch_size = static_cast<uint32_t>(sizes.withoutOverlapScratchSizeInBytes);
+        state_size = static_cast<uint32_t>(sizes.stateSizeInBytes);
+        // const uint64_t frame_size = noisy.pixel_count() * noisy.bytes_per_pixel();
+
+        std::cout << scratch_size << std::endl;
+        std::cout << state_size << std::endl;
+
+        Float intensity_float = ek::zero<Float>(1);
+        Float scratch_float = ek::zero<Float>(scratch_size / sizeof(float));
+        Float state_float = ek::zero<Float>(state_size / sizeof(float));
+        Float output_data = ek::zero<Float>(noisy.pixel_count() * noisy.channel_count());
+        ek::eval(intensity_float, scratch_float, state_float, output_data);
+        ek::sync_thread();
+
+        CUdeviceptr intensity = 0;
+        CUdeviceptr scratch = 0;
+        CUdeviceptr state = 0;
+        intensity = intensity_float.data();
+        scratch = scratch_float.data();
+        state = state_float.data();
+        output.data = output_data.data();
+
+        output.width = noisy.width();
+        output.height = noisy.height();
+        output.format = OPTIX_PIXEL_FORMAT_FLOAT4;
+        output.rowStrideInBytes = noisy.width() * noisy.bytes_per_pixel();
+        output.pixelStrideInBytes = noisy.bytes_per_pixel();
+        DynamicBuffer<Float> noisy_data = ek::load<DynamicBuffer<Float>>(noisy.data(), noisy.pixel_count() * noisy.channel_count());
+        inputs[0].data = noisy_data.data();
+        inputs[0].width = noisy.width();
+        inputs[0].height = noisy.height();
+        inputs[0].format = OPTIX_PIXEL_FORMAT_FLOAT4;
+        inputs[0].rowStrideInBytes = noisy.width() * noisy.bytes_per_pixel();
+        inputs[0].pixelStrideInBytes = noisy.bytes_per_pixel();
+
+        // std::cout << noisy.pixel_format() << std::endl;
+        // std::cout << noisy.has_alpha() << std::endl;
+        // std::cout << noisy.bytes_per_pixel() << std::endl;
+        std::cout << noisy_data << std::endl;
+        
+
+        unsigned int nb_channels = 1;
+        if(albedo != nullptr) {
+
+            DynamicBuffer<Float> albedo_data = ek::load<DynamicBuffer<Float>>(albedo->data(), albedo->pixel_count() * albedo->channel_count());
+            inputs[1].data = albedo_data.data();
+            inputs[1].width = albedo->width();
+            inputs[1].height = albedo->height();
+            inputs[1].format = OPTIX_PIXEL_FORMAT_FLOAT4;
+            inputs[1].rowStrideInBytes = albedo->width() * albedo->bytes_per_pixel();
+            inputs[1].pixelStrideInBytes = albedo->bytes_per_pixel();
+            nb_channels++;
+        }
+        if(normals != nullptr) {
+            DynamicBuffer<Float> normals_data = ek::load<DynamicBuffer<Float>>(normals->data(), normals->pixel_count() * normals->channel_count());
+            inputs[2].data = normals_data.data();
+            inputs[2].width = normals->width();
+            inputs[2].height = normals->height();
+            inputs[2].format = OPTIX_PIXEL_FORMAT_FLOAT4;
+            inputs[2].rowStrideInBytes = normals->width() * normals->bytes_per_pixel();
+            inputs[2].pixelStrideInBytes = normals->bytes_per_pixel();
+            nb_channels++;
+        }
+
+        optix_check(optixDenoiserSetup(denoiser, 0, noisy.width(), noisy.height(), state, state_size, scratch, scratch_size));
+
+        params.denoiseAlpha = 0;
+        params.hdrIntensity = intensity;
+        params.blendFactor  = 0.0f;
+
+        optix_check(optixDenoiserComputeIntensity(denoiser, 0, inputs, intensity, scratch, scratch_size)); 
+        optix_check(optixDenoiserInvoke(denoiser, 0, &params, state, state_size, inputs, nb_channels, 
+                                        0, 0, &output, scratch, scratch_size));
+
+        Float denoised_data = ek::map<Float>(output.data, noisy.pixel_count() * noisy.channel_count());
+        // Float denoised_data = ek::map<Float>(output.data, 114688);
+
+        ek::eval();
+        ek::sync_thread();
+
+        std::cout << denoised_data << std::endl;
+        optix_check(optixDenoiserDestroy(denoiser));
+        return denoised_data;
+    }
+    return Float(0.0);
+}
+
+template <typename Float>
+Float denoise (const Bitmap& noisy) {
+    return denoise<Float>(noisy, nullptr, nullptr);
+}
+
+NAMESPACE_END(mitsuba)

--- a/include/mitsuba/render/denoiser.h
+++ b/include/mitsuba/render/denoiser.h
@@ -21,9 +21,9 @@ public:
     ~Denoiser();
 
     TensorXf denoise(const TensorXf &noisy, const TensorXf *albedo = nullptr,
-                      const TensorXf *normals = nullptr,
-                      const TensorXf *previous_denoised = nullptr,
-                      const TensorXf *flow = nullptr);
+                     const TensorXf *normals = nullptr,
+                     const TensorXf *previous_denoised = nullptr,
+                     const TensorXf *flow = nullptr);
 
     ref<Bitmap> denoise(const ref<Bitmap> &noisy,
                         const std::string &albedo_ch = "",
@@ -36,6 +36,7 @@ public:
 
     MI_DECLARE_CLASS()
 private:
+    ScalarVector2u m_input_size;
     CUdeviceptr m_state;
     uint32_t m_state_size;
     CUdeviceptr m_scratch;

--- a/include/mitsuba/render/denoiser.h
+++ b/include/mitsuba/render/denoiser.h
@@ -20,20 +20,20 @@ public:
 
     ~Denoiser();
 
-    TensorXf denoise(const TensorXf &noisy,
-                     bool denoise_alpha = true,
-                     const TensorXf *albedo = nullptr,
-                     const TensorXf *normals = nullptr,
-                     const TensorXf *previous_denoised = nullptr,
-                     const TensorXf *flow = nullptr);
-
-    ref<Bitmap> denoise(const ref<Bitmap> &noisy,
+    TensorXf operator()(const TensorXf &noisy,
                         bool denoise_alpha = true,
-                        const std::string &albedo_ch = "",
-                        const std::string &normals_ch = "",
-                        const std::string &flow_ch = "",
-                        const std::string &previous_denoised_ch = "",
-                        const std::string &noisy_ch = "<root>");
+                        const TensorXf *albedo = nullptr,
+                        const TensorXf *normals = nullptr,
+                        const TensorXf *previous_denoised = nullptr,
+                        const TensorXf *flow = nullptr);
+
+    ref<Bitmap> operator()(const ref<Bitmap> &noisy,
+                           bool denoise_alpha = true,
+                           const std::string &albedo_ch = "",
+                           const std::string &normals_ch = "",
+                           const std::string &flow_ch = "",
+                           const std::string &previous_denoised_ch = "",
+                           const std::string &noisy_ch = "<root>");
 
     virtual std::string to_string() const override;
 

--- a/include/mitsuba/render/denoiser.h
+++ b/include/mitsuba/render/denoiser.h
@@ -1,128 +1,52 @@
-// #prsagma once
+#pragma once
 
 #include <mitsuba/core/bitmap.h>
-#include <mitsuba/core/platform.h>
+#include <mitsuba/render/fwd.h>
 #include <mitsuba/render/optix_api.h>
-#include <enoki-jit/optix.h>
-#include <enoki/array.h>
-#include <iostream>
-#include <exception>
-
-#define optix_check(call) if(call != 0) {std::cerr << "Optix call failed" << std::endl; return Float(0.0);}                  
+#include <drjit/tensor.h>
 
 NAMESPACE_BEGIN(mitsuba)
 
-template <typename Float>
-Float denoise(const Bitmap& noisy, Bitmap* albedo, Bitmap* normals) {
-    if constexpr (ek::is_array_v<Float>) {
-        OptixDeviceContext context = jit_optix_context();
+/**
+ * OptiX Denoiser
+ */
+template <typename Float, typename Spectrum>
+class MI_EXPORT_LIB Denoiser : public Object {
+public:
+    MI_IMPORT_TYPES()
 
-        OptixDenoiser denoiser = nullptr;  
-        OptixDenoiserSizes sizes = {};
-        OptixDenoiserParams params = {};
-        OptixDenoiserOptions options = {};
-        OptixDenoiserModelKind modelKind = albedo == nullptr ? OPTIX_DENOISER_MODEL_KIND_HDR : OPTIX_DENOISER_MODEL_KIND_AOV;
-        options.inputKind = albedo == nullptr ? OPTIX_DENOISER_INPUT_RGB : OPTIX_DENOISER_INPUT_RGB_ALBEDO_NORMAL;
+    Denoiser(const ScalarVector2u &input_size, bool albedo, bool normals,
+             bool temporal);
 
-        uint32_t scratch_size = 0;
-        uint32_t state_size = 0;
+    ~Denoiser();
 
-        OptixImage2D inputs[3] = {};
-        OptixImage2D output;
+    TensorXf denoise(const TensorXf &noisy, const TensorXf *albedo = nullptr,
+                      const TensorXf *normals = nullptr,
+                      const TensorXf *previous_denoised = nullptr,
+                      const TensorXf *flow = nullptr);
 
-        optix_check(optixDenoiserCreate(context, &options, &denoiser)); 
-        optix_check(optixDenoiserSetModel(denoiser, modelKind, nullptr, 0));
-        optix_check(optixDenoiserComputeMemoryResources(denoiser, noisy.width(), noisy.height(), &sizes));
-        scratch_size = static_cast<uint32_t>(sizes.withoutOverlapScratchSizeInBytes);
-        state_size = static_cast<uint32_t>(sizes.stateSizeInBytes);
-        // const uint64_t frame_size = noisy.pixel_count() * noisy.bytes_per_pixel();
+    ref<Bitmap> denoise(const ref<Bitmap> &noisy,
+                        const std::string &albedo_ch = "",
+                        const std::string &normals_ch = "",
+                        const std::string &flow_ch = "",
+                        const std::string &previous_denoised_ch = "",
+                        const std::string &noisy_ch = "<root>");
 
-        std::cout << scratch_size << std::endl;
-        std::cout << state_size << std::endl;
+    virtual std::string to_string() const override;
 
-        Float intensity_float = ek::zero<Float>(1);
-        Float scratch_float = ek::zero<Float>(scratch_size / sizeof(float));
-        Float state_float = ek::zero<Float>(state_size / sizeof(float));
-        Float output_data = ek::zero<Float>(noisy.pixel_count() * noisy.channel_count());
-        ek::eval(intensity_float, scratch_float, state_float, output_data);
-        ek::sync_thread();
+    MI_DECLARE_CLASS()
+private:
+    CUdeviceptr m_state;
+    uint32_t m_state_size;
+    CUdeviceptr m_scratch;
+    uint32_t m_scratch_size;
+    OptixDenoiserOptions m_options;
+    bool m_temporal;
+    OptixDenoiser m_denoiser;
+    CUdeviceptr m_hdr_intensity;
+    CUdeviceptr m_output_data;
+};
 
-        CUdeviceptr intensity = 0;
-        CUdeviceptr scratch = 0;
-        CUdeviceptr state = 0;
-        intensity = intensity_float.data();
-        scratch = scratch_float.data();
-        state = state_float.data();
-        output.data = output_data.data();
-
-        output.width = noisy.width();
-        output.height = noisy.height();
-        output.format = OPTIX_PIXEL_FORMAT_FLOAT4;
-        output.rowStrideInBytes = noisy.width() * noisy.bytes_per_pixel();
-        output.pixelStrideInBytes = noisy.bytes_per_pixel();
-        DynamicBuffer<Float> noisy_data = ek::load<DynamicBuffer<Float>>(noisy.data(), noisy.pixel_count() * noisy.channel_count());
-        inputs[0].data = noisy_data.data();
-        inputs[0].width = noisy.width();
-        inputs[0].height = noisy.height();
-        inputs[0].format = OPTIX_PIXEL_FORMAT_FLOAT4;
-        inputs[0].rowStrideInBytes = noisy.width() * noisy.bytes_per_pixel();
-        inputs[0].pixelStrideInBytes = noisy.bytes_per_pixel();
-
-        // std::cout << noisy.pixel_format() << std::endl;
-        // std::cout << noisy.has_alpha() << std::endl;
-        // std::cout << noisy.bytes_per_pixel() << std::endl;
-        std::cout << noisy_data << std::endl;
-        
-
-        unsigned int nb_channels = 1;
-        if(albedo != nullptr) {
-
-            DynamicBuffer<Float> albedo_data = ek::load<DynamicBuffer<Float>>(albedo->data(), albedo->pixel_count() * albedo->channel_count());
-            inputs[1].data = albedo_data.data();
-            inputs[1].width = albedo->width();
-            inputs[1].height = albedo->height();
-            inputs[1].format = OPTIX_PIXEL_FORMAT_FLOAT4;
-            inputs[1].rowStrideInBytes = albedo->width() * albedo->bytes_per_pixel();
-            inputs[1].pixelStrideInBytes = albedo->bytes_per_pixel();
-            nb_channels++;
-        }
-        if(normals != nullptr) {
-            DynamicBuffer<Float> normals_data = ek::load<DynamicBuffer<Float>>(normals->data(), normals->pixel_count() * normals->channel_count());
-            inputs[2].data = normals_data.data();
-            inputs[2].width = normals->width();
-            inputs[2].height = normals->height();
-            inputs[2].format = OPTIX_PIXEL_FORMAT_FLOAT4;
-            inputs[2].rowStrideInBytes = normals->width() * normals->bytes_per_pixel();
-            inputs[2].pixelStrideInBytes = normals->bytes_per_pixel();
-            nb_channels++;
-        }
-
-        optix_check(optixDenoiserSetup(denoiser, 0, noisy.width(), noisy.height(), state, state_size, scratch, scratch_size));
-
-        params.denoiseAlpha = 0;
-        params.hdrIntensity = intensity;
-        params.blendFactor  = 0.0f;
-
-        optix_check(optixDenoiserComputeIntensity(denoiser, 0, inputs, intensity, scratch, scratch_size)); 
-        optix_check(optixDenoiserInvoke(denoiser, 0, &params, state, state_size, inputs, nb_channels, 
-                                        0, 0, &output, scratch, scratch_size));
-
-        Float denoised_data = ek::map<Float>(output.data, noisy.pixel_count() * noisy.channel_count());
-        // Float denoised_data = ek::map<Float>(output.data, 114688);
-
-        ek::eval();
-        ek::sync_thread();
-
-        std::cout << denoised_data << std::endl;
-        optix_check(optixDenoiserDestroy(denoiser));
-        return denoised_data;
-    }
-    return Float(0.0);
-}
-
-template <typename Float>
-Float denoise (const Bitmap& noisy) {
-    return denoise<Float>(noisy, nullptr, nullptr);
-}
+MI_EXTERN_CLASS(Denoiser)
 
 NAMESPACE_END(mitsuba)

--- a/include/mitsuba/render/denoiser.h
+++ b/include/mitsuba/render/denoiser.h
@@ -20,12 +20,15 @@ public:
 
     ~Denoiser();
 
-    TensorXf denoise(const TensorXf &noisy, const TensorXf *albedo = nullptr,
+    TensorXf denoise(const TensorXf &noisy,
+                     bool denoise_alpha = true,
+                     const TensorXf *albedo = nullptr,
                      const TensorXf *normals = nullptr,
                      const TensorXf *previous_denoised = nullptr,
                      const TensorXf *flow = nullptr);
 
     ref<Bitmap> denoise(const ref<Bitmap> &noisy,
+                        bool denoise_alpha = true,
                         const std::string &albedo_ch = "",
                         const std::string &normals_ch = "",
                         const std::string &flow_ch = "",

--- a/include/mitsuba/render/fwd.h
+++ b/include/mitsuba/render/fwd.h
@@ -8,6 +8,7 @@ NAMESPACE_BEGIN(mitsuba)
 
 struct BSDFContext;
 template <typename Float, typename Spectrum> class BSDF;
+template <typename Float, typename Spectrum> class Denoiser;
 template <typename Float, typename Spectrum> class Emitter;
 template <typename Float, typename Spectrum> class Endpoint;
 template <typename Float, typename Spectrum> class Film;
@@ -81,6 +82,7 @@ template <typename Float_, typename Spectrum_> struct RenderAliases {
     using MonteCarloIntegrator   = mitsuba::MonteCarloIntegrator<FloatU, SpectrumU>;
     using AdjointIntegrator      = mitsuba::AdjointIntegrator<FloatU, SpectrumU>;
     using BSDF                   = mitsuba::BSDF<FloatU, SpectrumU>;
+    using Denoiser               = mitsuba::Denoiser<FloatU, SpectrumU>;
     using Sensor                 = mitsuba::Sensor<FloatU, SpectrumU>;
     using ProjectiveCamera       = mitsuba::ProjectiveCamera<FloatU, SpectrumU>;
     using Emitter                = mitsuba::Emitter<FloatU, SpectrumU>;
@@ -167,6 +169,7 @@ template <typename Float_, typename Spectrum_> struct RenderAliases {
     using MonteCarloIntegrator   = typename RenderAliases::MonteCarloIntegrator;                   \
     using AdjointIntegrator      = typename RenderAliases::AdjointIntegrator;                      \
     using BSDF                   = typename RenderAliases::BSDF;                                   \
+    using Denoiser               = typename RenderAliases::Denoiser;                               \
     using Sensor                 = typename RenderAliases::Sensor;                                 \
     using ProjectiveCamera       = typename RenderAliases::ProjectiveCamera;                       \
     using Emitter                = typename RenderAliases::Emitter;                                \

--- a/include/mitsuba/render/fwd.h
+++ b/include/mitsuba/render/fwd.h
@@ -8,7 +8,7 @@ NAMESPACE_BEGIN(mitsuba)
 
 struct BSDFContext;
 template <typename Float, typename Spectrum> class BSDF;
-template <typename Float, typename Spectrum> class Denoiser;
+template <typename Float, typename Spectrum> class OptixDenoiser;
 template <typename Float, typename Spectrum> class Emitter;
 template <typename Float, typename Spectrum> class Endpoint;
 template <typename Float, typename Spectrum> class Film;
@@ -82,7 +82,7 @@ template <typename Float_, typename Spectrum_> struct RenderAliases {
     using MonteCarloIntegrator   = mitsuba::MonteCarloIntegrator<FloatU, SpectrumU>;
     using AdjointIntegrator      = mitsuba::AdjointIntegrator<FloatU, SpectrumU>;
     using BSDF                   = mitsuba::BSDF<FloatU, SpectrumU>;
-    using Denoiser               = mitsuba::Denoiser<FloatU, SpectrumU>;
+    using OptixDenoiser          = mitsuba::OptixDenoiser<FloatU, SpectrumU>;
     using Sensor                 = mitsuba::Sensor<FloatU, SpectrumU>;
     using ProjectiveCamera       = mitsuba::ProjectiveCamera<FloatU, SpectrumU>;
     using Emitter                = mitsuba::Emitter<FloatU, SpectrumU>;
@@ -169,7 +169,7 @@ template <typename Float_, typename Spectrum_> struct RenderAliases {
     using MonteCarloIntegrator   = typename RenderAliases::MonteCarloIntegrator;                   \
     using AdjointIntegrator      = typename RenderAliases::AdjointIntegrator;                      \
     using BSDF                   = typename RenderAliases::BSDF;                                   \
-    using Denoiser               = typename RenderAliases::Denoiser;                               \
+    using OptixDenoiser          = typename RenderAliases::OptixDenoiser;                          \
     using Sensor                 = typename RenderAliases::Sensor;                                 \
     using ProjectiveCamera       = typename RenderAliases::ProjectiveCamera;                       \
     using Emitter                = typename RenderAliases::Emitter;                                \

--- a/include/mitsuba/render/imageblock.h
+++ b/include/mitsuba/render/imageblock.h
@@ -29,8 +29,8 @@ NAMESPACE_BEGIN(mitsuba)
  * In addition to receiving samples via the \ref put() method, the image block
  * can also be queried via the \ref read() method, in which case the
  * reconstruction filter is used to compute suitable interpolation weights.
- * This is feature is useful for differentiable rendering, where we one needs
- * to evaluate the reverse-mode derivative of the \ref put() method.
+ * This is feature is useful for differentiable rendering, where one needs to
+ * evaluate the reverse-mode derivative of the \ref put() method.
  */
 
 template <typename Float, typename Spectrum>

--- a/include/mitsuba/render/optix_api.h
+++ b/include/mitsuba/render/optix_api.h
@@ -25,7 +25,7 @@ using OptixAccelPropertyType = int;
 using OptixProgramGroupKind  = int;
 using OptixDeviceContext     = void*;
 using OptixTask              = void*;
-using OptixDenoiser          = void*;
+using OptixDenoiserStructPtr = void*;
 
 // =====================================================
 //            Commonly used OptiX constants
@@ -317,17 +317,17 @@ D(optixSbtRecordPackHeader, OptixProgramGroup, void *);
 D(optixAccelCompact, OptixDeviceContext, CUstream, OptixTraversableHandle,
   CUdeviceptr, size_t, OptixTraversableHandle *);
 D(optixDenoiserCreate, OptixDeviceContext, OptixDenoiserModelKind,
-  const OptixDenoiserOptions *, OptixDenoiser *);
-D(optixDenoiserDestroy, OptixDenoiser);
-D(optixDenoiserComputeMemoryResources, const OptixDenoiser, unsigned int,
-  unsigned int, OptixDenoiserSizes *);
-D(optixDenoiserSetup, OptixDenoiser, CUstream, unsigned int, unsigned int,
-  CUdeviceptr, size_t, CUdeviceptr, size_t);
-D(optixDenoiserInvoke, OptixDenoiser, CUstream, const OptixDenoiserParams *,
-  CUdeviceptr, size_t, const OptixDenoiserGuideLayer *,
-  const OptixDenoiserLayer *, unsigned int, unsigned int, unsigned int,
-  CUdeviceptr, size_t);
-D(optixDenoiserComputeIntensity, OptixDenoiser, CUstream,
+  const OptixDenoiserOptions *, OptixDenoiserStructPtr *);
+D(optixDenoiserDestroy, OptixDenoiserStructPtr);
+D(optixDenoiserComputeMemoryResources, const OptixDenoiserStructPtr,
+  unsigned int, unsigned int, OptixDenoiserSizes *);
+D(optixDenoiserSetup, OptixDenoiserStructPtr, CUstream, unsigned int,
+  unsigned int, CUdeviceptr, size_t, CUdeviceptr, size_t);
+D(optixDenoiserInvoke, OptixDenoiserStructPtr, CUstream,
+  const OptixDenoiserParams *, CUdeviceptr, size_t,
+  const OptixDenoiserGuideLayer *, const OptixDenoiserLayer *, unsigned int, 
+  unsigned int, unsigned int, CUdeviceptr, size_t);
+D(optixDenoiserComputeIntensity, OptixDenoiserStructPtr, CUstream,
   const OptixImage2D *inputImage, CUdeviceptr, CUdeviceptr, size_t);
 
 #undef D

--- a/include/mitsuba/render/optix_api.h
+++ b/include/mitsuba/render/optix_api.h
@@ -25,6 +25,7 @@ using OptixAccelPropertyType = int;
 using OptixProgramGroupKind  = int;
 using OptixDeviceContext     = void*;
 using OptixTask              = void*;
+using OptixDenoiser          = void*;
 
 // =====================================================
 //            Commonly used OptiX constants
@@ -204,7 +205,6 @@ struct OptixProgramGroupHitgroup {
 struct OptixProgramGroupDesc {
     OptixProgramGroupKind kind;
     unsigned int flags;
-
     union {
         OptixProgramGroupSingleModule raygen;
         OptixProgramGroupSingleModule miss;
@@ -231,118 +231,60 @@ struct OptixShaderBindingTable {
     unsigned int callablesRecordCount;
 };
 
-/// Various sizes related to the denoiser.
-///
-/// \see #optixDenoiserComputeMemoryResources()
-struct OptixDenoiserSizes
-{
-    size_t       stateSizeInBytes;
-    size_t       withOverlapScratchSizeInBytes;
-    size_t       withoutOverlapScratchSizeInBytes;
+enum OptixPixelFormat {
+    OPTIX_PIXEL_FORMAT_HALF2  = 0x2207,
+    OPTIX_PIXEL_FORMAT_HALF3  = 0x2201,
+    OPTIX_PIXEL_FORMAT_HALF4  = 0x2202,
+    OPTIX_PIXEL_FORMAT_FLOAT2 = 0x2208,
+    OPTIX_PIXEL_FORMAT_FLOAT3 = 0x2203,
+    OPTIX_PIXEL_FORMAT_FLOAT4 = 0x2204,
+    OPTIX_PIXEL_FORMAT_UCHAR3 = 0x2205,
+    OPTIX_PIXEL_FORMAT_UCHAR4 = 0x2206
+};
+
+struct OptixImage2D {
+    CUdeviceptr data;
+    unsigned int width;
+    unsigned int height;
+    unsigned int rowStrideInBytes;
+    unsigned int pixelStrideInBytes;
+    OptixPixelFormat format;
+};
+
+enum OptixDenoiserModelKind {
+    OPTIX_DENOISER_MODEL_KIND_HDR = 0x2323,
+    OPTIX_DENOISER_MODEL_KIND_TEMPORAL = 0x2325
+};
+
+struct OptixDenoiserOptions {
+    unsigned int guideAlbedo;
+    unsigned int guideNormal;
+};
+
+struct OptixDenoiserSizes {
+    size_t stateSizeInBytes;
+    size_t withOverlapScratchSizeInBytes;
+    size_t withoutOverlapScratchSizeInBytes;
     unsigned int overlapWindowSizeInPixels;
 };
 
-/// Various parameters used by the denoiser
-///
-/// \see #optixDenoiserInvoke()
-/// \see #optixDenoiserComputeIntensity()
-/// \see #optixDenoiserComputeAverageColor()
-struct OptixDenoiserParams
-{
-    /// if set to nonzero value, denoise alpha channel (if present) in first inputLayer image
+struct OptixDenoiserParams {
     unsigned int denoiseAlpha;
-
-    /// average log intensity of input image (default null pointer). points to a single float.
-    /// with the default (null pointer) denoised results will not be optimal for very dark or
-    /// bright input images.
-    CUdeviceptr  hdrIntensity;
-
-    /// blend factor.
-    /// If set to 0 the output is 100% of the denoised input. If set to 1, the output is 100% of
-    /// the unmodified input. Values between 0 and 1 will linearly interpolate between the denoised
-    /// and unmodified input.
-    float        blendFactor;
-
-    /// this parameter is used when the OPTIX_DENOISER_MODEL_KIND_AOV model kind is set.
-    /// average log color of input image, separate for RGB channels (default null pointer).
-    /// points to three floats. with the default (null pointer) denoised results will not be
-    /// optimal.
-    CUdeviceptr  hdrAverageColor;
+    CUdeviceptr hdrIntensity;
+    float blendFactor;
+    CUdeviceptr hdrAverageColor;
 };
 
-/// Input kinds used by the denoiser.
-///
-/// RGB(A) values less than zero will be clamped to zero.
-/// Albedo values must be in the range [0..1] (values less than zero will be clamped to zero).
-/// The normals must be transformed into screen space. The z component is not used.
-/// \see #OptixDenoiserOptions::inputKind
-enum OptixDenoiserInputKind
-{
-    OPTIX_DENOISER_INPUT_RGB               = 0x2301,
-    OPTIX_DENOISER_INPUT_RGB_ALBEDO        = 0x2302,
-    OPTIX_DENOISER_INPUT_RGB_ALBEDO_NORMAL = 0x2303,
+struct OptixDenoiserGuideLayer {
+    OptixImage2D albedo;
+    OptixImage2D normal;
+    OptixImage2D flow;
 };
 
-/// Model kind used by the denoiser.
-///
-/// \see #optixDenoiserSetModel()
-enum OptixDenoiserModelKind
-{
-    /// Use the model provided by the associated pointer.  See the programming guide for a
-    /// description of how to format the data.
-    OPTIX_DENOISER_MODEL_KIND_USER = 0x2321,
-
-    /// Use the built-in model appropriate for low dynamic range input.
-    OPTIX_DENOISER_MODEL_KIND_LDR = 0x2322,
-
-    /// Use the built-in model appropriate for high dynamic range input.
-    OPTIX_DENOISER_MODEL_KIND_HDR = 0x2323,
-
-    /// Use the built-in model appropriate for high dynamic range input and support for AOVs
-    OPTIX_DENOISER_MODEL_KIND_AOV = 0x2324,
-
-};
-
-/// Options used by the denoiser
-///
-/// \see #optixDenoiserCreate()
-struct OptixDenoiserOptions
-{
-    /// The kind of denoiser input.
-    OptixDenoiserInputKind inputKind;
-};
-
-/// Pixel formats used by the denoiser.
-///
-/// \see #OptixImage2D::format
-enum OptixPixelFormat
-{
-    OPTIX_PIXEL_FORMAT_HALF3  = 0x2201,  ///< three halfs, RGB
-    OPTIX_PIXEL_FORMAT_HALF4  = 0x2202,  ///< four halfs, RGBA
-    OPTIX_PIXEL_FORMAT_FLOAT3 = 0x2203,  ///< three floats, RGB
-    OPTIX_PIXEL_FORMAT_FLOAT4 = 0x2204,  ///< four floats, RGBA
-    OPTIX_PIXEL_FORMAT_UCHAR3 = 0x2205,  ///< three unsigned chars, RGB
-    OPTIX_PIXEL_FORMAT_UCHAR4 = 0x2206   ///< four unsigned chars, RGBA
-};
-
-/// Image descriptor used by the denoiser.
-///
-/// \see #optixDenoiserInvoke(), #optixDenoiserComputeIntensity()
-struct OptixImage2D
-{
-    /// Pointer to the actual pixel data.
-    CUdeviceptr data;
-    /// Width of the image (in pixels)
-    unsigned int width;
-    /// Height of the image (in pixels)
-    unsigned int height;
-    /// Stride between subsequent rows of the image (in bytes).
-    unsigned int rowStrideInBytes;
-    /// Stride between subsequent pixels of the image (in bytes).
-    /// For now, only 0 or the value that corresponds to a dense packing of pixels (no gaps) is supported.
-    unsigned int pixelStrideInBytes;
-    /// Pixel format.
-    OptixPixelFormat format;
+struct OptixDenoiserLayer {
+    OptixImage2D input;
+    OptixImage2D previousOutput;
+    OptixImage2D output;
 };
 
 // =====================================================
@@ -374,6 +316,19 @@ D(optixProgramGroupDestroy, OptixProgramGroup);
 D(optixSbtRecordPackHeader, OptixProgramGroup, void *);
 D(optixAccelCompact, OptixDeviceContext, CUstream, OptixTraversableHandle,
   CUdeviceptr, size_t, OptixTraversableHandle *);
+D(optixDenoiserCreate, OptixDeviceContext, OptixDenoiserModelKind,
+  const OptixDenoiserOptions *, OptixDenoiser *);
+D(optixDenoiserDestroy, OptixDenoiser);
+D(optixDenoiserComputeMemoryResources, const OptixDenoiser, unsigned int,
+  unsigned int, OptixDenoiserSizes *);
+D(optixDenoiserSetup, OptixDenoiser, CUstream, unsigned int, unsigned int,
+  CUdeviceptr, size_t, CUdeviceptr, size_t);
+D(optixDenoiserInvoke, OptixDenoiser, CUstream, const OptixDenoiserParams *,
+  CUdeviceptr, size_t, const OptixDenoiserGuideLayer *,
+  const OptixDenoiserLayer *, unsigned int, unsigned int, unsigned int,
+  CUdeviceptr, size_t);
+D(optixDenoiserComputeIntensity, OptixDenoiser, CUstream,
+  const OptixImage2D *inputImage, CUdeviceptr, CUdeviceptr, size_t);
 
 #undef D
 

--- a/include/mitsuba/render/optixdenoiser.h
+++ b/include/mitsuba/render/optixdenoiser.h
@@ -31,7 +31,7 @@ public:
                         bool denoise_alpha = true,
                         const TensorXf *albedo = nullptr,
                         const TensorXf *normals = nullptr,
-                        const Transform4f *n_frame = nullptr,
+                        const Transform4f *normals_transform = nullptr,
                         const TensorXf *flow = nullptr,
                         const TensorXf *previous_denoised = nullptr) const;
 

--- a/include/mitsuba/render/optixdenoiser.h
+++ b/include/mitsuba/render/optixdenoiser.h
@@ -11,13 +11,37 @@
 NAMESPACE_BEGIN(mitsuba)
 
 /**
- * OptiX Denoiser
+ * \brief Wrapper for the OptiX AI denoiser
+ *
+ * The OptiX AI denoiser is wrapped in this object such that it can work
+ * directly with Mitsuba types and its conventions.
+ * 
+ * The denoiser works best when applied to noisy renderings that were produced
+ * with a \ref Film which used the `box` \ref ReconstructionFilter. With a
+ * filter that spans multiple pixels, the denoiser might identify some local
+ * variance as a feature of the scene and will not denoise it.
  */
 template <typename Float, typename Spectrum>
 class MI_EXPORT_LIB OptixDenoiser : public Object {
 public:
     MI_IMPORT_TYPES()
 
+    /**
+     * \brief Constructs an OptiX denoiser
+     *
+     * \param input_size
+     *      Resolution of noisy images that will be fed to the denoiser.
+     *
+     * \param albedo
+     *      Whether or not albedo information will also be given to the
+     *      denoiser.
+     *
+     * \param normals
+     *      Whether or not shading normals information will also be given to the
+     *      Denoiser.
+     *
+     * \return A callable object which will apply the OptiX denoiser.
+     */
     OptixDenoiser(const ScalarVector2u &input_size, bool albedo, bool normals,
              bool temporal);
 
@@ -27,6 +51,47 @@ public:
 
     ~OptixDenoiser();
 
+    /**
+     * \brief Apply denoiser on inputs which are \ref TensorXf objects.
+     *
+     * \param noisy
+     *      The noisy input. (tensor shape: (width, height, 3 | 4))
+     *
+     * \param denoise_alpha
+     *      Whether or not the alpha channel (if specified in the noisy input)
+     *      should be denoised too.
+     *
+     * \param albedo
+     *      Albedo information of the noisy rendering.
+     *      (tensor shape: (width, height, 3))
+     *
+     * \param normals
+     *      Shading normal information of the noisy rendering. The normals must
+     *      be in the coordinate frame of the sensor which was used to render
+     *      the noisy input. (tensor shape: (width, height, 3))
+     *
+     * \param normals_transform
+     *      A \ref Transform4f which is applied to the \c normals parameter
+     *      before denoising. This should be used to tranform the normals into
+     *      the correct coordinate frame.
+     *
+     * \param flow
+     *      With temporal denoising, this parameter is the optical flow between
+     *      the previous frame and the current one. It should capture the 2D
+     *      motion of each individual pixel.
+     *      When this parameter is unknown, it can been set to a
+     *      zero-initialized TensorXf of the correct size and still produce
+     *      convincing results. (tensor shape: (width, height, 2))
+     *
+     * \param previous_denoised
+     *      With temporal denoising, the previous denoised frame should be
+     *      passed here.
+     *      For the very first frame, the OptiX documentation recommends
+     *      passing the noisy input for this argument.
+     *      (tensor shape: (width, height, 3 | 4))
+     *
+     * \return The denoised input.
+     */
     TensorXf operator()(const TensorXf &noisy,
                         bool denoise_alpha = true,
                         const TensorXf *albedo = nullptr,
@@ -35,6 +100,54 @@ public:
                         const TensorXf *flow = nullptr,
                         const TensorXf *previous_denoised = nullptr) const;
 
+    /**
+     * \brief Apply denoiser on inputs which are \ref Bitmap objects.
+     *
+     * \param noisy
+     *      The noisy input. When passing additional information like albedo or
+     *      normals to the denoiser, this \ref Bitmap object must be a \ref
+     *      MultiChannel bitmap.
+     *
+     * \param denoise_alpha
+     *      Whether or not the alpha channel (if specified in the noisy input)
+     *      should be denoised too.
+     *
+     * \param albedo_ch
+     *      The name of the channel in the \c noisy parameter which contains
+     *      the albedo information of the noisy rendering.
+     *
+     * \param normals_ch
+     *      The name of the channel in the \c noisy parameter which contains
+     *      the shading normal information of the noisy rendering.
+     *      The normals must be in the coordinate frame of the sensor which was
+     *      used to render the noisy input.
+     *
+     * \param normals_transform
+     *      A \ref Transform4f which is applied to the \c normals parameter
+     *      before denoising. This should be used to tranform the normals into
+     *      the correct coordinate frame.
+     *
+     * \param flow_ch
+     *      With temporal denoising, this parameter is name of the channel in
+     *      the \c noisy parameter which contains the optical flow between
+     *      the previous frame and the current one. It should capture the 2D
+     *      motion of each individual pixel.
+     *      When this parameter is unknown, it can been set to a
+     *      zero-initialized TensorXf of the correct size and still produce
+     *      convincing results.
+     *
+     * \param previous_denoised_ch
+     *      With temporal denoising, this parameter is name of the channel in
+     *      the \c noisy parameter which contains the previous denoised frame.
+     *      For the very first frame, the OptiX documentation recommends
+     *      passing the noisy input for this argument.
+     *
+     * \param noisy_ch
+     *      The name of the channel in the \c noisy parameter which contains
+     *      the shading normal information of the noisy rendering.
+     *
+     * \return The denoised input.
+     */
     ref<Bitmap> operator()(const ref<Bitmap> &noisy,
                            bool denoise_alpha = true,
                            const std::string &albedo_ch = "",
@@ -48,7 +161,15 @@ public:
 
     MI_DECLARE_CLASS()
 private:
+    /// Helper function to inialize an OptixDenoiserStructPtr object
     void init(const ScalarVector2u &input_size, bool temporal);
+
+    /// Helper function to validate tensor sizes
+    void validate_input(const TensorXf &noisy,
+                        const TensorXf *albedo,
+                        const TensorXf *normals,
+                        const TensorXf *flow,
+                        const TensorXf *previous_denoised) const;
 
     ScalarVector2u m_input_size;
     CUdeviceptr m_state;

--- a/include/mitsuba/render/optixdenoiser.h
+++ b/include/mitsuba/render/optixdenoiser.h
@@ -1,6 +1,9 @@
 #pragma once
 
+#if defined(MI_ENABLE_CUDA)
+
 #include <mitsuba/core/bitmap.h>
+#include <mitsuba/core/transform.h>
 #include <mitsuba/render/fwd.h>
 #include <mitsuba/render/optix_api.h>
 #include <drjit/tensor.h>
@@ -11,14 +14,14 @@ NAMESPACE_BEGIN(mitsuba)
  * OptiX Denoiser
  */
 template <typename Float, typename Spectrum>
-class MI_EXPORT_LIB Denoiser : public Object {
+class MI_EXPORT_LIB OptixDenoiser : public Object {
 public:
     MI_IMPORT_TYPES()
 
-    Denoiser(const ScalarVector2u &input_size, bool albedo, bool normals,
+    OptixDenoiser(const ScalarVector2u &input_size, bool albedo, bool normals,
              bool temporal);
 
-    ~Denoiser();
+    ~OptixDenoiser();
 
     TensorXf operator()(const TensorXf &noisy,
                         bool denoise_alpha = true,
@@ -46,11 +49,13 @@ private:
     uint32_t m_scratch_size;
     OptixDenoiserOptions m_options;
     bool m_temporal;
-    OptixDenoiser m_denoiser;
+    OptixDenoiserStructPtr m_denoiser;
     CUdeviceptr m_hdr_intensity;
     CUdeviceptr m_output_data;
 };
 
-MI_EXTERN_CLASS(Denoiser)
+MI_EXTERN_CLASS(OptixDenoiser)
 
 NAMESPACE_END(mitsuba)
+
+#endif // defined(MI_ENABLE_CUDA)

--- a/include/mitsuba/render/optixdenoiser.h
+++ b/include/mitsuba/render/optixdenoiser.h
@@ -21,27 +21,35 @@ public:
     OptixDenoiser(const ScalarVector2u &input_size, bool albedo, bool normals,
              bool temporal);
 
+    OptixDenoiser(const OptixDenoiser &other) = delete;
+
+    OptixDenoiser& operator=(const OptixDenoiser &other) = delete;
+
     ~OptixDenoiser();
 
     TensorXf operator()(const TensorXf &noisy,
                         bool denoise_alpha = true,
                         const TensorXf *albedo = nullptr,
                         const TensorXf *normals = nullptr,
-                        const TensorXf *previous_denoised = nullptr,
-                        const TensorXf *flow = nullptr);
+                        const Transform4f *n_frame = nullptr,
+                        const TensorXf *flow = nullptr,
+                        const TensorXf *previous_denoised = nullptr) const;
 
     ref<Bitmap> operator()(const ref<Bitmap> &noisy,
                            bool denoise_alpha = true,
                            const std::string &albedo_ch = "",
                            const std::string &normals_ch = "",
+                           const Transform4f &n_frame = Transform4f(),
                            const std::string &flow_ch = "",
                            const std::string &previous_denoised_ch = "",
-                           const std::string &noisy_ch = "<root>");
+                           const std::string &noisy_ch = "<root>") const;
 
     virtual std::string to_string() const override;
 
     MI_DECLARE_CLASS()
 private:
+    void init(const ScalarVector2u &input_size, bool temporal);
+
     ScalarVector2u m_input_size;
     CUdeviceptr m_state;
     uint32_t m_state_size;
@@ -51,7 +59,6 @@ private:
     bool m_temporal;
     OptixDenoiserStructPtr m_denoiser;
     CUdeviceptr m_hdr_intensity;
-    CUdeviceptr m_output_data;
 };
 
 MI_EXTERN_CLASS(OptixDenoiser)

--- a/resources/generate_stub_files.py
+++ b/resources/generate_stub_files.py
@@ -78,9 +78,10 @@ def process_type_hint(s):
         end = begin + result[begin:].index('>')
 
         new_default_value = result[begin:end]
-        new_default_value = new_default_value[:new_default_value.index(':')]
+        if ':' in new_default_value:
+            new_default_value = new_default_value[:new_default_value.index(':')]
+            result = result[:begin - 1] + new_default_value + result[end + 1:]
 
-        result = result[:begin - 1] + new_default_value + result[end + 1:]
         enum_match = default_enum_re.search(result, begin)
 
     return result

--- a/src/bsdfs/blendbsdf.cpp
+++ b/src/bsdfs/blendbsdf.cpp
@@ -217,6 +217,13 @@ public:
         return dr::clamp(m_weight->eval_1(si, active), 0.f, 1.f);
     }
 
+    Spectrum eval_diffuse_reflectance(const SurfaceInteraction3f &si,
+                                     Mask active) const override {
+        Float weight = eval_weight(si, active);
+        return m_nested_bsdf[0]->eval_diffuse_reflectance(si, active) * (1 - weight) +
+               m_nested_bsdf[1]->eval_diffuse_reflectance(si, active) * weight;
+    }
+
     std::string to_string() const override {
         std::ostringstream oss;
         oss << "BlendBSDF[" << std::endl

--- a/src/bsdfs/bumpmap.cpp
+++ b/src/bsdfs/bumpmap.cpp
@@ -221,6 +221,11 @@ public:
         return result;
     }
 
+    Spectrum eval_diffuse_reflectance(const SurfaceInteraction3f &si,
+                                      Mask active) const override {
+        return m_nested_bsdf->eval_diffuse_reflectance(si, active);
+    }
+
     std::string to_string() const override {
         std::ostringstream oss;
         oss << "BumpMap[" << std::endl

--- a/src/bsdfs/circular.cpp
+++ b/src/bsdfs/circular.cpp
@@ -149,6 +149,11 @@ public:
         }
     }
 
+    Spectrum eval_diffuse_reflectance(const SurfaceInteraction3f &si,
+                                      Mask active) const override {
+        return m_transmittance->eval(si, active);
+    }
+
     std::string to_string() const override {
         std::ostringstream oss;
         oss << "CircularPolarizer[" << std::endl

--- a/src/bsdfs/diffuse.cpp
+++ b/src/bsdfs/diffuse.cpp
@@ -178,6 +178,11 @@ public:
 
         return { depolarizer<Spectrum>(value) & active, dr::select(active, pdf, 0.f) };
     }
+ 
+    /// Return the diffuse reflectance value (if any)
+    Spectrum get_diffuse_reflectance(const SurfaceInteraction3f &si, Mask active) const override {
+        return m_reflectance->eval(si, active);
+    }
 
     std::string to_string() const override {
         std::ostringstream oss;

--- a/src/bsdfs/diffuse.cpp
+++ b/src/bsdfs/diffuse.cpp
@@ -178,7 +178,7 @@ public:
 
         return { depolarizer<Spectrum>(value) & active, dr::select(active, pdf, 0.f) };
     }
- 
+
     /// Return the diffuse reflectance value (if any)
     Spectrum get_diffuse_reflectance(const SurfaceInteraction3f &si, Mask active) const override {
         return m_reflectance->eval(si, active);

--- a/src/bsdfs/diffuse.cpp
+++ b/src/bsdfs/diffuse.cpp
@@ -179,8 +179,8 @@ public:
         return { depolarizer<Spectrum>(value) & active, dr::select(active, pdf, 0.f) };
     }
 
-    /// Return the diffuse reflectance value (if any)
-    Spectrum get_diffuse_reflectance(const SurfaceInteraction3f &si, Mask active) const override {
+    Spectrum eval_diffuse_reflectance(const SurfaceInteraction3f &si,
+                                      Mask active) const override {
         return m_reflectance->eval(si, active);
     }
 

--- a/src/bsdfs/mask.cpp
+++ b/src/bsdfs/mask.cpp
@@ -220,6 +220,11 @@ public:
         return dr::clamp(m_opacity->eval_1(si, active), 0.f, 1.f);
     }
 
+    Spectrum eval_diffuse_reflectance(const SurfaceInteraction3f &si,
+                                      Mask active) const override {
+        return m_nested_bsdf->eval_diffuse_reflectance(si, active);
+    }
+
     std::string to_string() const override {
         std::ostringstream oss;
         oss << "Mask[" << std::endl

--- a/src/bsdfs/plastic.cpp
+++ b/src/bsdfs/plastic.cpp
@@ -360,6 +360,10 @@ public:
                  dr::select(active, hemi_pdf * prob_diffuse, 0.f) };
     }
 
+    Spectrum get_diffuse_reflectance(const SurfaceInteraction3f &si, Mask active) const override {
+        return m_diffuse_reflectance->eval(si, active);
+    }
+
     std::string to_string() const override {
         std::ostringstream oss;
         oss << "SmoothPlastic[" << std::endl

--- a/src/bsdfs/plastic.cpp
+++ b/src/bsdfs/plastic.cpp
@@ -360,7 +360,8 @@ public:
                  dr::select(active, hemi_pdf * prob_diffuse, 0.f) };
     }
 
-    Spectrum get_diffuse_reflectance(const SurfaceInteraction3f &si, Mask active) const override {
+    Spectrum eval_diffuse_reflectance(const SurfaceInteraction3f &si,
+                                      Mask active) const override {
         return m_diffuse_reflectance->eval(si, active);
     }
 

--- a/src/bsdfs/principled.cpp
+++ b/src/bsdfs/principled.cpp
@@ -837,6 +837,11 @@ public:
         return pdf;
     }
 
+    Spectrum eval_diffuse_reflectance(const SurfaceInteraction3f &si,
+                                      Mask active) const override {
+        return m_base_color->eval(si, active);
+    }
+
     std::string to_string() const override {
         std::ostringstream oss;
         oss << "Principled BSDF :" << std::endl

--- a/src/bsdfs/principledthin.cpp
+++ b/src/bsdfs/principledthin.cpp
@@ -707,6 +707,11 @@ public:
         return pdf;
     }
 
+    Spectrum eval_diffuse_reflectance(const SurfaceInteraction3f &si,
+                                      Mask active) const override {
+        return m_base_color->eval(si, active);
+    }
+
     std::string to_string() const override {
         std::ostringstream oss;
         oss << "The Thin Principled BSDF :" << std::endl

--- a/src/bsdfs/roughplastic.cpp
+++ b/src/bsdfs/roughplastic.cpp
@@ -501,6 +501,11 @@ public:
         return { depolarizer<Spectrum>(value) & active, pdf };
     }
 
+    /// Return the diffuse reflectance value (if any)
+    Spectrum get_diffuse_reflectance(const SurfaceInteraction3f &si, Mask active) const override {
+        return m_diffuse_reflectance->eval(si, active);
+    }
+
     std::string to_string() const override {
         std::ostringstream oss;
         oss << "RoughPlastic[" << std::endl

--- a/src/bsdfs/roughplastic.cpp
+++ b/src/bsdfs/roughplastic.cpp
@@ -501,8 +501,8 @@ public:
         return { depolarizer<Spectrum>(value) & active, pdf };
     }
 
-    /// Return the diffuse reflectance value (if any)
-    Spectrum get_diffuse_reflectance(const SurfaceInteraction3f &si, Mask active) const override {
+    Spectrum eval_diffuse_reflectance(const SurfaceInteraction3f &si,
+                                      Mask active) const override {
         return m_diffuse_reflectance->eval(si, active);
     }
 

--- a/src/bsdfs/tests/test_twosided.py
+++ b/src/bsdfs/tests/test_twosided.py
@@ -91,3 +91,46 @@ def test03_sample_eval_pdf(variant_scalar_rgb):
                         v_eval_pdf = bsdf.eval_pdf(ctx, si, bs.wo)
                         assert dr.allclose(e_value, v_eval_pdf[0])
                         assert dr.allclose(p_pdf, v_eval_pdf[1])
+
+def test03_eval_diffuse_reflectance(variants_vec_rgb):
+    bsdf_front = mi.load_dict({
+        'type': 'diffuse',
+        'reflectance': {
+            'type': 'rgb',
+            'value': [0.1, 0.1, 0.1]
+        }
+    })
+    bsdf_back = mi.load_dict({
+        'type': 'diffuse',
+        'reflectance': {
+            'type': 'rgb',
+            'value': [0.9, 0.9, 0.9]
+        }
+    })
+    bsdf = mi.load_dict({
+        'type': 'twosided',
+        'a': bsdf_front,
+        'b': bsdf_back,
+    })
+
+    si = mi.SurfaceInteraction3f()
+    si.t = 0.1
+    si.p = [0, 0, 0]
+    si.n = [0, 0, 1]
+    si.sh_frame = mi.Frame3f(si.n)
+
+    n = 5
+    epsilon = 0.0001
+    for u in dr.linspace(mi.Float, epsilon, 1 - epsilon, n):
+        for v in dr.linspace(mi.Float, epsilon, 1 - epsilon, n):
+            si.wi = mi.warp.square_to_uniform_sphere([u / float(n-1),
+                                                      v / float(n-1)])
+            up = mi.Frame3f.cos_theta(si.wi) > 0.0
+
+            value = bsdf.eval_diffuse_reflectance(si)
+            value_front = bsdf_front.eval_diffuse_reflectance(si)
+            si.wi.z *= -1
+            value_back = bsdf_back.eval_diffuse_reflectance(si)
+
+            assert dr.allclose(dr.select(up, value - value_front, 0), 0.0)
+            assert dr.allclose(dr.select(up, 0, value - value_back), 0.0)

--- a/src/core/tests/test_bitmap.py
+++ b/src/core/tests/test_bitmap.py
@@ -5,15 +5,7 @@ import pytest
 import drjit as dr
 import mitsuba as mi
 
-def find_resource(fname):
-    path = os.path.dirname(os.path.realpath(__file__))
-    while True:
-        full = os.path.join(path, fname)
-        if os.path.exists(full):
-            return full
-        if path == '' or path == '/':
-            raise Exception("find_resource(): could not find \"%s\"" % fname)
-        path = os.path.dirname(path)
+from mitsuba.scalar_rgb.test.util import find_resource
 
 
 def test_read_convert_yc(variant_scalar_rgb, tmpdir):

--- a/src/integrators/aov.cpp
+++ b/src/integrators/aov.cpp
@@ -1,3 +1,4 @@
+#include <mitsuba/render/bsdf.h>
 #include <mitsuba/render/integrator.h>
 #include <mitsuba/render/records.h>
 
@@ -61,6 +62,7 @@ output file.
 
 Currently, the following AOVs types are available:
 
+    - :monosp:`albedo`: Albedo (diffuse reflectance) of the material.
     - :monosp:`depth`: Distance from the pinhole.
     - :monosp:`position`: World space position value.
     - :monosp:`uv`: UV coordinates.
@@ -82,9 +84,10 @@ template <typename Float, typename Spectrum>
 class AOVIntegrator final : public SamplingIntegrator<Float, Spectrum> {
 public:
     MI_IMPORT_BASE(SamplingIntegrator)
-    MI_IMPORT_TYPES(Scene, Sampler, Medium)
+    MI_IMPORT_TYPES(Scene, Sampler, Medium, BSDFPtr)
 
     enum class Type {
+        Albedo,
         Depth,
         Position,
         UV,
@@ -109,7 +112,12 @@ public:
             if (item.size() != 2 || item[0].empty() || item[1].empty())
                 Log(Warn, "Invalid AOV specification: require <name>:<type> pair");
 
-            if (item[1] == "depth") {
+            if (item[1] == "albedo") {
+                m_aov_types.push_back(Type::Albedo);
+                m_aov_names.push_back(item[0] + ".R");
+                m_aov_names.push_back(item[0] + ".G");
+                m_aov_names.push_back(item[0] + ".B");
+            } else if (item[1] == "depth") {
                 m_aov_types.push_back(Type::Depth);
                 m_aov_names.push_back(item[0] + ".T");
             } else if (item[1] == "position") {
@@ -199,6 +207,19 @@ public:
 
         for (size_t i = 0; i < m_aov_types.size(); ++i) {
             switch (m_aov_types[i]) {
+                case Type::Albedo: {
+                        BSDFPtr bsdf = si.bsdf(ray);
+                        Spectrum spec = bsdf->get_diffuse_reflectance(si, active);
+                        Color3f color;
+                        if constexpr (is_spectral_v<Spectrum>)
+                            color = spectrum_to_srgb(spec, ray.wavelengths, active);
+                        else
+                            color = spec;
+                        *aovs++ = color.r();
+                        *aovs++ = color.g();
+                        *aovs++ = color.b();
+                    }
+                    break;
                 case Type::Depth:
                     *aovs++ = dr::select(si.is_valid(), si.t, 0.f);
                     break;

--- a/src/integrators/aov.cpp
+++ b/src/integrators/aov.cpp
@@ -78,6 +78,9 @@ Note that integer-valued AOVs (e.g. :monosp:`prim_index`, :monosp:`shape_index`)
 are meaningless whenever there is only partial pixel coverage or when using a
 wide pixel reconstruction filter as it will result in fractional values.
 
+The :monosp:`albedo` AOV will evaluate the diffuse reflectance
+(\ref BSDF::eval_diffuse_reflectance) of the material. Note that depending on
+the material, this value might only be an approximation.
  */
 
 template <typename Float, typename Spectrum>
@@ -209,7 +212,7 @@ public:
             switch (m_aov_types[i]) {
                 case Type::Albedo: {
                         BSDFPtr bsdf = si.bsdf(ray);
-                        Spectrum spec = bsdf->get_diffuse_reflectance(si, active);
+                        Spectrum spec = bsdf->eval_diffuse_reflectance(si, active);
                         Color3f color;
                         if constexpr (is_spectral_v<Spectrum>)
                             color = spectrum_to_srgb(spec, ray.wavelengths, active);

--- a/src/python/main_v.cpp
+++ b/src/python/main_v.cpp
@@ -84,6 +84,7 @@ MI_PY_DECLARE(quad);
 // render
 MI_PY_DECLARE(BSDFSample);
 MI_PY_DECLARE(BSDF);
+MI_PY_DECLARE(denoiser);
 MI_PY_DECLARE(Emitter);
 MI_PY_DECLARE(Endpoint);
 MI_PY_DECLARE(Film);
@@ -185,6 +186,7 @@ PYBIND11_MODULE(MODULE_NAME, m) {
     MI_PY_IMPORT(DirectionSample);
     MI_PY_IMPORT(BSDFSample);
     MI_PY_IMPORT(BSDF);
+    MI_PY_IMPORT(denoiser);
     MI_PY_IMPORT(Film);
     MI_PY_IMPORT(fresnel);
     MI_PY_IMPORT(ImageBlock);

--- a/src/python/main_v.cpp
+++ b/src/python/main_v.cpp
@@ -84,9 +84,6 @@ MI_PY_DECLARE(quad);
 // render
 MI_PY_DECLARE(BSDFSample);
 MI_PY_DECLARE(BSDF);
-#if defined(MI_ENABLE_CUDA)
-MI_PY_DECLARE(OptixDenoiser);
-#endif // defined(MI_ENABLE_CUDA)
 MI_PY_DECLARE(Emitter);
 MI_PY_DECLARE(Endpoint);
 MI_PY_DECLARE(Film);
@@ -100,6 +97,9 @@ MI_PY_DECLARE(PreliminaryIntersection);
 MI_PY_DECLARE(Medium);
 MI_PY_DECLARE(mueller);
 MI_PY_DECLARE(MicrofacetDistribution);
+#if defined(MI_ENABLE_CUDA)
+MI_PY_DECLARE(OptixDenoiser);
+#endif // defined(MI_ENABLE_CUDA)
 MI_PY_DECLARE(PositionSample);
 MI_PY_DECLARE(PhaseFunction);
 MI_PY_DECLARE(DirectionSample);
@@ -188,15 +188,15 @@ PYBIND11_MODULE(MODULE_NAME, m) {
     MI_PY_IMPORT(DirectionSample);
     MI_PY_IMPORT(BSDFSample);
     MI_PY_IMPORT(BSDF);
-#if defined(MI_ENABLE_CUDA)
-    MI_PY_IMPORT(OptixDenoiser);
-#endif // defined(MI_ENABLE_CUDA)
     MI_PY_IMPORT(Film);
     MI_PY_IMPORT(fresnel);
     MI_PY_IMPORT(ImageBlock);
     MI_PY_IMPORT(Integrator);
     MI_PY_IMPORT_SUBMODULE(mueller);
     MI_PY_IMPORT(MicrofacetDistribution);
+#if defined(MI_ENABLE_CUDA)
+    MI_PY_IMPORT(OptixDenoiser);
+#endif // defined(MI_ENABLE_CUDA)
     MI_PY_IMPORT(PhaseFunction);
     MI_PY_IMPORT(Sampler);
     MI_PY_IMPORT(Sensor);

--- a/src/python/main_v.cpp
+++ b/src/python/main_v.cpp
@@ -84,7 +84,9 @@ MI_PY_DECLARE(quad);
 // render
 MI_PY_DECLARE(BSDFSample);
 MI_PY_DECLARE(BSDF);
-MI_PY_DECLARE(denoiser);
+#if defined(MI_ENABLE_CUDA)
+MI_PY_DECLARE(OptixDenoiser);
+#endif // defined(MI_ENABLE_CUDA)
 MI_PY_DECLARE(Emitter);
 MI_PY_DECLARE(Endpoint);
 MI_PY_DECLARE(Film);
@@ -186,7 +188,9 @@ PYBIND11_MODULE(MODULE_NAME, m) {
     MI_PY_IMPORT(DirectionSample);
     MI_PY_IMPORT(BSDFSample);
     MI_PY_IMPORT(BSDF);
-    MI_PY_IMPORT(denoiser);
+#if defined(MI_ENABLE_CUDA)
+    MI_PY_IMPORT(OptixDenoiser);
+#endif // defined(MI_ENABLE_CUDA)
     MI_PY_IMPORT(Film);
     MI_PY_IMPORT(fresnel);
     MI_PY_IMPORT(ImageBlock);

--- a/src/python/python/ad/integrators/common.py
+++ b/src/python/python/ad/integrators/common.py
@@ -380,7 +380,7 @@ class ADIntegrator(mi.CppADIntegrator):
                     "motion due to differentiable shape or camera pose "
                     "parameters. This is, however, incompatible with the box "
                     "reconstruction filter that is currently used. Please "
-                    "specify a a smooth reconstruction filter in your scene "
+                    "specify a smooth reconstruction filter in your scene "
                     "description (e.g. 'gaussian', which is actually the "
                     "default)")
 

--- a/src/python/python/test/util.py
+++ b/src/python/python/test/util.py
@@ -10,6 +10,16 @@ from inspect import getframeinfo, stack, signature, _empty
 import pytest
 import drjit as dr
 
+def find_resource(fname):
+    path = os.path.dirname(os.path.realpath(__file__))
+    while True:
+        full = os.path.join(path, fname)
+        if os.path.exists(full):
+            return full
+        if path == '' or path == '/':
+            raise Exception("find_resource(): could not find \"%s\"" % fname)
+        path = os.path.dirname(path)
+
 def fresolver_append_path(func):
     """
     Function decorator that adds the mitsuba project root

--- a/src/render/CMakeLists.txt
+++ b/src/render/CMakeLists.txt
@@ -44,6 +44,7 @@ add_library(mitsuba-render OBJECT
   ${INC_DIR}/records.h
 
   bsdf.cpp         ${INC_DIR}/bsdf.h
+  denoiser.cpp     ${INC_DIR}/denoiser.h
   emitter.cpp      ${INC_DIR}/emitter.h
   endpoint.cpp     ${INC_DIR}/endpoint.h
   film.cpp         ${INC_DIR}/film.h

--- a/src/render/CMakeLists.txt
+++ b/src/render/CMakeLists.txt
@@ -34,7 +34,14 @@ include_directories(
 )
 
 if (NOT MI_ENABLE_EMBREE)
-    set(LIBRENDER_EXTRA_SRC kdtree.cpp ${INC_DIR}/kdtree.h ${LIBRENDER_EXTRA_SRC})
+  set(LIBRENDER_EXTRA_SRC kdtree.cpp ${INC_DIR}/kdtree.h ${LIBRENDER_EXTRA_SRC})
+endif()
+
+if (MI_ENABLE_CUDA)
+  set(LIBRENDER_EXTRA_SRC
+    optixdenoiser.cpp ${INC_DIR}/optixdenoiser.h
+    ${LIBRENDER_EXTRA_SRC}
+  )
 endif()
 
 add_library(mitsuba-render OBJECT
@@ -44,7 +51,6 @@ add_library(mitsuba-render OBJECT
   ${INC_DIR}/records.h
 
   bsdf.cpp         ${INC_DIR}/bsdf.h
-  denoiser.cpp     ${INC_DIR}/denoiser.h
   emitter.cpp      ${INC_DIR}/emitter.h
   endpoint.cpp     ${INC_DIR}/endpoint.h
   film.cpp         ${INC_DIR}/film.h

--- a/src/render/bsdf.cpp
+++ b/src/render/bsdf.cpp
@@ -25,7 +25,7 @@ MI_VARIANT Spectrum BSDF<Float, Spectrum>::get_diffuse_reflectance(
     const SurfaceInteraction3f &si, Mask active) const {
     Vector3f placeholder = Vector3f(0.0f, 0.0f, 1.0f);
     BSDFContext ctx;
-    return eval(ctx, si, placeholder, active) * 3.14159265358979323846; //M_PI
+    return eval(ctx, si, placeholder, active) * dr::Pi<Float>;
 }
 
 template <typename Index>

--- a/src/render/bsdf.cpp
+++ b/src/render/bsdf.cpp
@@ -21,6 +21,13 @@ MI_VARIANT Spectrum BSDF<Float, Spectrum>::eval_null_transmission(
     return 0.f;
 }
 
+MI_VARIANT Spectrum BSDF<Float, Spectrum>::get_diffuse_reflectance(
+    const SurfaceInteraction3f &si, Mask active) const {
+    Vector3f placeholder = Vector3f(0.0f, 0.0f, 1.0f);
+    BSDFContext ctx;
+    return eval(ctx, si, placeholder, active) * 3.14159265358979323846; //M_PI
+}
+
 template <typename Index>
 std::string type_mask_to_string(Index type_mask) {
     std::ostringstream oss;

--- a/src/render/bsdf.cpp
+++ b/src/render/bsdf.cpp
@@ -21,11 +21,11 @@ MI_VARIANT Spectrum BSDF<Float, Spectrum>::eval_null_transmission(
     return 0.f;
 }
 
-MI_VARIANT Spectrum BSDF<Float, Spectrum>::get_diffuse_reflectance(
+MI_VARIANT Spectrum BSDF<Float, Spectrum>::eval_diffuse_reflectance(
     const SurfaceInteraction3f &si, Mask active) const {
-    Vector3f placeholder = Vector3f(0.0f, 0.0f, 1.0f);
+    Vector3f wo = Vector3f(0.0f, 0.0f, 1.0f);
     BSDFContext ctx;
-    return eval(ctx, si, placeholder, active) * dr::Pi<Float>;
+    return eval(ctx, si, wo, active) * dr::Pi<Float>;
 }
 
 template <typename Index>

--- a/src/render/denoiser.cpp
+++ b/src/render/denoiser.cpp
@@ -60,7 +60,7 @@ MI_VARIANT Denoiser<Float, Spectrum>::~Denoiser() {
 }
 
 MI_VARIANT
-typename Denoiser<Float, Spectrum>::TensorXf Denoiser<Float, Spectrum>::denoise(
+typename Denoiser<Float, Spectrum>::TensorXf Denoiser<Float, Spectrum>::operator()(
     const TensorXf &noisy, bool denoise_alpha, const TensorXf *albedo,
     const TensorXf *normals, const TensorXf *previous_denoised,
     const TensorXf *flow) {
@@ -150,7 +150,7 @@ typename Denoiser<Float, Spectrum>::TensorXf Denoiser<Float, Spectrum>::denoise(
 }
 
 MI_VARIANT
-ref<Bitmap> Denoiser<Float, Spectrum>::denoise(
+ref<Bitmap> Denoiser<Float, Spectrum>::operator()(
     const ref<Bitmap> &noisy_, bool denoise_alpha, const std::string &albedo_ch,
     const std::string &normals_ch, const std::string &flow_ch,
     const std::string &previous_denoised_ch, const std::string &noisy_ch) {
@@ -158,7 +158,7 @@ ref<Bitmap> Denoiser<Float, Spectrum>::denoise(
         size_t noisy_tensor_shape[3] = { noisy_->height(), noisy_->width(),
                                          noisy_->channel_count() };
         TensorXf noisy_tensor(noisy_->data(), 3, noisy_tensor_shape);
-        TensorXf denoised = denoise(noisy_tensor, denoise_alpha);
+        TensorXf denoised = (*this)(noisy_tensor, denoise_alpha);
 
         void *denoised_data =
             jit_malloc_migrate(denoised.data(), AllocType::Host, false);
@@ -246,7 +246,7 @@ ref<Bitmap> Denoiser<Float, Spectrum>::denoise(
 
     // Generate output
     TensorXf denoised =
-        denoise(noisy_tensor, albedo_tensor.get(), normals_tensor.get(),
+        (*this)(noisy_tensor, albedo_tensor.get(), normals_tensor.get(),
                 flow_tensor.get(), prev_denoised_tensor.get());
     void *denoised_data =
         jit_malloc_migrate(denoised.data(), AllocType::Host, false);

--- a/src/render/denoiser.cpp
+++ b/src/render/denoiser.cpp
@@ -1,0 +1,259 @@
+#include <mitsuba/render/denoiser.h>
+#include <mitsuba/render/optix_api.h>
+#include <drjit-core/optix.h>
+
+NAMESPACE_BEGIN(mitsuba)
+
+template <typename Float, typename Spectrum>
+static OptixImage2D optixImage2DfromTensor(
+    const typename Denoiser<Float, Spectrum>::TensorXf &tensor,
+    OptixPixelFormat pixel_format) {
+    return { (CUdeviceptr) tensor.data(),
+             (unsigned int) tensor.shape(1),
+             (unsigned int) tensor.shape(0),
+             (unsigned int) (tensor.shape(1) * tensor.shape(2) * sizeof(float)),
+             (unsigned int) (tensor.shape(2) * sizeof(float)),
+             pixel_format };
+}
+
+MI_VARIANT Denoiser<Float, Spectrum>::Denoiser(const ScalarVector2u &input_size,
+                                               bool albedo, bool normals,
+                                               bool temporal)
+    : m_temporal(temporal) {
+    if (normals && !albedo)
+        Throw("The denoiser cannot use normals to guide its process without "
+              "also providing albedo information!");
+
+    optix_initialize();
+
+    OptixDeviceContext context = jit_optix_context();
+    m_denoiser = nullptr;
+    m_options = {};
+    m_options.guideAlbedo = albedo;
+    m_options.guideNormal = normals;
+    OptixDenoiserModelKind model_kind = temporal
+                                            ? OPTIX_DENOISER_MODEL_KIND_TEMPORAL
+                                            : OPTIX_DENOISER_MODEL_KIND_HDR;
+    jit_optix_check(
+        optixDenoiserCreate(context, model_kind, &m_options, &m_denoiser));
+
+    OptixDenoiserSizes sizes = {};
+    jit_optix_check(optixDenoiserComputeMemoryResources(
+        m_denoiser, input_size.x(), input_size.y(), &sizes));
+    CUstream stream = jit_cuda_stream();
+    m_state_size = sizes.stateSizeInBytes;
+    m_state = jit_malloc(AllocType::Device, m_state_size);
+    m_scratch_size = sizes.withoutOverlapScratchSizeInBytes;
+    m_scratch = jit_malloc(AllocType::Device, m_scratch_size);
+    jit_optix_check(optixDenoiserSetup(m_denoiser, stream, input_size.x(),
+                                       input_size.y(), m_state, m_state_size,
+                                       m_scratch, m_scratch_size));
+    m_hdr_intensity = jit_malloc(AllocType::Device, sizeof(float));
+}
+
+MI_VARIANT Denoiser<Float, Spectrum>::~Denoiser() {
+    jit_optix_check(optixDenoiserDestroy(m_denoiser));
+    jit_free(m_hdr_intensity);
+    jit_free(m_state);
+    jit_free(m_scratch);
+}
+
+MI_VARIANT
+typename Denoiser<Float, Spectrum>::TensorXf Denoiser<Float, Spectrum>::denoise(
+    const TensorXf &noisy, const TensorXf *albedo, const TensorXf *normals,
+    const TensorXf *previous_denoised, const TensorXf *flow) {
+    using Array = typename TensorXf::Array;
+
+    // TODO check that input matches current state
+
+    OptixDenoiserLayer layers = {};
+    OptixPixelFormat input_pixel_format = (noisy.shape(2) == 3)
+                                              ? OPTIX_PIXEL_FORMAT_FLOAT3
+                                              : OPTIX_PIXEL_FORMAT_FLOAT4;
+    layers.input = optixImage2DfromTensor<Float, Spectrum>(
+        noisy, input_pixel_format);
+
+    layers.output = layers.input;
+    Array output_data = dr::empty<Array>(noisy.size());
+    layers.output.data = output_data.data();
+
+    CUstream stream = jit_cuda_stream();
+
+    OptixDenoiserParams params = {};
+    params.hdrIntensity = m_hdr_intensity;
+    params.denoiseAlpha = true;
+    jit_optix_check(optixDenoiserComputeIntensity(
+        m_denoiser, stream, &layers.input, m_hdr_intensity, m_scratch,
+        m_scratch_size));
+    params.blendFactor = 0.0f;
+    params.hdrAverageColor = nullptr;
+
+    OptixDenoiserGuideLayer guide_layer = {};
+
+    if (m_options.guideAlbedo)
+        guide_layer.albedo = optixImage2DfromTensor<Float, Spectrum>(
+            *albedo, OPTIX_PIXEL_FORMAT_FLOAT3);
+
+    std::unique_ptr<TensorXf> corrected_normals = nullptr;
+    if (m_options.guideNormal) {
+        // Change from right-handed coordinate system with (X=left, Y=up,
+        // Z=forward) to a right-handed system  with (X=right, Y=up, Z=backward)
+        corrected_normals = std::make_unique<TensorXf>(*normals);
+
+        UInt32 x_idx = dr::arange<UInt32>(0, corrected_normals->size(), 3);
+        Float x_values = dr::gather<Float>(corrected_normals->array(), x_idx);
+        dr::scatter(corrected_normals->array(), -x_values, x_idx);
+
+        UInt32 z_idx = dr::arange<UInt32>(2, corrected_normals->size(), 3);
+        Float z_values = dr::gather<Float>(corrected_normals->array(), z_idx);
+        dr::scatter(corrected_normals->array(), -z_values, z_idx);
+
+        guide_layer.normal = optixImage2DfromTensor<Float, Spectrum>(
+            *corrected_normals, OPTIX_PIXEL_FORMAT_FLOAT3);
+    }
+
+    if (m_temporal) {
+        guide_layer.flow = optixImage2DfromTensor<Float, Spectrum>(
+            *flow, OPTIX_PIXEL_FORMAT_FLOAT2);
+        layers.previousOutput = optixImage2DfromTensor<Float, Spectrum>(
+            *previous_denoised, input_pixel_format);
+    }
+
+    jit_optix_check(optixDenoiserInvoke(m_denoiser, stream, &params, m_state,
+                                        m_state_size, &guide_layer, &layers, 1,
+                                        0, 0, m_scratch, m_scratch_size));
+
+    size_t shape[3] = { noisy.shape(0), noisy.shape(1), noisy.shape(2) };
+    return TensorXf(std::move(output_data), 3, shape);
+}
+
+MI_VARIANT
+ref<Bitmap> Denoiser<Float, Spectrum>::denoise(
+    const ref<Bitmap> &noisy_, const std::string &albedo_ch,
+    const std::string &normals_ch, const std::string &flow_ch,
+    const std::string &previous_denoised_ch, const std::string &noisy_ch) {
+    size_t noisy_tensor_shape[3] = { noisy_->height(), noisy_->width(),
+                                     noisy_->channel_count() };
+    if (noisy_->pixel_format() != Bitmap::PixelFormat::MultiChannel) {
+        TensorXf noisy_tensor(noisy_->data(), 3, noisy_tensor_shape);
+        TensorXf denoised =
+            denoise(noisy_tensor, nullptr, nullptr, nullptr, nullptr);
+
+        void *denoised_data =
+            jit_malloc_migrate(denoised.data(), AllocType::Host, false);
+        jit_sync_thread();
+
+        return new Bitmap((denoised.shape(2) == 3) ? Bitmap::PixelFormat::RGB
+                                                   : Bitmap::PixelFormat::RGBA,
+                          Struct::Type::Float32,
+                          { denoised.shape(1), denoised.shape(0) },
+                          denoised.shape(2), {}, (uint8_t *) denoised_data);
+    }
+
+    const Bitmap *noisy_bmp = nullptr;
+    const Bitmap *albedo_bmp = nullptr;
+    const Bitmap *normals_bmp = nullptr;
+    const Bitmap *flow_bmp = nullptr;
+    const Bitmap *previous_denoised_bmp = nullptr;
+
+    bool found_albedo = albedo_ch == "";
+    bool found_normals = normals_ch == "";
+    bool found_flow = flow_ch == "";
+    bool found_previous_denoised = previous_denoised_ch == "";
+
+    std::vector<std::pair<std::string, ref<Bitmap>>> res = noisy_->split();
+    for (const auto &pair : res) {
+        if (found_albedo && found_normals && found_flow &&
+            found_previous_denoised && noisy_bmp != nullptr)
+            break;
+        if (!found_albedo && pair.first == albedo_ch) {
+            found_albedo = true;
+            albedo_bmp = pair.second.get();
+        }
+        if (!found_normals && pair.first == normals_ch) {
+            found_normals = true;
+            normals_bmp = pair.second.get();
+        }
+        if (!found_flow && pair.first == flow_ch) {
+            found_flow = true;
+            flow_bmp = pair.second.get();
+        }
+        if (!found_previous_denoised && pair.first == previous_denoised_ch) {
+            found_previous_denoised = true;
+            previous_denoised_bmp = pair.second.get();
+        }
+        if (noisy_bmp == nullptr && pair.first == noisy_ch)
+            noisy_bmp = pair.second.get();
+    }
+
+    const auto throw_missing_channel = [&](const std::string &channel) {
+        Throw("Could not find rendered image with channel name '%s' in:\n%s",
+              channel, noisy_->to_string());
+    };
+    if (noisy_bmp == nullptr)
+        throw_missing_channel(noisy_ch);
+    if (!found_albedo)
+        throw_missing_channel(albedo_ch);
+    if (!found_normals)
+        throw_missing_channel(normals_ch);
+    if (!found_flow)
+        throw_missing_channel(flow_ch);
+    if (!found_previous_denoised)
+        throw_missing_channel(previous_denoised_ch);
+
+    noisy_tensor_shape[2] = noisy_bmp->channel_count();
+    TensorXf noisy_tensor(noisy_bmp->data(), 3, noisy_tensor_shape);
+
+    std::unique_ptr<TensorXf> albedo_tensor = nullptr;
+    if (albedo_bmp != nullptr) {
+        size_t shape[3] = { noisy_->height(), noisy_->width(), 3 };
+        albedo_tensor =
+            std::make_unique<TensorXf>(albedo_bmp->data(), 3, shape);
+    }
+    std::unique_ptr<TensorXf> normals_tensor = nullptr;
+    if (normals_bmp != nullptr) {
+        size_t shape[3] = { noisy_->height(), noisy_->width(), 3 };
+        normals_tensor =
+            std::make_unique<TensorXf>(normals_bmp->data(), 3, shape);
+    }
+    std::unique_ptr<TensorXf> flow_tensor = nullptr;
+    if (flow_bmp != nullptr) {
+        size_t flow_shape[3] = { noisy_->height(), noisy_->width(), 2 };
+        flow_tensor =
+            std::make_unique<TensorXf>(flow_bmp->data(), 3, flow_shape);
+    }
+    std::unique_ptr<TensorXf> previous_denoised_tensor = nullptr;
+    if (previous_denoised_bmp!= nullptr)
+        previous_denoised_tensor = std::make_unique<TensorXf>(
+            previous_denoised_bmp->data(), 3, noisy_tensor_shape);
+
+    TensorXf denoised =
+        denoise(noisy_tensor, albedo_tensor.get(), normals_tensor.get(),
+                flow_tensor.get(), previous_denoised_tensor.get());
+
+    void *denoised_data =
+        jit_malloc_migrate(denoised.data(), AllocType::Host, false);
+    jit_sync_thread();
+
+    return new Bitmap((denoised.shape(2) == 3) ? Bitmap::PixelFormat::RGB
+                                               : Bitmap::PixelFormat::RGBA,
+                      Struct::Type::Float32,
+                      { denoised.shape(1), denoised.shape(0) },
+                      denoised.shape(2), {}, (uint8_t *) denoised_data);
+}
+
+MI_VARIANT
+std::string Denoiser<Float, Spectrum>::to_string() const {
+    std::ostringstream oss;
+    oss << "Denoiser[" << std::endl
+        << "  albedo = " << m_options.guideAlbedo << "," << std::endl
+        << "  normals = " << m_options.guideNormal << "," << std::endl
+        << "  temporal = " << m_temporal << std::endl
+        << "]";
+    return oss.str();
+}
+
+MI_IMPLEMENT_CLASS_VARIANT(Denoiser, Object, "denoiser")
+MI_INSTANTIATE_CLASS(Denoiser)
+
+NAMESPACE_END(mitsuba)

--- a/src/render/optix_api.cpp
+++ b/src/render/optix_api.cpp
@@ -27,6 +27,13 @@ void optix_initialize() {
     L(optixProgramGroupCreate);
     L(optixProgramGroupDestroy)
     L(optixSbtRecordPackHeader);
+    L(optixDenoiserCreate);
+    L(optixDenoiserSetModel);
+    L(optixDenoiserComputeMemoryResources);
+    L(optixDenoiserSetup);
+    L(optixDenoiserComputeIntensity);
+    L(optixDenoiserInvoke);
+    L(optixDenoiserDestroy);
 
     #undef L
 }

--- a/src/render/optix_api.cpp
+++ b/src/render/optix_api.cpp
@@ -28,12 +28,11 @@ void optix_initialize() {
     L(optixProgramGroupDestroy)
     L(optixSbtRecordPackHeader);
     L(optixDenoiserCreate);
-    L(optixDenoiserSetModel);
+    L(optixDenoiserDestroy);
     L(optixDenoiserComputeMemoryResources);
     L(optixDenoiserSetup);
-    L(optixDenoiserComputeIntensity);
     L(optixDenoiserInvoke);
-    L(optixDenoiserDestroy);
+    L(optixDenoiserComputeIntensity);
 
     #undef L
 }

--- a/src/render/optixdenoiser.cpp
+++ b/src/render/optixdenoiser.cpp
@@ -320,7 +320,7 @@ void OptixDenoiser<Float, Spectrum>::validate_input(
         Throw("The normals must have exactly 3 channels!");
     if (m_temporal && (flow->shape(2) != 2))
         Throw("The optical flow argument must have exactly 2 channels!");
-    if (m_temporal && (previous_denoised->shape(2) != noisy.shape(3)))
+    if (m_temporal && (previous_denoised->shape(2) != noisy.shape(2)))
         Throw("The denoised previous frame must have the same number of "
               "channels as the noisy input!");
 }

--- a/src/render/python/CMakeLists.txt
+++ b/src/render/python/CMakeLists.txt
@@ -2,6 +2,7 @@ set(RENDER_PY_V_SRC
   ${CMAKE_CURRENT_SOURCE_DIR}/bsdf_v.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/emitter_v.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/endpoint_v.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/denoiser_v.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/film_v.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/fresnel_v.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/imageblock_v.cpp

--- a/src/render/python/CMakeLists.txt
+++ b/src/render/python/CMakeLists.txt
@@ -2,7 +2,6 @@ set(RENDER_PY_V_SRC
   ${CMAKE_CURRENT_SOURCE_DIR}/bsdf_v.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/emitter_v.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/endpoint_v.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/optixdenoiser_v.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/film_v.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/fresnel_v.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/imageblock_v.cpp
@@ -11,6 +10,7 @@ set(RENDER_PY_V_SRC
   ${CMAKE_CURRENT_SOURCE_DIR}/medium_v.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/mueller_v.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/microfacet_v.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/optixdenoiser_v.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/phase_v.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/records_v.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/sampler_v.cpp

--- a/src/render/python/CMakeLists.txt
+++ b/src/render/python/CMakeLists.txt
@@ -2,7 +2,7 @@ set(RENDER_PY_V_SRC
   ${CMAKE_CURRENT_SOURCE_DIR}/bsdf_v.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/emitter_v.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/endpoint_v.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/denoiser_v.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/optixdenoiser_v.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/film_v.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/fresnel_v.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/imageblock_v.cpp

--- a/src/render/python/bsdf_v.cpp
+++ b/src/render/python/bsdf_v.cpp
@@ -60,6 +60,11 @@ public:
         PYBIND11_OVERRIDE_PURE(Return, BSDF, eval_pdf, ctx, si, wo, active);
     }
 
+    Spectrum get_diffuse_reflectance(const SurfaceInteraction3f &si,
+              Mask active) const override {
+        PYBIND11_OVERRIDE_PURE(Spectrum, BSDF, get_diffuse_reflectance, si, active);
+    }
+
     std::string to_string() const override {
         PYBIND11_OVERRIDE_PURE(std::string, BSDF, to_string,);
     }
@@ -96,6 +101,10 @@ template <typename Ptr, typename Cls> void bind_bsdf_generic(Cls &cls) {
              [](Ptr bsdf, const SurfaceInteraction3f &si, Mask active) {
                  return bsdf->eval_null_transmission(si, active);
              }, "si"_a, "active"_a = true, D(BSDF, eval_null_transmission))
+        .def("get_diffuse_reflectance",
+             [](Ptr bsdf, const SurfaceInteraction3f &si, Mask active) {
+                 return bsdf->get_diffuse_reflectance(si, active);
+             }, "si"_a, "active"_a = true)
         .def("flags", [](Ptr bsdf) { return bsdf->flags(); }, D(BSDF, flags))
         .def("needs_differentials",
              [](Ptr bsdf) { return bsdf->needs_differentials(); },

--- a/src/render/python/bsdf_v.cpp
+++ b/src/render/python/bsdf_v.cpp
@@ -60,9 +60,9 @@ public:
         PYBIND11_OVERRIDE_PURE(Return, BSDF, eval_pdf, ctx, si, wo, active);
     }
 
-    Spectrum get_diffuse_reflectance(const SurfaceInteraction3f &si,
-              Mask active) const override {
-        PYBIND11_OVERRIDE_PURE(Spectrum, BSDF, get_diffuse_reflectance, si, active);
+    Spectrum eval_diffuse_reflectance(const SurfaceInteraction3f &si,
+                                      Mask active) const override {
+        PYBIND11_OVERRIDE_PURE(Spectrum, BSDF, eval_diffuse_reflectance, si, active);
     }
 
     std::string to_string() const override {
@@ -101,10 +101,10 @@ template <typename Ptr, typename Cls> void bind_bsdf_generic(Cls &cls) {
              [](Ptr bsdf, const SurfaceInteraction3f &si, Mask active) {
                  return bsdf->eval_null_transmission(si, active);
              }, "si"_a, "active"_a = true, D(BSDF, eval_null_transmission))
-        .def("get_diffuse_reflectance",
+        .def("eval_diffuse_reflectance",
              [](Ptr bsdf, const SurfaceInteraction3f &si, Mask active) {
-                 return bsdf->get_diffuse_reflectance(si, active);
-             }, "si"_a, "active"_a = true)
+                 return bsdf->eval_diffuse_reflectance(si, active);
+             }, "si"_a, "active"_a = true, D(BSDF, eval_diffuse_reflectance))
         .def("flags", [](Ptr bsdf) { return bsdf->flags(); }, D(BSDF, flags))
         .def("needs_differentials",
              [](Ptr bsdf) { return bsdf->needs_differentials(); },

--- a/src/render/python/denoiser_v.cpp
+++ b/src/render/python/denoiser_v.cpp
@@ -1,0 +1,12 @@
+#include <mitsuba/render/denoiser.h>
+#include <mitsuba/python/python.h>
+
+MI_PY_EXPORT(denoiser) {
+    MI_PY_IMPORT_TYPES()
+    m.def("denoise",
+        py::overload_cast<const Bitmap &>(&denoise<Float>),
+        "noisy"_a, D(denoise))
+    .def("denoise",
+        py::overload_cast<const Bitmap &, Bitmap *, Bitmap *>(&denoise<Float>),
+        "noisy"_a, "albedo"_a, "normals"_a, D(denoise, 2));
+}

--- a/src/render/python/denoiser_v.cpp
+++ b/src/render/python/denoiser_v.cpp
@@ -13,7 +13,7 @@ MI_PY_EXPORT(denoiser) {
                                const TensorXf *>(&Denoiser::denoise),
              "noisy"_a, "albedo"_a = nullptr, "normals"_a = nullptr,
              "flow"_a = nullptr, "previous_denoised"_a = nullptr,
-             D(Denoiser, denoise1))
+             D(Denoiser, denoise))
         .def("denoise",
              py::overload_cast<const ref<Bitmap> &, const std::string &,
                                const std::string &, const std::string &,

--- a/src/render/python/denoiser_v.cpp
+++ b/src/render/python/denoiser_v.cpp
@@ -8,18 +8,20 @@ MI_PY_EXPORT(denoiser) {
              "input_size"_a, "albedo"_a = false, "normals"_a = false,
              "temporal"_a = false)
         .def("denoise",
-             py::overload_cast<const TensorXf &, const TensorXf *,
+             py::overload_cast<const TensorXf &, bool, const TensorXf *,
                                const TensorXf *, const TensorXf *,
                                const TensorXf *>(&Denoiser::denoise),
-             "noisy"_a, "albedo"_a = nullptr, "normals"_a = nullptr,
-             "flow"_a = nullptr, "previous_denoised"_a = nullptr,
+             "noisy"_a, "denoise_alpha"_a = true, "albedo"_a = nullptr,
+             "normals"_a = nullptr, "flow"_a = nullptr,
+             "previous_denoised"_a = nullptr,
              D(Denoiser, denoise))
         .def("denoise",
-             py::overload_cast<const ref<Bitmap> &, const std::string &,
+             py::overload_cast<const ref<Bitmap> &, bool, const std::string &,
                                const std::string &, const std::string &,
                                const std::string &, const std::string &>(
                  &Denoiser::denoise),
-             "noisy"_a, "albedo_ch"_a = "", "normals_ch"_a = "",
-             "flow_ch"_a = "", "previous_denoised_ch"_a = "",
-             "noisy_ch"_a = "<root>", D(Denoiser, denoise));
+             "noisy"_a, "denoise_alpha"_a = true, "albedo_ch"_a = "",
+             "normals_ch"_a = "", "flow_ch"_a = "",
+             "previous_denoised_ch"_a = "", "noisy_ch"_a = "<root>",
+             D(Denoiser, denoise));
 }

--- a/src/render/python/denoiser_v.cpp
+++ b/src/render/python/denoiser_v.cpp
@@ -7,19 +7,19 @@ MI_PY_EXPORT(denoiser) {
         .def(py::init<const ScalarVector2u &, bool, bool, bool>(),
              "input_size"_a, "albedo"_a = false, "normals"_a = false,
              "temporal"_a = false)
-        .def("denoise",
+        .def("__call__",
              py::overload_cast<const TensorXf &, bool, const TensorXf *,
                                const TensorXf *, const TensorXf *,
-                               const TensorXf *>(&Denoiser::denoise),
+                               const TensorXf *>(&Denoiser::operator()),
              "noisy"_a, "denoise_alpha"_a = true, "albedo"_a = nullptr,
              "normals"_a = nullptr, "flow"_a = nullptr,
              "previous_denoised"_a = nullptr,
              D(Denoiser, denoise))
-        .def("denoise",
+        .def("__call__",
              py::overload_cast<const ref<Bitmap> &, bool, const std::string &,
                                const std::string &, const std::string &,
                                const std::string &, const std::string &>(
-                 &Denoiser::denoise),
+             &Denoiser::operator()),
              "noisy"_a, "denoise_alpha"_a = true, "albedo_ch"_a = "",
              "normals_ch"_a = "", "flow_ch"_a = "",
              "previous_denoised_ch"_a = "", "noisy_ch"_a = "<root>",

--- a/src/render/python/denoiser_v.cpp
+++ b/src/render/python/denoiser_v.cpp
@@ -2,11 +2,24 @@
 #include <mitsuba/python/python.h>
 
 MI_PY_EXPORT(denoiser) {
-    MI_PY_IMPORT_TYPES()
-    m.def("denoise",
-        py::overload_cast<const Bitmap &>(&denoise<Float>),
-        "noisy"_a, D(denoise))
-    .def("denoise",
-        py::overload_cast<const Bitmap &, Bitmap *, Bitmap *>(&denoise<Float>),
-        "noisy"_a, "albedo"_a, "normals"_a, D(denoise, 2));
+    MI_PY_IMPORT_TYPES(Denoiser)
+    MI_PY_CLASS(Denoiser, Object)
+        .def(py::init<const ScalarVector2u &, bool, bool, bool>(),
+             "input_size"_a, "albedo"_a = false, "normals"_a = false,
+             "temporal"_a = false)
+        .def("denoise",
+             py::overload_cast<const TensorXf &, const TensorXf *,
+                               const TensorXf *, const TensorXf *,
+                               const TensorXf *>(&Denoiser::denoise),
+             "noisy"_a, "albedo"_a = nullptr, "normals"_a = nullptr,
+             "flow"_a = nullptr, "previous_denoised"_a = nullptr,
+             D(Denoiser, denoise1))
+        .def("denoise",
+             py::overload_cast<const ref<Bitmap> &, const std::string &,
+                               const std::string &, const std::string &,
+                               const std::string &, const std::string &>(
+                 &Denoiser::denoise),
+             "noisy"_a, "albedo_ch"_a = "", "normals_ch"_a = "",
+             "flow_ch"_a = "", "previous_denoised_ch"_a = "",
+             "noisy_ch"_a = "<root>", D(Denoiser, denoise));
 }

--- a/src/render/python/optixdenoiser_v.cpp
+++ b/src/render/python/optixdenoiser_v.cpp
@@ -11,20 +11,24 @@ MI_PY_EXPORT(OptixDenoiser) {
              "temporal"_a = false)
         .def("__call__",
              py::overload_cast<const TensorXf &, bool, const TensorXf *,
-                               const TensorXf *, const TensorXf *,
-                               const TensorXf *>(&OptixDenoiser::operator()),
+                               const TensorXf *, const Transform4f *,
+                               const TensorXf *, const TensorXf *>(
+             &OptixDenoiser::operator(), py::const_),
              "noisy"_a, "denoise_alpha"_a = true, "albedo"_a = nullptr,
-             "normals"_a = nullptr, "flow"_a = nullptr,
+             "normals"_a = nullptr, "n_frame"_a = nullptr, "flow"_a = nullptr,
              "previous_denoised"_a = nullptr,
              D(OptixDenoiser, operator_call))
         .def("__call__",
              py::overload_cast<const ref<Bitmap> &, bool, const std::string &,
+                               const std::string &, const Transform4f &,
                                const std::string &, const std::string &,
-                               const std::string &, const std::string &>(
-             &OptixDenoiser::operator()),
+                               const std::string &>(
+             &OptixDenoiser::operator(), py::const_),
              "noisy"_a, "denoise_alpha"_a = true, "albedo_ch"_a = "",
-             "normals_ch"_a = "", "flow_ch"_a = "",
+             "normals_ch"_a = "", "n_frame"_a = Transform4f(), "flow_ch"_a = "",
              "previous_denoised_ch"_a = "", "noisy_ch"_a = "<root>",
              D(OptixDenoiser, operator_call));
     // FIXME: documentation for overloadded pybind method
 }
+
+#endif // defined(MI_ENABLE_CUDA)

--- a/src/render/python/optixdenoiser_v.cpp
+++ b/src/render/python/optixdenoiser_v.cpp
@@ -8,7 +8,7 @@ MI_PY_EXPORT(OptixDenoiser) {
     MI_PY_CLASS(OptixDenoiser, Object)
         .def(py::init<const ScalarVector2u &, bool, bool, bool>(),
              "input_size"_a, "albedo"_a = false, "normals"_a = false,
-             "temporal"_a = false)
+             "temporal"_a = false, D(OptixDenoiser, OptixDenoiser))
         .def("__call__",
              py::overload_cast<const TensorXf &, bool, const TensorXf *,
                                const TensorXf *, const Transform4f *,
@@ -27,8 +27,7 @@ MI_PY_EXPORT(OptixDenoiser) {
              "noisy"_a, "denoise_alpha"_a = true, "albedo_ch"_a = "",
              "normals_ch"_a = "", "n_frame"_a = Transform4f(), "flow_ch"_a = "",
              "previous_denoised_ch"_a = "", "noisy_ch"_a = "<root>",
-             D(OptixDenoiser, operator_call));
-    // FIXME: documentation for overloadded pybind method
+             D(OptixDenoiser, operator_call, 2));
 }
 
 #endif // defined(MI_ENABLE_CUDA)

--- a/src/render/python/optixdenoiser_v.cpp
+++ b/src/render/python/optixdenoiser_v.cpp
@@ -1,27 +1,30 @@
-#include <mitsuba/render/denoiser.h>
+#if defined(MI_ENABLE_CUDA)
+
+#include <mitsuba/render/optixdenoiser.h>
 #include <mitsuba/python/python.h>
 
-MI_PY_EXPORT(denoiser) {
-    MI_PY_IMPORT_TYPES(Denoiser)
-    MI_PY_CLASS(Denoiser, Object)
+MI_PY_EXPORT(OptixDenoiser) {
+    MI_PY_IMPORT_TYPES(OptixDenoiser)
+    MI_PY_CLASS(OptixDenoiser, Object)
         .def(py::init<const ScalarVector2u &, bool, bool, bool>(),
              "input_size"_a, "albedo"_a = false, "normals"_a = false,
              "temporal"_a = false)
         .def("__call__",
              py::overload_cast<const TensorXf &, bool, const TensorXf *,
                                const TensorXf *, const TensorXf *,
-                               const TensorXf *>(&Denoiser::operator()),
+                               const TensorXf *>(&OptixDenoiser::operator()),
              "noisy"_a, "denoise_alpha"_a = true, "albedo"_a = nullptr,
              "normals"_a = nullptr, "flow"_a = nullptr,
              "previous_denoised"_a = nullptr,
-             D(Denoiser, denoise))
+             D(OptixDenoiser, operator_call))
         .def("__call__",
              py::overload_cast<const ref<Bitmap> &, bool, const std::string &,
                                const std::string &, const std::string &,
                                const std::string &, const std::string &>(
-             &Denoiser::operator()),
+             &OptixDenoiser::operator()),
              "noisy"_a, "denoise_alpha"_a = true, "albedo_ch"_a = "",
              "normals_ch"_a = "", "flow_ch"_a = "",
              "previous_denoised_ch"_a = "", "noisy_ch"_a = "<root>",
-             D(Denoiser, denoise));
+             D(OptixDenoiser, operator_call));
+    // FIXME: documentation for overloadded pybind method
 }

--- a/src/render/python/optixdenoiser_v.cpp
+++ b/src/render/python/optixdenoiser_v.cpp
@@ -9,25 +9,43 @@ MI_PY_EXPORT(OptixDenoiser) {
         .def(py::init<const ScalarVector2u &, bool, bool, bool>(),
              "input_size"_a, "albedo"_a = false, "normals"_a = false,
              "temporal"_a = false, D(OptixDenoiser, OptixDenoiser))
-        .def("__call__",
-             py::overload_cast<const TensorXf &, bool, const TensorXf *,
-                               const TensorXf *, const Transform4f *,
-                               const TensorXf *, const TensorXf *>(
-             &OptixDenoiser::operator(), py::const_),
-             "noisy"_a, "denoise_alpha"_a = true, "albedo"_a = nullptr,
-             "normals"_a = nullptr, "n_frame"_a = nullptr, "flow"_a = nullptr,
-             "previous_denoised"_a = nullptr,
-             D(OptixDenoiser, operator_call))
-        .def("__call__",
-             py::overload_cast<const ref<Bitmap> &, bool, const std::string &,
-                               const std::string &, const Transform4f &,
-                               const std::string &, const std::string &,
-                               const std::string &>(
-             &OptixDenoiser::operator(), py::const_),
-             "noisy"_a, "denoise_alpha"_a = true, "albedo_ch"_a = "",
-             "normals_ch"_a = "", "n_frame"_a = Transform4f(), "flow_ch"_a = "",
-             "previous_denoised_ch"_a = "", "noisy_ch"_a = "<root>",
-             D(OptixDenoiser, operator_call, 2));
+        .def(
+            "__call__",
+            [](const OptixDenoiser &denoiser, const TensorXf &noisy,
+               bool denoise_alpha, const TensorXf &albedo,
+               const TensorXf &normals, const py::object &transform,
+               const TensorXf &flow, const TensorXf &previous_denoised) {
+                Transform4f to_sensor;
+                if (!transform.is(py::none()))
+                    to_sensor = transform.cast<Transform4f>();
+
+                return denoiser(noisy, denoise_alpha, albedo, normals,
+                                to_sensor, flow, previous_denoised);
+            },
+            "noisy"_a, "denoise_alpha"_a = true, "albedo"_a = TensorXf(),
+            "normals"_a = TensorXf(), "to_sensor"_a = py::none(),
+            "flow"_a = TensorXf(), "previous_denoised"_a = TensorXf(),
+            D(OptixDenoiser, operator_call))
+        .def(
+            "__call__",
+            [](const OptixDenoiser &denoiser, const ref<Bitmap> &noisy,
+               bool denoise_alpha, const std::string &albedo_ch,
+               const std::string &normals_ch, const py::object &transform,
+               const std::string &flow_ch,
+               const std::string &previous_denoised_ch,
+               const std::string &noisy_ch) {
+                Transform4f to_sensor;
+                if (!transform.is(py::none()))
+                    to_sensor = transform.cast<Transform4f>();
+
+                return denoiser(noisy, denoise_alpha, albedo_ch, normals_ch,
+                                to_sensor, flow_ch, previous_denoised_ch,
+                                noisy_ch);
+            },
+            "noisy"_a, "denoise_alpha"_a = true, "albedo_ch"_a = "",
+            "normals_ch"_a = "", "to_sensor"_a = py::none(), "flow_ch"_a = "",
+            "previous_denoised_ch"_a = "", "noisy_ch"_a = "<root>",
+            D(OptixDenoiser, operator_call, 2));
 }
 
 #endif // defined(MI_ENABLE_CUDA)

--- a/src/render/scene_optix.inl
+++ b/src/render/scene_optix.inl
@@ -299,7 +299,7 @@ MI_VARIANT void Scene<Float, Spectrum>::accel_init_gpu(const Properties &/*props
 
         accel_parameters_changed_gpu();
 
-         Log(Info, "OptiX ready. (took %s)", util::time_string((float) timer.value()));
+        Log(Info, "OptiX ready. (took %s)", util::time_string((float) timer.value()));
     }
 }
 

--- a/src/render/tests/test_denoiser.py
+++ b/src/render/tests/test_denoiser.py
@@ -11,7 +11,7 @@ from mitsuba.scalar_rgb.test.util import fresolver_append_path
 ###
 
 
-def test01_denosier_construct(variants_any_cuda):
+def test01_denoiser_construct(variants_any_cuda):
     input_res = [33, 18]
 
     assert (
@@ -26,13 +26,13 @@ def test01_denosier_construct(variants_any_cuda):
 
 
 @fresolver_append_path
-def test02_denosier_denoise(variant_cuda_ad_rgb):
+def test02_denoiser_denoise(variant_cuda_ad_rgb):
     noisy = mi.TensorXf(mi.Bitmap("resources/data/tests/denoiser/noisy.exr"))
     ref = mi.TensorXf(mi.Bitmap("resources/data/tests/denoiser/ref.exr"))[...,:3]
 
     denoiser = mi.Denoiser(noisy.shape[:2])
     denoised = mi.util.convert_to_bitmap(
-        denoiser.denoise(noisy), uint8_srgb=False
+        denoiser(noisy), uint8_srgb=False
     )
     denoised = mi.TensorXf(denoised.convert(component_format=mi.Struct.Type.Float16))
 
@@ -43,16 +43,17 @@ def test02_denosier_denoise(variant_cuda_ad_rgb):
 
 
 @fresolver_append_path
-def test02_denosier_denoise_albedo(variant_cuda_ad_rgb):
+def test03_denosier_denoise_albedo(variant_cuda_ad_rgb):
     noisy = mi.TensorXf(mi.Bitmap("resources/data/tests/denoiser/noisy.exr"))
     albedo = mi.TensorXf(mi.Bitmap("resources/data/tests/denoiser/albedo.exr"))
     ref = mi.TensorXf(mi.Bitmap("resources/data/tests/denoiser/ref_albedo.exr"))
 
     denoiser = mi.Denoiser(noisy.shape[:2], True)
     denoised = mi.util.convert_to_bitmap(
-        denoiser.denoise(noisy, False, albedo), uint8_srgb=False
+        denoiser(noisy, False, albedo), uint8_srgb=False
     )
     denoised = mi.TensorXf(denoised.convert(component_format=mi.Struct.Type.Float16))
+    mi.Bitmap(denoised).write("/home/nroussel/rgl/mitsuba3/resources/data/tests/denoiser/denoised.exr")
 
     ref_tensor = mi.TensorXf(ref)[...,:3]
     denoised_tensor = mi.TensorXf(denoised)
@@ -64,7 +65,7 @@ def test02_denosier_denoise_albedo(variant_cuda_ad_rgb):
 
 
 @fresolver_append_path
-def test02_denosier_denoise_normals(variant_cuda_ad_rgb):
+def test04_denosier_denoise_normals(variant_cuda_ad_rgb):
     noisy = mi.TensorXf(mi.Bitmap("resources/data/tests/denoiser/noisy.exr"))
     albedo = mi.TensorXf(mi.Bitmap("resources/data/tests/denoiser/albedo.exr"))
     normals = mi.TensorXf(mi.Bitmap("resources/data/tests/denoiser/normals.exr"))
@@ -72,30 +73,8 @@ def test02_denosier_denoise_normals(variant_cuda_ad_rgb):
 
     denoiser = mi.Denoiser(noisy.shape[:2], True, True)
 
-    denoised = mi.convert_to_bitmap(
-        denoiser.denoise(noisy, False, albedo, normals), uint8_srgb=False
-    )
-    denoised = mi.TensorXf(denoised.convert(component_format=mi.Struct.Type.Float16))
-
-    ref_tensor = mi.TensorXf(ref)[...,:3]
-    denoised_tensor = mi.TensorXf(denoised)
-
-    ref_array = ref_tensor.array
-    denoised_array = denoised_tensor.array
-
-    assert dr.allclose(denoised_array, ref_array)
-
-
-@fresolver_append_path
-def test02_denosier_denoise_normals(variant_cuda_ad_rgb):
-    noisy = mi.TensorXf(mi.Bitmap("resources/data/tests/denoiser/noisy.exr"))
-    albedo = mi.TensorXf(mi.Bitmap("resources/data/tests/denoiser/albedo.exr"))
-    normals = mi.TensorXf(mi.Bitmap("resources/data/tests/denoiser/normals.exr"))
-    ref = mi.TensorXf(mi.Bitmap("resources/data/tests/denoiser/ref_normals.exr"))
-
-    denoiser = mi.Denoiser(noisy.shape[:2], True, True)
     denoised = mi.util.convert_to_bitmap(
-        denoiser.denoise(noisy, False, albedo, normals), uint8_srgb=False
+        denoiser(noisy, False, albedo, normals), uint8_srgb=False
     )
     denoised = mi.TensorXf(denoised.convert(component_format=mi.Struct.Type.Float16))
 
@@ -106,3 +85,25 @@ def test02_denosier_denoise_normals(variant_cuda_ad_rgb):
     denoised_array = denoised_tensor.array
 
     assert dr.allclose(denoised_array, ref_array)
+
+
+#@fresolver_append_path
+#def test05_denosier_denoise_normals(variant_cuda_ad_rgb):
+#    noisy = mi.TensorXf(mi.Bitmap("resources/data/tests/denoiser/noisy.exr"))
+#    albedo = mi.TensorXf(mi.Bitmap("resources/data/tests/denoiser/albedo.exr"))
+#    normals = mi.TensorXf(mi.Bitmap("resources/data/tests/denoiser/normals.exr"))
+#    ref = mi.TensorXf(mi.Bitmap("resources/data/tests/denoiser/ref_normals.exr"))
+#
+#    denoiser = mi.Denoiser(noisy.shape[:2], True, True, True)
+#    denoised = mi.util.convert_to_bitmap(
+#        denoiser(noisy, False, albedo, normals), uint8_srgb=False
+#    )
+#    denoised = mi.TensorXf(denoised.convert(component_format=mi.Struct.Type.Float16))
+#
+#    ref_tensor = mi.TensorXf(ref)[...,:3]
+#    denoised_tensor = mi.TensorXf(denoised)
+#
+#    ref_array = ref_tensor.array
+#    denoised_array = denoised_tensor.array
+#
+#    assert dr.allclose(denoised_array, ref_array)

--- a/src/render/tests/test_denoiser.py
+++ b/src/render/tests/test_denoiser.py
@@ -15,12 +15,12 @@ def test01_denoiser_construct(variants_any_cuda):
     input_res = [33, 18]
 
     assert (
-        "Denoiser[\n  albedo = 0,\n  normals = 0,\n  temporal = 0\n]""" ==
-        str(mi.Denoiser(input_res))
+        "OptixDenoiser[\n  albedo = 0,\n  normals = 0,\n  temporal = 0\n]""" ==
+        str(mi.OptixDenoiser(input_res))
     )
 
     with pytest.raises(Exception) as e:
-        mi.Denoiser(input_res, albedo=False, normals=True)
+        mi.OptixDenoiser(input_res, albedo=False, normals=True)
     e.match("The denoiser cannot use normals to guide its process without " +
             "also providing albedo information!")
 
@@ -30,7 +30,7 @@ def test02_denoiser_denoise(variant_cuda_ad_rgb):
     noisy = mi.TensorXf(mi.Bitmap("resources/data/tests/denoiser/noisy.exr"))
     ref = mi.TensorXf(mi.Bitmap("resources/data/tests/denoiser/ref.exr"))[...,:3]
 
-    denoiser = mi.Denoiser(noisy.shape[:2])
+    denoiser = mi.OptixDenoiser(noisy.shape[:2])
     denoised = mi.util.convert_to_bitmap(
         denoiser(noisy), uint8_srgb=False
     )
@@ -43,12 +43,12 @@ def test02_denoiser_denoise(variant_cuda_ad_rgb):
 
 
 @fresolver_append_path
-def test03_denosier_denoise_albedo(variant_cuda_ad_rgb):
+def test03_denoiser_denoise_albedo(variant_cuda_ad_rgb):
     noisy = mi.TensorXf(mi.Bitmap("resources/data/tests/denoiser/noisy.exr"))
     albedo = mi.TensorXf(mi.Bitmap("resources/data/tests/denoiser/albedo.exr"))
     ref = mi.TensorXf(mi.Bitmap("resources/data/tests/denoiser/ref_albedo.exr"))
 
-    denoiser = mi.Denoiser(noisy.shape[:2], True)
+    denoiser = mi.OptixDenoiser(noisy.shape[:2], True)
     denoised = mi.util.convert_to_bitmap(
         denoiser(noisy, False, albedo), uint8_srgb=False
     )
@@ -65,13 +65,13 @@ def test03_denosier_denoise_albedo(variant_cuda_ad_rgb):
 
 
 @fresolver_append_path
-def test04_denosier_denoise_normals(variant_cuda_ad_rgb):
+def test04_denoiser_denoise_normals(variant_cuda_ad_rgb):
     noisy = mi.TensorXf(mi.Bitmap("resources/data/tests/denoiser/noisy.exr"))
     albedo = mi.TensorXf(mi.Bitmap("resources/data/tests/denoiser/albedo.exr"))
     normals = mi.TensorXf(mi.Bitmap("resources/data/tests/denoiser/normals.exr"))
     ref = mi.TensorXf(mi.Bitmap("resources/data/tests/denoiser/ref_normals.exr"))
 
-    denoiser = mi.Denoiser(noisy.shape[:2], True, True)
+    denoiser = mi.OptixDenoiser(noisy.shape[:2], True, True)
 
     denoised = mi.util.convert_to_bitmap(
         denoiser(noisy, False, albedo, normals), uint8_srgb=False
@@ -88,13 +88,13 @@ def test04_denosier_denoise_normals(variant_cuda_ad_rgb):
 
 
 #@fresolver_append_path
-#def test05_denosier_denoise_normals(variant_cuda_ad_rgb):
+#def test05_denoiser_denoise_normals(variant_cuda_ad_rgb):
 #    noisy = mi.TensorXf(mi.Bitmap("resources/data/tests/denoiser/noisy.exr"))
 #    albedo = mi.TensorXf(mi.Bitmap("resources/data/tests/denoiser/albedo.exr"))
 #    normals = mi.TensorXf(mi.Bitmap("resources/data/tests/denoiser/normals.exr"))
 #    ref = mi.TensorXf(mi.Bitmap("resources/data/tests/denoiser/ref_normals.exr"))
 #
-#    denoiser = mi.Denoiser(noisy.shape[:2], True, True, True)
+#    denoiser = mi.OptixDenoiser(noisy.shape[:2], True, True, True)
 #    denoised = mi.util.convert_to_bitmap(
 #        denoiser(noisy, False, albedo, normals), uint8_srgb=False
 #    )

--- a/src/render/tests/test_denoiser.py
+++ b/src/render/tests/test_denoiser.py
@@ -1,0 +1,108 @@
+import pytest
+import mitsuba as mi
+import drjit as dr
+
+from mitsuba.scalar_rgb.test.util import fresolver_append_path
+
+###
+### Reference images are generated using the `optixDenoiser` example provided
+### with the OptiX 7.4 SDK. The example will always output float16 EXRs with an
+### alpha channel.
+###
+
+
+def test01_denosier_construct(variants_any_cuda):
+    input_res = [33, 18]
+
+    assert (
+        "Denoiser[\n  albedo = 0,\n  normals = 0,\n  temporal = 0\n]""" ==
+        str(mi.Denoiser(input_res))
+    )
+
+    with pytest.raises(Exception) as e:
+        mi.Denoiser(input_res, albedo=False, normals=True)
+    e.match("The denoiser cannot use normals to guide its process without " +
+            "also providing albedo information!")
+
+
+@fresolver_append_path
+def test02_denosier_denoise(variant_cuda_ad_rgb):
+    noisy = mi.TensorXf(mi.Bitmap("resources/data/tests/denoiser/noisy.exr"))
+    ref = mi.TensorXf(mi.Bitmap("resources/data/tests/denoiser/ref.exr"))[...,:3]
+
+    denoiser = mi.Denoiser(noisy.shape[:2])
+    denoised = mi.util.convert_to_bitmap(
+        denoiser.denoise(noisy), uint8_srgb=False
+    )
+    denoised = mi.TensorXf(denoised.convert(component_format=mi.Struct.Type.Float16))
+
+    ref_array = ref.array
+    denoised_array = denoised.array
+
+    assert dr.allclose(denoised_array, ref_array)
+
+
+@fresolver_append_path
+def test02_denosier_denoise_albedo(variant_cuda_ad_rgb):
+    noisy = mi.TensorXf(mi.Bitmap("resources/data/tests/denoiser/noisy.exr"))
+    albedo = mi.TensorXf(mi.Bitmap("resources/data/tests/denoiser/albedo.exr"))
+    ref = mi.TensorXf(mi.Bitmap("resources/data/tests/denoiser/ref_albedo.exr"))
+
+    denoiser = mi.Denoiser(noisy.shape[:2], True)
+    denoised = mi.util.convert_to_bitmap(
+        denoiser.denoise(noisy, False, albedo), uint8_srgb=False
+    )
+    denoised = mi.TensorXf(denoised.convert(component_format=mi.Struct.Type.Float16))
+
+    ref_tensor = mi.TensorXf(ref)[...,:3]
+    denoised_tensor = mi.TensorXf(denoised)
+
+    ref_array = ref_tensor.array
+    denoised_array = denoised_tensor.array
+
+    assert dr.allclose(denoised_array, ref_array)
+
+
+@fresolver_append_path
+def test02_denosier_denoise_normals(variant_cuda_ad_rgb):
+    noisy = mi.TensorXf(mi.Bitmap("resources/data/tests/denoiser/noisy.exr"))
+    albedo = mi.TensorXf(mi.Bitmap("resources/data/tests/denoiser/albedo.exr"))
+    normals = mi.TensorXf(mi.Bitmap("resources/data/tests/denoiser/normals.exr"))
+    ref = mi.TensorXf(mi.Bitmap("resources/data/tests/denoiser/ref_normals.exr"))
+
+    denoiser = mi.Denoiser(noisy.shape[:2], True, True)
+
+    denoised = mi.convert_to_bitmap(
+        denoiser.denoise(noisy, False, albedo, normals), uint8_srgb=False
+    )
+    denoised = mi.TensorXf(denoised.convert(component_format=mi.Struct.Type.Float16))
+
+    ref_tensor = mi.TensorXf(ref)[...,:3]
+    denoised_tensor = mi.TensorXf(denoised)
+
+    ref_array = ref_tensor.array
+    denoised_array = denoised_tensor.array
+
+    assert dr.allclose(denoised_array, ref_array)
+
+
+@fresolver_append_path
+def test02_denosier_denoise_normals(variant_cuda_ad_rgb):
+    noisy = mi.TensorXf(mi.Bitmap("resources/data/tests/denoiser/noisy.exr"))
+    albedo = mi.TensorXf(mi.Bitmap("resources/data/tests/denoiser/albedo.exr"))
+    normals = mi.TensorXf(mi.Bitmap("resources/data/tests/denoiser/normals.exr"))
+    ref = mi.TensorXf(mi.Bitmap("resources/data/tests/denoiser/ref_normals.exr"))
+
+    denoiser = mi.Denoiser(noisy.shape[:2], True, True)
+    denoised = mi.util.convert_to_bitmap(
+        denoiser.denoise(noisy, False, albedo, normals), uint8_srgb=False
+    )
+    denoised = mi.TensorXf(denoised.convert(component_format=mi.Struct.Type.Float16))
+
+    ref_tensor = mi.TensorXf(ref)[...,:3]
+    denoised_tensor = mi.TensorXf(denoised)
+
+    ref_array = ref_tensor.array
+    denoised_array = denoised_tensor.array
+
+    assert dr.allclose(denoised_array, ref_array)

--- a/src/render/tests/test_megakernel.py
+++ b/src/render/tests/test_megakernel.py
@@ -2,16 +2,7 @@ import pytest
 import drjit as dr
 import mitsuba as mi
 
-def find_resource(fname):
-    import os
-    path = os.path.dirname(os.path.realpath(__file__))
-    while True:
-        full = os.path.join(path, fname)
-        if os.path.exists(full):
-            return full
-        if path == '' or path == '/':
-            raise Exception("find_resource(): could not find \"%s\"" % fname)
-        path = os.path.dirname(path)
+from mitsuba.scalar_rgb.test.util import find_resource
 
 def write_kernels(*args, output_dir='kernels', scene_fname=None):
     import os

--- a/src/render/tests/test_optixdenoiser.py
+++ b/src/render/tests/test_optixdenoiser.py
@@ -7,7 +7,8 @@ from mitsuba.scalar_rgb.test.util import fresolver_append_path
 ###
 ### Reference images are generated using the `optixDenoiser` example provided
 ### with the OptiX 7.4 SDK. The example will always output float16 EXRs with an
-### alpha channel.
+### alpha channel. The script to generate the reference images is located at
+### `mitsuba3/resources/data/tests/denoiser/denoiser_ref.py`.
 ###
 
 
@@ -85,7 +86,6 @@ def test04_denoiser_denoise_normals(variant_cuda_ad_rgb):
     ref = mi.TensorXf(mi.Bitmap("resources/data/tests/denoiser/ref_normals.exr"))
 
     normals = fix_normals(normals)
-    mi.Bitmap(normals).write("resources/data/tests/denoiser/normals_input_test.exr")
 
     denoiser = mi.OptixDenoiser(noisy.shape[:2], True, True)
     denoised = mi.util.convert_to_bitmap(
@@ -103,52 +103,55 @@ def test04_denoiser_denoise_normals(variant_cuda_ad_rgb):
 
 @fresolver_append_path
 def test05_denoiser_denoise_temporal(variant_cuda_ad_rgb):
-    #noisy = mi.TensorXf(mi.Bitmap("resources/data/tests/denoiser/noisy.exr"))
-    #albedo = mi.TensorXf(mi.Bitmap("resources/data/tests/denoiser/albedo.exr"))
-    #normals = mi.TensorXf(mi.Bitmap("resources/data/tests/denoiser/normals.exr"))
-    #flow = mi.TensorXf(mi.Bitmap("resources/data/tests/denoiser/flow.exr"))
-    #previous_denoised = noisy
-    #ref = mi.TensorXf(mi.Bitmap("resources/data/tests/denoiser/ref_temporal.exr"))
+    noisy = mi.TensorXf(mi.Bitmap("resources/data/tests/denoiser/noisy.exr"))
+    albedo = mi.TensorXf(mi.Bitmap("resources/data/tests/denoiser/albedo.exr"))
+    normals = mi.TensorXf(mi.Bitmap("resources/data/tests/denoiser/normals.exr"))
+    flow = mi.TensorXf(mi.Bitmap("resources/data/tests/denoiser/flow.exr"))
+    previous_denoised = noisy
+    ref = mi.TensorXf(mi.Bitmap("resources/data/tests/denoiser/ref_temporal.exr"))
 
-    #normals = fix_normals(mi.TensorXf(normals))
+    normals = fix_normals(mi.TensorXf(normals))
 
-    #denoiser = mi.OptixDenoiser(noisy.shape[:2], True, True, True)
-    #denoised = mi.util.convert_to_bitmap(
-    #    denoiser(noisy, False, albedo, normals, flow, previous_denoised), uint8_srgb=False
-    #)
-    #denoised = mi.TensorXf(denoised.convert(component_format=mi.Struct.Type.Float16))
+    denoiser = mi.OptixDenoiser(noisy.shape[:2], True, True, True)
+    denoised = mi.util.convert_to_bitmap(
+        denoiser(noisy, False, albedo, normals, flow=flow, previous_denoised=previous_denoised),
+        uint8_srgb=False
+    )
+    denoised = mi.TensorXf(denoised.convert(component_format=mi.Struct.Type.Float16))
 
-    #ref_tensor = mi.TensorXf(ref)[...,:3]
-    #denoised_tensor = mi.TensorXf(denoised)
+    ref_tensor = mi.TensorXf(ref)[...,:3]
+    denoised_tensor = mi.TensorXf(denoised)
 
-    #ref_array = ref_tensor.array
-    #denoised_array = denoised_tensor.array
+    ref_array = ref_tensor.array
+    denoised_array = denoised_tensor.array
 
-    #assert dr.allclose(denoised_array, ref_array)
-    assert True
+    assert dr.allclose(denoised_array, ref_array)
 
 @fresolver_append_path
 def test05_denoiser_denoise_multichannel_bitmap(variant_cuda_ad_rgb):
-    #noisy = mi.TensorXf(mi.Bitmap("resources/data/tests/denoiser/noisy.exr"))
-    #albedo = mi.TensorXf(mi.Bitmap("resources/data/tests/denoiser/albedo.exr"))
-    #normals = mi.TensorXf(mi.Bitmap("resources/data/tests/denoiser/normals.exr"))
-    #flow = mi.TensorXf(mi.Bitmap("resources/data/tests/denoiser/flow.exr"))
-    #previous_denoised = noisy
-    #ref = mi.TensorXf(mi.Bitmap("resources/data/tests/denoiser/ref_temporal.exr"))
+    ref = mi.TensorXf(mi.Bitmap("resources/data/tests/denoiser/ref_normals.exr"))
 
-    #normals = fix_normals(mi.TensorXf(normals))
+    scene = mi.load_file("resources/data/scenes/cbox/cbox-rgb.xml", res=64)
+    sensor = scene.sensors()[0]
+    integrator = mi.load_dict({
+        'type': 'aov',
+        'aovs': 'albedo:albedo,sh_normal:sh_normal',
+        'img': {
+            'type': 'path',
+            'max_depth' : 6,
+        }
+    })
+    mi.render(scene, spp=2, integrator=integrator, sensor=sensor)
+    multichannel = sensor.film().bitmap()
 
-    #denoiser = mi.OptixDenoiser(noisy.shape[:2], True, True, True)
-    #denoised = mi.util.convert_to_bitmap(
-    #    denoiser(noisy, False, albedo, normals, flow, previous_denoised), uint8_srgb=False
-    #)
-    #denoised = mi.TensorXf(denoised.convert(component_format=mi.Struct.Type.Float16))
+    denoiser = mi.OptixDenoiser(multichannel.size(), True, True)
+    denoised = denoiser(multichannel, False, "albedo", "sh_normal", sensor.world_transform().inverse())
+    denoised = mi.TensorXf(denoised.convert(component_format=mi.Struct.Type.Float16))
 
-    #ref_tensor = mi.TensorXf(ref)[...,:3]
-    #denoised_tensor = mi.TensorXf(denoised)
+    ref_tensor = mi.TensorXf(ref)[...,:3]
+    denoised_tensor = mi.TensorXf(denoised)
 
-    #ref_array = ref_tensor.array
-    #denoised_array = denoised_tensor.array
+    ref_array = ref_tensor.array
+    denoised_array = denoised_tensor.array
 
-    #assert dr.allclose(denoised_array, ref_array)
-    assert True
+    assert dr.allclose(denoised_array, ref_array)

--- a/src/render/tests/test_optixdenoiser.py
+++ b/src/render/tests/test_optixdenoiser.py
@@ -30,8 +30,8 @@ def test01_denoiser_construct(variants_any_cuda):
     input_res = [33, 18]
 
     assert (
-        "OptixDenoiser[\n  albedo = 0,\n  normals = 0,\n  temporal = 0\n]""" ==
-        str(mi.OptixDenoiser(input_res))
+        "OptixDenoiser[\n  input_size = [33, 18],\n  albedo = 0,\n  " +
+        "normals = 0,\n  temporal = 0\n]" == str(mi.OptixDenoiser(input_res))
     )
 
     with pytest.raises(Exception) as e:

--- a/src/render/tests/test_optixdenoiser.py
+++ b/src/render/tests/test_optixdenoiser.py
@@ -11,6 +11,20 @@ from mitsuba.scalar_rgb.test.util import fresolver_append_path
 ###
 
 
+def fix_normals(normals):
+    # Normals are already in correct frame for OptiX, so we need to rotate them
+    # by 180 degrees first as the OptixDenoiser always does that
+    new_normals = dr.zeros(mi.Normal3f, normals.shape[0] * normals.shape[1])
+    for i in range(3):
+        new_normals[i] = dr.ravel(normals)[i::3]
+    new_normals[0] = -new_normals[0]
+    new_normals[2] = -new_normals[2]
+    for i in range(3):
+        normals[..., i] = new_normals[i]
+
+    return normals
+
+
 def test01_denoiser_construct(variants_any_cuda):
     input_res = [33, 18]
 
@@ -70,16 +84,8 @@ def test04_denoiser_denoise_normals(variant_cuda_ad_rgb):
     normals = mi.TensorXf(mi.Bitmap("resources/data/tests/denoiser/normals.exr"))
     ref = mi.TensorXf(mi.Bitmap("resources/data/tests/denoiser/ref_normals.exr"))
 
-    # Normals are already in correct frame for OptiX, so we need to rotate them
-    # by 180 degrees first as the OptixDenoiser always does that
-    normals = mi.TensorXf(normals)
-    new_normals = dr.zeros(mi.Normal3f, normals.shape[0] * normals.shape[1])
-    for i in range(3):
-        new_normals[i] = dr.ravel(normals)[i::3]
-    new_normals[0] = -new_normals[0]
-    new_normals[2] = -new_normals[2]
-    for i in range(3):
-        normals[..., i] = new_normals[i]
+    normals = fix_normals(normals)
+    mi.Bitmap(normals).write("resources/data/tests/denoiser/normals_input_test.exr")
 
     denoiser = mi.OptixDenoiser(noisy.shape[:2], True, True)
     denoised = mi.util.convert_to_bitmap(
@@ -95,24 +101,54 @@ def test04_denoiser_denoise_normals(variant_cuda_ad_rgb):
 
     assert dr.allclose(denoised_array, ref_array)
 
+@fresolver_append_path
+def test05_denoiser_denoise_temporal(variant_cuda_ad_rgb):
+    #noisy = mi.TensorXf(mi.Bitmap("resources/data/tests/denoiser/noisy.exr"))
+    #albedo = mi.TensorXf(mi.Bitmap("resources/data/tests/denoiser/albedo.exr"))
+    #normals = mi.TensorXf(mi.Bitmap("resources/data/tests/denoiser/normals.exr"))
+    #flow = mi.TensorXf(mi.Bitmap("resources/data/tests/denoiser/flow.exr"))
+    #previous_denoised = noisy
+    #ref = mi.TensorXf(mi.Bitmap("resources/data/tests/denoiser/ref_temporal.exr"))
 
-#@fresolver_append_path
-#def test05_denoiser_denoise_normals(variant_cuda_ad_rgb):
-#    noisy = mi.TensorXf(mi.Bitmap("resources/data/tests/denoiser/noisy.exr"))
-#    albedo = mi.TensorXf(mi.Bitmap("resources/data/tests/denoiser/albedo.exr"))
-#    normals = mi.TensorXf(mi.Bitmap("resources/data/tests/denoiser/normals.exr"))
-#    ref = mi.TensorXf(mi.Bitmap("resources/data/tests/denoiser/ref_normals.exr"))
-#
-#    denoiser = mi.OptixDenoiser(noisy.shape[:2], True, True, True)
-#    denoised = mi.util.convert_to_bitmap(
-#        denoiser(noisy, False, albedo, normals), uint8_srgb=False
-#    )
-#    denoised = mi.TensorXf(denoised.convert(component_format=mi.Struct.Type.Float16))
-#
-#    ref_tensor = mi.TensorXf(ref)[...,:3]
-#    denoised_tensor = mi.TensorXf(denoised)
-#
-#    ref_array = ref_tensor.array
-#    denoised_array = denoised_tensor.array
-#
-#    assert dr.allclose(denoised_array, ref_array)
+    #normals = fix_normals(mi.TensorXf(normals))
+
+    #denoiser = mi.OptixDenoiser(noisy.shape[:2], True, True, True)
+    #denoised = mi.util.convert_to_bitmap(
+    #    denoiser(noisy, False, albedo, normals, flow, previous_denoised), uint8_srgb=False
+    #)
+    #denoised = mi.TensorXf(denoised.convert(component_format=mi.Struct.Type.Float16))
+
+    #ref_tensor = mi.TensorXf(ref)[...,:3]
+    #denoised_tensor = mi.TensorXf(denoised)
+
+    #ref_array = ref_tensor.array
+    #denoised_array = denoised_tensor.array
+
+    #assert dr.allclose(denoised_array, ref_array)
+    assert True
+
+@fresolver_append_path
+def test05_denoiser_denoise_multichannel_bitmap(variant_cuda_ad_rgb):
+    #noisy = mi.TensorXf(mi.Bitmap("resources/data/tests/denoiser/noisy.exr"))
+    #albedo = mi.TensorXf(mi.Bitmap("resources/data/tests/denoiser/albedo.exr"))
+    #normals = mi.TensorXf(mi.Bitmap("resources/data/tests/denoiser/normals.exr"))
+    #flow = mi.TensorXf(mi.Bitmap("resources/data/tests/denoiser/flow.exr"))
+    #previous_denoised = noisy
+    #ref = mi.TensorXf(mi.Bitmap("resources/data/tests/denoiser/ref_temporal.exr"))
+
+    #normals = fix_normals(mi.TensorXf(normals))
+
+    #denoiser = mi.OptixDenoiser(noisy.shape[:2], True, True, True)
+    #denoised = mi.util.convert_to_bitmap(
+    #    denoiser(noisy, False, albedo, normals, flow, previous_denoised), uint8_srgb=False
+    #)
+    #denoised = mi.TensorXf(denoised.convert(component_format=mi.Struct.Type.Float16))
+
+    #ref_tensor = mi.TensorXf(ref)[...,:3]
+    #denoised_tensor = mi.TensorXf(denoised)
+
+    #ref_array = ref_tensor.array
+    #denoised_array = denoised_tensor.array
+
+    #assert dr.allclose(denoised_array, ref_array)
+    assert True


### PR DESCRIPTION
## Description
This PR adds a wrapper for the Optix AI Denoiser.

The new `OptixDenoiser` class  has the following features:
* Denoise a noisy rendering without any extra information
* Denoising when also given the albedo and/or shading normals, to improve the denoising quality
* Temporal denoising, for which the optical flow and the previous frame (denoised) must also be provided

Important notes: 
* `box` filter must be used to produce the noisy rendering
* The shading normals must be in the coordinate frame of the sensor
* With temporal denoising, the optical flow can be set to zero and still produce convincing results

The `aov` integrator now also supports `albedo`. It actually only computes an approximation of the true albedo, as it will return the diffuse reflectance (`eval_diffuse_reflectance`) of the BSDFs.

## Testing
New tests are added for the `OptixDenoiser` to verify its implementation (`test_optixdenoiser.py`). In these tests, the denoised outputs are compared to references which are generated with the denoiser example in the OptiX SDK. (The `resources/data/tests/denoiser/denoiser_ref.py` script can generate these references)

