### PR TITLE
Fix typo in documentation - s/wavelenths/wavelengths/

### DIFF
--- a/docs/src/key_topics/scene_format.rst
+++ b/docs/src/key_topics/scene_format.rst
@@ -287,7 +287,7 @@ Here is an example:
     ...
 
 Mitsuba provides a function (:py:meth:`mitsuba.spectrum_to_file`) to create such
-file, given the wavelenths and its values.
+file, given the wavelengths and its values.
 
 For more details regarding spectral information in Mitsuba 3, please have a look
 at the :ref:`corresponding section <sec-spectra>` in the plugin documentation.


### PR DESCRIPTION
<!-- Please add the labels (e.g. bug fix, feature, ..) corresponding to this PR -->

## Description

Fixes typo in documentation.

## Testing

No testing completed.

## Checklist

<!-- Please make sure to complete this checklist before requesting a review. -->

- [x] My code follows the [style guidelines](https://mitsuba.readthedocs.io/en/latest/src/developer_guide.html#coding-style) of this project
- [x] My changes generate no new warnings
- [x] My code also compiles for `cuda_*` and `llvm_*` variants. If you can't test this, please leave below
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 3 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba/blob/master/LICENSE)