### PR TITLE
Fix numerical instabilities with box filter splatting

### DIFF
--- a/src/python/python/ad/integrators/common.py
+++ b/src/python/python/ad/integrators/common.py
@@ -407,7 +407,10 @@ class ADIntegrator(mi.CppADIntegrator):
                 # Return a reparameterized image position
                 pos_f = ds.uv + film.crop_offset()
 
-        return ray, weight, pos_f, reparam_det
+        # With box filter, ignore random offset to prevent numerical instabilities
+        splatting_pos = mi.Vector2f(pos) if rfilter.is_box_filter() else pos_f
+
+        return ray, weight, splatting_pos, reparam_det
 
     def prepare(self,
                 sensor: mi.Sensor,

--- a/src/render/imageblock.cpp
+++ b/src/render/imageblock.cpp
@@ -133,8 +133,8 @@ MI_VARIANT void ImageBlock<Float, Spectrum>::put_block(const ImageBlock *block) 
 }
 
 MI_VARIANT void ImageBlock<Float, Spectrum>::put(const Point2f &pos,
-                                                  const Float *values,
-                                                  Mask active) {
+                                                 const Float *values,
+                                                 Mask active) {
     ScopedPhase sp(ProfilerPhase::ImageBlockPut);
     constexpr bool JIT = dr::is_jit_v<Float>;
 
@@ -175,7 +175,7 @@ MI_VARIANT void ImageBlock<Float, Spectrum>::put(const Point2f &pos,
         UInt32 index = dr::fmadd(p.y(), m_size.x(), p.x()) * m_channel_count;
 
         // The sample could be out of bounds
-        active = active && dr::all(p < m_size);
+        active &= dr::all(p < m_size);
 
         // Accumulate!
         if constexpr (!JIT) {


### PR DESCRIPTION
## Description

When using `box` reconstruction filter, it can happen that samples get splatted on neighboring pixels due to numerical instabilities. This can be seen for instance when rendering a depth image with one sample per pixel (see issue #287).

In this patch, the integrators provide a splatting position that doesn't contain the random offset in order to prevent this problem.