### PR TITLE
Fix cleanup function callbacks in Python

### DIFF
--- a/src/python/main.cpp
+++ b/src/python/main.cpp
@@ -127,6 +127,12 @@ PYBIND11_MODULE(mitsuba_ext, m) {
     MI_PY_IMPORT(Sensor);
     MI_PY_IMPORT(FilmFlags);
 
+    // Register a cleanup callback function to wait for pending tasks
+    auto atexit = py::module_::import("atexit");
+    atexit.attr("register")(py::cpp_function([]() {
+        Thread::wait_for_tasks();
+    }));
+
     /* Register a cleanup callback function that is invoked when
        the 'mitsuba::Object' Python type is garbage collected */
     py::cpp_function cleanup_callback(

--- a/src/render/scene_optix.inl
+++ b/src/render/scene_optix.inl
@@ -350,6 +350,9 @@ MI_VARIANT void Scene<Float, Spectrum>::accel_parameters_changed_gpu() {
                     &buffer_sizes
                 ));
 
+                if (s.ias_buffer)
+                    jit_free(s.ias_buffer);
+
                 void* d_temp_buffer
                     = jit_malloc(AllocType::Device, buffer_sizes.tempSizeInBytes);
                 s.ias_buffer
@@ -371,6 +374,7 @@ MI_VARIANT void Scene<Float, Spectrum>::accel_parameters_changed_gpu() {
                 ));
 
                 jit_free(d_temp_buffer);
+                jit_free(build_input.instanceArray.instances);
             }
         }
 

--- a/src/shapes/instance.cpp
+++ b/src/shapes/instance.cpp
@@ -37,7 +37,7 @@ details on how to create instances, refer to the :ref:`shape-shapegroup` plugin.
         :width: 100%
         :align: center
 
-    The Stanford bunny loaded a single time and instanciated 1365 times (equivalent to 100 million
+    The Stanford bunny loaded a single time and instantiated 1365 times (equivalent to 100 million
     triangles)
 
 .. warning::


### PR DESCRIPTION
Currently, Mitsuba relies on reference counting to trigger cleanup callback functions at Python interpreter shutdown. This isn't reliable hence in this PR we switch to using of the [`atexit` Python module](https://docs.python.org/3/library/atexit.html) as suggested in the [pybind11 documentation](https://pybind11.readthedocs.io/en/stable/advanced/misc.html#module-destructors).

This PR will fix the issue #299.