### PR TITLE
Lower required Nvidia GPU architecture

### DIFF
--- a/resources/ptx/Makefile
+++ b/resources/ptx/Makefile
@@ -9,7 +9,7 @@ all: optix_rt.ptx
 optix_rt.ptx: $(mts_optix_main) $(mts_include_folder)/* $(mts_shape_folder)/*
 	nvcc $(mts_optix_main) \
 		 -I $(mts_include_folder) -I $(mts_shape_folder) -I $(OPTIX_PATH) \
-		 -O3 -gencode arch=compute_61,code=compute_61 --ptx
+		 -O3 -gencode arch=compute_50,code=compute_50 --ptx
 
 clean:
 	rm -f optix_rt.ptx

--- a/resources/ptx/optix_rt.ptx
+++ b/resources/ptx/optix_rt.ptx
@@ -7,7 +7,7 @@
 //
 
 .version 7.6
-.target sm_61
+.target sm_50
 .address_size 64
 
 	// .globl	__intersection__cylinder


### PR DESCRIPTION
This PR fixes #182.
It updates the `drjit` submodule where we now properly check if asynchronous memory allocations are supported. It also modifies the `.ptx` generation for custom shapes so as to be supported by older Nvidia GPU architectures.

(Very few changes, PR opened to run the CI)