### PR TITLE
Use BSDF::eval_pdf_sample() in path.cpp

### DIFF
--- a/src/integrators/path.cpp
+++ b/src/integrators/path.cpp
@@ -179,15 +179,19 @@ public:
             if (dr::none_or<false>(active_next))
                 break; // early exit for scalar mode
 
+            BSDFPtr bsdf = si.bsdf(ray);
+
             // ---------------------- Emitter sampling ----------------------
 
             // Perform emitter sampling?
-            BSDFPtr bsdf = si.bsdf(ray);
             Mask active_em = active_next && has_flag(bsdf->flags(), BSDFFlags::Smooth);
 
+            DirectionSample3f ds;
+            Spectrum em_weight;
+            Vector3f wo;
             if (dr::any_or<true>(active_em)) {
                 // Sample the emitter
-                auto [ds, em_weight] = scene->sample_emitter_direction(
+                std::tie(ds, em_weight) = scene->sample_emitter_direction(
                     si, sampler->next_2d(), true, active_em);
                 active_em &= dr::neq(ds.pdf, 0.f);
 
@@ -199,10 +203,20 @@ public:
                     em_weight = dr::select(dr::neq(ds.pdf, 0), em_val / ds.pdf, 0);
                 }
 
-                // Evaluate BSDF * cos(theta)
-                Vector3f wo = si.to_local(ds.d);
-                auto [bsdf_val, bsdf_pdf] =
-                    bsdf->eval_pdf(bsdf_ctx, si, wo, active_em);
+                wo = si.to_local(ds.d);
+            }
+
+            // ------ Evaluate BSDF * cos(theta) and sample direction -------
+
+            Float sample_1 = sampler->next_1d();
+            Point2f sample_2 = sampler->next_2d();
+
+            auto [bsdf_val, bsdf_pdf, bsdf_sample, bsdf_weight]
+                = bsdf->eval_pdf_sample(bsdf_ctx, si, wo, sample_1, sample_2);
+
+            // --------------- Emitter sampling contribution ----------------
+
+            if (dr::any_or<true>(active_em)) {
                 bsdf_val = si.to_world_mueller(bsdf_val, -wo, si.wi);
 
                 // Compute the MIS weight
@@ -216,11 +230,6 @@ public:
 
             // ---------------------- BSDF sampling ----------------------
 
-            Float sample_1 = sampler->next_1d();
-            Point2f sample_2 = sampler->next_2d();
-
-            auto [bsdf_sample, bsdf_weight] =
-                bsdf->sample(bsdf_ctx, si, sample_1, sample_2, active_next);
             bsdf_weight = si.to_world_mueller(bsdf_weight, -bsdf_sample.wo, si.wi);
 
             ray = si.spawn_ray(si.to_world(bsdf_sample.wo));

--- a/src/render/bsdf.cpp
+++ b/src/render/bsdf.cpp
@@ -16,6 +16,18 @@ BSDF<Float, Spectrum>::eval_pdf(const BSDFContext &ctx,
     return { eval(ctx, si, wo, active), pdf(ctx, si, wo, active) };
 }
 
+MI_VARIANT std::tuple<Spectrum, Float, BSDFSample3<Float, Spectrum>, Spectrum>
+BSDF<Float, Spectrum>::eval_pdf_sample(const BSDFContext &ctx,
+                                       const SurfaceInteraction3f &si,
+                                       const Vector3f &wo,
+                                       Float sample1,
+                                       const Point2f &sample2,
+                                       Mask active) const {
+        auto [e_val, pdf_val] = eval_pdf(ctx, si, wo, active);
+        auto [bs, bsdf_weight] = sample(ctx, si, sample1, sample2, active);
+        return { e_val, pdf_val, bs, bsdf_weight };
+}
+
 MI_VARIANT Spectrum BSDF<Float, Spectrum>::eval_null_transmission(
     const SurfaceInteraction3f & /* si */, Mask /* active */) const {
     return 0.f;

--- a/src/render/python/bsdf_v.cpp
+++ b/src/render/python/bsdf_v.cpp
@@ -97,6 +97,13 @@ template <typename Ptr, typename Cls> void bind_bsdf_generic(Cls &cls) {
                 const Vector3f &wo,
                 Mask active) { return bsdf->eval_pdf(ctx, si, wo, active);
              }, "ctx"_a, "si"_a, "wo"_a, "active"_a = true, D(BSDF, eval_pdf))
+        .def("eval_pdf_sample",
+             [](Ptr bsdf, const BSDFContext &ctx, const SurfaceInteraction3f &si,
+                const Vector3f &wo, Float sample1, const Point2f &sample2,
+                Mask active) {
+                    return bsdf->eval_pdf_sample(ctx, si, wo, sample1, sample2, active);
+                }, "ctx"_a, "si"_a, "wo"_a, "sample1"_a, "sample2"_a, "active"_a = true,
+                D(BSDF, eval_pdf))
         .def("eval_null_transmission",
              [](Ptr bsdf, const SurfaceInteraction3f &si, Mask active) {
                  return bsdf->eval_null_transmission(si, active);


### PR DESCRIPTION
This PR adds the `eval_pdf_sample` method to `BSDF` and uses it in the `path.cpp` integrator.

This reduces the number of virtual function calls performed by the integrator and reduces the rendering time by ~20% in `cuda_*` modes.

More work needs to be done to integrate such changes in the Python integrators (e.g. `prb`) as we need fine control over the differentiation of the BSDF routines (and detach sampling).