### PR TITLE
Support large launches with up to 2^32 threads on OptiX backend

### DIFF
--- a/include/mitsuba/render/bsdf.h
+++ b/include/mitsuba/render/bsdf.h
@@ -448,7 +448,7 @@ public:
      *     A uniformly distributed sample on \f$[0,1]^2\f$. It is
      *     used to generate the sampled direction.
      */
-    virtual std::tuple<Spectrum, Float, BSDFSample3<Float, Spectrum>, Spectrum>
+    virtual std::tuple<Spectrum, Float, BSDFSample3f, Spectrum>
     eval_pdf_sample(const BSDFContext &ctx,
                     const SurfaceInteraction3f &si,
                     const Vector3f &wo,

--- a/src/integrators/path.cpp
+++ b/src/integrators/path.cpp
@@ -1,4 +1,4 @@
-#include <random>
+#include <tuple>
 #include <mitsuba/core/ray.h>
 #include <mitsuba/core/properties.h>
 #include <mitsuba/render/bsdf.h>

--- a/src/python/python/ad/integrators/common.py
+++ b/src/python/python/ad/integrators/common.py
@@ -465,17 +465,12 @@ class ADIntegrator(mi.CppADIntegrator):
 
         wavefront_size = dr.prod(film_size) * spp
 
-        is_llvm = dr.is_llvm_v(mi.Float)
-        wavefront_size_limit = 0xffffffff if is_llvm else 0x40000000
-
-        if wavefront_size >  wavefront_size_limit:
+        if wavefront_size > 2**32:
             raise Exception(
-                "Tried to perform a %s-based rendering with a total sample "
-                "count of %u, which exceeds 2^%u = %u (the upper limit "
-                "for this backend). Please use fewer samples per pixel or "
-                "render using multiple passes." %
-                ("LLVM JIT" if is_llvm else "OptiX", wavefront_size,
-                 dr.log2i(wavefront_size_limit) + 1, wavefront_size_limit))
+                "The total number of Monte Carlo samples required by this "
+                "rendering task (%i) exceeds 2^32 = 4294967296. Please use "
+                "fewer samples per pixel or render using multiple passes."
+                % wavefront_size)
 
         sampler.seed(seed, wavefront_size)
         film.prepare(aovs)

--- a/src/render/bsdf.cpp
+++ b/src/render/bsdf.cpp
@@ -16,7 +16,7 @@ BSDF<Float, Spectrum>::eval_pdf(const BSDFContext &ctx,
     return { eval(ctx, si, wo, active), pdf(ctx, si, wo, active) };
 }
 
-MI_VARIANT std::tuple<Spectrum, Float, BSDFSample3<Float, Spectrum>, Spectrum>
+MI_VARIANT std::tuple<Spectrum, Float, typename BSDF<Float, Spectrum>::BSDFSample3f, Spectrum>
 BSDF<Float, Spectrum>::eval_pdf_sample(const BSDFContext &ctx,
                                        const SurfaceInteraction3f &si,
                                        const Vector3f &wo,

--- a/src/render/integrator.cpp
+++ b/src/render/integrator.cpp
@@ -192,31 +192,38 @@ SamplingIntegrator<Float, Spectrum>::render(Scene *scene,
         if (develop)
             result = film->develop();
     } else {
+        size_t wavefront_size = (size_t) film_size.x() *
+                                (size_t) film_size.y() * (size_t) spp_per_pass,
+               wavefront_size_limit =
+                   dr::is_llvm_v<Float> ? 0xffffffffu : 0x40000000u;
+
+        if (wavefront_size > wavefront_size_limit) {
+            spp_per_pass /= (wavefront_size + wavefront_size_limit - 1) /
+                            wavefront_size_limit;
+            n_passes = spp / spp_per_pass;
+            wavefront_size = (size_t) film_size.x() * (size_t) film_size.y() *
+                             (size_t) spp_per_pass;
+
+            Log(Warn,
+                "The requested rendering task involves %zu Monte Carlo "
+                "samples, which exceeds the upper limit of 2^%zu = %zu for "
+                "this variant. Mitsuba will instead split the rendering task "
+                "%zu smaller passes to avoid exceeding the limits.",
+                wavefront_size, dr::log2i(wavefront_size_limit + 1),
+                wavefront_size_limit, n_passes);
+        }
+
         dr::sync_thread(); // Separate from scene initialization (for timings)
 
         Log(Info, "Starting render job (%ux%u, %u sample%s%s)",
             film_size.x(), film_size.y(), spp, spp == 1 ? "" : "s",
-            n_passes > 1 ? tfm::format(", %u passes,", n_passes) : "");
+            n_passes > 1 ? tfm::format(", %u passes", n_passes) : "");
 
         if (n_passes > 1 && !evaluate) {
             Log(Warn, "render(): forcing 'evaluate=true' since multi-pass "
                       "rendering was requested.");
             evaluate = true;
         }
-
-        size_t wavefront_size = (size_t) film_size.x() *
-                                (size_t) film_size.y() * (size_t) spp_per_pass,
-               wavefront_size_limit =
-                   dr::is_llvm_v<Float> ? 0xffffffffu : 0x40000000u;
-
-        if (wavefront_size > wavefront_size_limit)
-            Throw("Tried to perform a %s-based rendering with a total sample "
-                  "count of %zu, which exceeds 2^%zu = %zu (the upper limit "
-                  "for this backend). Please use fewer samples per pixel or "
-                  "render using multiple passes.",
-                  dr::is_llvm_v<Float> ? "LLVM JIT" : "OptiX",
-                  wavefront_size, dr::log2i(wavefront_size_limit + 1),
-                  wavefront_size_limit);
 
         // Inform the sampler about the passes (needed in vectorized modes)
         sampler->set_samples_per_wavefront(spp_per_pass);
@@ -514,7 +521,8 @@ AdjointIntegrator<Float, Spectrum>::render(Scene *scene,
 
     uint32_t n_passes = spp / spp_per_pass;
 
-    size_t samples_per_pass = spp_per_pass * (size_t) dr::prod(film_size);
+    size_t samples_per_pass =
+        (size_t) film_size.x() * (size_t) film_size.y() * (size_t) spp_per_pass;
 
     std::vector<std::string> aovs = aov_names();
     if (!aovs.empty())
@@ -619,23 +627,28 @@ AdjointIntegrator<Float, Spectrum>::render(Scene *scene,
             evaluate = true;
         }
 
-        size_t wavefront_size = (size_t) film_size.x() *
-                                (size_t) film_size.y() * (size_t) spp_per_pass,
-               wavefront_size_limit =
-                   dr::is_llvm_v<Float> ? 0xffffffffu : 0x40000000u;
+        size_t wavefront_size_limit =
+            dr::is_llvm_v<Float> ? 0xffffffffu : 0x40000000u;
 
-        if (wavefront_size > wavefront_size_limit)
-            Throw("Tried to perform a %s-based rendering with a total sample "
-                  "count of %zu, which exceeds 2^%zu = %zu (the upper limit "
-                  "for this backend). Please use fewer samples per pixel or "
-                  "render using multiple passes.",
-                  dr::is_llvm_v<Float> ? "LLVM JIT" : "OptiX",
-                  wavefront_size, dr::log2i(wavefront_size_limit + 1),
-                  wavefront_size_limit);
+        if (samples_per_pass > wavefront_size_limit) {
+            spp_per_pass /= (samples_per_pass + wavefront_size_limit - 1) /
+                            wavefront_size_limit;
+            n_passes = spp / spp_per_pass;
+            samples_per_pass = (size_t) film_size.x() * (size_t) film_size.y() *
+                               (size_t) spp_per_pass;
+
+            Log(Warn,
+                "The requested rendering task involves %zu Monte Carlo "
+                "samples, which exceeds the upper limit of 2^%zu = %zu for "
+                "this variant. Mitsuba will instead split the rendering task "
+                "%zu smaller passes to avoid exceeding the limits.",
+                samples_per_pass, dr::log2i(wavefront_size_limit + 1),
+                wavefront_size_limit, n_passes);
+        }
 
         Log(Info, "Starting render job (%ux%u, %u sample%s%s)",
             crop_size.x(), crop_size.y(), spp, spp == 1 ? "" : "s",
-            n_passes > 1 ? tfm::format(", %u passes,", n_passes) : "");
+            n_passes > 1 ? tfm::format(", %u passes", n_passes) : "");
 
         // Inform the sampler about the passes (needed in vectorized modes)
         sampler->set_samples_per_wavefront(spp_per_pass);


### PR DESCRIPTION
This commit should be merged following
https://github.com/mitsuba-renderer/drjit-core/pull/33. It adjusts the error messages that catch overly large wavefronts to the new capabilities of the OptiX backend.