### PR TITLE
Set correct CUDA contexts before OptiX operations

### DIFF
--- a/include/mitsuba/render/optix/shapes.h
+++ b/include/mitsuba/render/optix/shapes.h
@@ -172,6 +172,8 @@ void build_gas(const OptixDeviceContext &context,
         handle.count = (uint32_t) shapes_count;
     };
 
+    scoped_optix_context guard;
+
     build_single_gas(shape_meshes, out_accel.meshes);
     build_single_gas(shape_others, out_accel.others);
 }

--- a/include/mitsuba/render/optix_api.h
+++ b/include/mitsuba/render/optix_api.h
@@ -309,12 +309,10 @@ D(optixModuleCreateFromPTXWithTasks, OptixDeviceContext,
   const OptixModuleCompileOptions *, const OptixPipelineCompileOptions *,
   const char *, size_t, char *, size_t *, OptixModule *, OptixTask *);
 D(optixModuleGetCompilationState, OptixModule, int *);
-D(optixModuleDestroy, OptixModule);
 D(optixTaskExecute, OptixTask, OptixTask *, unsigned int, unsigned int *);
 D(optixProgramGroupCreate, OptixDeviceContext, const OptixProgramGroupDesc *,
   unsigned int, const OptixProgramGroupOptions *, char *, size_t *,
   OptixProgramGroup *);
-D(optixProgramGroupDestroy, OptixProgramGroup);
 D(optixSbtRecordPackHeader, OptixProgramGroup, void *);
 D(optixAccelCompact, OptixDeviceContext, CUstream, OptixTraversableHandle,
   CUdeviceptr, size_t, OptixTraversableHandle *);
@@ -336,7 +334,15 @@ D(optixDenoiserComputeIntensity, OptixDenoiserStructPtr, CUstream,
 
 NAMESPACE_BEGIN(mitsuba)
 extern MI_EXPORT_LIB void optix_initialize();
-extern MI_EXPORT_LIB void optix_shutdown();
+
+/**
+ * \brief RAII wrapper which sets the CUDA context associated to the OptiX
+ * context for the current scope.
+ */
+struct scoped_optix_context {
+    scoped_optix_context();
+    ~scoped_optix_context();
+};
 NAMESPACE_END(mitsuba)
 
 #endif // defined(MI_ENABLE_CUDA)

--- a/src/render/optix_api.cpp
+++ b/src/render/optix_api.cpp
@@ -22,10 +22,8 @@ void optix_initialize() {
     L(optixAccelCompact);
     L(optixModuleCreateFromPTXWithTasks);
     L(optixModuleGetCompilationState);
-    L(optixModuleDestroy)
     L(optixTaskExecute);
     L(optixProgramGroupCreate);
-    L(optixProgramGroupDestroy)
     L(optixSbtRecordPackHeader);
     L(optixDenoiserCreate);
     L(optixDenoiserDestroy);
@@ -35,6 +33,14 @@ void optix_initialize() {
     L(optixDenoiserComputeIntensity);
 
     #undef L
+}
+
+scoped_optix_context::scoped_optix_context() {
+    jit_cuda_push_context(jit_cuda_context());
+}
+
+scoped_optix_context::~scoped_optix_context() {
+    jit_cuda_pop_context();
 }
 
 NAMESPACE_END(mitsuba)

--- a/src/render/optixdenoiser.cpp
+++ b/src/render/optixdenoiser.cpp
@@ -29,6 +29,8 @@ MI_VARIANT OptixDenoiser<Float, Spectrum>::OptixDenoiser(
 
     optix_initialize();
 
+    scoped_optix_context guard;
+
     OptixDeviceContext context = jit_optix_context();
     OptixDenoiserModelKind model_kind = temporal
                                             ? OPTIX_DENOISER_MODEL_KIND_TEMPORAL
@@ -66,6 +68,8 @@ OptixDenoiser<Float, Spectrum>::operator()(
     const TensorXf &normals, const Transform4f &to_sensor, const TensorXf &flow,
     const TensorXf &previous_denoised) const {
     using TensorArray = typename TensorXf::Array;
+
+    scoped_optix_context guard;
 
     validate_input(noisy, albedo, normals, flow, previous_denoised);
 

--- a/src/render/scene_optix.inl
+++ b/src/render/scene_optix.inl
@@ -413,6 +413,8 @@ MI_VARIANT void Scene<Float, Spectrum>::accel_parameters_changed_gpu() {
                 s.ias_buffer
                     = jit_malloc(AllocType::Device, buffer_sizes.outputSizeInBytes);
 
+                scoped_optix_context guard;
+
                 jit_optix_check(optixAccelBuild(
                     config.context,
                     (CUstream) jit_cuda_stream(),


### PR DESCRIPTION
Some OptiX operations require the current CUDA context to be the same as the one which was used to create the `OptixDeviceContext` which is passed as an argument to said operations. This was not the case in Mitsuba so far.

This PR fixes this by using an RAII-style scoped guard to set and unset the appropriate CUDA context for OptiX.