### PR TITLE
Add support for `dr.dispatch()`

### DIFF
--- a/include/mitsuba/python/python.h
+++ b/include/mitsuba/python/python.h
@@ -227,6 +227,24 @@ template <typename Array> void bind_drjit_ptr_array(py::class_<Array> &cls) {
                     return dr::reinterpret_array<UInt32>(a);
                 });
     }
+
+    if constexpr (dr::is_jit_v<Array>) {
+        cls.def_static("registry_get_max_", []() {
+            return jit_registry_get_max(dr::backend_v<Array>, Array::CallSupport::Domain);
+        });
+
+        cls.def_static("registry_get_ptr_", [](uint32_t i) -> py::object {
+            void *ptr = jit_registry_get_ptr(dr::backend_v<Array>, Array::CallSupport::Domain, i);
+            if (ptr) {
+                py::object mitsuba_ext = py::module::import("mitsuba.mitsuba_ext");
+                using Caster = py::object(*)(mitsuba::Object *);
+                Caster cast_object = (Caster) (void *)((py::capsule) mitsuba_ext.attr("cast_object"));
+                return cast_object((mitsuba::Object *) ptr);
+            } else {
+                return py::none();
+            }
+        });
+    }
 }
 
 #define MI_PY_CHECK_ALIAS(Type, Name)                \

--- a/src/render/tests/test_dispatch.py
+++ b/src/render/tests/test_dispatch.py
@@ -1,0 +1,69 @@
+import drjit as dr
+import mitsuba as mi
+import pytest
+
+@pytest.mark.parametrize("recorded", [True, False])
+def test01_dispatch(variants_vec_rgb, recorded):
+    dr.set_flag(dr.JitFlag.VCallRecord, recorded)
+
+    bsdf1 = mi.load_dict({'type': 'diffuse'})
+    bsdf2 = mi.load_dict({'type': 'conductor'})
+
+    mask = mi.Bool([True, True, False, False])
+
+    bsdf_ptr = dr.select(mask, mi.BSDFPtr(bsdf1), mi.BSDFPtr(bsdf2))
+
+    def func(self, si, wo):
+        print(f'Tracing -> {self.class_().name()}')
+        return self.eval(mi.BSDFContext(), si, wo)
+
+    si = dr.zeros(mi.SurfaceInteraction3f)
+    si.n = [0, 0, 1]
+    si.sh_frame = mi.Frame3f(si.n)
+    si.wi = [0, 0, 1]
+    wo = mi.Vector3f(0, 0, 1)
+    ctx = mi.BSDFContext()
+
+    res = dr.dispatch(bsdf_ptr, func, si, wo)
+    dr.eval(res)
+
+    assert dr.allclose(res, bsdf_ptr.eval(ctx, si, wo))
+
+
+@pytest.mark.parametrize("recorded", [True, False])
+def test02_dispatch_sparse_registry(variants_vec_rgb, recorded):
+    dr.set_flag(dr.JitFlag.VCallRecord, recorded)
+
+    bsdf1 = mi.load_dict({'type': 'diffuse'})
+    bsdf2 = mi.load_dict({'type': 'plastic'})
+    bsdf3 = mi.load_dict({'type': 'conductor'})
+
+    del bsdf2
+
+    mask = mi.Bool([True, True, False, False])
+
+    bsdf_ptr = dr.select(mask, mi.BSDFPtr(bsdf1), mi.BSDFPtr(bsdf3))
+
+    def func(self, si, wo):
+        return self.eval(mi.BSDFContext(), si, wo)
+
+    si = dr.zeros(mi.SurfaceInteraction3f)
+    si.n = [0, 0, 1]
+    si.sh_frame = mi.Frame3f(si.n)
+    si.wi = [0, 0, 1]
+    wo = mi.Vector3f(0, 0, 1)
+    ctx = mi.BSDFContext()
+
+    res = dr.dispatch(bsdf_ptr, func, si, wo)
+    dr.eval(res)
+
+    assert dr.allclose(res, bsdf_ptr.eval(ctx, si, wo))
+
+    dr.registry_trim()
+
+    res = dr.dispatch(bsdf_ptr, func, si, wo)
+    dr.eval(res)
+
+    assert dr.allclose(res, bsdf_ptr.eval(ctx, si, wo))
+
+


### PR DESCRIPTION
This PR adds the necessary bindings to the pointer array type (e.g. `BSDFPtr`) to support `dr.dispatch()`. It also adds a few unit tests to tests this feature.