### PR TITLE
Major Dr.Jit update

### DIFF
--- a/include/mitsuba/core/distr_2d.h
+++ b/include/mitsuba/core/distr_2d.h
@@ -1,5 +1,14 @@
 #pragma once
 
+/* GCC emits lots of warnings about unused 'weight_parameter' fields
+   for parameter-free distributions. Those warnings cannot be disabled
+   with the usual DRJIT_MARK_USED() macro */
+
+#if defined(__GNUC__)
+#  pragma GCC diagnostic push
+#  pragma GCC diagnostic ignored "-Wunused-value"
+#endif
+
 #include <mitsuba/core/warp.h>
 #include <mitsuba/core/util.h>
 #include <drjit/dynamic.h>
@@ -1451,3 +1460,8 @@ protected:
 // =======================================================================
 
 NAMESPACE_END(mitsuba)
+
+#if defined(__GNUC__)
+#  pragma GCC diagnostic pop
+#  pragma GCC diagnostic ignored "-Wunused-value"
+#endif

--- a/include/mitsuba/render/imageblock.h
+++ b/include/mitsuba/render/imageblock.h
@@ -86,9 +86,8 @@ public:
      *    Disabled by default.
      *
      * \param coalesce
-     *   This parameter is only relevant for JIT variants (it is enabled by
-     *   default only in LLVM mode), where it subtly affects the behavior of
-     *   the performance-critical \ref put() method.
+     *   This parameter is only relevant for JIT variants, where it subtly
+     *   affects the behavior of the performance-critical \ref put() method.
      *
      *   In coalesced mode, \ref put() conservatively bounds the footprint
      *   and traverses it in lockstep across the whole wavefront. This causes
@@ -121,7 +120,7 @@ public:
                const ReconstructionFilter *rfilter = nullptr,
                bool border = std::is_scalar_v<Float>,
                bool normalize = false,
-               bool coalesce = dr::is_llvm_v<Float>,
+               bool coalesce = dr::is_jit_v<Float>,
                bool warn_negative = std::is_scalar_v<Float>,
                bool warn_invalid = std::is_scalar_v<Float>);
 
@@ -142,7 +141,7 @@ public:
                const ReconstructionFilter *rfilter = nullptr,
                bool border = std::is_scalar_v<Float>,
                bool normalize = false,
-               bool coalesce = dr::is_llvm_v<Float>,
+               bool coalesce = dr::is_jit_v<Float>,
                bool warn_negative = std::is_scalar_v<Float>,
                bool warn_invalid = std::is_scalar_v<Float>);
 

--- a/src/core/plugin.cpp
+++ b/src/core/plugin.cpp
@@ -196,6 +196,13 @@ ref<Object> PluginManager::create_object(const Properties &props,
     Assert(plugin_class != nullptr);
     ref<Object> object = plugin_class->construct(props);
 
+#if defined(MI_ENABLE_LLVM) || defined(MI_ENABLE_CUDA)
+    // Ensures queued side effects are consistently compiled into cacheable kernels
+    if (string::starts_with(variant, "cuda_") ||
+        string::starts_with(variant, "llvm_"))
+        dr::eval();
+#endif
+
     if (!object->class_()->derives_from(class_)) {
         const Class *oc = object->class_();
         if (oc->parent())

--- a/src/core/plugin.cpp
+++ b/src/core/plugin.cpp
@@ -177,7 +177,21 @@ ref<Object> PluginManager::create_object(const Properties &props,
     if (class_->name() == "Scene")
        return class_->construct(props);
 
-    const Class *plugin_class = get_plugin_class(props.plugin_name(), class_->variant());
+    std::string variant = class_->variant();
+    const Class *plugin_class = get_plugin_class(props.plugin_name(), variant);
+
+    /* Construct each plugin in its own scope to isolate them from each other.
+     * This is important when plugins are created in parallel. */
+
+#if defined(MI_ENABLE_LLVM)
+    if (string::starts_with(variant, "llvm_"))
+        jit_new_scope(JitBackend::LLVM);
+#endif
+
+#if defined(MI_ENABLE_CUDA)
+    if (string::starts_with(variant, "cuda_"))
+        jit_new_scope(JitBackend::CUDA);
+#endif
 
     Assert(plugin_class != nullptr);
     ref<Object> object = plugin_class->construct(props);

--- a/src/core/plugin.cpp
+++ b/src/core/plugin.cpp
@@ -183,16 +183,6 @@ ref<Object> PluginManager::create_object(const Properties &props,
     /* Construct each plugin in its own scope to isolate them from each other.
      * This is important when plugins are created in parallel. */
 
-#if defined(MI_ENABLE_LLVM)
-    if (string::starts_with(variant, "llvm_"))
-        jit_new_scope(JitBackend::LLVM);
-#endif
-
-#if defined(MI_ENABLE_CUDA)
-    if (string::starts_with(variant, "cuda_"))
-        jit_new_scope(JitBackend::CUDA);
-#endif
-
     Assert(plugin_class != nullptr);
     ref<Object> object = plugin_class->construct(props);
 

--- a/src/core/python/xml_v.cpp
+++ b/src/core/python/xml_v.cpp
@@ -50,14 +50,17 @@ MI_PY_EXPORT(xml) {
                     );
             }
 
-            py::gil_scoped_release release;
+            std::vector<ref<Object>> objects;
+            {
+                py::gil_scoped_release release;
 
-            std::vector<ref<Object>> objects = xml::load_file(
-                name, GET_VARIANT(), param, update_scene, parallel);
+                objects = xml::load_file(name, GET_VARIANT(), param, update_scene,
+                                         parallel);
+            }
 
             return single_object_or_list(objects);
         },
-        "path"_a, "update_scene"_a = false, "parallel"_a = !dr::is_jit_v<Float>,
+        "path"_a, "update_scene"_a = false, "parallel"_a = true,
         D(xml, load_file));
 
     m.def(
@@ -73,14 +76,17 @@ MI_PY_EXPORT(xml) {
                     );
             }
 
-            py::gil_scoped_release release;
+            std::vector<ref<Object>> objects;
+            {
+                py::gil_scoped_release release;
 
-            std::vector<ref<Object>> objects = xml::load_string(
-                name, GET_VARIANT(), param, parallel);
+                objects =
+                    xml::load_string(name, GET_VARIANT(), param, parallel);
+            }
 
             return single_object_or_list(objects);
         },
-        "string"_a, "parallel"_a = !dr::is_jit_v<Float>,
+        "string"_a, "parallel"_a = true,
         D(xml, load_string));
 
     m.def(

--- a/src/core/python/xml_v.cpp
+++ b/src/core/python/xml_v.cpp
@@ -53,9 +53,7 @@ MI_PY_EXPORT(xml) {
             std::vector<ref<Object>> objects;
             {
                 py::gil_scoped_release release;
-
-                objects = xml::load_file(name, GET_VARIANT(), param, update_scene,
-                                         parallel);
+                objects = xml::load_file(name, GET_VARIANT(), param, update_scene, parallel);
             }
 
             return single_object_or_list(objects);
@@ -79,9 +77,7 @@ MI_PY_EXPORT(xml) {
             std::vector<ref<Object>> objects;
             {
                 py::gil_scoped_release release;
-
-                objects =
-                    xml::load_string(name, GET_VARIANT(), param, parallel);
+                objects = xml::load_string(name, GET_VARIANT(), param, parallel);
             }
 
             return single_object_or_list(objects);

--- a/src/core/python/xml_v.cpp
+++ b/src/core/python/xml_v.cpp
@@ -98,11 +98,6 @@ MI_PY_EXPORT(xml) {
 
             py::object out = single_object_or_list(objects);
 
-            if constexpr (dr::is_jit_v<Float>) {
-                dr::eval();
-                dr::sync_thread();
-            }
-
             return out;
         },
         "dict"_a,

--- a/src/core/xml.cpp
+++ b/src/core/xml.cpp
@@ -1103,14 +1103,6 @@ static Task *instantiate_node(XMLParseContext &ctx,
 
         try {
             inst.object = PluginManager::instance()->create_object(props, inst.class_);
-            #if defined(MI_ENABLE_CUDA) || defined(MI_ENABLE_LLVM)
-                if (ctx.is_jit()) {
-                    // Ensures dr::scatter occurring in object constructors are flushed
-                    dr::eval();
-                    if (ctx.parallel)
-                        dr::sync_thread();
-                }
-            #endif
         } catch (const std::exception &e) {
             Throw("Error while loading \"%s\" (near %s): could not instantiate "
                   "%s plugin of type \"%s\": %s",

--- a/src/films/hdrfilm.cpp
+++ b/src/films/hdrfilm.cpp
@@ -260,7 +260,7 @@ public:
                               (uint32_t) m_channels.size(), m_filter.get(),
                               border /* border */,
                               normalize /* normalize */,
-                              dr::is_llvm_v<Float> /* coalesce */,
+                              dr::is_jit_v<Float> /* coalesce */,
                               warn /* warn_negative */,
                               warn /* warn_invalid */);
     }

--- a/src/films/specfilm.cpp
+++ b/src/films/specfilm.cpp
@@ -259,7 +259,7 @@ public:
                               (uint32_t) m_channels.size(), m_filter.get(),
                               border /* border */,
                               normalize /* normalize */,
-                              dr::is_llvm_v<Float> /* coalesce */,
+                              dr::is_jit_v<Float> /* coalesce */,
                               false /* warn_negative */,
                               false /* warn_invalid */);
     }

--- a/src/integrators/path.cpp
+++ b/src/integrators/path.cpp
@@ -186,9 +186,10 @@ public:
             // Perform emitter sampling?
             Mask active_em = active_next && has_flag(bsdf->flags(), BSDFFlags::Smooth);
 
-            DirectionSample3f ds;
-            Spectrum em_weight;
-            Vector3f wo;
+            DirectionSample3f ds = dr::zeros<DirectionSample3f>();
+            Spectrum em_weight = dr::zeros<Spectrum>();
+            Vector3f wo = dr::zeros<Vector3f>();
+
             if (dr::any_or<true>(active_em)) {
                 // Sample the emitter
                 std::tie(ds, em_weight) = scene->sample_emitter_direction(

--- a/src/mitsuba/mitsuba.cpp
+++ b/src/mitsuba/mitsuba.cpp
@@ -86,11 +86,6 @@ Options:
         supported width is legal and causes arithmetic operations to be
         replicated multiple times.
 
-    -P
-        Force parallel scene loading, which is disabled by default
-        in JIT modes since interferes with the ability to reuse
-        cached compiled kernels across separate runs of the renderer.
-
 )";
 }
 
@@ -177,7 +172,6 @@ int main(int argc, char *argv[]) {
 
     // Specialized flags for the JIT compiler
     auto arg_optim_lev = parser.add(StringVec{ "-O" }, true);
-    auto arg_load_par  = parser.add(StringVec{ "-P" });
     auto arg_wavefront = parser.add(StringVec{ "-W" });
     auto arg_source    = parser.add(StringVec{ "-S" });
     auto arg_vec_width = parser.add(StringVec{ "-V" }, true);
@@ -316,8 +310,6 @@ int main(int argc, char *argv[]) {
 
         size_t sensor_i  = (*arg_sensor_i ? arg_sensor_i->as_int() : 0);
 
-        bool parallel_loading = !(llvm || cuda) || (*arg_load_par);
-
         // Append the mitsuba directory to the FileResolver search path list
         ref<Thread> thread = Thread::thread();
         ref<FileResolver> fr = thread->file_resolver();
@@ -362,7 +354,7 @@ int main(int argc, char *argv[]) {
             // Try and parse a scene from the passed file.
             std::vector<ref<Object>> parsed =
                 xml::load_file(arg_extra->as_string(), mode, params,
-                               *arg_update, parallel_loading);
+                               *arg_update, true);
 
             if (parsed.size() != 1)
                 Throw("Root element of the input file is expanded into "

--- a/src/render/python/imageblock_v.cpp
+++ b/src/render/python/imageblock_v.cpp
@@ -10,7 +10,7 @@ MI_PY_EXPORT(ImageBlock) {
                       bool>(),
              "size"_a, "offset"_a, "channel_count"_a, "rfilter"_a = nullptr,
              "border"_a = std::is_scalar_v<Float>, "normalize"_a = false,
-             "coalesce"_a      = dr::is_llvm_v<Float>,
+             "coalesce"_a      = dr::is_jit_v<Float>,
              "warn_negative"_a = std::is_scalar_v<Float>,
              "warn_invalid"_a  = std::is_scalar_v<Float>)
         .def(py::init<const TensorXf &, const ScalarPoint2i &,
@@ -18,7 +18,7 @@ MI_PY_EXPORT(ImageBlock) {
                       bool>(),
              "tensor"_a, "offset"_a = ScalarPoint2i(0), "rfilter"_a = nullptr,
              "border"_a = std::is_scalar_v<Float>, "normalize"_a = false,
-             "coalesce"_a      = dr::is_llvm_v<Float>,
+             "coalesce"_a      = dr::is_jit_v<Float>,
              "warn_negative"_a = std::is_scalar_v<Float>,
              "warn_invalid"_a  = std::is_scalar_v<Float>)
         .def("put_block", &ImageBlock::put_block, D(ImageBlock, put), "block"_a)

--- a/src/render/python/imageblock_v.cpp
+++ b/src/render/python/imageblock_v.cpp
@@ -10,7 +10,7 @@ MI_PY_EXPORT(ImageBlock) {
                       bool>(),
              "size"_a, "offset"_a, "channel_count"_a, "rfilter"_a = nullptr,
              "border"_a = std::is_scalar_v<Float>, "normalize"_a = false,
-             "coalesce"_a      = dr::is_jit_v<Float>,
+             "coalesce"_a = dr::is_jit_v<Float>,
              "warn_negative"_a = std::is_scalar_v<Float>,
              "warn_invalid"_a  = std::is_scalar_v<Float>)
         .def(py::init<const TensorXf &, const ScalarPoint2i &,
@@ -18,7 +18,7 @@ MI_PY_EXPORT(ImageBlock) {
                       bool>(),
              "tensor"_a, "offset"_a = ScalarPoint2i(0), "rfilter"_a = nullptr,
              "border"_a = std::is_scalar_v<Float>, "normalize"_a = false,
-             "coalesce"_a      = dr::is_jit_v<Float>,
+             "coalesce"_a = dr::is_jit_v<Float>,
              "warn_negative"_a = std::is_scalar_v<Float>,
              "warn_invalid"_a  = std::is_scalar_v<Float>)
         .def("put_block", &ImageBlock::put_block, D(ImageBlock, put), "block"_a)

--- a/src/render/scene_optix.inl
+++ b/src/render/scene_optix.inl
@@ -477,10 +477,9 @@ MI_VARIANT void Scene<Float, Spectrum>::accel_release_gpu() {
 
         if (s->own_sbt) {
             /* This will decrease the reference count of the shader binding table
-            JIT variable which might trigger the release of the OptiX SBT if no
-            ray tracing calls are pending. */
-            UInt32 handle = UInt32::steal(s->sbt_jit_index);
-            handle = 0;
+               JIT variable which might trigger the release of the OptiX SBT if
+               no ray tracing calls are pending. */
+            (void) UInt32::steal(s->sbt_jit_index);
         }
 
         delete s;
@@ -497,10 +496,9 @@ MI_VARIANT void Scene<Float, Spectrum>::static_accel_shutdown_gpu() {
             OptixConfig &config = optix_configs[j];
             if (config.pipeline_jit_index) {
                 /* Decrease the reference count of the pipeline JIT variable.
-                This will trigger the release of the OptiX pipeline data
-                structure if no ray tracing calls are pending. */
-                UInt32 handle = UInt32::steal(config.pipeline_jit_index);
-                handle = 0;
+                   This will trigger the release of the OptiX pipeline data
+                   structure if no ray tracing calls are pending. */
+                (void) UInt32::steal(config.pipeline_jit_index);
 
                 for (size_t i = 0; i < 2 * CUSTOM_OPTIX_SHAPE_COUNT; i++)
                     free(config.custom_shapes_program_names[i]);

--- a/src/render/scene_optix.inl
+++ b/src/render/scene_optix.inl
@@ -218,11 +218,16 @@ size_t init_optix_config(bool has_meshes, bool has_others, bool has_instances) {
             config.program_groups
         ));
 
+        // Create this variable in the JIT scope 0 to ensure a consistent
+        // ordering in the generated PTX kernel (e.g. for other scenes).
+        uint32_t scope = jit_scope(JitBackend::CUDA);
+        jit_set_scope(JitBackend::CUDA, 0);
         config.pipeline_jit_index = jit_optix_configure_pipeline(
             &config.pipeline_compile_options,
             config.module,
             config.program_groups, PROGRAM_GROUP_COUNT
         );
+        jit_set_scope(JitBackend::CUDA, scope);
     }
 
     return config_index;


### PR DESCRIPTION
This PR updates the revision of Dr.Jit to incorporate a few major improvements:

- Variables are now consistently ordered, which improves the effectiveness of the function de-duplication optimization

- The 4 billion variable limit is gone

- Scene loading can now occur in parallel in JIT modes

For details, see

- https://github.com/mitsuba-renderer/drjit-core/pull/38
- https://github.com/mitsuba-renderer/drjit-core/pull/39
- https://github.com/mitsuba-renderer/drjit-core/pull/40
- https://github.com/mitsuba-renderer/drjit-core/pull/41