### PR TITLE
Coalesce ImageBlock writes in CUDA/OptiX mode

### DIFF
--- a/include/mitsuba/render/imageblock.h
+++ b/include/mitsuba/render/imageblock.h
@@ -86,9 +86,8 @@ public:
      *    Disabled by default.
      *
      * \param coalesce
-     *   This parameter is only relevant for JIT variants (it is enabled by
-     *   default only in LLVM mode), where it subtly affects the behavior of
-     *   the performance-critical \ref put() method.
+     *   This parameter is only relevant for JIT variants, where it subtly
+     *   affects the behavior of the performance-critical \ref put() method.
      *
      *   In coalesced mode, \ref put() conservatively bounds the footprint
      *   and traverses it in lockstep across the whole wavefront. This causes
@@ -121,7 +120,7 @@ public:
                const ReconstructionFilter *rfilter = nullptr,
                bool border = std::is_scalar_v<Float>,
                bool normalize = false,
-               bool coalesce = dr::is_llvm_v<Float>,
+               bool coalesce = dr::is_jit_v<Float>,
                bool warn_negative = std::is_scalar_v<Float>,
                bool warn_invalid = std::is_scalar_v<Float>);
 
@@ -142,7 +141,7 @@ public:
                const ReconstructionFilter *rfilter = nullptr,
                bool border = std::is_scalar_v<Float>,
                bool normalize = false,
-               bool coalesce = dr::is_llvm_v<Float>,
+               bool coalesce = dr::is_jit_v<Float>,
                bool warn_negative = std::is_scalar_v<Float>,
                bool warn_invalid = std::is_scalar_v<Float>);
 

--- a/src/films/hdrfilm.cpp
+++ b/src/films/hdrfilm.cpp
@@ -260,7 +260,7 @@ public:
                               (uint32_t) m_channels.size(), m_filter.get(),
                               border /* border */,
                               normalize /* normalize */,
-                              dr::is_llvm_v<Float> /* coalesce */,
+                              dr::is_jit_v<Float> /* coalesce */,
                               warn /* warn_negative */,
                               warn /* warn_invalid */);
     }

--- a/src/films/specfilm.cpp
+++ b/src/films/specfilm.cpp
@@ -259,7 +259,7 @@ public:
                               (uint32_t) m_channels.size(), m_filter.get(),
                               border /* border */,
                               normalize /* normalize */,
-                              dr::is_llvm_v<Float> /* coalesce */,
+                              dr::is_jit_v<Float> /* coalesce */,
                               false /* warn_negative */,
                               false /* warn_invalid */);
     }

--- a/src/render/python/imageblock_v.cpp
+++ b/src/render/python/imageblock_v.cpp
@@ -10,7 +10,7 @@ MI_PY_EXPORT(ImageBlock) {
                       bool>(),
              "size"_a, "offset"_a, "channel_count"_a, "rfilter"_a = nullptr,
              "border"_a = std::is_scalar_v<Float>, "normalize"_a = false,
-             "coalesce"_a      = dr::is_llvm_v<Float>,
+             "coalesce"_a      = dr::is_jit_v<Float>,
              "warn_negative"_a = std::is_scalar_v<Float>,
              "warn_invalid"_a  = std::is_scalar_v<Float>)
         .def(py::init<const TensorXf &, const ScalarPoint2i &,
@@ -18,7 +18,7 @@ MI_PY_EXPORT(ImageBlock) {
                       bool>(),
              "tensor"_a, "offset"_a = ScalarPoint2i(0), "rfilter"_a = nullptr,
              "border"_a = std::is_scalar_v<Float>, "normalize"_a = false,
-             "coalesce"_a      = dr::is_llvm_v<Float>,
+             "coalesce"_a      = dr::is_jit_v<Float>,
              "warn_negative"_a = std::is_scalar_v<Float>,
              "warn_invalid"_a  = std::is_scalar_v<Float>)
         .def("put_block", &ImageBlock::put_block, D(ImageBlock, put), "block"_a)


### PR DESCRIPTION
This commit adjusts ``ImageBlock`` defaults so that it will try to generate more coherent scatter-reductions. We previously already did this on LLVM, where it improves performance quite a bit. It will similarly help on CUDA/OptiX once https://github.com/mitsuba-renderer/drjit-core/pull/42 is merged.