### PR TITLE
Upgrade to new Dr.Jit version using an abstract node-based IR

### DIFF
--- a/src/render/scene_embree.inl
+++ b/src/render/scene_embree.inl
@@ -276,10 +276,10 @@ Scene<Float, Spectrum>::ray_intersect_preliminary_cpu(const Ray3f &ray,
                       "supported by Embree!", jit_width);
         }
 
-        UInt64 func_v  = UInt64::steal(jit_var_new_pointer(
+        UInt64 func_v  = UInt64::steal(jit_var_pointer(
                    JitBackend::LLVM, func_ptr, m_accel_handle.index(), 0)),
                scene_v = UInt64::steal(
-                   jit_var_new_pointer(JitBackend::LLVM, scene_ptr, 0, 0));
+                   jit_var_pointer(JitBackend::LLVM, scene_ptr, 0, 0));
 
         UInt32 zero = dr::zeros<UInt32>();
 
@@ -393,10 +393,10 @@ Scene<Float, Spectrum>::ray_test_cpu(const Ray3f &ray, Mask coherent, Mask activ
                       "width %u, which is not supported by Embree!", jit_width);
         }
 
-        UInt64 func_v  = UInt64::steal(jit_var_new_pointer(
+        UInt64 func_v  = UInt64::steal(jit_var_pointer(
                    JitBackend::LLVM, func_ptr, m_accel_handle.index(), 0)),
                scene_v = UInt64::steal(
-                   jit_var_new_pointer(JitBackend::LLVM, scene_ptr, 0, 0));
+                   jit_var_pointer(JitBackend::LLVM, scene_ptr, 0, 0));
 
         UInt32 zero = dr::zeros<UInt32>();
 

--- a/src/render/scene_native.inl
+++ b/src/render/scene_native.inl
@@ -198,9 +198,9 @@ Scene<Float, Spectrum>::ray_intersect_preliminary_cpu(const Ray3f &ray,
         }
 
         UInt64 func_v = UInt64::steal(
-                   jit_var_new_pointer(JitBackend::LLVM, func_ptr, m_accel_handle.index(), 0)),
+                   jit_var_pointer(JitBackend::LLVM, func_ptr, m_accel_handle.index(), 0)),
                scene_v = UInt64::steal(
-                   jit_var_new_pointer(JitBackend::LLVM, scene_ptr, 0, 0));
+                   jit_var_pointer(JitBackend::LLVM, scene_ptr, 0, 0));
 
         UInt32 zero = dr::zeros<UInt32>();
         Float ray_mint = dr::zeros<Float>();
@@ -284,9 +284,9 @@ Scene<Float, Spectrum>::ray_test_cpu(const Ray3f &ray,
         }
 
         UInt64 func_v = UInt64::steal(
-                   jit_var_new_pointer(JitBackend::LLVM, func_ptr, m_accel_handle.index(), 0)),
+                   jit_var_pointer(JitBackend::LLVM, func_ptr, m_accel_handle.index(), 0)),
                scene_v = UInt64::steal(
-                   jit_var_new_pointer(JitBackend::LLVM, scene_ptr, 0, 0));
+                   jit_var_pointer(JitBackend::LLVM, scene_ptr, 0, 0));
 
         UInt32 zero = dr::zeros<UInt32>();
         Float ray_mint = dr::zeros<Float>();

--- a/src/samplers/tests/test_independent.py
+++ b/src/samplers/tests/test_independent.py
@@ -11,7 +11,6 @@ def test01_construct(variant_scalar_rgb):
     })
     assert sampler is not None
     assert sampler.sample_count() == 58
-    return sampler
 
 
 def test02_sample_vs_pcg32(variant_scalar_rgb):


### PR DESCRIPTION
This commit propagates a few significant changes in Dr.Jit(-Core) to the Mitsuba project.

- Previously, Dr.Jit used a string-based IR representation, which meant that snippets of LLVM/PTX IR were spread across many implementation files. This design arose organically and made it difficult to extend the system.

  This PR switches to an abstract (backend-agnostic) node-based IR. Code generation is now centralized in a backend-specific part that consumes this abstract IR. The new design should facilitate future extensions, e.g., to add an Apple Metal backend.

- The process of turning a computation graph into a textural IR representation was streamlined through a new `StringBuffer` class. This change does not impact functionality, but it allowed to shorten and simplify a large amount of backend code.

- On recent LLVM versions (15.0.0+) Dr.Jit now generates IR with opaque pointers. This change is necessary to maintain compatibility with future LLVM versions since typed pointers are deprecated. More information about opaque pointers is available here: https://llvm.org/docs/OpaquePointers.html.

The referenced Dr.Jit(-Core) changes are in the following PRs:

- https://github.com/mitsuba-renderer/drjit-core/pull/51,
- https://github.com/mitsuba-renderer/drjit-core/pull/52, and
- https://github.com/mitsuba-renderer/drjit/pull/113

This commit also fixes a minor pytest warning.