### PR TITLE
Correct envmap mis_compensation docs

### DIFF
--- a/src/emitters/envmap.cpp
+++ b/src/emitters/envmap.cpp
@@ -47,7 +47,7 @@ Environment emitter (:monosp:`envmap`)
    - |bool|
    - Compensate sampling for the presence of other Monte Carlo techniques that
      will be combined using multiple importance sampling (MIS)? This is
-     extremely cheap to do and can slightly reduce variance. (Default: true)
+     extremely cheap to do and can slightly reduce variance. (Default: false)
 
  * - data
    - |tensor|


### PR DESCRIPTION
<!-- Please add the labels (e.g. bug fix, feature, ..) corresponding to this PR -->

## Description

@Speierers turned off envmap `mis_compensation` by default in  https://github.com/mitsuba-renderer/mitsuba3/commit/a19ed6b6a975a029a10d1fc499532e57a39f048d turned off as part of https://github.com/mitsuba-renderer/mitsuba3/pull/70. I'm not sure why it was disabled but for my project, direct emitter sampling with `sample_emitter_direction` converges faster with it off (due to the blue sky being picked up more), so I'm not complaining.

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes # (issue)

## Testing

<!-- Please describe the tests that you added to verify your changes. -->

## Checklist

<!-- Please make sure to complete this checklist before requesting a review. -->

- [x] My code follows the [style guidelines](https://mitsuba.readthedocs.io/en/latest/src/developer_guide.html#coding-style) of this project
- [x] My changes generate no new warnings
- [x] My code also compiles for `cuda_*` and `llvm_*` variants. If you can't test this, please leave below
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 3 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba/blob/master/LICENSE)