### PR TITLE
blendphase: Fix missing initialization

### DIFF
--- a/src/phase/blendphase.cpp
+++ b/src/phase/blendphase.cpp
@@ -122,8 +122,8 @@ public:
             return { wo, pdf };
         }
 
-        Vector3f wo;
-        Float pdf;
+        Vector3f wo = dr::zeros<Vector3f>();
+        Float pdf = dr::zeros<Float>();
 
         Mask m0 = active && sample1 > weight,
              m1 = active && sample1 <= weight;

--- a/src/phase/tests/test_blendphase.py
+++ b/src/phase/tests/test_blendphase.py
@@ -61,7 +61,7 @@ def test02_eval_all(variant_scalar_rgb):
     assert dr.allclose(value, expected)
 
 
-def test03_sample_all(variant_scalar_rgb):
+def test03_sample_all(variants_all_rgb):
     weight = 0.2
     g = 0.2
 


### PR DESCRIPTION
## Description

This PR adds missing initializations to the `sample()` method in the `blendphase` plugin. Closes #488.

## Testing

I updated one test to have it run on JIT backends.

## Checklist

- [x] My code follows the [style guidelines](https://mitsuba.readthedocs.io/en/latest/src/developer_guide.html#coding-style) of this project
- [x] My changes generate no new warnings
- [x] My code also compiles for `cuda_*` and `llvm_*` variants. If you can't test this, please leave below
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 3 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba/blob/master/LICENSE)