### PR TITLE
Fix parallel scene loading with Python plugins

### DIFF
--- a/src/core/tests/test_xml.py
+++ b/src/core/tests/test_xml.py
@@ -411,3 +411,17 @@ def test30_invalid_parameter_name(variant_scalar_rgb):
         </scene>
         """)
     e.match('Invalid character in parameter name')
+
+
+def test31_python_plugins_parallel(variants_vec_backends_once_rgb):
+    class DummyBSDF(mi.BSDF):
+        def __init__(self, props):
+            mi.BSDF.__init__(self, props)
+
+    mi.register_bsdf('dummy', DummyBSDF)
+
+    mi.load_string(""""
+    <scene version='3.0.0'>
+        <bsdf type='dummy'/>
+    </scene>
+    """, parallel=True)


### PR DESCRIPTION
This PR fixes #457.

When loading a scene in parallel which makes use of custom Python plugins, none of the worker threads have the appropriate thread-local variant information (with the exception of the main thread).
This would produce the error seen in #457, as the workers that need to instantiate Python plugins will not be able to successfully call the constructor.

This PR sets the thread-local information, if needed, whenever a Python plugin is instantiated in C++ (more specifically: whenever a Python Plugin is instantiated through its RTTI-`Class`  object).