### PR TITLE
Make Endpoint (emitters & sensors) members opaque

### DIFF
--- a/include/mitsuba/render/endpoint.h
+++ b/include/mitsuba/render/endpoint.h
@@ -384,6 +384,8 @@ public:
 
     void traverse(TraversalCallback *callback) override;
 
+    void parameters_changed(const std::vector<std::string> &keys = {}) override;
+
     DRJIT_VCALL_REGISTER(Float, mitsuba::Endpoint)
     MI_DECLARE_CLASS()
 protected:

--- a/include/mitsuba/render/sensor.h
+++ b/include/mitsuba/render/sensor.h
@@ -135,15 +135,16 @@ public:
     // =============================================================
 
     void traverse(TraversalCallback *callback) override {
-        callback->put_parameter("shutter_open", m_shutter_open,           +ParamFlags::NonDifferentiable);
-        callback->put_parameter("shutter_open_time", m_shutter_open_time, +ParamFlags::NonDifferentiable);
-        callback->put_object("film", m_film.get(),                        +ParamFlags::NonDifferentiable);
-        callback->put_object("sampler", m_sampler.get(),                  +ParamFlags::NonDifferentiable);
         Base::traverse(callback);
+        callback->put_parameter("shutter_open",      m_shutter_open,      +ParamFlags::NonDifferentiable);
+        callback->put_parameter("shutter_open_time", m_shutter_open_time, +ParamFlags::NonDifferentiable);
+        callback->put_object("film",                 m_film.get(),        +ParamFlags::NonDifferentiable);
+        callback->put_object("sampler",              m_sampler.get(),     +ParamFlags::NonDifferentiable);
     }
 
-    void parameters_changed(const std::vector<std::string> &/*keys*/ = {}) override {
+    void parameters_changed(const std::vector<std::string> &keys = {}) override {
         m_resolution = ScalarVector2f(m_film->crop_size());
+        Base::parameters_changed(keys);
     }
 
     DRJIT_VCALL_REGISTER(Float, mitsuba::Sensor)

--- a/src/emitters/directional.cpp
+++ b/src/emitters/directional.cpp
@@ -91,8 +91,9 @@ public:
     }
 
     void traverse(TraversalCallback *callback) override {
-        callback->put_object("irradiance", m_irradiance.get(), +ParamFlags::Differentiable);
-        callback->put_parameter("to_world", *m_to_world.ptr(), +ParamFlags::NonDifferentiable);
+        Base::traverse(callback);
+        callback->put_object("irradiance",   m_irradiance.get(), +ParamFlags::Differentiable);
+        callback->put_parameter("to_world", *m_to_world.ptr(),   +ParamFlags::NonDifferentiable);
     }
 
     void set_scene(const Scene *scene) override {

--- a/src/emitters/directionalarea.cpp
+++ b/src/emitters/directionalarea.cpp
@@ -81,6 +81,7 @@ public:
     void set_shape(Shape *shape) override {
         Base::set_shape(shape);
         m_area = m_shape->surface_area();
+        dr::make_opaque(m_area);
     }
 
     std::pair<Ray3f, Spectrum> sample_ray(Float time, Float wavelength_sample,

--- a/src/emitters/envmap.cpp
+++ b/src/emitters/envmap.cpp
@@ -237,8 +237,9 @@ public:
     }
 
     void traverse(TraversalCallback *callback) override {
-        callback->put_parameter("scale",    m_scale,           +ParamFlags::Differentiable);
-        callback->put_parameter("data",     m_data,            ParamFlags::Differentiable | ParamFlags::Discontinuous);
+        Base::traverse(callback);
+        callback->put_parameter("scale",     m_scale,          +ParamFlags::Differentiable);
+        callback->put_parameter("data",      m_data,            ParamFlags::Differentiable | ParamFlags::Discontinuous);
         callback->put_parameter("to_world", *m_to_world.ptr(), +ParamFlags::NonDifferentiable);
     }
 
@@ -304,6 +305,7 @@ public:
 
             m_warp = Warp(luminance.get(), res);
         }
+        Base::parameters_changed(keys);
     }
 
     void set_scene(const Scene *scene) override {

--- a/src/emitters/spot.cpp
+++ b/src/emitters/spot.cpp
@@ -102,29 +102,26 @@ public:
         }
         dr::set_attr(this, "flags", m_flags);
 
-        m_cutoff_angle = props.get<ScalarFloat>("cutoff_angle", 20.0f);
-        m_beam_width   = props.get<ScalarFloat>("beam_width", m_cutoff_angle * 3.0f / 4.0f);
-        m_cutoff_angle = dr::deg_to_rad(m_cutoff_angle);
+        ScalarFloat cutoff_angle = props.get<ScalarFloat>("cutoff_angle", 20.0f);
+        m_beam_width   = props.get<ScalarFloat>("beam_width", cutoff_angle * 3.0f / 4.0f);
+        m_cutoff_angle = dr::deg_to_rad(cutoff_angle);
         m_beam_width   = dr::deg_to_rad(m_beam_width);
         m_inv_transition_width = 1.0f / (m_cutoff_angle - m_beam_width);
         m_cos_cutoff_angle = dr::cos(m_cutoff_angle);
         m_cos_beam_width   = dr::cos(m_beam_width);
         Assert(m_cutoff_angle >= m_beam_width);
         m_uv_factor = dr::tan(m_cutoff_angle);
+
+        dr::make_opaque(m_beam_width, m_cutoff_angle, m_uv_factor,
+                        m_cos_beam_width, m_cos_cutoff_angle,
+                        m_inv_transition_width);
     }
 
     void traverse(TraversalCallback *callback) override {
-        callback->put_object("intensity",   m_intensity.get(), +ParamFlags::Differentiable);
-        callback->put_object("texture",     m_texture.get(),   +ParamFlags::Differentiable);
-        callback->put_parameter("to_world", *m_to_world.ptr(), +ParamFlags::NonDifferentiable);
-    }
-
-    void parameters_changed(const std::vector<std::string> &keys) override {
-        if (keys.empty() || string::contains(keys, "to_world")) {
-            // Update the scalar value of the matrix
-            m_to_world = m_to_world.value();
-        }
-        Base::parameters_changed();
+        Base::traverse(callback);
+        callback->put_object("intensity",    m_intensity.get(), +ParamFlags::Differentiable);
+        callback->put_object("texture",      m_texture.get(),   +ParamFlags::Differentiable);
+        callback->put_parameter("to_world", *m_to_world.ptr(),  +ParamFlags::NonDifferentiable);
     }
 
     /**
@@ -279,8 +276,8 @@ public:
 private:
     ref<Texture> m_intensity;
     ref<Texture> m_texture;
-    ScalarFloat m_beam_width, m_cutoff_angle, m_uv_factor;
-    ScalarFloat m_cos_beam_width, m_cos_cutoff_angle, m_inv_transition_width;
+    Float m_beam_width, m_cutoff_angle, m_uv_factor;
+    Float m_cos_beam_width, m_cos_cutoff_angle, m_inv_transition_width;
 };
 
 

--- a/src/render/endpoint.cpp
+++ b/src/render/endpoint.cpp
@@ -10,6 +10,7 @@ NAMESPACE_BEGIN(mitsuba)
 MI_VARIANT Endpoint<Float, Spectrum>::Endpoint(const Properties &props) : m_id(props.id()) {
     m_to_world = (ScalarTransform4f) props.get<ScalarTransform4f>(
         "to_world", ScalarTransform4f());
+    dr::make_opaque(m_to_world);
 
     for (auto &[name, obj] : props.objects(false)) {
         Medium *medium = dynamic_cast<Medium *>(obj.get());
@@ -113,6 +114,13 @@ MI_VARIANT Spectrum Endpoint<Float, Spectrum>::eval(const SurfaceInteraction3f &
 MI_VARIANT void Endpoint<Float, Spectrum>::traverse(TraversalCallback *callback) {
     if (m_medium)
         callback->put_object("medium", m_medium.get(), +ParamFlags::Differentiable);
+}
+
+MI_VARIANT void Endpoint<Float, Spectrum>::parameters_changed(const std::vector<std::string> &keys) {
+    if (keys.empty() || string::contains(keys, "to_world")) {
+        // Update the scalar value of the matrix
+        m_to_world = m_to_world.value();
+    }
 }
 
 MI_IMPLEMENT_CLASS_VARIANT(Endpoint, Object)

--- a/src/sensors/irradiancemeter.cpp
+++ b/src/sensors/irradiancemeter.cpp
@@ -119,15 +119,15 @@ public:
         using string::indent;
 
         std::ostringstream oss;
-        oss << "IrradianceMeter[" << std::endl
-            << "  surface_area = ";
+        oss << "IrradianceMeter[" << std::endl << "  surface_area = ";
 
-        if (m_shape) oss << m_shape->surface_area();
-            else         oss << " <no shape attached!>";
+        if (m_shape)
+            oss << m_shape->surface_area();
+        else
+            oss << " <no shape attached!>";
         oss << "," << std::endl;
 
-        oss << "  film = " << indent(m_film) << "," << std::endl
-            << "]";
+        oss << "  film = " << indent(m_film) << "," << std::endl << "]";
         return oss.str();
     }
 

--- a/src/sensors/orthographic.cpp
+++ b/src/sensors/orthographic.cpp
@@ -95,10 +95,6 @@ public:
     }
 
     void parameters_changed(const std::vector<std::string> &keys) override {
-        if (keys.empty() || string::contains(keys, "to_world")) {
-            // Update the scalar value of the matrix
-            m_to_world = m_to_world.value();
-        }
         Base::parameters_changed(keys);
         update_camera_transforms();
     }

--- a/src/sensors/perspective.cpp
+++ b/src/sensors/perspective.cpp
@@ -143,29 +143,27 @@ public:
         if (m_to_world.scalar().has_scale())
             Throw("Scale factors in the camera-to-world transformation are not allowed!");
 
-        update_camera_transforms();
-
         m_principal_point_offset = ScalarPoint2f(
             props.get<ScalarFloat>("principal_point_offset_x", 0.f),
             props.get<ScalarFloat>("principal_point_offset_y", 0.f)
         );
+
+        update_camera_transforms();
     }
 
     void traverse(TraversalCallback *callback) override {
         Base::traverse(callback);
-        callback->put_parameter("x_fov", m_x_fov,              ParamFlags::Differentiable | ParamFlags::Discontinuous);
+        callback->put_parameter("x_fov",     m_x_fov,          ParamFlags::Differentiable | ParamFlags::Discontinuous);
         callback->put_parameter("to_world", *m_to_world.ptr(), ParamFlags::Differentiable | ParamFlags::Discontinuous);
     }
 
     void parameters_changed(const std::vector<std::string> &keys) override {
+        Base::parameters_changed(keys);
         if (keys.empty() || string::contains(keys, "to_world")) {
-            // Update the scalar value of the matrix
-            m_to_world = m_to_world.value();
             if (m_to_world.scalar().has_scale())
                 Throw("Scale factors in the camera-to-world transformation are not allowed!");
         }
 
-        Base::parameters_changed(keys);
         update_camera_transforms();
     }
 
@@ -193,7 +191,7 @@ public:
         m_normalization = 1.f / m_image_rect.volume();
         m_needs_sample_3 = false;
 
-        dr::make_opaque(m_to_world, m_camera_to_sample, m_sample_to_camera, m_dx, m_dy, m_x_fov,
+        dr::make_opaque(m_camera_to_sample, m_sample_to_camera, m_dx, m_dy, m_x_fov,
                         m_image_rect, m_normalization, m_principal_point_offset);
     }
 

--- a/src/sensors/thinlens.cpp
+++ b/src/sensors/thinlens.cpp
@@ -20,7 +20,7 @@ Perspective camera with a thin lens (:monosp:`thinlens`)
    - |transform|
    - Specifies an optional camera-to-world transformation.
      (Default: none (i.e. camera space = world space))
-   - |exposed|
+   - |exposed|, |differentiable|, |discontinuous|
 
  * - aperture_radius
    - |float|
@@ -171,19 +171,18 @@ public:
     void traverse(TraversalCallback *callback) override {
         Base::traverse(callback);
         callback->put_parameter("aperture_radius", m_aperture_radius, ParamFlags::Differentiable | ParamFlags::Discontinuous);
-        callback->put_parameter("focus_distance", m_focus_distance,   ParamFlags::Differentiable | ParamFlags::Discontinuous);
-        callback->put_parameter("x_fov", m_x_fov,                     ParamFlags::Differentiable | ParamFlags::Discontinuous);
-        callback->put_parameter("to_world", *m_to_world.ptr(),        ParamFlags::Differentiable | ParamFlags::Discontinuous);
+        callback->put_parameter("focus_distance",  m_focus_distance,  ParamFlags::Differentiable | ParamFlags::Discontinuous);
+        callback->put_parameter("x_fov",           m_x_fov,           ParamFlags::Differentiable | ParamFlags::Discontinuous);
+        callback->put_parameter("to_world",       *m_to_world.ptr(),  ParamFlags::Differentiable | ParamFlags::Discontinuous);
     }
 
     void parameters_changed(const std::vector<std::string> &keys) override {
+        Base::parameters_changed(keys);
         if (keys.empty() || string::contains(keys, "to_world")) {
-            // Update the scalar value of the matrix
-            m_to_world = m_to_world.value();
             if (m_to_world.scalar().has_scale())
                 Throw("Scale factors in the camera-to-world transformation are not allowed!");
         }
-        Base::parameters_changed(keys);
+
         update_camera_transforms();
     }
 
@@ -210,7 +209,7 @@ public:
         m_image_rect.expand(Point2f(pmax.x(), pmax.y()) / pmax.z());
         m_normalization = 1.f / m_image_rect.volume();
 
-        dr::make_opaque(m_to_world, m_camera_to_sample, m_sample_to_camera, m_dx, m_dy,
+        dr::make_opaque(m_camera_to_sample, m_sample_to_camera, m_dx, m_dy,
                         m_x_fov, m_image_rect, m_normalization);
     }
 


### PR DESCRIPTION
## Description

This PR is a follow-up to these two discussions:
* https://github.com/mitsuba-renderer/mitsuba3/discussions/565
* https://github.com/mitsuba-renderer/mitsuba3/discussions/570

Emitters currently make very little use of the `dr::opaque` mechanism, which can produce very long JIT compilation times as the kernels will grow linearly with the number of emitters. This PR is pass over all emitters and sensors to mark their members as opaque when reasonable.

Emitters for which there is usually only one instance in a scene, such as an `envmap` or `constant` can safely bake their members' values into the kernel and were hence not marked as opaque in this PR. 