### PR TITLE
Fixed dead url in documentation 

### DIFF
--- a/src/emitters/envmap.cpp
+++ b/src/emitters/envmap.cpp
@@ -76,7 +76,8 @@ The plugin can work with all types of images that are natively supported by Mits
 map will contain high-dynamic range data that can only be represented using the
 OpenEXR or RGBE file formats.
 High quality free light probes are available on 
-`Bernhard Vogl's <http://dativ.at/lightprobes/>`_ websites.
+`Bernhard Vogl's <http://dativ.at/lightprobes/>`_ website or 
+`Polyhaven <https://polyhaven.com/hdris>`_.
 
 .. tabs::
     .. code-tab:: xml

--- a/src/emitters/envmap.cpp
+++ b/src/emitters/envmap.cpp
@@ -75,8 +75,7 @@ The plugin can work with all types of images that are natively supported by Mits
 (i.e. JPEG, PNG, OpenEXR, RGBE, TGA, and BMP). In practice, a good environment
 map will contain high-dynamic range data that can only be represented using the
 OpenEXR or RGBE file formats.
-High quality free light probes are available on
-`Paul Debevec's <http://gl.ict.usc.edu/Data/HighResProbes>`_ and
+High quality free light probes are available on 
 `Bernhard Vogl's <http://dativ.at/lightprobes/>`_ websites.
 
 .. tabs::


### PR DESCRIPTION
## Description

1. Removed broken URL.
2. Added new link to Polyhaven HDRI's https://polyhaven.com/hdris.

## Checklist

- [x] My code follows the [style guidelines](https://mitsuba.readthedocs.io/en/latest/src/developer_guide.html#coding-style) of this project
- [x] My changes generate no new warnings
- [ ] My code also compiles for `cuda_*` and `llvm_*` variants. If you can't test this, please leave below
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] I give permission that the Mitsuba 3 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba/blob/master/LICENSE)