### PR TITLE
Small fix in memory_order syntax for C++20 compatibility

### DIFF
--- a/include/mitsuba/core/atomic.h
+++ b/include/mitsuba/core/atomic.h
@@ -51,7 +51,7 @@ public:
 protected:
     /// Apply a FP operation atomically (verified that this will be nicely inlined in the above operators)
     template <typename Func> AtomicFloat& do_atomic(Func func) {
-        Storage old_bits = m_bits.load(std::memory_order::memory_order_relaxed), new_bits;
+        Storage old_bits = m_bits.load(std::memory_order_relaxed), new_bits;
         do {
             new_bits = dr::memcpy_cast<Storage>(func(dr::memcpy_cast<Type>(old_bits)));
             if (new_bits == old_bits)


### PR DESCRIPTION
(PR to run CI)