### PR TITLE
Fix sensor pybindings for implemented virtual functions

### DIFF
--- a/src/render/python/sensor_v.cpp
+++ b/src/render/python/sensor_v.cpp
@@ -21,7 +21,7 @@ public:
     sample_ray_differential(Float time, Float sample1, const Point2f &sample2,
                             const Point2f &sample3, Mask active) const override {
         using Return = std::pair<RayDifferential3f, Spectrum>;
-        PYBIND11_OVERRIDE_PURE(Return, Sensor, sample_ray_differential, time, sample1, sample2, sample3,
+        PYBIND11_OVERRIDE(Return, Sensor, sample_ray_differential, time, sample1, sample2, sample3,
                                active);
     }
 
@@ -65,7 +65,7 @@ public:
     sample_wavelengths(const SurfaceInteraction3f &si, Float sample,
                        Mask active) const override {
         using Return = std::pair<Wavelength, Spectrum>;
-        PYBIND11_OVERRIDE_PURE(Return, Sensor, sample_wavelengths, si, sample, active);
+        PYBIND11_OVERRIDE(Return, Sensor, sample_wavelengths, si, sample, active);
     }
 
     ScalarBoundingBox3f bbox() const override {


### PR DESCRIPTION
## Description

Sensor implementation of virtual functions sample_wavelengths or sample_ray_differential is not visible to the new child class defined in Python due to a bug in Sensor pybind11 bindings.

## Testing

Following code runtime errors with the latest master due to: 
```
RuntimeError: Tried to call pure virtual function "Sensor::sample_wavelengths"' or
RuntimeError: Tried to call pure virtual function "Sensor::sample_ray_differential"
```
This commit fixes the problem.

```
import mitsuba as mi
import drjit as dr

mi.set_variant("llvm_ad_rgb")

class NewSensor(mi.Sensor):
    def sample_ray(self, time, wavelength_sample, position_sample, aperture_sample, active=True):
        wavelengths, wav_weight = self.sample_wavelengths(dr.zeros(mi.SurfaceInteraction3f),
                                                          wavelength_sample, active)
        return mi.Ray3f(), wav_weight


mi.register_sensor('newsensor', lambda props: NewSensor(props))

sensor = mi.load_dict({
    'type': 'newsensor'
})

sensor.sample_ray(0, mi.Float((0., 0., 0.)), mi.Point2f(0, 0), mi.Point2f(0, 0), False)

sensor.sample_ray_differential(0, mi.Float((0., 0., 0.)), mi.Point2f(0, 0), mi.Point2f(0, 0), True)
```

## Checklist
- [x] My code follows the [style guidelines](https://mitsuba.readthedocs.io/en/latest/src/developer_guide.html#coding-style) of this project
- [x] My changes generate no new warnings
- [x] My code also compiles for `cuda_*` and `llvm_*` variants. If you can't test this, please leave below
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 3 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba/blob/master/LICENSE)