### PR TITLE
Fix upsampling using box filter

### DIFF
--- a/include/mitsuba/core/rfilter.h
+++ b/include/mitsuba/core/rfilter.h
@@ -167,6 +167,11 @@ template <typename Scalar_> struct Resampler {
 
                     /* Perform the evaluation and record the weight */
                     auto weight = rfilter->eval(pos * inv_scale);
+
+                    /* Handle the (numerical) edge case of the pixel center missing
+                       the filter support when upsampling using the box filter. */
+                    if (target_res > source_res && rfilter->is_box_filter())
+                        weight = Float(1.0);
                     m_weights[i * m_taps + j] = static_cast<Scalar>(weight);
                     sum += double(weight);
                 }

--- a/src/rfilters/tests/test_rfilter.py
+++ b/src/rfilters/tests/test_rfilter.py
@@ -57,12 +57,20 @@ def test07_resampler_box(variant_scalar_rgb):
     assert resampler.taps() == 1
     resampler.resample(a, 1, b, 1, 1)
 
-    # # Resample to same size
+    # Resample to smaller size
     resampler = mi.Resampler(f, 5, 3)
     b = dr.zeros(Float, 3)
     assert resampler.taps() == 2
     resampler.resample(a, 1, b, 1, 1)
     assert dr.all(b == [0.125, 0.5, 0.875])
+
+    # Resample to larger size
+    a = dr.linspace(Float, 0, 1, 2)
+    resampler = mi.Resampler(f, 2, 3)
+    b = dr.zeros(Float, 3)
+    assert resampler.taps() == 1
+    resampler.resample(a, 1, b, 1, 1)
+    assert dr.all(b == [0.0, 1.0, 1.0])
 
 
 def test08_resampler_boundary_conditions(variant_scalar_rgb):


### PR DESCRIPTION
Fixes issue #613 

The problem is the usual problem of the box filter evaluation being numerically slightly unstable.

E.g., when upsampling an array from length 2 to 3, the middle pixel will evaluate a contribution from a lower level pixel exactly at 0.5 and therefore fall outside of the box filter support. 

```
|.....|.....| (input array)
|...|...|...| (output array)
      ^
      |
  problematic pixel
```

I added a special code path for box filtered upsampling. It's not super elegant, but a relatively minimal modification of the existing code. The alternative would be to add a completely separate box filter upsampling code path, which would be a bit cumbersome in this class. I also added a corresponding test.