### PR TITLE
Change write_ply to write UVs in fields s,t instead of u,v

### DIFF
--- a/src/render/mesh.cpp
+++ b/src/render/mesh.cpp
@@ -176,8 +176,8 @@ MI_VARIANT void Mesh<Float, Spectrum>::write_ply(const std::string &filename) co
     }
 
     if (has_vertex_texcoords()) {
-        stream->write_line("property float u");
-        stream->write_line("property float v");
+        stream->write_line("property float s");
+        stream->write_line("property float t");
     }
 
     for (const auto&[name, attribute]: vertex_attributes)


### PR DESCRIPTION
Currently Mitsuba's `write_ply` function writes UV coordinates to fields "u" and "v" in the PLY file. This seems logical, but it turns out that both Blender and Meshlab do not recognize those as UV coordinates. They both however seem to be able to recognize fields named "s" and "t". 

The following code writes out Mitsuba's default cube as a PLY file. I've attached the result with and without this proposed change in a ZIP file. The PLY file ending in `uv` was created using master, and the other one using this proposed change. With the change, the file loads correctly in Blender. Without the change, the loaded Blender object does not have UV coordinates. Similarly, Meshlab will also not recognize the "uv" file correctly.

```
import mitsuba as mi
mi.set_variant('llvm_ad_rgb')

m = mi.load_dict({'type': 'cube'})
m.write_ply('cube_mitsuba.ply')
```

[cubes.zip](https://github.com/mitsuba-renderer/mitsuba3/files/11149159/cubes.zip)

Before merging, it would be good to double check that this doesn't break anything in the blender plugin @bathal1.


