### PR TITLE
Add Python bindings to access the underlying buffer of a MemoryStream

### DIFF
--- a/include/mitsuba/core/mstream.h
+++ b/include/mitsuba/core/mstream.h
@@ -110,6 +110,9 @@ public:
     /// Return whether or not the memory stream owns the underlying buffer
     bool owns_buffer() const { return m_owns_buffer; }
 
+    /// Return the underlying raw byte array
+    const uint8_t *raw_buffer() const { return m_data; }
+
     //! @}
     // =========================================================================
 

--- a/src/core/python/stream.cpp
+++ b/src/core/python/stream.cpp
@@ -94,7 +94,10 @@ MI_PY_EXPORT(MemoryStream) {
         .def(py::init<size_t>(), D(MemoryStream, MemoryStream),
             "capacity"_a = 512)
         .def_method(MemoryStream, capacity)
-        .def_method(MemoryStream, owns_buffer);
+        .def_method(MemoryStream, owns_buffer)
+        .def("raw_buffer", [](MemoryStream &s) -> py::bytes {
+            return py::bytes(reinterpret_cast<const char*>(s.raw_buffer()), s.size());
+        });
 }
 
 MI_PY_EXPORT(ZStream) {

--- a/src/core/tests/test_stream.py
+++ b/src/core/tests/test_stream.py
@@ -213,9 +213,12 @@ def test07_memory_stream():
     assert s.can_write()
     assert s.can_read()
 
-    s.write_string('hello world')
+    string = 'hello world'
     s.set_byte_order(Stream.EBigEndian)
+    s.write_string(string)
 
+    reference = int(len(string)).to_bytes(4, 'big') + bytes(string, encoding='ascii')
+    assert s.raw_buffer() == reference
     assert str(s) == """MemoryStream[
   host_byte_order = little-endian,
   byte_order = big-endian,


### PR DESCRIPTION
This adds an accessor function and python binding for the MemoryStream's underlying data buffer. I found this useful to be able to write Bitmap data to an arbitrary output stream in Python by going from Bitmap to MemoryStream to my custom output stream. Concretely, this is helpful to write Bitmap data to file systems that aren't supported by Mitsuba's file stream.