### PR TITLE
Fix memory usage of PRB integrators

### DIFF
--- a/include/mitsuba/python/docstr.h
+++ b/include/mitsuba/python/docstr.h
@@ -2874,6 +2874,9 @@ static const char *__doc_mitsuba_Film_put_block =
 R"doc(Merge an image block into the film. This methods should be thread-
 safe.)doc";
 
+static const char *__doc_mitsuba_Film_clear =
+R"doc(Clear the film content to zero.)doc";
+
 static const char *__doc_mitsuba_Film_rfilter = R"doc(Return the image reconstruction filter (const version))doc";
 
 static const char *__doc_mitsuba_Film_sample_border =

--- a/include/mitsuba/render/film.h
+++ b/include/mitsuba/render/film.h
@@ -60,6 +60,9 @@ public:
     /// Merge an image block into the film. This methods should be thread-safe.
     virtual void put_block(const ImageBlock *block) = 0;
 
+    /// Clear the film contents to zero.
+    virtual void clear() = 0;
+
     /// Return a image buffer object storing the developed image
     virtual TensorXf develop(bool raw = false) const = 0;
 

--- a/src/films/hdrfilm.cpp
+++ b/src/films/hdrfilm.cpp
@@ -283,6 +283,11 @@ public:
         m_storage->put_block(block);
     }
 
+    void clear() override {
+        if (m_storage)
+            m_storage->clear();
+    }
+
     TensorXf develop(bool raw = false) const override {
         if (!m_storage)
             Throw("No storage allocated, was prepare() called first?");

--- a/src/films/specfilm.cpp
+++ b/src/films/specfilm.cpp
@@ -304,6 +304,11 @@ public:
         std::lock_guard<std::mutex> lock(m_mutex);
         m_storage->put_block(block);
     }
+    
+    void clear() override {
+        if (m_storage)
+            m_storage->clear();
+    }
 
     TensorXf develop(bool raw = false) const override {
         if (!m_storage)

--- a/src/python/python/ad/integrators/common.py
+++ b/src/python/python/ad/integrators/common.py
@@ -63,7 +63,7 @@ class ADIntegrator(mi.CppADIntegrator):
 
         if isinstance(sensor, int):
             sensor = scene.sensors()[sensor]
-        
+
         film = sensor.film()
 
         # Disable derivatives in all of the following
@@ -99,17 +99,16 @@ class ADIntegrator(mi.CppADIntegrator):
             block.set_coalesce(block.coalesce() and spp >= 4)
 
             # Accumulate into the image block
-            alpha = dr.select(valid, mi.Float(1), mi.Float(0))
-            if mi.has_flag(film.flags(), mi.FilmFlags.Special):
-                aovs = film.prepare_sample(L * weight, ray.wavelengths,
-                                           block.channel_count(), alpha=alpha)
-                block.put(pos, aovs)
-                del aovs
-            else:
-                block.put(pos, ray.wavelengths, L * weight, alpha)
+            ADIntegrator._splat_to_block(
+                block, film, pos,
+                value=L * weight,
+                weight=1.0,
+                alpha=dr.select(valid, mi.Float(1), mi.Float(0)),
+                wavelengths=ray.wavelengths
+            )
 
             # Explicitly delete any remaining unused variables
-            del sampler, ray, weight, pos, L, valid, alpha
+            del sampler, ray, weight, pos, L, valid
             gc.collect()
 
             # Perform the weight division and return an image tensor
@@ -174,21 +173,13 @@ class ADIntegrator(mi.CppADIntegrator):
                 #   Σ (fi Li det)
                 #  ---------------
                 #   Σ (fi det)
-                if (dr.all(mi.has_flag(film.flags(), mi.FilmFlags.Special))):
-                    aovs = film.prepare_sample(L * weight * det, ray.wavelengths,
-                                               block.channel_count(),
-                                               weight=det,
-                                               alpha=dr.select(valid, mi.Float(1), mi.Float(0)))
-                    block.put(pos, aovs)
-                    del aovs
-                else:
-                    block.put(
-                        pos=pos,
-                        wavelengths=ray.wavelengths,
-                        value=L * weight * det,
-                        weight=det,
-                        alpha=dr.select(valid, mi.Float(1), mi.Float(0))
-                    )
+                ADIntegrator._splat_to_block(
+                    block, film, pos,
+                    value=L * weight * det,
+                    weight=det,
+                    alpha=dr.select(valid, mi.Float(1), mi.Float(0)),
+                    wavelengths=ray.wavelengths
+                )
 
                 # Perform the weight division and return an image tensor
                 film.put_block(block)
@@ -253,21 +244,13 @@ class ADIntegrator(mi.CppADIntegrator):
                 block.set_coalesce(block.coalesce() and spp >= 4)
 
                 # Accumulate into the image block
-                if mi.has_flag(film.flags(), mi.FilmFlags.Special):
-                    aovs = film.prepare_sample(L * weight * det, ray.wavelengths,
-                                               block.channel_count(),
-                                               weight=det,
-                                               alpha=dr.select(valid, mi.Float(1), mi.Float(0)))
-                    block.put(pos, aovs)
-                    del aovs
-                else:
-                    block.put(
-                        pos=pos,
-                        wavelengths=ray.wavelengths,
-                        value=L * weight * det,
-                        weight=det,
-                        alpha=dr.select(valid, mi.Float(1), mi.Float(0))
-                    )
+                ADIntegrator._splat_to_block(
+                    block, film, pos,
+                    value=L * weight * det,
+                    weight=det,
+                    alpha=dr.select(valid, mi.Float(1), mi.Float(0)),
+                    wavelengths=ray.wavelengths
+                )
 
                 film.put_block(block)
 
@@ -479,6 +462,30 @@ class ADIntegrator(mi.CppADIntegrator):
 
         return sampler, spp
 
+    def _splat_to_block(block: mi.ImageBlock,
+                       film: mi.Film,
+                       pos: mi.Point2f,
+                       value: mi.Spectrum,
+                       weight: mi.Float,
+                       alpha: mi.Float,
+                       wavelengths: mi.Spectrum):
+        '''Helper function to splat values to a imageblock'''
+        if (dr.all(mi.has_flag(film.flags(), mi.FilmFlags.Special))):
+            aovs = film.prepare_sample(value, wavelengths,
+                                        block.channel_count(),
+                                        weight=weight,
+                                        alpha=alpha)
+            block.put(pos, aovs)
+            del aovs
+        else:
+            block.put(
+                pos=pos,
+                wavelengths=wavelengths,
+                value=value,
+                weight=weight,
+                alpha=alpha
+            )
+
     def sample(self,
                mode: dr.ADMode,
                scene: mi.Scene,
@@ -682,6 +689,19 @@ class RBIntegrator(ADIntegrator):
                 active=mi.Bool(True)
             )
 
+            # Launch the Monte Carlo sampling process in forward mode (2)
+            δL, valid_2, state_out_2 = self.sample(
+                mode=dr.ADMode.Forward,
+                scene=scene,
+                sampler=sampler,
+                ray=ray,
+                depth=mi.UInt32(0),
+                δL=None,
+                state_in=state_out,
+                reparam=reparam,
+                active=mi.Bool(True)
+            )
+
             # Differentiable camera pose parameters or a reparameterization
             # have an effect on the measurement integral performed at the
             # sensor. We account for this here by differentiating the
@@ -703,56 +723,23 @@ class RBIntegrator(ADIntegrator):
                     sample_pos_deriv.set_coalesce(sample_pos_deriv.coalesce() and spp >= 4)
 
                     # Deposit samples with gradient tracking for 'pos'.
-                    if (dr.all(mi.has_flag(film.flags(), mi.FilmFlags.Special))):
-                        aovs = film.prepare_sample(L * weight * det, ray.wavelengths,
-                                                            sample_pos_deriv.channel_count(),
-                                                            weight=det,
-                                                            alpha=dr.select(valid, mi.Float(1), mi.Float(0)))
-                        sample_pos_deriv.put(pos, aovs)
-                        del aovs
-                    else:
-                        sample_pos_deriv.put(
-                            pos=pos,
-                            wavelengths=ray.wavelengths,
-                            value=L * weight * det,
-                            weight=det,
-                            alpha=dr.select(valid, mi.Float(1), mi.Float(0))
-                        )
+                    ADIntegrator._splat_to_block(
+                        sample_pos_deriv, film, pos,
+                        value=L * weight * det,
+                        weight=det,
+                        alpha=dr.select(valid, mi.Float(1), mi.Float(0)),
+                        wavelengths=ray.wavelengths
+                    )
 
                     # Compute the derivative of the reparameterized image ..
                     tensor = sample_pos_deriv.tensor()
-                    dr.forward_to(tensor,
-                                  flags=dr.ADFlag.ClearInterior | dr.ADFlag.ClearEdges)
+                    dr.forward_to(tensor, flags=dr.ADFlag.ClearInterior | dr.ADFlag.ClearEdges)
 
                     dr.schedule(tensor, dr.grad(tensor))
 
                     # Done with this part, let's detach the image-space position
                     dr.disable_grad(pos)
                     del tensor
-
-            # Probably a little overkill, but why not.. If there are any
-            # DrJit arrays to be collected by Python's cyclic GC, then
-            # freeing them may enable loop simplifications in dr.eval().
-            gc.collect()
-
-            # Launch a kernel with everything so far
-            dr.eval(state_out)
-
-            # Garbage collect unused values to simplify kernel about to be run
-            del L, valid, params
-
-            # Launch the Monte Carlo sampling process in forward mode
-            δL, valid_2, state_out_2 = self.sample(
-                mode=dr.ADMode.Forward,
-                scene=scene,
-                sampler=sampler,
-                ray=ray,
-                depth=mi.UInt32(0),
-                δL=None,
-                state_in=state_out,
-                reparam=reparam,
-                active=mi.Bool(True)
-            )
 
             # Prepare an ImageBlock as specified by the film
             block = film.create_block()
@@ -761,27 +748,24 @@ class RBIntegrator(ADIntegrator):
             block.set_coalesce(block.coalesce() and spp >= 4)
 
             # Accumulate into the image block
-            if (dr.all(mi.has_flag(film.flags(), mi.FilmFlags.Special))):
-                aovs = film.prepare_sample(δL * weight, ray.wavelengths,
-                                           block.channel_count(),
-                                           alpha=dr.select(valid_2, mi.Float(1), mi.Float(0)))
-                block.put(pos, aovs)
-                del aovs
-            else:
-                block.put(
-                    pos=pos,
-                    wavelengths=ray.wavelengths,
-                    value=δL * weight,
-                    alpha=dr.select(valid_2, mi.Float(1), mi.Float(0))
-                )
+            ADIntegrator._splat_to_block(
+                block, film, pos,
+                value=δL * weight,
+                weight=1.0,
+                alpha=dr.select(valid_2, mi.Float(1), mi.Float(0)),
+                wavelengths=ray.wavelengths
+            )
 
             # Perform the weight division and return an image tensor
             film.put_block(block)
 
             # Explicitly delete any remaining unused variables
-            del sampler, ray, weight, pos, δL, valid_2, \
+            del sampler, ray, weight, pos, L, valid, δL, valid_2, params, \
                 state_out, state_out_2, block
 
+            # Probably a little overkill, but why not.. If there are any
+            # DrJit arrays to be collected by Python's cyclic GC, then
+            # freeing them may enable loop simplifications in dr.eval().
             gc.collect()
 
             result_grad = film.develop()
@@ -789,7 +773,7 @@ class RBIntegrator(ADIntegrator):
             # Potentially add the derivative of the reparameterized samples
             if sample_pos_deriv is not None:
                 with dr.resume_grad():
-                    film.prepare(aovs)
+                    film.clear()
                     film.put_block(sample_pos_deriv)
                     reparam_result = film.develop()
                     dr.forward_to(reparam_result)
@@ -884,6 +868,59 @@ class RBIntegrator(ADIntegrator):
             ray, weight, pos, det = self.sample_rays(scene, sensor,
                                                      sampler, reparam)
 
+            def splatting_and_backward_gradient_image(value: mi.Spectrum,
+                                                      weight: mi.Float,
+                                                      alpha: mi.Float):
+                '''
+                Backward propagation of the gradient image through the sample
+                splatting and weight division steps.
+                '''
+
+                # Prepare an ImageBlock as specified by the film
+                block = film.create_block()
+
+                # Only use the coalescing feature when rendering enough samples
+                block.set_coalesce(block.coalesce() and spp >= 4)
+
+                ADIntegrator._splat_to_block(
+                    block, film, pos,
+                    value=value,
+                    weight=weight,
+                    alpha=alpha,
+                    wavelengths=ray.wavelengths
+                )
+
+                film.put_block(block)
+
+                # Probably a little overkill, but why not.. If there are any
+                # DrJit arrays to be collected by Python's cyclic GC, then
+                # freeing them may enable loop simplifications in dr.eval().
+                gc.collect()
+
+                image = film.develop()
+
+                dr.set_grad(image, grad_in)
+                dr.enqueue(dr.ADMode.Backward, image)
+                dr.traverse(mi.Float, dr.ADMode.Backward)
+
+            # Differentiate sample splatting and weight division steps to
+            # retrieve the adjoint radiance (e.g. 'δL')
+            with dr.resume_grad():
+                with dr.suspend_grad(pos, det, ray, weight):
+                    L = dr.full(mi.Spectrum, 1.0, dr.width(ray))
+                    dr.enable_grad(L)
+
+                    splatting_and_backward_gradient_image(
+                        value=L * weight,
+                        weight=1.0,
+                        alpha=1.0
+                    )
+
+                    δL = dr.grad(L)
+
+            # Clear the dummy data splatted on the film above
+            film.clear()
+
             # Launch the Monte Carlo sampling process in primal mode (1)
             L, valid, state_out = self.sample(
                 mode=dr.ADMode.Primal,
@@ -896,55 +933,6 @@ class RBIntegrator(ADIntegrator):
                 reparam=None,
                 active=mi.Bool(True)
             )
-
-            # Prepare an ImageBlock as specified by the film
-            block = film.create_block()
-
-            # Only use the coalescing feature when rendering enough samples
-            block.set_coalesce(block.coalesce() and spp >= 4)
-
-            with dr.resume_grad():
-                dr.enable_grad(L)
-
-                # Accumulate into the image block.
-                # After reparameterizing the camera ray, we need to evaluate
-                #   Σ (fi Li det)
-                #  ---------------
-                #   Σ (fi det)
-                if (dr.all(mi.has_flag(sensor.film().flags(), mi.FilmFlags.Special))):
-                    aovs = sensor.film().prepare_sample(L * weight * det, ray.wavelengths,
-                                                        block.channel_count(),
-                                                        weight=det,
-                                                        alpha=dr.select(valid, mi.Float(1), mi.Float(0)))
-                    block.put(pos, aovs)
-                    del aovs
-                else:
-                    block.put(
-                        pos=pos,
-                        wavelengths=ray.wavelengths,
-                        value=L * weight * det,
-                        weight=det,
-                        alpha=dr.select(valid, mi.Float(1), mi.Float(0))
-                    )
-
-                sensor.film().put_block(block)
-
-                # Probably a little overkill, but why not.. If there are any
-                # DrJit arrays to be collected by Python's cyclic GC, then
-                # freeing them may enable loop simplifications in dr.eval().
-                del valid
-                gc.collect()
-
-                # This step launches a kernel
-                dr.schedule(state_out, block.tensor())
-                image = sensor.film().develop()
-
-                # Differentiate sample splatting and weight division steps to
-                # retrieve the adjoint radiance
-                dr.set_grad(image, grad_in)
-                dr.enqueue(dr.ADMode.Backward, image)
-                dr.traverse(mi.Float, dr.ADMode.Backward)
-                δL = dr.grad(L)
 
             # Launch Monte Carlo sampling in backward AD mode (2)
             L_2, valid_2, state_out_2 = self.sample(
@@ -959,9 +947,23 @@ class RBIntegrator(ADIntegrator):
                 active=mi.Bool(True)
             )
 
+            # Propagate gradient image to sample positions if necessary
+            if reparam is not None:
+                with dr.resume_grad():
+                    # Accumulate into the image block.
+                    # After reparameterizing the camera ray, we need to evaluate
+                    #   Σ (fi Li det)
+                    #  ---------------
+                    #   Σ (fi det)
+                    splatting_and_backward_gradient_image(
+                        value=L * weight * det,
+                        weight=det,
+                        alpha=dr.select(valid, mi.Float(1), mi.Float(0))
+                    )
+
             # We don't need any of the outputs here
             del L_2, valid_2, state_out, state_out_2, δL, \
-                ray, weight, pos, block, sampler
+                ray, weight, pos, sampler
 
             gc.collect()
 

--- a/src/render/python/film_v.cpp
+++ b/src/render/python/film_v.cpp
@@ -22,6 +22,10 @@ public:
         PYBIND11_OVERRIDE_PURE(void, Film, put_block, block);
     }
 
+    void clear() override {
+        PYBIND11_OVERRIDE_PURE(void, Film, clear);
+    }
+
     TensorXf develop(bool raw = false) const override {
         PYBIND11_OVERRIDE_PURE(TensorXf, Film, develop, raw);
     }
@@ -76,6 +80,7 @@ MI_PY_EXPORT(Film) {
         .def(py::init<const Properties &>(), "props"_a)
         .def_method(Film, prepare, "aovs"_a)
         .def_method(Film, put_block, "block"_a)
+        .def_method(Film, clear)
         .def_method(Film, develop, "raw"_a = false)
         .def_method(Film, bitmap, "raw"_a = false)
         .def_method(Film, write, "path"_a)


### PR DESCRIPTION
## Description

This PR reorganizes the kernels generated by `RBIntegrator.render_backward()` in order to avoid the need to store intermediate rendering state to memory (e.g. `state_out`).  This issue was originally raised in #655.

With the patch, the integrator first computes the adjoint radiance by differentiating the sample splatting and weight division. This doesn't require any information from the 1st phase of PRB, hence can be done independently. This will generate two kernels: one for the ray generation, and one for the splatting. Then the integrator generates a fused kernel that computes phase 1 and 2 of PRB. Here only the ray generation operations are duplicated, which shouldn't a real impact on performances. Finally, for reparameterized integrators (e.g. `prb_reparam`), the radiance computed in phase 1 (e.g. `L`) is backpropagated through the film splatting and weight division to compute the gradients of the sample positions. Compared to the original implementation, this will introduce an extra kernel that computes the splatting a second time in the case of reparameterized integrator.

This PR also adds `Film::clear()` that clears the content of a film (e.g. after calling `put_block()`), needed for this patch.

## Example

To test this patch, here are some statistics and information about the kernels launched in the `render_backward()` method when differentiating the color of the red wall of the Cornell Box scene with 4096 samples per pixels.

### Before the patch

**Kernels**:
1. PHASE 1: (n=268435456, in=54, out=3, se=100, ops=1821)
2. ADJOINT RADIANCE: (n=196608, in=3, out=0, se=2, ops=35)
3. PHASE 2: (n=268435456, in=63, out=0, se=1, ops=2118)

**Memory usage**:
2.042 MiB/3.003 GiB used (peak: 3.003 GiB)

### After the patch

**Kernels**:
1. ADJOINT RADIANCE (ray gen): (n=268435456, in=3, out=0, se=100, ops=665):
2. ADJOINT RADIANCE (splat): (n=196608, in=3, out=0, se=2, ops=35):
3. PHASE 1 + 2: (n=268435456, in=80, out=0, se=1, ops=2775)

**Memory usage**:
1.042 MiB/3.047 MiB used (peak: 3.047 MiB)

Not only the memory usage is drastically reduced as it is now independent of the SPP, but the total number of operations over the 3 kernels is smaller after the patch.

## Testing

This patch should be covered by the tests in `test_ad_integrators.py`.
