### PR TITLE
Bitmap class: release GIL only after handling Python inputs

### DIFF
--- a/src/core/python/bitmap.cpp
+++ b/src/core/python/bitmap.cpp
@@ -99,13 +99,14 @@ MI_PY_EXPORT(Bitmap) {
                    bool srgb_gamma = b.srgb_gamma();
                    if (!srgb.is(py::none()))
                        srgb_gamma = srgb.cast<bool>();
+
+                   py::gil_scoped_release release;
                    return b.convert(pixel_format, component_format, srgb_gamma,
                                     alpha_transform);
             },
              D(Bitmap, convert),
              "pixel_format"_a = py::none(), "component_format"_a = py::none(),
-             "srgb_gamma"_a = py::none(), "alpha_transform"_a = Bitmap::AlphaTransform::Empty,
-             py::call_guard<py::gil_scoped_release>())
+             "srgb_gamma"_a = py::none(), "alpha_transform"_a = Bitmap::AlphaTransform::Empty)
         .def("convert", py::overload_cast<Bitmap *>(&Bitmap::convert, py::const_),
              D(Bitmap, convert, 2), "target"_a,
              py::call_guard<py::gil_scoped_release>())


### PR DESCRIPTION
There is a small bug in the Bitmap Python bindings: the GIL should only be released after any Python operations are completed, not before. Otherwise it incurs undefined behavior due to Python internals updating without the GIL being held.