### PR TITLE
Shape texture attribute

### DIFF
--- a/include/mitsuba/python/docstr.h
+++ b/include/mitsuba/python/docstr.h
@@ -4294,6 +4294,8 @@ static const char *__doc_mitsuba_Mesh_embree_geometry = R"doc(Return the Embree 
 
 static const char *__doc_mitsuba_Mesh_ensure_pmf_built = R"doc()doc";
 
+static const char *__doc_mitsuba_Mesh_has_attribute = R"doc()doc";
+
 static const char *__doc_mitsuba_Mesh_eval_attribute = R"doc()doc";
 
 static const char *__doc_mitsuba_Mesh_eval_attribute_1 = R"doc()doc";
@@ -7116,7 +7118,7 @@ static const char *__doc_mitsuba_Shape_emitter = R"doc(Return the area emitter a
 
 static const char *__doc_mitsuba_Shape_emitter_2 = R"doc(Return the area emitter associated with this shape (if any))doc";
 
-static const char *__doc_mitsuba_Shape_eval_attribute =
+static const char *__doc_mitsuba_Shape_has_attribute =
 R"doc(Evaluate a specific shape attribute at the given surface interaction.
 
 Shape attributes are user-provided fields that provide extra
@@ -7124,7 +7126,7 @@ information at an intersection. An example of this would be a per-
 vertex or per-face color on a triangle mesh.
 
 Parameter ``name``:
-    Name of the attribute to evaluate
+    Name of the attribute
 
 Parameter ``si``:
     Surface interaction associated with the query
@@ -7133,6 +7135,12 @@ Returns:
     An unpolarized spectral power distribution or reflectance value
 
 The default implementation throws an exception.)doc";
+
+static const char *__doc_mitsuba_Shape_eval_attribute =
+R"doc(Returns whether this shape contains the specified attribute.
+
+Parameter ``name``:
+    Name of the attribute to evaluate)doc";
 
 static const char *__doc_mitsuba_Shape_eval_attribute_1 =
 R"doc(Monochromatic evaluation of a shape attribute at the given surface
@@ -7149,9 +7157,7 @@ Parameter ``si``:
     Surface interaction associated with the query
 
 Returns:
-    An scalar intensity or reflectance value
-
-The default implementation throws an exception.)doc";
+    An scalar intensity or reflectance value)doc";
 
 static const char *__doc_mitsuba_Shape_eval_attribute_3 =
 R"doc(Trichromatic evaluation of a shape attribute at the given surface
@@ -7168,9 +7174,7 @@ Parameter ``si``:
     Surface interaction associated with the query
 
 Returns:
-    An trichromatic intensity or reflectance value
-
-The default implementation throws an exception.)doc";
+    An trichromatic intensity or reflectance value)doc";
 
 static const char *__doc_mitsuba_Shape_eval_parameterization =
 R"doc(Parameterize the mesh using UV values

--- a/include/mitsuba/render/mesh.h
+++ b/include/mitsuba/render/mesh.h
@@ -183,6 +183,8 @@ public:
                                                              uint32_t recursion_depth = 0,
                                                              Mask active = true) const override;
 
+    virtual Mask has_attribute(const std::string &name, Mask active = true) const override;
+
     virtual UnpolarizedSpectrum eval_attribute(const std::string &name,
                                                const SurfaceInteraction3f &si,
                                                Mask active = true) const override;

--- a/include/mitsuba/render/shape.h
+++ b/include/mitsuba/render/shape.h
@@ -283,6 +283,14 @@ public:
     virtual Float surface_area() const;
 
     /**
+     * \brief Returns whether this shape contains the specified attribute.
+     *
+     * \param name
+     *     Name of the attribute
+     */
+    virtual Mask has_attribute(const std::string &name, Mask active = true) const;
+
+    /**
      * \brief Evaluate a specific shape attribute at the given surface interaction.
      *
      * Shape attributes are user-provided fields that provide extra
@@ -297,8 +305,6 @@ public:
      *
      * \return
      *     An unpolarized spectral power distribution or reflectance value
-     *
-     * The default implementation throws an exception.
      */
     virtual UnpolarizedSpectrum eval_attribute(const std::string &name,
                                                const SurfaceInteraction3f &si,
@@ -319,8 +325,6 @@ public:
      *
      * \return
      *     An scalar intensity or reflectance value
-     *
-     * The default implementation throws an exception.
      */
     virtual Float eval_attribute_1(const std::string &name,
                                    const SurfaceInteraction3f &si,
@@ -341,8 +345,6 @@ public:
      *
      * \return
      *     An trichromatic intensity or reflectance value
-     *
-     * The default implementation throws an exception.
      */
     virtual Color3f eval_attribute_3(const std::string &name,
                                      const SurfaceInteraction3f &si,
@@ -641,6 +643,7 @@ NAMESPACE_END(mitsuba)
 
 DRJIT_VCALL_TEMPLATE_BEGIN(mitsuba::Shape)
     DRJIT_VCALL_METHOD(compute_surface_interaction)
+    DRJIT_VCALL_METHOD(has_attribute)
     DRJIT_VCALL_METHOD(eval_attribute)
     DRJIT_VCALL_METHOD(eval_attribute_1)
     DRJIT_VCALL_METHOD(eval_attribute_3)

--- a/include/mitsuba/render/shape.h
+++ b/include/mitsuba/render/shape.h
@@ -7,6 +7,7 @@
 #include <mitsuba/core/bbox.h>
 #include <mitsuba/core/field.h>
 #include <drjit/packet.h>
+#include <unordered_map>
 
 #if defined(MI_ENABLE_CUDA)
 #  include <mitsuba/render/optix/common.h>
@@ -24,7 +25,7 @@ NAMESPACE_BEGIN(mitsuba)
 template <typename Float, typename Spectrum>
 class MI_EXPORT_LIB Shape : public Object {
 public:
-    MI_IMPORT_TYPES(BSDF, Medium, Emitter, Sensor, MeshAttribute);
+    MI_IMPORT_TYPES(BSDF, Medium, Emitter, Sensor, MeshAttribute, Texture);
 
     // Use 32 bit indices to keep track of indices to conserve memory
     using ScalarIndex = uint32_t;
@@ -560,6 +561,8 @@ protected:
     ref<Medium> m_interior_medium;
     ref<Medium> m_exterior_medium;
     std::string m_id;
+
+    std::unordered_map<std::string, ref<Texture>> m_texture_attributes;
 
     field<Transform4f, ScalarTransform4f> m_to_world;
     field<Transform4f, ScalarTransform4f> m_to_object;

--- a/src/core/tests/test_xml.py
+++ b/src/core/tests/test_xml.py
@@ -277,7 +277,7 @@ def test22_fileresolver_unchanged(variant_scalar_rgb):
 
 def test23_unreferenced_object(variant_scalar_rgb):
     plugins = [('bsdf', 'diffuse'), ('emitter', 'point'),
-               ('shape', 'sphere'), ('sensor', 'perspective')]
+               ('sensor', 'perspective')]
 
     for interface, name in plugins:
         with pytest.raises(Exception) as e:

--- a/src/render/mesh.cpp
+++ b/src/render/mesh.cpp
@@ -901,12 +901,8 @@ Mesh<Float, Spectrum>::eval_attribute(const std::string& name,
                                       const SurfaceInteraction3f &si,
                                       Mask active) const {
     const auto& it = m_mesh_attributes.find(name);
-    if (it == m_mesh_attributes.end()) {
-        if constexpr (dr::is_jit_v<Float>)
-            return 0.f;
-        else
-            Throw("Invalid attribute requested %s.", name.c_str());
-    }
+    if (it == m_mesh_attributes.end())
+        return Base::eval_attribute(name, si, active);
 
     const auto& attr = it->second;
     if (attr.size == 1)
@@ -930,12 +926,8 @@ Mesh<Float, Spectrum>::eval_attribute_1(const std::string& name,
                                         const SurfaceInteraction3f &si,
                                         Mask active) const {
     const auto& it = m_mesh_attributes.find(name);
-    if (it == m_mesh_attributes.end()) {
-        if constexpr (dr::is_jit_v<Float>)
-            return 0.f;
-        else
-            Throw("Invalid attribute requested %s.", name.c_str());
-    }
+    if (it == m_mesh_attributes.end())
+        return Base::eval_attribute_1(name, si, active);
 
     const auto& attr = it->second;
     if (attr.size == 1) {
@@ -953,12 +945,8 @@ Mesh<Float, Spectrum>::eval_attribute_3(const std::string& name,
                                         const SurfaceInteraction3f &si,
                                         Mask active) const {
     const auto& it = m_mesh_attributes.find(name);
-    if (it == m_mesh_attributes.end()) {
-        if constexpr (dr::is_jit_v<Float>)
-            return 0.f;
-        else
-            Throw("Invalid attribute requested %s.", name.c_str());
-    }
+    if (it == m_mesh_attributes.end())
+        return Base::eval_attribute_3(name, si, active);
 
     const auto& attr = it->second;
     if (attr.size == 3) {

--- a/src/render/mesh.cpp
+++ b/src/render/mesh.cpp
@@ -896,6 +896,14 @@ MI_VARIANT void Mesh<Float, Spectrum>::add_attribute(const std::string& name,
     m_mesh_attributes.insert({ name, { dim, type, buffer } });
 }
 
+MI_VARIANT typename Mesh<Float, Spectrum>::Mask
+Mesh<Float, Spectrum>::has_attribute(const std::string& name, Mask active) const {
+    const auto& it = m_mesh_attributes.find(name);
+    if (it == m_mesh_attributes.end())
+        return Base::has_attribute(name, active);
+    return true;
+}
+
 MI_VARIANT typename Mesh<Float, Spectrum>::UnpolarizedSpectrum
 Mesh<Float, Spectrum>::eval_attribute(const std::string& name,
                                       const SurfaceInteraction3f &si,

--- a/src/render/python/shape_v.cpp
+++ b/src/render/python/shape_v.cpp
@@ -56,6 +56,11 @@ template <typename Ptr, typename Cls> void bind_shape_generic(Cls &cls) {
             },
             "ray"_a, "pi"_a, "ray_flags"_a = +RayFlags::All,
             "active"_a = true, D(Shape, compute_surface_interaction))
+       .def("has_attribute",
+            [](Ptr shape, const std::string &name, const Mask &active) {
+                return shape->has_attribute(name, active);
+            },
+            "name"_a, "active"_a = true, D(Shape, has_attribute))
        .def("eval_attribute",
             [](Ptr shape, const std::string &name,
                const SurfaceInteraction3f &si, const Mask &active) {

--- a/src/render/shape.cpp
+++ b/src/render/shape.cpp
@@ -446,6 +446,11 @@ Shape<Float, Spectrum>::ray_intersect(const Ray3f &ray, uint32_t ray_flags, Mask
     return pi.compute_surface_interaction(ray, ray_flags, active);
 }
 
+MI_VARIANT typename Shape<Float, Spectrum>::Mask
+Shape<Float, Spectrum>::has_attribute(const std::string& name, Mask /*active*/) const {
+    return m_texture_attributes.find(name) != m_texture_attributes.end();
+}
+
 MI_VARIANT typename Shape<Float, Spectrum>::UnpolarizedSpectrum
 Shape<Float, Spectrum>::eval_attribute(const std::string & name,
                                        const SurfaceInteraction3f & si,

--- a/src/render/shape.cpp
+++ b/src/render/shape.cpp
@@ -29,6 +29,7 @@ MI_VARIANT Shape<Float, Spectrum>::Shape(const Properties &props) : m_id(props.i
         Sensor *sensor   = dynamic_cast<Sensor *>(obj.get());
         BSDF *bsdf       = dynamic_cast<BSDF *>(obj.get());
         Medium *medium   = dynamic_cast<Medium *>(obj.get());
+        Texture *texture = dynamic_cast<Texture *>(obj.get());
 
         if (emitter) {
             if (m_emitter)
@@ -52,6 +53,8 @@ MI_VARIANT Shape<Float, Spectrum>::Shape(const Properties &props) : m_id(props.i
                     Throw("Only a single exterior medium can be specified per shape.");
                 m_exterior_medium = medium;
             }
+        } else if (texture) {
+            m_texture_attributes.insert({ name, texture });
         } else {
             continue;
         }
@@ -444,38 +447,51 @@ Shape<Float, Spectrum>::ray_intersect(const Ray3f &ray, uint32_t ray_flags, Mask
 }
 
 MI_VARIANT typename Shape<Float, Spectrum>::UnpolarizedSpectrum
-Shape<Float, Spectrum>::eval_attribute(const std::string & /*name*/,
-                                       const SurfaceInteraction3f & /*si*/,
-                                       Mask /*active*/) const {
-    /* When virtual function calls are recorded in symbolic mode,
-       we can't throw an exception here. */
-    if constexpr (dr::is_jit_v<Float>)
-        return 0.f;
-    else
-        NotImplementedError("eval_attribute");
+Shape<Float, Spectrum>::eval_attribute(const std::string & name,
+                                       const SurfaceInteraction3f & si,
+                                       Mask active) const {
+    const auto& it = m_texture_attributes.find(name);
+    if (it == m_texture_attributes.end()) {
+        if constexpr (dr::is_jit_v<Float>)
+            return 0.f;
+        else
+            Throw("Invalid attribute requested %s.", name.c_str());
+    }
+
+    const auto& texture = it->second;
+    return texture->eval(si, active);
 }
 
 MI_VARIANT Float
-Shape<Float, Spectrum>::eval_attribute_1(const std::string& /*name*/,
-                                         const SurfaceInteraction3f &/*si*/,
-                                         Mask /*active*/) const {
-    /* When virtual function calls are recorded in symbolic mode,
-       we can't throw an exception here. */
-    if constexpr (dr::is_jit_v<Float>)
-        return 0.f;
-    else
-        NotImplementedError("eval_attribute_1");
+Shape<Float, Spectrum>::eval_attribute_1(const std::string& name,
+                                         const SurfaceInteraction3f &si,
+                                         Mask active) const {
+    const auto& it = m_texture_attributes.find(name);
+    if (it == m_texture_attributes.end()) {
+        if constexpr (dr::is_jit_v<Float>)
+            return 0.f;
+        else
+            Throw("Invalid attribute requested %s.", name.c_str());
+    }
+
+    const auto& texture = it->second;
+    return texture->eval_1(si, active);
 }
+
 MI_VARIANT typename Shape<Float, Spectrum>::Color3f
-Shape<Float, Spectrum>::eval_attribute_3(const std::string& /*name*/,
-                                         const SurfaceInteraction3f &/*si*/,
-                                         Mask /*active*/) const {
-    /* When virtual function calls are recorded in symbolic mode,
-       we can't throw an exception here. */
-    if constexpr (dr::is_jit_v<Float>)
-        return 0.f;
-    else
-        NotImplementedError("eval_attribute_3");
+Shape<Float, Spectrum>::eval_attribute_3(const std::string& name,
+                                         const SurfaceInteraction3f &si,
+                                         Mask active) const {
+    const auto& it = m_texture_attributes.find(name);
+    if (it == m_texture_attributes.end()) {
+        if constexpr (dr::is_jit_v<Float>)
+            return 0.f;
+        else
+            Throw("Invalid attribute requested %s.", name.c_str());
+    }
+
+    const auto& texture = it->second;
+    return texture->eval_3(si, active);
 }
 
 MI_VARIANT Float Shape<Float, Spectrum>::surface_area() const {

--- a/src/render/tests/test_mesh.py
+++ b/src/render/tests/test_mesh.py
@@ -981,3 +981,30 @@ def test23_write_stream(variants_all_rgb, tmp_path):
     fs = mi.FileStream(filepath, mi.FileStream.ERead)
     mesh.write_ply(ms)
     assert fs.size() == ms.size()
+
+
+@fresolver_append_path
+def test24_texture_attributes(variants_all_rgb):
+
+    texture = mi.load_dict({
+        "type": "bitmap",
+        "filename" : "resources/data/common/textures/flower.bmp",
+    })
+
+    mesh = mi.load_dict({
+        "type" : "obj",
+        "id" : "rect",
+        "filename" : "resources/data/common/meshes/rectangle.obj",
+        "attribute_1": texture
+    })
+
+    assert dr.all(mesh.has_attribute('attribute_1'))
+    assert not dr.any(mesh.has_attribute('foo'))
+
+    si = mi.SurfaceInteraction3f()
+    si.uv = mi.Point2f(0.5)
+
+    assert dr.allclose(mesh.eval_attribute('attribute_1', si), texture.eval(si))
+
+
+


### PR DESCRIPTION
This PR adds the ability to set texture attributes to shape (not only `mesh`!), which can later be queried using the existing `eval_attribute()` method. This feature can be essential to design complex integrators that require to know shape attributes at render time. It can also become handy for quick prototyping, testing and visualization using Mitsuba.

This PR also add the `Shape::has_attribute()` method.

## Example

Here is a short example of how this new feature can be used:

```python
    mesh = mi.load_dict({
        "type" : "obj",
        "id" : "rect",
        "filename" : "resources/data/common/meshes/rectangle.obj",
        "attribute_1":  {
            "type": "bitmap",
            "filename" : "resources/data/common/textures/flower.bmp",
        }
    })

    si = mi.SurfaceInteraction3f()
    si.uv = mi.Point2f(0.5)

    color = mesh.eval_attribute('attribute_1', si),
```