### PR TITLE
Add `dr::` prefix in curve plugins

### DIFF
--- a/src/shapes/bsplinecurve.cpp
+++ b/src/shapes/bsplinecurve.cpp
@@ -141,7 +141,7 @@ public:
 
     BSplineCurve(const Properties &props) : Base(props) {
 #if !defined(MI_ENABLE_EMBREE)
-        if constexpr (!is_jit_v<Float>)
+        if constexpr (!dr::is_jit_v<Float>)
             Throw("The B-spline curve is only available with Embree in scalar "
                   "variants!");
 #endif

--- a/src/shapes/linearcurve.cpp
+++ b/src/shapes/linearcurve.cpp
@@ -129,7 +129,7 @@ public:
 
     LinearCurve(const Properties &props) : Base(props) {
 #if !defined(MI_ENABLE_EMBREE)
-        if constexpr (!is_jit_v<Float>)
+        if constexpr (!dr::is_jit_v<Float>)
             Throw("The linear curve is only available with Embree in scalar "
                   "variants!");
 #endif


### PR DESCRIPTION
## Description

This commit adds a `dr::` prefix to the `is_jit_v` calls in the new curve plugins. This fixes compilation errors on my setup.

<details><summary><b>Error message</b></summary>

```
FAILED: src/shapes/CMakeFiles/bsplinecurve.dir/bsplinecurve.cpp.o 
/usr/bin/clang++-11 -DLITTLE_ENDIAN -DMI_ENABLE_AUTODIFF=1 -DMI_ENABLE_LLVM=1 -Dbsplinecurve_EXPORTS -I/home/leroyv/Documents/src/thirdparty/mitsuba3/include -I/home/leroyv/Documents/src/thirdparty/mitsuba3/ext/tinyformat -I/home/leroyv/Documents/src/thirdparty/mitsuba3/build/include -I/home/leroyv/Documents/src/thirdparty/mitsuba3/ext/drjit/include -I/home/leroyv/Documents/src/thirdparty/mitsuba3/ext/drjit/ext/drjit-core/include -I/home/leroyv/Documents/src/thirdparty/mitsuba3/ext/drjit/ext/drjit-core/ext/nanothread/include -stdlib=libc++ -D_LIBCPP_VERSION -fcolor-diagnostics -O3 -DNDEBUG -fPIC -fvisibility=hidden   -fno-math-errno -ffp-contract=fast -fno-trapping-math -march=native -Wall -Wextra -Wno-unused-local-typedefs -Wdouble-promotion -std=gnu++17 -MD -MT src/shapes/CMakeFiles/bsplinecurve.dir/bsplinecurve.cpp.o -MF src/shapes/CMakeFiles/bsplinecurve.dir/bsplinecurve.cpp.o.d -o src/shapes/CMakeFiles/bsplinecurve.dir/bsplinecurve.cpp.o -c /home/leroyv/Documents/src/thirdparty/mitsuba3/src/shapes/bsplinecurve.cpp
/home/leroyv/Documents/src/thirdparty/mitsuba3/src/shapes/bsplinecurve.cpp:144:24: error: use of undeclared identifier 'is_jit_v'
        if constexpr (!is_jit_v<Float>)
                       ^
```
</details>

<details><summary><b>System information</b></summary>

```
  OS: Ubuntu 22.04.2 LTS
  CPU: AMD Ryzen 9 5900X 12-Core Processor
  GPU: NVIDIA GeForce GT 730
  Python: 3.10.5 | packaged by conda-forge | (main, Jun 14 2022, 07:04:59) [GCC 10.3.0]
  NVidia driver: 470.182.03
  LLVM: 15.0.7

  Dr.Jit: 0.4.2
  Mitsuba: 3.3.0
     Is custom build? True
     Compiled with: Clang 11.1.0
     Variants:
        scalar_rgb
        scalar_spectral
        llvm_rgb
        llvm_ad_rgb
```
</details>


## Checklist

<!-- Please make sure to complete this checklist before requesting a review. -->

- [x] My code follows the [style guidelines](https://mitsuba.readthedocs.io/en/latest/src/developer_guide.html#coding-style) of this project
- [x] My changes generate no new warnings
- [x] My code also compiles for `cuda_*` and `llvm_*` variants. If you can't test this, please leave below
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 3 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba/blob/master/LICENSE)