### PR TITLE
[✨feature] Add `mi.variant_context()`

### DIFF
--- a/src/python/python/__init__.py
+++ b/src/python/python/__init__.py
@@ -1,4 +1,4 @@
-from .util import traverse, SceneParameters, render, cornell_box
+from .util import traverse, SceneParameters, render, cornell_box, variant_context
 from . import chi2
 from . import xml
 from . import ad

--- a/src/python/python/tests/test_util.py
+++ b/src/python/python/tests/test_util.py
@@ -285,3 +285,30 @@ def test05_render_fwd_assert(variants_all_ad_rgb):
     with pytest.raises(Exception) as e:
         img = mi.render(scene)
         dr.forward_to(img)
+
+
+def test06_variant_context():
+    # Select the first variant which is not 'scalar_rgb'
+    for variant in mi.variants():
+        if variant != "scalar_rgb":
+            override_variant = variant
+            break
+    else:
+        pytest.skip("Only the 'scalar_rgb' variant was compiled.")
+
+    # Now, the test
+    mi.set_variant("scalar_rgb")
+
+    # The active variant is temporarily overridden
+    with mi.variant_context(override_variant):
+        assert mi.variant() == override_variant
+    assert mi.variant() == "scalar_rgb"
+
+    # The initial variant is restored if an exception is raised
+    try:
+        with mi.variant_context(override_variant):
+            assert mi.variant() == override_variant
+            raise RuntimeError
+    except RuntimeError:
+        pass
+    assert mi.variant() == "scalar_rgb"

--- a/src/python/python/util.py
+++ b/src/python/python/util.py
@@ -1,5 +1,6 @@
 from __future__ import annotations as __annotations__ # Delayed parsing of type annotations
 
+import contextlib
 from collections.abc import Mapping
 
 import drjit as dr
@@ -696,3 +697,20 @@ def cornell_box():
             }
         },
     }
+
+
+@contextlib.contextmanager
+def variant_context(*args) -> None:
+    '''
+    Temporarily override the active variant. Arguments are interpreted as
+    they are in :func:`mitsuba.set_variant`.
+    '''
+
+    old_variant = mi.variant()
+    try:
+        mi.set_variant(*args)
+        yield
+    except Exception:
+        raise
+    finally:
+        mi.set_variant(old_variant)


### PR DESCRIPTION
## Description

This PR adds a variant override context manager. It works as follows:

```python
mi.set_variant("scalar_rgb")

with mi.variant_context("llvm_rgb"):
    # Do some preprocessing faster with the LLVM backend
    ...

mi.render(my_scene)  # Will be rendered using "scalar_rgb"
```

I wrote this using a function-based context manager and checked that the initial variant is recovered if an exception occurs.

~~I also added a return value to `mi.set_variant()` so that the selected variant is known when multiple arguments are passed. This allows things like this (arguably of limited utility):~~

```python
mi.set_variant("scalar_rgb")

with mi.variant_context("llvm_rgb", "llvm_ad_rgb") as mi_variant:
    logging.debug("Using variant %s", mi_variant)
    ...

mi.render(my_scene)  # Will be rendered using "scalar_rgb"
```

## Testing

I added unit tests to the `test_util.py` suite.

## Checklist

- [x] My code follows the [style guidelines](https://mitsuba.readthedocs.io/en/latest/src/developer_guide.html#coding-style) of this project
- [x] My changes generate no new warnings
- [x] My code also compiles for `cuda_*` and `llvm_*` variants. If you can't test this, please leave below
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 3 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba/blob/master/LICENSE)