### PR TITLE
[✨Feature] SceneParameters - IPython tab-autocomplete and __repr__ alignment fix

### DIFF
--- a/src/python/python/util.py
+++ b/src/python/python/util.py
@@ -95,8 +95,8 @@ class SceneParameters(Mapping):
     def __repr__(self) -> str:
         if len(self) == 0:
             return f'SceneParameters[]'
-        name_length = int(max([len(k) for k in self.properties.keys()]) + 2)
-        type_length = int(max([len(type(v).__name__) for k, v in self.properties.items()]))
+        name_length = int(max(len(k) for k in self.properties.keys()) + 2)
+        type_length = int(max(len(type(v[0] if v[1] is None else self.get_property(*v[:3])).__name__) for k, v in self.properties.items()))
         param_list = '\n'
         param_list += '  ' + '-' * (name_length + 53) + '\n'
         param_list += f"  {'Name':{name_length}}  {'Flags':7}  {'Type':{type_length}} {'Parent'}\n"
@@ -135,6 +135,9 @@ class SceneParameters(Mapping):
         return self.__iter__()
 
     def keys(self):
+        return self.properties.keys()
+
+    def _ipython_key_completions_(self):
         return self.properties.keys()
 
     def flags(self, key: str):


### PR DESCRIPTION
## Description

Fixes alignment of `type` in the output of `SceneParameters.__repr__` and adds `_ipython_key_completions_` method for tab-autocomplete in notebooks and ipython-based environments.

## Testing

Tested in jupyter environment, no changes to API.

## Checklist

- [x] My code follows the [style guidelines](https://mitsuba.readthedocs.io/en/latest/src/developer_guide.html#coding-style) of this project
- [x] My changes generate no new warnings
- [x] My code also compiles for `cuda_*` and `llvm_*` variants. If you can't test this, please leave below
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 3 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba/blob/master/LICENSE)