### PR TITLE
Detach vertex normals from previous AD graph on recomputation

### DIFF
--- a/src/render/mesh.cpp
+++ b/src/render/mesh.cpp
@@ -339,6 +339,11 @@ MI_VARIANT void Mesh<Float, Spectrum>::recompute_vertex_normals() {
 
         normals = dr::normalize(normals);
 
+        // Disconnect the vertex normal buffer from any pre-existing AD
+        // graph. Otherwise an AD graph might be unnecessarily retained
+        // here, despite the following lines re-initializing the normals.
+        dr::disable_grad(m_vertex_normals);
+
         UInt32 ni = dr::arange<UInt32>(m_vertex_count) * 3;
         for (size_t i = 0; i < 3; ++i)
             dr::scatter(m_vertex_normals,


### PR DESCRIPTION
Fixes #711 

The mesh class should make sure that the vertex normal field is detached from any prior AD graph on recomputation, otherwise this can cause an ever growing dependency chain during an optimization.

Detaching the vertex normals here doesn't change anything about the result of the computation, as either way in this function the vertex normals are being overwritten. But since the write happens through scatter operations, DrJit cannot know that the previously connected AD graph isn't used anymore.