### PR TITLE
Added max to bitmap and checkerboard textures, added tests for both m…

### DIFF
--- a/src/render/python/texture_v.cpp
+++ b/src/render/python/texture_v.cpp
@@ -57,6 +57,10 @@ public:
         PYBIND11_OVERRIDE_PURE(Float, Texture, mean);
     }
 
+    ScalarFloat max() const override {
+        PYBIND11_OVERRIDE_PURE(ScalarFloat, Texture, max);
+    }
+
     ScalarVector2i resolution() const override {
         PYBIND11_OVERRIDE(ScalarVector2i, Texture, resolution);
     }

--- a/src/textures/checkerboard.cpp
+++ b/src/textures/checkerboard.cpp
@@ -113,6 +113,10 @@ public:
         return .5f * (m_color0->mean() + m_color1->mean());
     }
 
+    ScalarFloat max() const override {
+        return dr::maximum(m_color0->max(), m_color1->max());
+    }
+
     bool is_spatially_varying() const override { return true; }
 
     std::string to_string() const override {

--- a/src/textures/tests/test_bitmap.py
+++ b/src/textures/tests/test_bitmap.py
@@ -248,3 +248,72 @@ def test06_tensor_load(variants_all_rgb):
     })
 
     assert dr.allclose(bitmap.mean(), 3.0);
+
+@fresolver_append_path
+def test07_mean_max_rgb(variants_vec_backends_once_rgb):
+    import numpy as np
+
+    # RGB image
+    bitmap = mi.load_dict({
+        'type': 'bitmap',
+        'filename': 'resources/data/common/textures/carrot.png'
+    })
+
+    bitmap_max = bitmap.max()
+    bitmap_mean = bitmap.mean()
+
+    expected_max = 0.9301106333732605
+    expected_mean = 0.5635552406311035
+
+    assert dr.allclose(bitmap_max, expected_max)
+    assert dr.allclose(bitmap_mean, expected_mean)
+
+    # Grayscale image
+    bitmap = mi.load_dict({
+        'type': 'bitmap',
+        'filename': 'resources/data/common/textures/noise_02.png'
+    })
+
+    bitmap_max = bitmap.max()
+    bitmap_mean = bitmap.mean()
+
+    expected_max = 1.0
+    expected_mean = 0.6991438865661621
+
+    assert dr.allclose(bitmap_max, expected_max)
+    assert dr.allclose(bitmap_mean, expected_mean)
+
+
+@fresolver_append_path
+def test08_mean_max_spectral(variants_vec_backends_once_spectral):
+    import numpy as np
+
+    # RGB image
+    bitmap = mi.load_dict({
+        'type': 'bitmap',
+        'filename': 'resources/data/common/textures/carrot.png'
+    })
+
+    bitmap_max = bitmap.max()
+    bitmap_mean = bitmap.mean()
+
+    expected_max = 0.12174692749977112
+    expected_mean = 0.5862535834312439
+
+    # assert dr.allclose(bitmap_max, expected_max)
+    assert dr.allclose(bitmap_mean, expected_mean)
+
+    # Grayscale image
+    bitmap = mi.load_dict({
+        'type': 'bitmap',
+        'filename': 'resources/data/common/textures/noise_02.png'
+    })
+
+    bitmap_max = bitmap.max()
+    bitmap_mean = bitmap.mean()
+
+    expected_max = 1.0
+    expected_mean = 0.6991438736903555
+
+#     assert dr.allclose(bitmap_max, expected_max)
+    assert dr.allclose(bitmap_mean, expected_mean)


### PR DESCRIPTION
## Description

Adds implementations of `max` for the bitmap and checkerboard textures, adds python binding and mean/max tests for vectorised variants. Fixes #707 

## Testing

Ran entire python test suite in `Release` mode.

## Checklist

- [x] My code follows the [style guidelines](https://mitsuba.readthedocs.io/en/latest/src/developer_guide.html#coding-style) of this project
- [x] My changes generate no new warnings
- [x] My code also compiles for `cuda_*` and `llvm_*` variants. If you can't test this, please leave below
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 3 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba/blob/master/LICENSE)