### PR TITLE
Improve numerical precision in prb.py 

### DIFF
--- a/src/python/python/ad/integrators/prb.py
+++ b/src/python/python/ad/integrators/prb.py
@@ -146,9 +146,9 @@ class PRBIntegrator(RBIntegrator):
                 if not primal:
                     # Given the detached emitter sample, *recompute* its
                     # contribution with AD to enable light source optimization
-                    ds.d = dr.normalize(ds.p - si.p)
+                    ds.d = dr.replace_grad(ds.d, dr.normalize(ds.p - si.p))
                     em_val = scene.eval_emitter_direction(si, ds, active_em)
-                    em_weight = dr.select(dr.neq(ds.pdf, 0), em_val / ds.pdf, 0)
+                    em_weight = dr.replace_grad(em_weight, dr.select(dr.neq(ds.pdf, 0), em_val / ds.pdf, 0))
                     dr.disable_grad(ds.d)
 
                 # Evaluate BSDF * cos(theta) differentiably


### PR DESCRIPTION
In the last phase of PRB, local contribution is substracted to the the total path contribution at every bounce. This commit ensures the substracted values are exactly equivalent to the ones computed in the previous phases using the replace_grad routine when re-attaching the detached emitter sample.