### PR TITLE
Add Uniform::eval_1_grad()

### DIFF
--- a/src/spectra/uniform.cpp
+++ b/src/spectra/uniform.cpp
@@ -77,6 +77,11 @@ public:
         return m_value;
     }
 
+    Vector2f eval_1_grad(const SurfaceInteraction3f & /*it*/, Mask active) const override {
+        MI_MASKED_FUNCTION(ProfilerPhase::TextureEvaluate, active);
+        return 0.0;
+    }
+
     Wavelength pdf_spectrum(const SurfaceInteraction3f & /*si*/, Mask /*active*/) const override {
         NotImplementedError("pdf");
     }


### PR DESCRIPTION
This PR adds `eval_1_grad()` to the `uniform` plugin (e.g. when used for bumpmapping).