### PR TITLE
Add Integrator::m_hide_emitters bindings

### DIFF
--- a/src/render/python/integrator_v.cpp
+++ b/src/render/python/integrator_v.cpp
@@ -244,6 +244,8 @@ public:
     std::string to_string() const override {
         PYBIND11_OVERRIDE(std::string, Base, to_string, );
     }
+
+    using Base::m_hide_emitters;
 };
 
 MI_PY_EXPORT(Integrator) {
@@ -295,7 +297,8 @@ MI_PY_EXPORT(Integrator) {
                 return std::make_tuple(spec, mask, aovs);
             },
             "scene"_a, "sampler"_a, "ray"_a, "medium"_a = nullptr,
-            "active"_a = true, D(SamplingIntegrator, sample));
+            "active"_a = true, D(SamplingIntegrator, sample))
+        .def_readwrite("hide_emitters", &PySamplingIntegrator::m_hide_emitters);
 
     MI_PY_REGISTER_OBJECT("register_integrator", Integrator)
 


### PR DESCRIPTION
This PR adds the missing bindings for `Integrator::m_hide_emitters` which we might want to access from within a custom integrator plugin.