### PR TITLE
Add support of resources type in load_dict

### DIFF
--- a/docs/src/key_topics/scene_format.rst
+++ b/docs/src/key_topics/scene_format.rst
@@ -658,3 +658,21 @@ dictionary. For this purpose, you can specify a nested dictionary with
             }
         }
     }
+
+As in the XML scene description, it is possible to add a path to the list of
+search paths. In the following example, the texture file can be found in the
+``/home/username/data/textures/`` folder. Note that this added path can be
+relative or absolute.
+
+.. code-block:: python
+
+    {
+        "type": "scene",
+        'foo': { 'type': 'resources', 'path': '/home/username/data/textures'},
+        "bsdf": {
+            "type": "diffuse",
+            "reflectance": {
+                "type": "bitmap",
+                "filename": "my_texture.exr", # relative to the folder defined above
+        }
+    }


### PR DESCRIPTION
## Overview

The proposed changes add support for additional external resources folders in the `mi.load_dict()` routine. This is similar to the [existing `resources` tag](https://mitsuba.readthedocs.io/en/stable/src/key_topics/scene_format.html#external-resource-folders) in the XML scene file description.

## Different solutions

### A

Currently, the syntax looks as follow:

```python
mi.load_dict({
    'type': 'scene',
    'foo': { 'type': 'resources', 'path': '../data/textures'},
     ...
})
```

It is a bit redondant to have to define both the `'type'` as `'resources'` and then the `'path'`.  And `'foo'` here is useless.

### B

Another option would be to detect that we have specifying a external resources folder using the LHS key (e.g. here `'foo'`), although this might conflict with other scene objects (e.g. the `path` integrator). Also, with this solution, only a single external folder can be defined.

```python
mi.load_dict({
    'type': 'scene',
    'resources': '../data/textures',
    ...
})
```

### C

As an alternative solution, we could leverage the extra keyword arguments passed to `mi.load_dict()` to specify such paths.

```python
mi.load_dict({
    'type': 'scene',
    ...
}, resources=['../data/textures'])
```

Any thoughts?