### PR TITLE
Add support for spectral phase functions

### DIFF
--- a/docs/generated/extracted_rst_api.rst
+++ b/docs/generated/extracted_rst_api.rst
@@ -181,7 +181,7 @@
         Parameter ``arg0`` (float):
             *no description available*
 
-        
+
 .. py:class:: mitsuba.BSDF
 
     Base class: :py:obj:`mitsuba.Object`
@@ -5205,10 +5205,10 @@
     .. py:method:: __init__(self, p, mode=<EMode., ERead)
 
         Constructs a new FileStream by opening the file pointed by ``p``.
-        
+
         The file is opened in read-only or read/write mode as specified by
         ``mode``.
-        
+
         Throws if trying to open a non-existing file in with write disabled.
         Throws an exception if the file cannot be opened / created.
 
@@ -5221,7 +5221,7 @@
         Parameter ``ERead`` (0>):
             *no description available*
 
-        
+
     .. py:class:: mitsuba.FileStream.EMode
 
         Members:
@@ -7699,15 +7699,15 @@
 
         Construct a hierarchical sample warping scheme for floating point data
         of resolution ``size``.
-        
+
         ``param_res`` and ``param_values`` are only needed for conditional
         distributions (see the text describing the Hierarchical2D class).
-        
+
         If ``normalize`` is set to ``False``, the implementation will not re-
         scale the distribution so that it integrates to ``1``. It can still be
         sampled (proportionally), but returned density values will reflect the
         unnormalized values.
-        
+
         If ``enable_sampling`` is set to ``False``, the implementation will
         not construct the hierarchy needed for sample warping, which saves
         memory in case this functionality is not needed (e.g. if only the
@@ -7727,7 +7727,7 @@
         Parameter ``enable_sampling`` (bool):
             *no description available*
 
-        
+
     .. py:method:: mitsuba.Hierarchical2D0.eval(self, pos, param=[], active=True)
 
         Evaluate the density at position ``pos``. The distribution is
@@ -7818,15 +7818,15 @@
 
         Construct a hierarchical sample warping scheme for floating point data
         of resolution ``size``.
-        
+
         ``param_res`` and ``param_values`` are only needed for conditional
         distributions (see the text describing the Hierarchical2D class).
-        
+
         If ``normalize`` is set to ``False``, the implementation will not re-
         scale the distribution so that it integrates to ``1``. It can still be
         sampled (proportionally), but returned density values will reflect the
         unnormalized values.
-        
+
         If ``enable_sampling`` is set to ``False``, the implementation will
         not construct the hierarchy needed for sample warping, which saves
         memory in case this functionality is not needed (e.g. if only the
@@ -7846,7 +7846,7 @@
         Parameter ``build_hierarchy`` (bool):
             *no description available*
 
-        
+
     .. py:method:: mitsuba.Hierarchical2D1.eval(self, pos, param=[0.0], active=True)
 
         Evaluate the density at position ``pos``. The distribution is
@@ -7937,15 +7937,15 @@
 
         Construct a hierarchical sample warping scheme for floating point data
         of resolution ``size``.
-        
+
         ``param_res`` and ``param_values`` are only needed for conditional
         distributions (see the text describing the Hierarchical2D class).
-        
+
         If ``normalize`` is set to ``False``, the implementation will not re-
         scale the distribution so that it integrates to ``1``. It can still be
         sampled (proportionally), but returned density values will reflect the
         unnormalized values.
-        
+
         If ``enable_sampling`` is set to ``False``, the implementation will
         not construct the hierarchy needed for sample warping, which saves
         memory in case this functionality is not needed (e.g. if only the
@@ -7965,7 +7965,7 @@
         Parameter ``build_hierarchy`` (bool):
             *no description available*
 
-        
+
     .. py:method:: mitsuba.Hierarchical2D2.eval(self, pos, param=[0.0, 0.0], active=True)
 
         Evaluate the density at position ``pos``. The distribution is
@@ -8056,15 +8056,15 @@
 
         Construct a hierarchical sample warping scheme for floating point data
         of resolution ``size``.
-        
+
         ``param_res`` and ``param_values`` are only needed for conditional
         distributions (see the text describing the Hierarchical2D class).
-        
+
         If ``normalize`` is set to ``False``, the implementation will not re-
         scale the distribution so that it integrates to ``1``. It can still be
         sampled (proportionally), but returned density values will reflect the
         unnormalized values.
-        
+
         If ``enable_sampling`` is set to ``False``, the implementation will
         not construct the hierarchy needed for sample warping, which saves
         memory in case this functionality is not needed (e.g. if only the
@@ -8084,7 +8084,7 @@
         Parameter ``build_hierarchy`` (bool):
             *no description available*
 
-        
+
     .. py:method:: mitsuba.Hierarchical2D3.eval(self, pos, param=[0.0, 0.0, 0.0], active=True)
 
         Evaluate the density at position ``pos``. The distribution is
@@ -10465,7 +10465,7 @@
 
     .. py:data:: Trace
 
-        
+
 
     .. py:data:: Debug
 
@@ -10509,7 +10509,7 @@
         Parameter ``arg0`` (:py:obj:`mitsuba.LogLevel`):
             *no description available*
 
-        
+
     .. py:method:: mitsuba.Logger.add_appender(self, arg0)
 
         Add an appender to this logger
@@ -10780,15 +10780,15 @@
 
         Construct a marginal sample warping scheme for floating point data of
         resolution ``size``.
-        
+
         ``param_res`` and ``param_values`` are only needed for conditional
         distributions (see the text describing the Marginal2D class).
-        
+
         If ``normalize`` is set to ``False``, the implementation will not re-
         scale the distribution so that it integrates to ``1``. It can still be
         sampled (proportionally), but returned density values will reflect the
         unnormalized values.
-        
+
         If ``enable_sampling`` is set to ``False``, the implementation will
         not construct the cdf needed for sample warping, which saves memory in
         case this functionality is not needed (e.g. if only the interpolation
@@ -10806,7 +10806,7 @@
         Parameter ``enable_sampling`` (bool):
             *no description available*
 
-        
+
     .. py:method:: mitsuba.MarginalContinuous2D0.eval(self, pos, param=[], active=True)
 
         Evaluate the density at position ``pos``. The distribution is
@@ -10905,15 +10905,15 @@
 
         Construct a marginal sample warping scheme for floating point data of
         resolution ``size``.
-        
+
         ``param_res`` and ``param_values`` are only needed for conditional
         distributions (see the text describing the Marginal2D class).
-        
+
         If ``normalize`` is set to ``False``, the implementation will not re-
         scale the distribution so that it integrates to ``1``. It can still be
         sampled (proportionally), but returned density values will reflect the
         unnormalized values.
-        
+
         If ``enable_sampling`` is set to ``False``, the implementation will
         not construct the cdf needed for sample warping, which saves memory in
         case this functionality is not needed (e.g. if only the interpolation
@@ -10931,7 +10931,7 @@
         Parameter ``build_hierarchy`` (bool):
             *no description available*
 
-        
+
     .. py:method:: mitsuba.MarginalContinuous2D1.eval(self, pos, param=[0.0], active=True)
 
         Evaluate the density at position ``pos``. The distribution is
@@ -11030,15 +11030,15 @@
 
         Construct a marginal sample warping scheme for floating point data of
         resolution ``size``.
-        
+
         ``param_res`` and ``param_values`` are only needed for conditional
         distributions (see the text describing the Marginal2D class).
-        
+
         If ``normalize`` is set to ``False``, the implementation will not re-
         scale the distribution so that it integrates to ``1``. It can still be
         sampled (proportionally), but returned density values will reflect the
         unnormalized values.
-        
+
         If ``enable_sampling`` is set to ``False``, the implementation will
         not construct the cdf needed for sample warping, which saves memory in
         case this functionality is not needed (e.g. if only the interpolation
@@ -11056,7 +11056,7 @@
         Parameter ``build_hierarchy`` (bool):
             *no description available*
 
-        
+
     .. py:method:: mitsuba.MarginalContinuous2D2.eval(self, pos, param=[0.0, 0.0], active=True)
 
         Evaluate the density at position ``pos``. The distribution is
@@ -11155,15 +11155,15 @@
 
         Construct a marginal sample warping scheme for floating point data of
         resolution ``size``.
-        
+
         ``param_res`` and ``param_values`` are only needed for conditional
         distributions (see the text describing the Marginal2D class).
-        
+
         If ``normalize`` is set to ``False``, the implementation will not re-
         scale the distribution so that it integrates to ``1``. It can still be
         sampled (proportionally), but returned density values will reflect the
         unnormalized values.
-        
+
         If ``enable_sampling`` is set to ``False``, the implementation will
         not construct the cdf needed for sample warping, which saves memory in
         case this functionality is not needed (e.g. if only the interpolation
@@ -11181,7 +11181,7 @@
         Parameter ``build_hierarchy`` (bool):
             *no description available*
 
-        
+
     .. py:method:: mitsuba.MarginalContinuous2D3.eval(self, pos, param=[0.0, 0.0, 0.0], active=True)
 
         Evaluate the density at position ``pos``. The distribution is
@@ -11280,15 +11280,15 @@
 
         Construct a marginal sample warping scheme for floating point data of
         resolution ``size``.
-        
+
         ``param_res`` and ``param_values`` are only needed for conditional
         distributions (see the text describing the Marginal2D class).
-        
+
         If ``normalize`` is set to ``False``, the implementation will not re-
         scale the distribution so that it integrates to ``1``. It can still be
         sampled (proportionally), but returned density values will reflect the
         unnormalized values.
-        
+
         If ``enable_sampling`` is set to ``False``, the implementation will
         not construct the cdf needed for sample warping, which saves memory in
         case this functionality is not needed (e.g. if only the interpolation
@@ -11306,7 +11306,7 @@
         Parameter ``enable_sampling`` (bool):
             *no description available*
 
-        
+
     .. py:method:: mitsuba.MarginalDiscrete2D0.eval(self, pos, param=[], active=True)
 
         Evaluate the density at position ``pos``. The distribution is
@@ -11405,15 +11405,15 @@
 
         Construct a marginal sample warping scheme for floating point data of
         resolution ``size``.
-        
+
         ``param_res`` and ``param_values`` are only needed for conditional
         distributions (see the text describing the Marginal2D class).
-        
+
         If ``normalize`` is set to ``False``, the implementation will not re-
         scale the distribution so that it integrates to ``1``. It can still be
         sampled (proportionally), but returned density values will reflect the
         unnormalized values.
-        
+
         If ``enable_sampling`` is set to ``False``, the implementation will
         not construct the cdf needed for sample warping, which saves memory in
         case this functionality is not needed (e.g. if only the interpolation
@@ -11431,7 +11431,7 @@
         Parameter ``build_hierarchy`` (bool):
             *no description available*
 
-        
+
     .. py:method:: mitsuba.MarginalDiscrete2D1.eval(self, pos, param=[0.0], active=True)
 
         Evaluate the density at position ``pos``. The distribution is
@@ -11530,15 +11530,15 @@
 
         Construct a marginal sample warping scheme for floating point data of
         resolution ``size``.
-        
+
         ``param_res`` and ``param_values`` are only needed for conditional
         distributions (see the text describing the Marginal2D class).
-        
+
         If ``normalize`` is set to ``False``, the implementation will not re-
         scale the distribution so that it integrates to ``1``. It can still be
         sampled (proportionally), but returned density values will reflect the
         unnormalized values.
-        
+
         If ``enable_sampling`` is set to ``False``, the implementation will
         not construct the cdf needed for sample warping, which saves memory in
         case this functionality is not needed (e.g. if only the interpolation
@@ -11556,7 +11556,7 @@
         Parameter ``build_hierarchy`` (bool):
             *no description available*
 
-        
+
     .. py:method:: mitsuba.MarginalDiscrete2D2.eval(self, pos, param=[0.0, 0.0], active=True)
 
         Evaluate the density at position ``pos``. The distribution is
@@ -11655,15 +11655,15 @@
 
         Construct a marginal sample warping scheme for floating point data of
         resolution ``size``.
-        
+
         ``param_res`` and ``param_values`` are only needed for conditional
         distributions (see the text describing the Marginal2D class).
-        
+
         If ``normalize`` is set to ``False``, the implementation will not re-
         scale the distribution so that it integrates to ``1``. It can still be
         sampled (proportionally), but returned density values will reflect the
         unnormalized values.
-        
+
         If ``enable_sampling`` is set to ``False``, the implementation will
         not construct the cdf needed for sample warping, which saves memory in
         case this functionality is not needed (e.g. if only the interpolation
@@ -11681,7 +11681,7 @@
         Parameter ``build_hierarchy`` (bool):
             *no description available*
 
-        
+
     .. py:method:: mitsuba.MarginalDiscrete2D3.eval(self, pos, param=[0.0, 0.0, 0.0], active=True)
 
         Evaluate the density at position ``pos``. The distribution is
@@ -11833,7 +11833,7 @@
 
     Base class: :py:obj:`mitsuba.Object`
 
-    .. py:method:: mitsuba.Medium.eval_tr_and_pdf(self, mi, active)
+    .. py:method:: mitsuba.Medium.transmittance_eval_pdf(self, mi, active)
 
         Compute the transmittance and PDF
 
@@ -12052,7 +12052,7 @@
         Returns → drjit.llvm.ad.Bool:
             *no description available*
 
-    .. py:method:: mitsuba.MediumPtr.eval_tr_and_pdf(self, mi, active)
+    .. py:method:: mitsuba.MediumPtr.transmittance_eval_pdf(self, mi, active)
 
         Compute the transmittance and PDF
 
@@ -12385,7 +12385,7 @@
         Parameter ``capacity`` (int):
             *no description available*
 
-        
+
     .. py:method:: mitsuba.MemoryStream.capacity(self)
 
         Return the current capacity of the underlying memory buffer
@@ -13116,25 +13116,25 @@
     .. py:method:: __init__(self, input_size, albedo=False, normals=False, temporal=False)
 
         Constructs an OptiX denoiser
-        
+
         Parameter ``input_size`` (:py:obj:`mitsuba.ScalarVector2u`):
             Resolution of noisy images that will be fed to the denoiser.
-        
+
         Parameter ``albedo`` (bool):
             Whether or not albedo information will also be given to the
             denoiser.
-        
+
         Parameter ``normals`` (bool):
             Whether or not shading normals information will also be given to
             the Denoiser.
-        
+
         Returns:
             A callable object which will apply the OptiX denoiser.
 
         Parameter ``temporal`` (bool):
             *no description available*
 
-        
+
     .. py:method:: mitsuba.OptixDenoiser.__call__(overloaded)
 
 
@@ -13555,19 +13555,19 @@
 
     .. py:data:: Empty
 
-        
+
 
     .. py:data:: Isotropic
 
-        
+
 
     .. py:data:: Anisotropic
 
-        
+
 
     .. py:data:: Microflake
 
-        
+
 
     .. py:method:: __init__(self, value)
 
@@ -14856,22 +14856,22 @@
 
         Create a new Resampler object that transforms between the specified
         resolutions
-        
+
         This constructor precomputes all information needed to efficiently
         perform the desired resampling operation. For that reason, it is most
         efficient if it can be used over and over again (e.g. to resample the
         equal-sized rows of a bitmap)
-        
+
         Parameter ``source_res`` (int):
             Source resolution
-        
+
         Parameter ``target_res`` (int):
             Desired target resolution
 
         Parameter ``rfilter`` (:py:obj:`mitsuba.ReconstructionFilter`):
             *no description available*
 
-        
+
     .. py:method:: mitsuba.Resampler.boundary_condition(self)
 
         Return the boundary condition that should be used when looking up
@@ -17333,7 +17333,7 @@
         Private constructor (use
         :py:func:`mitsuba.traverse()` instead)
 
-        
+
     .. py:method:: mitsuba.SceneParameters.items()
 
         Returns → a set-like object providing a view on D's items:
@@ -18915,7 +18915,7 @@
         Parameter ``passes`` (int):
             *no description available*
 
-        
+
     .. py:method:: mitsuba.Spiral.block_count(self)
 
         Return the total number of blocks
@@ -18972,7 +18972,7 @@
 
         .. py:data:: EBigEndian
 
-            
+
 
         .. py:data:: ELittleEndian
 
@@ -19460,14 +19460,14 @@
     .. py:method:: __init__(self, arg0)
 
         Create a new stream appender
-        
+
         Remark:
             This constructor is not exposed in the Python bindings
 
         Parameter ``arg0`` (str):
             *no description available*
 
-        
+
     .. py:method:: mitsuba.StreamAppender.logs_to_file(self)
 
         Does this appender log to a file
@@ -19508,16 +19508,16 @@
         Parameter ``HostByteOrder`` (2>):
             *no description available*
 
-        
+
     .. py:class:: mitsuba.Struct.ByteOrder
 
         Members:
 
-            LittleEndian : 
+            LittleEndian :
 
-            BigEndian : 
+            BigEndian :
 
-            HostByteOrder : 
+            HostByteOrder :
 
         .. py:method:: __init__(self, value)
 
@@ -19650,29 +19650,29 @@
 
         Members:
 
-            Int8 : 
+            Int8 :
 
-            UInt8 : 
+            UInt8 :
 
-            Int16 : 
+            Int16 :
 
-            UInt16 : 
+            UInt16 :
 
-            Int32 : 
+            Int32 :
 
-            UInt32 : 
+            UInt32 :
 
-            Int64 : 
+            Int64 :
 
-            UInt64 : 
+            UInt64 :
 
-            Float16 : 
+            Float16 :
 
-            Float32 : 
+            Float32 :
 
-            Float64 : 
+            Float64 :
 
-            Invalid : 
+            Invalid :
 
 
         .. py:method:: __init__(self, value)
@@ -23303,31 +23303,31 @@
 
         .. py:data:: EIdlePriority
 
-            
+
 
         .. py:data:: ELowestPriority
 
-            
+
 
         .. py:data:: ELowPriority
 
-            
+
 
         .. py:data:: ENormalPriority
 
-            
+
 
         .. py:data:: EHighPriority
 
-            
+
 
         .. py:data:: EHighestPriority
 
-            
+
 
         .. py:data:: ERealtimePriority
 
-            
+
 
         .. py:method:: __init__(self, value)
 
@@ -26217,14 +26217,14 @@
         Parameter ``level`` (int):
             *no description available*
 
-        
+
     .. py:class:: mitsuba.ZStream.EStreamType
 
         Members:
 
         .. py:data:: EDeflateStream
 
-            
+
 
         .. py:data:: EGZipStream
 
@@ -26275,30 +26275,30 @@
 
         Parameter ``lr``:
             learning rate
-        
+
         Parameter ``beta_1``:
             controls the exponential averaging of first order gradient moments
-        
+
         Parameter ``beta_2``:
             controls the exponential averaging of second order gradient moments
-        
+
         Parameter ``mask_updates``:
             if enabled, parameters and state variables will only be updated in a
             given iteration if it received nonzero gradients in that iteration
-        
+
         Parameter ``uniform``:
             if enabled, the optimizer will use the 'UniformAdam' variant of Adam
             [Nicolet et al. 2021], where the update rule uses the *maximum* of
             the second moment estimates at the current step instead of the
             per-element second moments.
-        
+
         Parameter ``params`` (:py:class:`dict`):
             Optional dictionary-like object containing parameters to optimize.
 
         Parameter ``params`` (dict | None):
             *no description available*
 
-        
+
     .. py:method:: mitsuba.ad.Adam.step()
 
         Take a gradient step
@@ -26380,14 +26380,14 @@
 
         Parameter ``lr``:
             learning rate
-        
+
         Parameter ``params`` (:py:class:`dict`):
             Dictionary-like object containing parameters to optimize.
 
         Parameter ``params`` (dict):
             *no description available*
 
-        
+
     .. py:method:: mitsuba.ad.Optimizer.set_learning_rate()
 
         Set the learning rate.
@@ -26428,23 +26428,23 @@
 
         Parameter ``lr``:
             learning rate
-        
+
         Parameter ``momentum``:
             momentum factor
-        
+
         Parameter ``mask_updates``:
             if enabled, parameters and state variables will only be updated
             in a given iteration if it received nonzero gradients in that iteration.
             This only has an effect if momentum is enabled.
             See :py:class:`mitsuba.optimizers.Adam`'s documentation for more details.
-        
+
         Parameter ``params`` (:py:class:`dict`):
             Optional dictionary-like object containing parameters to optimize.
 
         Parameter ``params`` (dict | None):
             *no description available*
 
-        
+
     .. py:method:: mitsuba.ad.SGD.step()
 
         Take a gradient step

--- a/include/mitsuba/python/docstr.h
+++ b/include/mitsuba/python/docstr.h
@@ -4088,7 +4088,7 @@ static const char *__doc_mitsuba_Medium_Medium_2 = R"doc()doc";
 
 static const char *__doc_mitsuba_Medium_class = R"doc()doc";
 
-static const char *__doc_mitsuba_Medium_eval_tr_and_pdf =
+static const char *__doc_mitsuba_Medium_transmittance_eval_pdf =
 R"doc(Compute the transmittance and PDF
 
 This function evaluates the transmittance and PDF of sampling a

--- a/include/mitsuba/python/docstr.h
+++ b/include/mitsuba/python/docstr.h
@@ -5183,10 +5183,10 @@ static const char *__doc_mitsuba_PhaseFunction_class = R"doc()doc";
 
 static const char *__doc_mitsuba_PhaseFunction_component_count = R"doc(Number of components this phase function is comprised of.)doc";
 
-static const char *__doc_mitsuba_PhaseFunction_eval =
-R"doc(Evaluates the phase function model
+static const char *__doc_mitsuba_PhaseFunction_eval_pdf =
+R"doc(Evaluates the phase function model value and pdf
 
-The function returns the value (which equals the PDF) of the phase
+The function returns the value (which often equals the PDF) of the phase
 function in the query direction.
 
 Parameter ``ctx``:
@@ -5202,7 +5202,7 @@ Parameter ``wo``:
     An outgoing direction to evaluate.
 
 Returns:
-    The value of the phase function in direction wo)doc";
+    The value and sampling pdf of the phase function in direction wo)doc";
 
 static const char *__doc_mitsuba_PhaseFunction_flags = R"doc(Flags for this phase function.)doc";
 
@@ -5264,7 +5264,7 @@ Parameter ``sample2``:
     generate the sampled direction.
 
 Returns:
-    A sampled direction wo)doc";
+    A sampled direction wo and the corresponding weight and PDF)doc";
 
 static const char *__doc_mitsuba_PhaseFunction_set_id = R"doc(Set a string identifier)doc";
 

--- a/include/mitsuba/render/medium.h
+++ b/include/mitsuba/render/medium.h
@@ -66,8 +66,9 @@ public:
      *
      */
     std::pair<UnpolarizedSpectrum, UnpolarizedSpectrum>
-    eval_tr_and_pdf(const MediumInteraction3f &mi,
-                    const SurfaceInteraction3f &si, Mask active) const;
+    transmittance_eval_pdf(const MediumInteraction3f &mi,
+                           const SurfaceInteraction3f &si,
+                           Mask active) const;
 
     /// Return the phase function of this medium
     MI_INLINE const PhaseFunction *phase_function() const {
@@ -127,7 +128,7 @@ DRJIT_VCALL_TEMPLATE_BEGIN(mitsuba::Medium)
     DRJIT_VCALL_METHOD(get_majorant)
     DRJIT_VCALL_METHOD(intersect_aabb)
     DRJIT_VCALL_METHOD(sample_interaction)
-    DRJIT_VCALL_METHOD(eval_tr_and_pdf)
+    DRJIT_VCALL_METHOD(transmittance_eval_pdf)
     DRJIT_VCALL_METHOD(get_scattering_coefficients)
 DRJIT_VCALL_TEMPLATE_END(mitsuba::Medium)
 

--- a/include/mitsuba/render/phase.h
+++ b/include/mitsuba/render/phase.h
@@ -22,19 +22,7 @@ enum class PhaseFunctionFlags : uint32_t {
     Microflake  = 0x04
 };
 
-constexpr uint32_t operator|(PhaseFunctionFlags f1, PhaseFunctionFlags f2) {
-    return (uint32_t) f1 | (uint32_t) f2;
-}
-constexpr uint32_t operator|(uint32_t f1, PhaseFunctionFlags f2) { return f1 | (uint32_t) f2; }
-constexpr uint32_t operator&(PhaseFunctionFlags f1, PhaseFunctionFlags f2) {
-    return (uint32_t) f1 & (uint32_t) f2;
-}
-constexpr uint32_t operator&(uint32_t f1, PhaseFunctionFlags f2) { return f1 & (uint32_t) f2; }
-constexpr uint32_t operator~(PhaseFunctionFlags f1) { return ~(uint32_t) f1; }
-constexpr uint32_t operator+(PhaseFunctionFlags e) { return (uint32_t) e; }
-template <typename UInt32> constexpr auto has_flag(UInt32 flags, PhaseFunctionFlags f) {
-    return (flags & (uint32_t) f) != 0;
-}
+MI_DECLARE_ENUM_OPERATORS(PhaseFunctionFlags)
 
 /**
  * \brief Context data structure for phase function evaluation and sampling

--- a/include/mitsuba/render/phase.h
+++ b/include/mitsuba/render/phase.h
@@ -129,16 +129,16 @@ public:
      *     A uniformly distributed sample on \f$[0,1]^2\f$. It is
      *     used to generate the sampled direction.
      *
-     * \return A sampled direction wo
+     * \return A sampled direction wo and its corresponding weight and PDF
      */
-    virtual std::pair<Vector3f, Float> sample(const PhaseFunctionContext &ctx,
-                                              const MediumInteraction3f &mi,
-                                              Float sample1, const Point2f &sample2,
-                                              Mask active = true) const = 0;
+    virtual std::tuple<Vector3f, Spectrum, Float> sample(const PhaseFunctionContext &ctx,
+                                                         const MediumInteraction3f &mi,
+                                                         Float sample1, const Point2f &sample2,
+                                                         Mask active = true) const = 0;
     /**
-     * \brief Evaluates the phase function model
+     * \brief Evaluates the phase function model value and PDF
      *
-     * The function returns the value (which equals the PDF) of the phase
+     * The function returns the value (which often equals the PDF) of the phase
      * function in the query direction.
      *
      * \param ctx
@@ -153,10 +153,12 @@ public:
      * \param wo
      *     An outgoing direction to evaluate.
      *
-     * \return The value of the phase function in direction wo
+     * \return The value and the sampling PDF of the phase function in direction wo
      */
-    virtual Float eval(const PhaseFunctionContext &ctx, const MediumInteraction3f &mi,
-                       const Vector3f &wo, Mask active = true) const = 0;
+    virtual std::pair<Spectrum, Float> eval_pdf(const PhaseFunctionContext &ctx,
+                                                const MediumInteraction3f &mi,
+                                                const Vector3f &wo,
+                                                Mask active = true) const = 0;
 
     /**
      * \brief Returns the microflake projected area
@@ -248,7 +250,7 @@ NAMESPACE_END(mitsuba)
 
 DRJIT_VCALL_TEMPLATE_BEGIN(mitsuba::PhaseFunction)
     DRJIT_VCALL_METHOD(sample)
-    DRJIT_VCALL_METHOD(eval)
+    DRJIT_VCALL_METHOD(eval_pdf)
     DRJIT_VCALL_METHOD(projected_area)
     DRJIT_VCALL_METHOD(max_projected_area)
     DRJIT_VCALL_GETTER(flags, uint32_t)

--- a/src/integrators/volpath.cpp
+++ b/src/integrators/volpath.cpp
@@ -175,7 +175,7 @@ public:
 
                 dr::masked(mei.t, active_medium && (si.t < mei.t)) = dr::Infinity<Float>;
                 if (dr::any_or<true>(is_spectral)) {
-                    auto [tr, free_flight_pdf] = medium->eval_tr_and_pdf(mei, si, is_spectral);
+                    auto [tr, free_flight_pdf] = medium->transmittance_eval_pdf(mei, si, is_spectral);
                     Float tr_pdf = index_spectrum(free_flight_pdf, channel);
                     dr::masked(throughput, is_spectral) *= dr::select(tr_pdf > 0.f, tr / tr_pdf, 0.f);
                 }

--- a/src/integrators/volpathmis.cpp
+++ b/src/integrators/volpathmis.cpp
@@ -216,7 +216,7 @@ public:
                 dr::masked(mei.t, active_medium && (si.t < mei.t)) = dr::Infinity<Float>;
 
                 if (dr::any_or<true>(is_spectral)) {
-                    auto [tr, free_flight_pdf] = medium->eval_tr_and_pdf(mei, si, is_spectral);
+                    auto [tr, free_flight_pdf] = medium->transmittance_eval_pdf(mei, si, is_spectral);
                     update_weights(p_over_f, free_flight_pdf, tr, channel, is_spectral);
                     update_weights(p_over_f_nee, free_flight_pdf, tr, channel, is_spectral);
                 }

--- a/src/phase/hg.cpp
+++ b/src/phase/hg.cpp
@@ -69,11 +69,11 @@ public:
                (temp * dr::sqrt(temp));
     }
 
-    std::pair<Vector3f, Float> sample(const PhaseFunctionContext & /* ctx */,
-                                      const MediumInteraction3f &mi,
-                                      Float /* sample1 */,
-                                      const Point2f &sample2,
-                                      Mask active) const override {
+    std::tuple<Vector3f, Spectrum, Float> sample(const PhaseFunctionContext & /* ctx */,
+                                                 const MediumInteraction3f &mi,
+                                                 Float /* sample1 */,
+                                                 const Point2f &sample2,
+                                                 Mask active) const override {
         MI_MASKED_FUNCTION(ProfilerPhase::PhaseFunctionSample, active);
 
         Float sqr_term  = (1.f - dr::sqr(m_g)) / (1.f - m_g + 2.f * m_g * sample2.x()),
@@ -88,13 +88,16 @@ public:
         Vector3f wo = mi.to_world(
             Vector3f(sin_theta * cos_phi, sin_theta * sin_phi, -cos_theta));
 
-        return { wo, eval_hg(-cos_theta) };
+        return { wo, 1.f, eval_hg(-cos_theta) };
     }
 
-    Float eval(const PhaseFunctionContext & /* ctx */, const MediumInteraction3f &mi,
-               const Vector3f &wo, Mask active) const override {
+    std::pair<Spectrum, Float> eval_pdf(const PhaseFunctionContext & /* ctx */,
+                                        const MediumInteraction3f &mi,
+                                        const Vector3f &wo,
+                                        Mask active) const override {
         MI_MASKED_FUNCTION(ProfilerPhase::PhaseFunctionEvaluate, active);
-        return eval_hg(dr::dot(wo, mi.wi));
+        Float pdf = eval_hg(dr::dot(wo, mi.wi));
+        return { pdf, pdf };
     }
 
     std::string to_string() const override {

--- a/src/phase/isotropic.cpp
+++ b/src/phase/isotropic.cpp
@@ -37,22 +37,25 @@ public:
         m_components.push_back(m_flags);
     }
 
-    std::pair<Vector3f, Float> sample(const PhaseFunctionContext & /* ctx */,
-                                      const MediumInteraction3f & /* mi */,
-                                      Float /* sample1 */,
-                                      const Point2f &sample2,
-                                      Mask active) const override {
+    std::tuple<Vector3f, Spectrum, Float> sample(const PhaseFunctionContext & /* ctx */,
+                                                 const MediumInteraction3f & /* mi */,
+                                                 Float /* sample1 */,
+                                                 const Point2f &sample2,
+                                                 Mask active) const override {
         MI_MASKED_FUNCTION(ProfilerPhase::PhaseFunctionSample, active);
 
         auto wo  = warp::square_to_uniform_sphere(sample2);
         auto pdf = warp::square_to_uniform_sphere_pdf(wo);
-        return { wo, pdf };
+        return { wo, 1.f, pdf };
     }
 
-    Float eval(const PhaseFunctionContext & /* ctx */, const MediumInteraction3f & /* mi */,
-               const Vector3f &wo, Mask active) const override {
+    std::pair<Spectrum, Float> eval_pdf(const PhaseFunctionContext & /* ctx */,
+                                        const MediumInteraction3f & /* mi */,
+                                        const Vector3f &wo,
+                                        Mask active) const override {
         MI_MASKED_FUNCTION(ProfilerPhase::PhaseFunctionEvaluate, active);
-        return warp::square_to_uniform_sphere_pdf(wo);
+        Float pdf = warp::square_to_uniform_sphere_pdf(wo);
+        return { pdf, pdf };
     }
 
     std::string to_string() const override { return "IsotropicPhaseFunction[]"; }

--- a/src/phase/rayleigh.cpp
+++ b/src/phase/rayleigh.cpp
@@ -51,11 +51,11 @@ public:
         return (3.f / 16.f) * dr::InvPi<Float> * (1.f + dr::sqr(cos_theta));
     }
 
-    std::pair<Vector3f, Float> sample(const PhaseFunctionContext & /* ctx */,
-                                      const MediumInteraction3f &mi,
-                                      Float /* sample1 */,
-                                      const Point2f &sample,
-                                      Mask active) const override {
+    std::tuple<Vector3f, Spectrum, Float> sample(const PhaseFunctionContext & /* ctx */,
+                                                 const MediumInteraction3f &mi,
+                                                 Float /* sample1 */,
+                                                 const Point2f &sample,
+                                                 Mask active) const override {
         MI_MASKED_FUNCTION(ProfilerPhase::PhaseFunctionSample, active);
 
         Float z   = 2.f * (2.f * sample.x() - 1.f);
@@ -70,14 +70,16 @@ public:
 
         wo = mi.to_world(wo);
         Float pdf = eval_rayleigh(-cos_theta);
-        return { wo, pdf };
+        return { wo, 1.f, pdf };
     }
 
-    Float eval(const PhaseFunctionContext & /* ctx */,
-               const MediumInteraction3f &mi, const Vector3f &wo,
-               Mask active) const override {
+    std::pair<Spectrum, Float> eval_pdf(const PhaseFunctionContext & /* ctx */,
+                                        const MediumInteraction3f & mi,
+                                        const Vector3f &wo,
+                                        Mask active) const override {
         MI_MASKED_FUNCTION(ProfilerPhase::PhaseFunctionEvaluate, active);
-        return eval_rayleigh(dot(wo, mi.wi));
+        Float pdf = eval_rayleigh(dot(wo, mi.wi));
+        return { pdf, pdf };
     }
 
     std::string to_string() const override { return "RayleighPhaseFunction[]"; }

--- a/src/phase/tabphase.cpp
+++ b/src/phase/tabphase.cpp
@@ -75,11 +75,11 @@ public:
         m_distr.update();
     }
 
-    std::pair<Vector3f, Float> sample(const PhaseFunctionContext & /* ctx */,
-                                      const MediumInteraction3f &mi,
-                                      Float /* sample1 */,
-                                      const Point2f &sample2,
-                                      Mask active) const override {
+    std::tuple<Vector3f, Spectrum, Float> sample(const PhaseFunctionContext & /* ctx */,
+                                                 const MediumInteraction3f &mi,
+                                                 Float /* sample1 */,
+                                                 const Point2f &sample2,
+                                                 Mask active) const override {
         MI_MASKED_FUNCTION(ProfilerPhase::PhaseFunctionSample, active);
 
         // Sample a direction in physics convention.
@@ -100,12 +100,13 @@ public:
         Float pdf = m_distr.eval_pdf_normalized(cos_theta_prime, active) *
                     dr::InvTwoPi<ScalarFloat>;
 
-        return { wo, pdf };
+        return { wo, 1.f, pdf };
     }
 
-    Float eval(const PhaseFunctionContext & /* ctx */,
-               const MediumInteraction3f &mi, const Vector3f &wo,
-               Mask active) const override {
+    std::pair<Spectrum, Float> eval_pdf(const PhaseFunctionContext & /* ctx */,
+                                        const MediumInteraction3f &mi,
+                                        const Vector3f &wo,
+                                        Mask active) const override {
         MI_MASKED_FUNCTION(ProfilerPhase::PhaseFunctionEvaluate, active);
 
         // The data is laid out in physics convention
@@ -113,8 +114,8 @@ public:
         // This parameterization differs from the convention used internally by
         // Mitsuba and is the reason for the minus sign below.
         Float cos_theta = -dot(wo, mi.wi);
-        return m_distr.eval_pdf_normalized(cos_theta, active) *
-               dr::InvTwoPi<ScalarFloat>;
+        Float pdf = m_distr.eval_pdf_normalized(cos_theta, active) * dr::InvTwoPi<ScalarFloat>;
+        return { pdf, pdf };
     }
 
     std::string to_string() const override {

--- a/src/phase/tests/test_blendphase.py
+++ b/src/phase/tests/test_blendphase.py
@@ -57,7 +57,7 @@ def test02_eval_all(variant_scalar_rgb):
     expected = (1.0 - weight) * dr.inv_four_pi + weight * dr.inv_four_pi * (1.0 - g) / (
         1.0 + g
     ) ** 2
-    value = phase.eval(ctx, mei, wo)
+    value = phase.eval_pdf(ctx, mei, wo)[0]
     assert dr.allclose(value, expected)
 
 
@@ -87,12 +87,12 @@ def test03_sample_all(variants_all_rgb):
 
     # -- Sample above weight: first component (isotropic) is selected
     expected_a = dr.inv_four_pi
-    wo_a, pdf_a = phase.sample(ctx, mei, 0.3, [0.5, 0.5])
+    wo_a, w_a, pdf_a = phase.sample(ctx, mei, 0.3, [0.5, 0.5])
     assert dr.allclose(pdf_a, expected_a)
 
     # -- Sample below weight: second component (HG) is selected
     expected_b = dr.inv_four_pi * (1 - g) / (1 + g) ** 2
-    wo_b, pdf_b = phase.sample(ctx, mei, 0.1, [0, 0])
+    wo_b, w_b, pdf_b = phase.sample(ctx, mei, 0.1, [0, 0])
     assert dr.allclose(pdf_b, expected_b)
 
 
@@ -121,14 +121,16 @@ def test04_eval_components(variant_scalar_rgb):
     # Evaluate the two components separately
 
     ctx.component = 0
-    value0 = phase.eval(ctx, mei, wo)
+    value0, pdf0 = phase.eval_pdf(ctx, mei, wo)
     expected0 = (1 - weight) * dr.inv_four_pi
     assert dr.allclose(value0, expected0)
+    assert dr.allclose(value0, pdf0)
 
     ctx.component = 1
-    value1 = phase.eval(ctx, mei, wo)
+    value1, pdf1 = phase.eval_pdf(ctx, mei, wo)
     expected1 = weight * dr.inv_four_pi * (1.0 - g) / (1.0 + g) ** 2
     assert dr.allclose(value1, expected1)
+    assert dr.allclose(value1, pdf1)
 
 
 def test05_sample_components(variant_scalar_rgb):
@@ -159,20 +161,20 @@ def test05_sample_components(variant_scalar_rgb):
     ctx.component = 0
 
     expected_a = (1 - weight) *  dr.inv_four_pi
-    wo_a, pdf_a = phase.sample(ctx, mei, 0.3, [0.5, 0.5])
+    wo_a, w_a, pdf_a = phase.sample(ctx, mei, 0.3, [0.5, 0.5])
     assert dr.allclose(pdf_a, expected_a)
 
     expected_b = (1 - weight) *  dr.inv_four_pi
-    wo_b, pdf_b = phase.sample(ctx, mei, 0.1, [0.5, 0.5])
+    wo_b, w_b, pdf_b = phase.sample(ctx, mei, 0.1, [0.5, 0.5])
     assert dr.allclose(pdf_b, expected_b)
 
     # -- Select component 1: second component is always sampled
     ctx.component = 1
 
     expected_a = weight *  dr.inv_four_pi * (1 - g) / (1 + g) ** 2
-    wo_a, pdf_a = phase.sample(ctx, mei, 0.3, [0.0, 0.0])
+    wo_a, w_a, pdf_a = phase.sample(ctx, mei, 0.3, [0.0, 0.0])
     assert dr.allclose(pdf_a, expected_a)
 
     expected_b = weight * dr.inv_four_pi * (1 - g) / (1 + g) ** 2
-    wo_b, pdf_b = phase.sample(ctx, mei, 0.1, [0.0, 0.0])
+    wo_b, w_b, pdf_b = phase.sample(ctx, mei, 0.1, [0.0, 0.0])
     assert dr.allclose(pdf_b, expected_b)

--- a/src/phase/tests/test_isotropic.py
+++ b/src/phase/tests/test_isotropic.py
@@ -16,7 +16,7 @@ def test02_eval(variant_scalar_rgb):
     theta  = dr.linspace(mi.Float, dr.pi / 2, 4)
     ph  = dr.linspace(mi.Float, 0, dr.pi, 4)
     wo = [dr.sin(theta), 0, dr.cos(theta)]
-    v_eval = p.eval(ctx, mei, wo)
+    v_eval = p.eval_pdf(ctx, mei, wo)[0]
 
     assert dr.allclose(v_eval, 1.0 / (4 * dr.pi))
 

--- a/src/phase/tests/test_tabphase.py
+++ b/src/phase/tests/test_tabphase.py
@@ -58,7 +58,7 @@ def test_eval(variant_scalar_rgb):
     mei.wi = wi
     tab_eval = np.zeros_like(ref_eval)
     for i, wo in enumerate(wos):
-        tab_eval[i] = tab.eval(ctx, mei, wo)
+        tab_eval[i] = tab.eval_pdf(ctx, mei, wo)[1]
 
     # Compare reference and plugin outputs
     assert np.allclose(ref_eval, tab_eval)
@@ -79,7 +79,7 @@ def test_sample(variant_scalar_rgb):
     mei.wi = [0, 0, 1]
 
     # The passed sample corresponds to forward scattering
-    wo, pdf = tab.sample(ctx, mei, 0, (1, 0))
+    wo, w, pdf = tab.sample(ctx, mei, 0, (1, 0))
 
     # The sampled direction indicates forward scattering in the "graphics"
     # convention
@@ -132,4 +132,4 @@ def test_traverse(variant_scalar_rgb):
     mei = mi.MediumInteraction3f()
     mei.wi = np.array([0, 0, -1])
     wo = [0, 0, 1]
-    assert dr.allclose(phase.eval(ctx, mei, wo), dr.inv_two_pi * 1.5 / ref_integral)
+    assert dr.allclose(phase.eval_pdf(ctx, mei, wo)[0], dr.inv_two_pi * 1.5 / ref_integral)

--- a/src/phase/tests/test_trampoline.py
+++ b/src/phase/tests/test_trampoline.py
@@ -12,10 +12,11 @@ def test01_create_and_eval(variants_vec_rgb):
         def sample(self, ctx, mei, sample1, sample2, active=True):
             wo = mi.warp.square_to_uniform_sphere(sample2)
             pdf = mi.warp.square_to_uniform_sphere_pdf(wo)
-            return (wo, pdf)
+            return (wo, 1.0, pdf)
 
-        def eval(self, ctx, mei, wo, active=True):
-            return mi.warp.square_to_uniform_sphere_pdf(wo)
+        def eval_pdf(self, ctx, mei, wo, active=True):
+            pdf = mi.warp.square_to_uniform_sphere_pdf(wo)
+            return pdf, pdf
 
         def to_string(self):
             return "MyIsotropicPhaseFunction[]"
@@ -35,6 +36,6 @@ def test01_create_and_eval(variants_vec_rgb):
     ph = dr.linspace(mi.Float, 0, dr.pi, 4)
 
     wo = [dr.sin(theta), 0, dr.cos(theta)]
-    v_eval = p.eval(ctx, mei, wo)
+    v_eval, v_pdf = p.eval_pdf(ctx, mei, wo)
 
-    assert dr.allclose(v_eval, 1.0 / (4 * dr.pi))
+    assert dr.allclose(v_pdf, 1.0 / (4 * dr.pi))

--- a/src/python/python/ad/integrators/prbvolpath.py
+++ b/src/python/python/ad/integrators/prbvolpath.py
@@ -166,7 +166,7 @@ class PRBVolpathIntegrator(RBIntegrator):
                 mei.t[active_medium & (si.t < mei.t)] = dr.inf
 
                 # Evaluate ratio of transmittance and free-flight PDF
-                tr, free_flight_pdf = medium.eval_tr_and_pdf(mei, si, active_medium)
+                tr, free_flight_pdf = medium.transmittance_eval_pdf(mei, si, active_medium)
                 tr_pdf = index_spectrum(free_flight_pdf, channel)
                 weight = mi.Spectrum(1.0)
                 weight[active_medium] *= dr.select(tr_pdf > 0.0, tr / dr.detach(tr_pdf), 0.0)
@@ -363,7 +363,7 @@ class PRBVolpathIntegrator(RBIntegrator):
             if self.nee_handle_homogeneous:
                 active_homogeneous = active_medium & medium.is_homogeneous()
                 mei.t[active_homogeneous] = dr.minimum(remaining_dist, si.t)
-                tr_multiplier[active_homogeneous] = medium.eval_tr_and_pdf(mei, si, active_homogeneous)[0]
+                tr_multiplier[active_homogeneous] = medium.transmittance_eval_pdf(mei, si, active_homogeneous)[0]
                 mei.t[active_homogeneous] = dr.inf
 
             escaped_medium = active_medium & ~mei.is_valid()

--- a/src/python/python/chi2.py
+++ b/src/python/python/chi2.py
@@ -616,7 +616,7 @@ def PhaseFunctionAdapter(phase_type, extra, wi=[0, 0, 1], ctx=None):
         n = dr.width(sample)
         plugin = instantiate(args)
         mei, ctx = make_context(n)
-        wo, pdf = plugin.sample(ctx, mei, sample[0], [sample[1], sample[2]])
+        wo, weight, pdf = plugin.sample(ctx, mei, sample[0], [sample[1], sample[2]])
         w = dr.full(mi.Float, 1.0, dr.width(pdf))
         w[dr.eq(pdf, 0)] = 0
         return wo, w
@@ -625,7 +625,7 @@ def PhaseFunctionAdapter(phase_type, extra, wi=[0, 0, 1], ctx=None):
         n = dr.width(wo)
         plugin = instantiate(args)
         mei, ctx = make_context(n)
-        return plugin.eval(ctx, mei, wo)
+        return plugin.eval_pdf(ctx, mei, wo)[1]
 
     return sample_functor, pdf_functor
 

--- a/src/render/medium.cpp
+++ b/src/render/medium.cpp
@@ -84,9 +84,9 @@ Medium<Float, Spectrum>::sample_interaction(const Ray3f &ray, Float sample,
 MI_VARIANT
 std::pair<typename Medium<Float, Spectrum>::UnpolarizedSpectrum,
           typename Medium<Float, Spectrum>::UnpolarizedSpectrum>
-Medium<Float, Spectrum>::eval_tr_and_pdf(const MediumInteraction3f &mi,
-                                         const SurfaceInteraction3f &si,
-                                         Mask active) const {
+Medium<Float, Spectrum>::transmittance_eval_pdf(const MediumInteraction3f &mi,
+                                                const SurfaceInteraction3f &si,
+                                                Mask active) const {
     MI_MASKED_FUNCTION(ProfilerPhase::MediumEvaluate, active);
 
     Float t      = dr::minimum(mi.t, si.t) - mi.mint;

--- a/src/render/python/medium_v.cpp
+++ b/src/render/python/medium_v.cpp
@@ -65,12 +65,12 @@ template <typename Ptr, typename Cls> void bind_medium_generic(Cls &cls) {
                 return ptr->sample_interaction(ray, sample, channel, active); },
             "ray"_a, "sample"_a, "channel"_a, "active"_a,
             D(Medium, sample_interaction))
-       .def("eval_tr_and_pdf",
+       .def("transmittance_eval_pdf",
             [](Ptr ptr, const MediumInteraction3f &mi,
                const SurfaceInteraction3f &si, Mask active) {
-                return ptr->eval_tr_and_pdf(mi, si, active); },
+                return ptr->transmittance_eval_pdf(mi, si, active); },
             "mi"_a, "si"_a, "active"_a,
-            D(Medium, eval_tr_and_pdf))
+            D(Medium, transmittance_eval_pdf))
        .def("get_scattering_coefficients",
             [](Ptr ptr, const MediumInteraction3f &mi, Mask active = true) {
                 return ptr->get_scattering_coefficients(mi, active); },

--- a/src/render/python/phase_v.cpp
+++ b/src/render/python/phase_v.cpp
@@ -10,17 +10,20 @@ public:
 
     PyPhaseFunction(const Properties &props) : PhaseFunction(props) {}
 
-    std::pair<Vector3f, Float> sample(const PhaseFunctionContext &ctx,
-                    const MediumInteraction3f &mi,
-                    Float sample1, const Point2f &sample2,
-                    Mask active) const override {
-        using Return = std::pair<Vector3f, Float>;
+    std::tuple<Vector3f, Spectrum, Float> sample(const PhaseFunctionContext &ctx,
+                                                 const MediumInteraction3f &mi,
+                                                 Float sample1, const Point2f &sample2,
+                                                 Mask active) const override {
+        using Return = std::tuple<Vector3f, Spectrum, Float>;
         PYBIND11_OVERRIDE_PURE(Return, PhaseFunction, sample, ctx, mi, sample1, sample2, active);
     }
 
-    Float eval(const PhaseFunctionContext &ctx, const MediumInteraction3f &mi,
-               const Vector3f &wo, Mask active) const override {
-        PYBIND11_OVERRIDE_PURE(Float, PhaseFunction, eval, ctx, mi, wo, active);
+    std::pair<Spectrum, Float> eval_pdf(const PhaseFunctionContext &ctx,
+                                        const MediumInteraction3f &mi,
+                                        const Vector3f &wo,
+                                        Mask active) const override {
+        using Return = std::pair<Spectrum, Float>;
+        PYBIND11_OVERRIDE_PURE(Return, PhaseFunction, eval_pdf, ctx, mi, wo, active);
     }
 
     Float projected_area(const MediumInteraction3f &mi, Mask active) const override {
@@ -48,12 +51,12 @@ template <typename Ptr, typename Cls> void bind_phase_generic(Cls &cls) {
                Mask active) { return ptr->sample(ctx, mi, s1, s2, active); },
             "ctx"_a, "mi"_a, "sample1"_a, "sample2"_a, "active"_a = true,
             D(PhaseFunction, sample))
-       .def("eval",
+       .def("eval_pdf",
             [](Ptr ptr, const PhaseFunctionContext &ctx,
                const MediumInteraction3f &mi, const Vector3f &wo,
-               Mask active) { return ptr->eval(ctx, mi, wo, active); },
+               Mask active) { return ptr->eval_pdf(ctx, mi, wo, active); },
             "ctx"_a, "mi"_a, "wo"_a, "active"_a = true,
-            D(PhaseFunction, eval))
+            D(PhaseFunction, eval_pdf))
        .def("projected_area",
             [](Ptr ptr, const MediumInteraction3f &mi,
                Mask active) { return ptr->projected_area(mi, active); },
@@ -105,7 +108,7 @@ MI_PY_EXPORT(PhaseFunction) {
     bind_phase_generic<PhaseFunction *>(phase);
 
     if constexpr (dr::is_array_v<PhaseFunctionPtr>) {
-        py::object dr       = py::module_::import("drjit"),
+        py::object dr = py::module_::import("drjit"),
                    dr_array = dr.attr("ArrayBase");
 
         py::class_<PhaseFunctionPtr> cls(m, "PhaseFunctionPtr", dr_array);


### PR DESCRIPTION
This PR modifies the interface of the `PhaseFunction` class to support spectral evaluation. This is done by replacing the `eval()` method by `eval_pdf()` which returns both a spectrum value and the corresponding sampling PDF. `PhaseFunction::sample()` now also returns a sampling weight similar to the one returned by `BSDF::sample()`.

The `volpath`, `volpathmis` and `prbvolpath` integrators were modified to account for theses changes.

On top of this, this PR also renames `Medium::tr_and_pdf` into `Medium::transmission_eval_pdf` to be more consistent with other plugin interfaces.