### PR TITLE
Expose m_film member in Sensor python bindings

### DIFF
--- a/src/render/python/sensor_v.cpp
+++ b/src/render/python/sensor_v.cpp
@@ -78,6 +78,7 @@ public:
 
     using Sensor::m_needs_sample_2;
     using Sensor::m_needs_sample_3;
+    using Sensor::m_film;
 };
 
 MI_PY_EXPORT(Sensor) {
@@ -94,7 +95,8 @@ MI_PY_EXPORT(Sensor) {
         .def("film", py::overload_cast<>(&Sensor::film, py::const_), D(Sensor, film))
         .def("sampler", py::overload_cast<>(&Sensor::sampler, py::const_), D(Sensor, sampler))
         .def_readwrite("m_needs_sample_2", &PySensor::m_needs_sample_2)
-        .def_readwrite("m_needs_sample_3", &PySensor::m_needs_sample_3);
+        .def_readwrite("m_needs_sample_3", &PySensor::m_needs_sample_3)
+        .def_readwrite("m_film", &PySensor::m_film);
 
     MI_PY_REGISTER_OBJECT("register_sensor", Sensor)
 


### PR DESCRIPTION
Short patch that adds bindings to the underlying Film object in sensors. For instance this can be used to access the film object from a Python custom sensor plugin.