### PR TITLE
Add SensorPtr::sample_ray_differential bindings

### DIFF
--- a/src/render/python/sensor_v.cpp
+++ b/src/render/python/sensor_v.cpp
@@ -11,18 +11,16 @@ public:
 
     std::pair<Ray3f, Spectrum>
     sample_ray(Float time, Float sample1, const Point2f &sample2,
-           const Point2f &sample3, Mask active) const override {
+               const Point2f &sample3, Mask active) const override {
         using Return = std::pair<Ray3f, Spectrum>;
-        PYBIND11_OVERRIDE_PURE(Return, Sensor, sample_ray, time, sample1, sample2, sample3,
-                               active);
+        PYBIND11_OVERRIDE_PURE(Return, Sensor, sample_ray, time, sample1, sample2, sample3, active);
     }
 
     std::pair<RayDifferential3f, Spectrum>
     sample_ray_differential(Float time, Float sample1, const Point2f &sample2,
                             const Point2f &sample3, Mask active) const override {
         using Return = std::pair<RayDifferential3f, Spectrum>;
-        PYBIND11_OVERRIDE(Return, Sensor, sample_ray_differential, time, sample1, sample2, sample3,
-                               active);
+        PYBIND11_OVERRIDE(Return, Sensor, sample_ray_differential, time, sample1, sample2, sample3, active);
     }
 
     std::pair<DirectionSample3f, Spectrum>
@@ -87,7 +85,8 @@ MI_PY_EXPORT(Sensor) {
     MI_PY_TRAMPOLINE_CLASS(PySensor, Sensor, Endpoint)
         .def(py::init<const Properties&>())
         .def("sample_ray_differential", &Sensor::sample_ray_differential,
-            "time"_a, "sample1"_a, "sample2"_a, "sample3"_a, "active"_a = true)
+             "time"_a, "sample1"_a, "sample2"_a, "sample3"_a, "active"_a = true,
+             D(Sensor, sample_ray_differential))
         .def_method(Sensor, shutter_open)
         .def_method(Sensor, shutter_open_time)
         .def_method(Sensor, needs_aperture_sample)
@@ -115,11 +114,18 @@ MI_PY_EXPORT(Sensor) {
 
         cls.def("sample_ray",
                 [](SensorPtr ptr, Float time, Float sample1, const Point2f &sample2,
-                const Point2f &sample3, Mask active) {
+                   const Point2f &sample3, Mask active) {
                     return ptr->sample_ray(time, sample1, sample2, sample3, active);
                 },
                 "time"_a, "sample1"_a, "sample2"_a, "sample3"_a, "active"_a = true,
                 D(Endpoint, sample_ray))
+        .def("sample_ray_differential",
+                [](SensorPtr ptr, Float time, Float sample1, const Point2f &sample2,
+                   const Point2f &sample3, Mask active) {
+                    return ptr->sample_ray_differential(time, sample1, sample2, sample3, active);
+                },
+                "time"_a, "sample1"_a, "sample2"_a, "sample3"_a, "active"_a = true,
+                D(Sensor, sample_ray_differential))
         .def("sample_direction",
                 [](SensorPtr ptr, const Interaction3f &it, const Point2f &sample, Mask active) {
                     return ptr->sample_direction(it, sample, active);


### PR DESCRIPTION
Short patch to add missing bindings for `SensorPtr::sample_ray_differential`.