### PR TITLE
Fix Python plugin reference leak

### DIFF
--- a/include/mitsuba/core/object.h
+++ b/include/mitsuba/core/object.h
@@ -118,6 +118,11 @@ public:
      */
     virtual std::string to_string() const;
 
+    /// Set a cleanup callback for Python-defined plugins.
+    void set_py_cleanup(const std::function<void()> &callback) {
+        m_py_cleanup_callback = callback;
+    }
+
 protected:
     /** \brief Virtual protected deconstructor.
      * (Will only be called by \ref ref)
@@ -128,6 +133,9 @@ private:
     mutable std::atomic<int> m_ref_count { 0 };
 
     static Class *m_class;
+
+    // Cleanup function for Python-defined objects.
+    std::function<void()> m_py_cleanup_callback;
 };
 
 /**

--- a/include/mitsuba/python/python.h
+++ b/include/mitsuba/python/python.h
@@ -78,8 +78,12 @@ PYBIND11_DECLARE_HOLDER_TYPE(T, mitsuba::ref<T>, true);
                         o = constructor(&p);                                   \
                     }                                                          \
                                                                                \
-                    ref<Name> o2 = o.cast<Name*>();                            \
-                    o.release();                                               \
+                    Name *o2 = o.cast<Name*>();                                \
+                    auto handle = o.release(); /* Manage ref count manually. */\
+                    o2->set_py_cleanup([handle]() {                            \
+                        py::gil_scoped_acquire gil;                            \
+                        handle.dec_ref();                                      \
+                    });                                                        \
                     return o2;                                                 \
                 },                                                             \
                 nullptr);                                                      \


### PR DESCRIPTION
There is a known issue in Mitsuba that a reference to the Python object is leaked when a Python-defined plugin is instantiated.

The original reason we had to leak this reference was to keep the Python object alive beyond the scope of the initialization call in `python.h`. The problem is that due to this leak, the Python object is never deallocated and may end up in a partially invalid state (e.g., see the nested emitter example in #771).

Ideally, we could fully transfer the ownership of the Python object to C++ and Mitsuba's `ref` object. This doesn't seem to be possible in pybind11 and as far as I can tell is a known limitation. It will be fixed in nanobind (see the [docs](https://nanobind.readthedocs.io/en/latest/ownership.html#intrusive-reference-counting)).

This PR implements a relatively straightforward fix that should work until the transition to Nanobind is complete. The solution that seems to work is to keep a Python object handle in a cleanup callback lambda, and then explicitly invoke the cleanup call when the object's reference count decreases from 2 to 1 (i.e., the only remaining reference is the Python object). This isn't very elegant but appears to solve the problem on my end.

Not sure if we want to merge this, but I thought I would share this since the transition to Nanobind might still take some time (?). The leaked reference ended up causing some unforeseen issues on my end, so maybe others can benefit from a fix as well.