### PR TITLE
SDFGrid: Adding Embree support

### DIFF
--- a/docs/generate_plugin_doc.py
+++ b/docs/generate_plugin_doc.py
@@ -16,6 +16,8 @@ SHAPE_ORDERING = [
     'cylinder',
     'disk',
     'rectangle',
+    'cube',
+    'sdfgrid',
     'shapegroup',
     'instance'
 ]

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -546,3 +546,18 @@
     year = {2021},
     month = aug,
     doi = {10.1145/3450626.3459807} }
+
+
+@article{Hansson-Soderlund2022SDF,
+  author =       {Herman Hansson Söderlund and Alex Evans and Tomas Akenine-Möller}, 
+  title =        {Ray Tracing of Signed Distance Function Grids},
+  year =         {2022},
+  month =        {September},
+  day =          {21},
+  journal =      {Journal of Computer Graphics Techniques (JCGT)},
+  volume =       11,
+  number =       3,
+  pages =        {94--113},
+  url =          {http://jcgt.org/published/0011/03/06/},
+  issn =         {2331-7418}
+}

--- a/include/mitsuba/render/shape.h
+++ b/include/mitsuba/render/shape.h
@@ -132,9 +132,13 @@ public:
      *
      * \param ray
      *     The ray to be tested for an intersection
+     *
+     * \param prim_index
+     *     Index of the primitive to be intersected
      */
     virtual PreliminaryIntersection3f ray_intersect_preliminary(const Ray3f &ray,
-                                                                Mask active = true) const;
+                                                                Mask active = true,
+                                                                ScalarIndex prim_index = 0) const;
 
     /**
      * \brief Fast ray shadow test
@@ -148,8 +152,11 @@ public:
      *
      * \param ray
      *     The ray to be tested for an intersection
+     * 
+     * \param prim_index
+     *     Index of the primitive to be intersected
      */
-    virtual Mask ray_test(const Ray3f &ray, Mask active = true) const;
+    virtual Mask ray_test(const Ray3f &ray, Mask active = true, ScalarIndex prim_index = 0) const;
 
     /**
      * \brief Compute and return detailed information related to a surface interaction
@@ -221,18 +228,20 @@ public:
     virtual bool ray_test_scalar(const ScalarRay3f &ray) const;
 
     /// Macro to declare packet versions of the scalar routine above
-    #define MI_DECLARE_RAY_INTERSECT_PACKET(N)                            \
-        using FloatP##N   = dr::Packet<dr::scalar_t<Float>, N>;            \
-        using UInt32P##N  = dr::uint32_array_t<FloatP##N>;                 \
-        using MaskP##N    = dr::mask_t<FloatP##N>;                         \
-        using Point2fP##N = Point<FloatP##N, 2>;                           \
-        using Point3fP##N = Point<FloatP##N, 3>;                           \
-        using Ray3fP##N   = Ray<Point3fP##N, Spectrum>;                    \
-        virtual std::tuple<FloatP##N, Point2fP##N, UInt32P##N, UInt32P##N> \
-        ray_intersect_preliminary_packet(const Ray3fP##N &ray,             \
-                                         MaskP##N active = true) const;    \
-        virtual MaskP##N ray_test_packet(const Ray3fP##N &ray,             \
-                                         MaskP##N active = true) const;
+    #define MI_DECLARE_RAY_INTERSECT_PACKET(N)                                  \
+        using FloatP##N   = dr::Packet<dr::scalar_t<Float>, N>;                 \
+        using UInt32P##N  = dr::uint32_array_t<FloatP##N>;                      \
+        using MaskP##N    = dr::mask_t<FloatP##N>;                              \
+        using Point2fP##N = Point<FloatP##N, 2>;                                \
+        using Point3fP##N = Point<FloatP##N, 3>;                                \
+        using Ray3fP##N   = Ray<Point3fP##N, Spectrum>;                         \
+        virtual std::tuple<FloatP##N, Point2fP##N, UInt32P##N, UInt32P##N>      \
+        ray_intersect_preliminary_packet(const Ray3fP##N &ray,                  \
+                                         MaskP##N active = true,                \
+                                         ScalarIndex prim_index = 0) const;     \
+        virtual MaskP##N ray_test_packet(const Ray3fP##N &ray,                  \
+                                         MaskP##N active = true,                \
+                                         ScalarIndex prim_index = 0) const;
 
     MI_DECLARE_RAY_INTERSECT_PACKET(4)
     MI_DECLARE_RAY_INTERSECT_PACKET(8)
@@ -580,56 +589,56 @@ protected:
 MI_EXTERN_CLASS(Shape)
 NAMESPACE_END(mitsuba)
 
-#define MI_IMPLEMENT_RAY_INTERSECT_PACKET(N)                                   \
-    using typename Base::FloatP##N;                                            \
-    using typename Base::UInt32P##N;                                           \
-    using typename Base::MaskP##N;                                             \
-    using typename Base::Point2fP##N;                                          \
-    using typename Base::Point3fP##N;                                          \
-    using typename Base::Ray3fP##N;                                            \
-    std::tuple<FloatP##N, Point2fP##N, UInt32P##N, UInt32P##N>                 \
-    ray_intersect_preliminary_packet(                                          \
-        const Ray3fP##N &ray, MaskP##N active) const override {                \
-        (void) ray; (void) active;                                             \
-        if constexpr (!dr::is_cuda_v<Float>)                                   \
-            return ray_intersect_preliminary_impl<FloatP##N>(ray, active);     \
-        else                                                                   \
-            Throw("ray_intersect_preliminary_packet() CUDA not supported");    \
-    }                                                                          \
-    MaskP##N ray_test_packet(const Ray3fP##N &ray, MaskP##N active)            \
-        const override {                                                       \
-        (void) ray; (void) active;                                             \
-        if constexpr (!dr::is_cuda_v<Float>)                                   \
-            return ray_test_impl<FloatP##N>(ray, active);                      \
-        else                                                                   \
-            Throw("ray_intersect_preliminary_packet() CUDA not supported");    \
+#define MI_IMPLEMENT_RAY_INTERSECT_PACKET(N)                                                \
+    using typename Base::FloatP##N;                                                         \
+    using typename Base::UInt32P##N;                                                        \
+    using typename Base::MaskP##N;                                                          \
+    using typename Base::Point2fP##N;                                                       \
+    using typename Base::Point3fP##N;                                                       \
+    using typename Base::Ray3fP##N;                                                         \
+    std::tuple<FloatP##N, Point2fP##N, UInt32P##N, UInt32P##N>                              \
+    ray_intersect_preliminary_packet(                                                       \
+        const Ray3fP##N &ray, MaskP##N active, ScalarIndex prim_index) const override {     \
+        (void) ray; (void) active;                                                          \
+        if constexpr (!dr::is_cuda_v<Float>)                                                \
+            return ray_intersect_preliminary_impl<FloatP##N>(ray, active, prim_index);      \
+        else                                                                                \
+            Throw("ray_intersect_preliminary_packet() CUDA not supported");                 \
+    }                                                                                       \
+    MaskP##N ray_test_packet(const Ray3fP##N &ray, MaskP##N active, ScalarIndex prim_index) \
+        const override {                                                                    \
+        (void) ray; (void) active;                                                          \
+        if constexpr (!dr::is_cuda_v<Float>)                                                \
+            return ray_test_impl<FloatP##N>(ray, active, prim_index);                       \
+        else                                                                                \
+            Throw("ray_intersect_preliminary_packet() CUDA not supported");                 \
     }
 
 // Macro to define ray intersection methods given an *_impl() templated implementation
-#define MI_SHAPE_DEFINE_RAY_INTERSECT_METHODS()                                \
-    PreliminaryIntersection3f ray_intersect_preliminary(                       \
-        const Ray3f &ray, Mask active) const override {                        \
-        MI_MASK_ARGUMENT(active);                                              \
-        PreliminaryIntersection3f pi = dr::zeros<PreliminaryIntersection3f>(); \
-        std::tie(pi.t, pi.prim_uv, pi.shape_index, pi.prim_index) =            \
-            ray_intersect_preliminary_impl<Float>(ray, active);                \
-        pi.shape = this;                                                       \
-        return pi;                                                             \
-    }                                                                          \
-    Mask ray_test(const Ray3f &ray, Mask active) const override {              \
-        MI_MASK_ARGUMENT(active);                                              \
-        return ray_test_impl<Float>(ray, active);                              \
-    }                                                                          \
-    using typename Base::ScalarRay3f;                                          \
-    std::tuple<ScalarFloat, ScalarPoint2f, ScalarUInt32, ScalarUInt32>         \
-    ray_intersect_preliminary_scalar(const ScalarRay3f &ray) const override {  \
-        return ray_intersect_preliminary_impl<ScalarFloat>(ray, true);         \
-    }                                                                          \
-    ScalarMask ray_test_scalar(const ScalarRay3f &ray) const override {        \
-        return ray_test_impl<ScalarFloat>(ray, true);                          \
-    }                                                                          \
-    MI_IMPLEMENT_RAY_INTERSECT_PACKET(4)                                       \
-    MI_IMPLEMENT_RAY_INTERSECT_PACKET(8)                                       \
+#define MI_SHAPE_DEFINE_RAY_INTERSECT_METHODS()                                             \
+    PreliminaryIntersection3f ray_intersect_preliminary(                                    \
+        const Ray3f &ray, Mask active, ScalarIndex prim_index = 0) const override {         \
+        MI_MASK_ARGUMENT(active);                                                           \
+        PreliminaryIntersection3f pi = dr::zeros<PreliminaryIntersection3f>();              \
+        std::tie(pi.t, pi.prim_uv, pi.shape_index, pi.prim_index) =                         \
+            ray_intersect_preliminary_impl<Float>(ray, active, prim_index);                 \
+        pi.shape = this;                                                                    \
+        return pi;                                                                          \
+    }                                                                                       \
+    Mask ray_test(const Ray3f &ray, Mask active, ScalarIndex prim_index) const override {   \
+        MI_MASK_ARGUMENT(active);                                                           \
+        return ray_test_impl<Float>(ray, active, prim_index);                               \
+    }                                                                                       \
+    using typename Base::ScalarRay3f;                                                       \
+    std::tuple<ScalarFloat, ScalarPoint2f, ScalarUInt32, ScalarUInt32>                      \
+    ray_intersect_preliminary_scalar(const ScalarRay3f &ray) const override {               \
+        return ray_intersect_preliminary_impl<ScalarFloat>(ray, true, 0);                   \
+    }                                                                                       \
+    ScalarMask ray_test_scalar(const ScalarRay3f &ray) const override {                     \
+        return ray_test_impl<ScalarFloat>(ray, true, 0);                                    \
+    }                                                                                       \
+    MI_IMPLEMENT_RAY_INTERSECT_PACKET(4)                                                    \
+    MI_IMPLEMENT_RAY_INTERSECT_PACKET(8)                                                    \
     MI_IMPLEMENT_RAY_INTERSECT_PACKET(16)
 
 // -----------------------------------------------------------------------

--- a/src/render/python/shape_v.cpp
+++ b/src/render/python/shape_v.cpp
@@ -82,15 +82,10 @@ template <typename Ptr, typename Cls> void bind_shape_generic(Cls &cls) {
             },
             "name"_a, "si"_a, "active"_a = true, D(Shape, eval_attribute_3))
        .def("ray_intersect_preliminary",
-            [](Ptr shape, const Ray3f &ray, const Mask &active) {
-                return shape->ray_intersect_preliminary(ray, active);
+            [](Ptr shape, const Ray3f &ray, uint32_t prim_index, const Mask &active) {
+                return shape->ray_intersect_preliminary(ray, prim_index, active);
             },
-            "ray"_a, "active"_a = true, D(Shape, ray_intersect_preliminary))
-       .def("ray_intersect_preliminary",
-            [](Ptr shape, const Ray3f &ray, const Mask &active) {
-                return shape->ray_intersect_preliminary(ray, active);
-            },
-            "ray"_a, "active"_a = true, D(Shape, ray_intersect_preliminary))
+            "ray"_a, "prim_index"_a = 0, "active"_a = true, D(Shape, ray_intersect_preliminary))
        .def("ray_intersect",
             [](Ptr shape, const Ray3f &ray, uint32_t flags, const Mask &active) {
                 return shape->ray_intersect(ray, flags, active);
@@ -99,7 +94,7 @@ template <typename Ptr, typename Cls> void bind_shape_generic(Cls &cls) {
             D(Shape, ray_intersect))
        .def("ray_test",
             [](Ptr shape, const Ray3f &ray, const Mask &active) {
-                return shape->ray_test(ray, active);
+                return shape->ray_test(ray, 0, active);
             },
             "ray"_a, "active"_a = true, D(Shape, ray_test))
        .def("sample_position",

--- a/src/render/scene_optix.inl
+++ b/src/render/scene_optix.inl
@@ -30,7 +30,10 @@ struct OptixSceneState {
     OptixShaderBindingTable sbt = {};
     OptixAccelData accel;
     OptixTraversableHandle ias_handle = 0ull;
-    void* ias_buffer = nullptr;
+    struct InstanceData {
+        void* buffer = nullptr;             // Device-visible storage for IAS 
+        void* inputs = nullptr;             // Device-visible storage for OptixInstance array
+    } ias_data;
     size_t config_index;
     uint32_t sbt_jit_index;
     bool own_sbt;
@@ -381,7 +384,7 @@ MI_VARIANT void Scene<Float, Spectrum>::accel_parameters_changed_gpu() {
             if (config.pipeline_compile_options.traversableGraphFlags == OPTIX_TRAVERSABLE_GRAPH_FLAG_ALLOW_SINGLE_GAS) {
                 if (ias.size() != 1)
                     Throw("OPTIX_TRAVERSABLE_GRAPH_FLAG_ALLOW_SINGLE_GAS used but found multiple IASs.");
-                s.ias_buffer = nullptr;
+                s.ias_data = {};
                 s.ias_handle = ias[0].traversableHandle;
             } else {
                 // Build a "master" IAS that contains all the IAS of the scene (meshes,
@@ -395,12 +398,14 @@ MI_VARIANT void Scene<Float, Spectrum>::accel_parameters_changed_gpu() {
                 void* d_ias = jit_malloc(AllocType::HostPinned, ias_data_size);
                 jit_memcpy_async(JitBackend::CUDA, d_ias, ias.data(), ias_data_size);
 
-                jit_free(s.ias_buffer);
+                jit_free(s.ias_data.buffer);
+                jit_free(s.ias_data.inputs);
+                s.ias_data = {};
+                s.ias_data.inputs = jit_malloc_migrate(d_ias, AllocType::Device, 1);
 
                 OptixBuildInput build_input;
                 build_input.type = OPTIX_BUILD_INPUT_TYPE_INSTANCES;
-                build_input.instanceArray.instances = 
-                    (CUdeviceptr)jit_malloc_migrate(d_ias, AllocType::Device, 1);
+                build_input.instanceArray.instances = (CUdeviceptr)s.ias_data.inputs;
                 build_input.instanceArray.numInstances = (unsigned int) ias.size();
 
                 OptixAccelBufferSizes buffer_sizes;
@@ -414,7 +419,7 @@ MI_VARIANT void Scene<Float, Spectrum>::accel_parameters_changed_gpu() {
 
                 void* d_temp_buffer
                     = jit_malloc(AllocType::Device, buffer_sizes.tempSizeInBytes);
-                s.ias_buffer
+                s.ias_data.buffer
                     = jit_malloc(AllocType::Device, buffer_sizes.outputSizeInBytes);
 
                 scoped_optix_context guard;
@@ -427,7 +432,7 @@ MI_VARIANT void Scene<Float, Spectrum>::accel_parameters_changed_gpu() {
                     1, // num build inputs
                     (CUdeviceptr)d_temp_buffer,
                     buffer_sizes.tempSizeInBytes,
-                    (CUdeviceptr)s.ias_buffer,
+                    (CUdeviceptr)s.ias_data.buffer,
                     buffer_sizes.outputSizeInBytes,
                     &s.ias_handle,
                     0, // emitted property list
@@ -454,11 +459,13 @@ MI_VARIANT void Scene<Float, Spectrum>::accel_parameters_changed_gpu() {
             [](uint32_t /* index */, int should_free, void *payload) {
                 if (should_free) {
                     Log(Debug, "Free OptiX IAS..");
-                    jit_free(payload);
-                    // TODO should also free build_input.instanceArray.instances
+                    auto* s = (OptixSceneState *)payload;
+                    jit_free(s->ias_data.buffer);
+                    jit_free(s->ias_data.inputs);
+                    delete s;
                 }
             },
-            (void *) s.ias_buffer
+            (void *) m_accel
         );
 
         clear_shapes_dirty();
@@ -485,9 +492,6 @@ MI_VARIANT void Scene<Float, Spectrum>::accel_release_gpu() {
                no ray tracing calls are pending. */
             (void) UInt32::steal(s->sbt_jit_index);
         }
-
-        delete s;
-
         m_accel = nullptr;
     }
 }

--- a/src/render/shape.cpp
+++ b/src/render/shape.cpp
@@ -100,7 +100,7 @@ template <typename Float, typename Spectrum>
 void embree_bbox(const struct RTCBoundsFunctionArguments* args) {
     MI_IMPORT_TYPES(Shape)
     const Shape* shape = (const Shape*) args->geometryUserPtr;
-    ScalarBoundingBox3f bbox = shape->bbox();
+    ScalarBoundingBox3f bbox = shape->bbox(args->primID);
     RTCBounds* bounds_o = args->bounds_o;
     bounds_o->lower_x = (float) bbox.min.x();
     bounds_o->lower_y = (float) bbox.min.y();
@@ -115,6 +115,7 @@ void embree_intersect_scalar(int* valid,
                              void* geometryUserPtr,
                              unsigned int geomID,
                              unsigned int instID,
+                             unsigned int primID,
                              RTCRay* rtc_ray,
                              RTCHit* rtc_hit) {
     MI_IMPORT_TYPES(Shape)
@@ -139,13 +140,13 @@ void embree_intersect_scalar(int* valid,
 
     // Check whether this is a shadow ray or not
     if (rtc_hit) {
-        PreliminaryIntersection3f pi = shape->ray_intersect_preliminary(ray);
+        PreliminaryIntersection3f pi = shape->ray_intersect_preliminary(ray, true, primID);
         if (dr::all(pi.is_valid())) {
             rtc_ray->tfar      = (float) dr::slice(pi.t);
             rtc_hit->u         = (float) dr::slice(pi.prim_uv.x());
             rtc_hit->v         = (float) dr::slice(pi.prim_uv.y());
             rtc_hit->geomID    = geomID;
-            rtc_hit->primID    = 0;
+            rtc_hit->primID    = primID;
             rtc_hit->instID[0] = instID;
 #if !defined(NDEBUG)
             rtc_hit->Ng_x      = 0.f;
@@ -154,14 +155,16 @@ void embree_intersect_scalar(int* valid,
 #endif
         }
     } else {
-        if (dr::all(shape->ray_test(ray)))
+        if (dr::all(shape->ray_test(ray, true, primID)))
             rtc_ray->tfar = -dr::Infinity<float>;
     }
 }
 
 template <typename Float, typename Spectrum, size_t N, typename RTCRay_, typename RTCHit_>
 static void embree_intersect_packet(int *valid, void *geometryUserPtr,
-                                    unsigned int geomID, unsigned int instID,
+                                    unsigned int geomID, 
+                                    unsigned int instID,
+                                    unsigned int primID,
                                     RTCRay_ *rtc_ray,
                                     RTCHit_ *rtc_hit) {
     MI_IMPORT_TYPES(Shape)
@@ -197,16 +200,16 @@ static void embree_intersect_packet(int *valid, void *geometryUserPtr,
 
     // Check whether this is a shadow ray or not
     if (rtc_hit) {
-        auto [t, prim_uv, s_idx, p_idx] = shape->ray_intersect_preliminary_packet(ray, active);
+        auto [t, prim_uv, s_idx, p_idx] = shape->ray_intersect_preliminary_packet(ray, active, primID);
         active &= dr::neq(t, dr::Infinity<Float>);
         dr::store_aligned(rtc_ray->tfar,      Float32P(dr::select(active, t,           ray.maxt)));
         dr::store_aligned(rtc_hit->u,         Float32P(dr::select(active, prim_uv.x(), dr::load_aligned<Float32P>(rtc_hit->u))));
         dr::store_aligned(rtc_hit->v,         Float32P(dr::select(active, prim_uv.y(), dr::load_aligned<Float32P>(rtc_hit->v))));
         dr::store_aligned(rtc_hit->geomID,    dr::select(active, UInt32P(geomID), dr::load_aligned<UInt32P>(rtc_hit->geomID)));
-        dr::store_aligned(rtc_hit->primID,    dr::select(active, UInt32P(0),      dr::load_aligned<UInt32P>(rtc_hit->primID)));
+        dr::store_aligned(rtc_hit->primID,    dr::select(active, UInt32P(primID), dr::load_aligned<UInt32P>(rtc_hit->primID)));
         dr::store_aligned(rtc_hit->instID[0], dr::select(active, UInt32P(instID), dr::load_aligned<UInt32P>(rtc_hit->instID[0])));
     } else {
-        active &= shape->ray_test_packet(ray, active);
+        active &= shape->ray_test_packet(ray, active, primID);
         dr::store_aligned(rtc_ray->tfar, Float32P(dr::select(active, -dr::Infinity<Float>, tfar)));
     }
 }
@@ -217,7 +220,7 @@ void embree_intersect(const RTCIntersectFunctionNArguments* args) {
         case 1:
             embree_intersect_scalar<Float, Spectrum>(
                 args->valid, args->geometryUserPtr, args->geomID,
-                args->context->instID[0],
+                args->context->instID[0], args->primID,
                 &((RTCRayHit *) args->rayhit)->ray,
                 &((RTCRayHit *) args->rayhit)->hit);
             break;
@@ -225,7 +228,7 @@ void embree_intersect(const RTCIntersectFunctionNArguments* args) {
         case 4:
             embree_intersect_packet<Float, Spectrum, 4>(
                 args->valid, args->geometryUserPtr, args->geomID,
-                args->context->instID[0],
+                args->context->instID[0], args->primID,
                 &((RTCRayHit4 *) args->rayhit)->ray,
                 &((RTCRayHit4 *) args->rayhit)->hit);
             break;
@@ -233,7 +236,7 @@ void embree_intersect(const RTCIntersectFunctionNArguments* args) {
         case 8:
             embree_intersect_packet<Float, Spectrum, 8>(
                 args->valid, args->geometryUserPtr, args->geomID,
-                args->context->instID[0],
+                args->context->instID[0], args->primID,
                 &((RTCRayHit8 *) args->rayhit)->ray,
                 &((RTCRayHit8 *) args->rayhit)->hit);
             break;
@@ -241,7 +244,7 @@ void embree_intersect(const RTCIntersectFunctionNArguments* args) {
         case 16:
             embree_intersect_packet<Float, Spectrum, 16>(
                 args->valid, args->geometryUserPtr, args->geomID,
-                args->context->instID[0],
+                args->context->instID[0], args->primID,
                 &((RTCRayHit16 *) args->rayhit)->ray,
                 &((RTCRayHit16 *) args->rayhit)->hit);
             break;
@@ -257,7 +260,7 @@ void embree_occluded(const RTCOccludedFunctionNArguments* args) {
         case 1:
             embree_intersect_scalar<Float, Spectrum>(
                 args->valid, args->geometryUserPtr, args->geomID,
-                args->context->instID[0],
+                args->context->instID[0], args->primID,
                 (RTCRay *) args->ray,
                 (RTCHit *) nullptr);
             break;
@@ -265,7 +268,7 @@ void embree_occluded(const RTCOccludedFunctionNArguments* args) {
         case 4:
             embree_intersect_packet<Float, Spectrum, 4>(
                 args->valid, args->geometryUserPtr, args->geomID,
-                args->context->instID[0],
+                args->context->instID[0], args->primID,
                 (RTCRay4 *) args->ray,
                 (RTCHit4 *) nullptr);
             break;
@@ -273,7 +276,7 @@ void embree_occluded(const RTCOccludedFunctionNArguments* args) {
         case 8:
             embree_intersect_packet<Float, Spectrum, 8>(
                 args->valid, args->geometryUserPtr, args->geomID,
-                args->context->instID[0],
+                args->context->instID[0], args->primID,
                 (RTCRay8 *) args->ray,
                 (RTCHit8 *) nullptr);
             break;
@@ -281,7 +284,7 @@ void embree_occluded(const RTCOccludedFunctionNArguments* args) {
         case 16:
             embree_intersect_packet<Float, Spectrum, 16>(
                 args->valid, args->geometryUserPtr, args->geomID,
-                args->context->instID[0],
+                args->context->instID[0], args->primID,
                 (RTCRay16 *) args->ray,
                 (RTCHit16 *) nullptr);
             break;
@@ -294,7 +297,7 @@ void embree_occluded(const RTCOccludedFunctionNArguments* args) {
 MI_VARIANT RTCGeometry Shape<Float, Spectrum>::embree_geometry(RTCDevice device) {
     if constexpr (!dr::is_cuda_v<Float>) {
         RTCGeometry geom = rtcNewGeometry(device, RTC_GEOMETRY_TYPE_USER);
-        rtcSetGeometryUserPrimitiveCount(geom, 1);
+        rtcSetGeometryUserPrimitiveCount(geom, primitive_count());
         rtcSetGeometryUserData(geom, (void *) this);
         rtcSetGeometryBoundsFunction(geom, embree_bbox<Float, Spectrum>, nullptr);
         rtcSetGeometryIntersectFunction(geom, embree_intersect<Float, Spectrum>);
@@ -383,7 +386,8 @@ MI_VARIANT Float Shape<Float, Spectrum>::pdf_direction(const Interaction3f & /*i
 }
 
 MI_VARIANT typename Shape<Float, Spectrum>::PreliminaryIntersection3f
-Shape<Float, Spectrum>::ray_intersect_preliminary(const Ray3f & /*ray*/, Mask /*active*/) const {
+Shape<Float, Spectrum>::ray_intersect_preliminary(const Ray3f & /*ray*/, 
+                                                  Mask /*active*/, uint32_t /*prim_index*/) const {
     NotImplementedError("ray_intersect_preliminary");
 }
 
@@ -396,20 +400,21 @@ Shape<Float, Spectrum>::ray_intersect_preliminary_scalar(const ScalarRay3f & /*r
     NotImplementedError("ray_intersect_preliminary_scalar");
 }
 
-#define MI_DEFAULT_RAY_INTERSECT_PACKET(N)                                    \
-    MI_VARIANT std::tuple<typename Shape<Float, Spectrum>::FloatP##N,         \
-                           typename Shape<Float, Spectrum>::Point2fP##N,       \
-                           typename Shape<Float, Spectrum>::UInt32P##N,        \
-                           typename Shape<Float, Spectrum>::UInt32P##N>        \
-    Shape<Float, Spectrum>::ray_intersect_preliminary_packet(                  \
-        const Ray3fP##N & /*ray*/, MaskP##N /*active*/) const {                \
-        NotImplementedError("ray_intersect_preliminary_packet");               \
-    }                                                                          \
-    MI_VARIANT typename Shape<Float, Spectrum>::MaskP##N                      \
-    Shape<Float, Spectrum>::ray_test_packet(const Ray3fP##N &ray,              \
-                                            MaskP##N active) const {           \
-        auto res = ray_intersect_preliminary_packet(ray, active);              \
-        return dr::neq(std::get<0>(res), dr::Infinity<Float>);                 \
+#define MI_DEFAULT_RAY_INTERSECT_PACKET(N)                                                          \
+    MI_VARIANT std::tuple<typename Shape<Float, Spectrum>::FloatP##N,                               \
+                           typename Shape<Float, Spectrum>::Point2fP##N,                            \
+                           typename Shape<Float, Spectrum>::UInt32P##N,                             \
+                           typename Shape<Float, Spectrum>::UInt32P##N>                             \
+    Shape<Float, Spectrum>::ray_intersect_preliminary_packet(                                       \
+        const Ray3fP##N & /*ray*/, MaskP##N /*active*/, uint32_t /*prim_index*/) const {            \
+        NotImplementedError("ray_intersect_preliminary_packet");                                    \
+    }                                                                                               \
+    MI_VARIANT typename Shape<Float, Spectrum>::MaskP##N                                            \
+    Shape<Float, Spectrum>::ray_test_packet(const Ray3fP##N &ray,                                   \
+                                            MaskP##N active,                                        \
+                                            uint32_t prim_index) const {                            \
+        auto res = ray_intersect_preliminary_packet(ray, active, prim_index);                       \
+        return dr::neq(std::get<0>(res), dr::Infinity<Float>);                                      \
     }
 
 MI_DEFAULT_RAY_INTERSECT_PACKET(4)
@@ -417,9 +422,9 @@ MI_DEFAULT_RAY_INTERSECT_PACKET(8)
 MI_DEFAULT_RAY_INTERSECT_PACKET(16)
 
 MI_VARIANT typename Shape<Float, Spectrum>::Mask
-Shape<Float, Spectrum>::ray_test(const Ray3f &ray, Mask active) const {
+Shape<Float, Spectrum>::ray_test(const Ray3f &ray, Mask active, uint32_t prim_index) const {
     MI_MASK_ARGUMENT(active);
-    return ray_intersect_preliminary(ray, active).is_valid();
+    return ray_intersect_preliminary(ray, active, prim_index).is_valid();
 }
 
 MI_VARIANT

--- a/src/render/shapegroup.cpp
+++ b/src/render/shapegroup.cpp
@@ -90,14 +90,13 @@ MI_VARIANT void ShapeGroup<Float, Spectrum>::traverse(TraversalCallback *callbac
 }
 
 MI_VARIANT void ShapeGroup<Float, Spectrum>::parameters_changed(const std::vector<std::string> &/*keys*/) {
-    if constexpr (!dr::is_cuda_v<Float>) {
-        for (auto &s : m_shapes) {
-            if (s->dirty()) {
-                m_dirty = true;
-                break;
-            }
+    for (auto &s : m_shapes) {
+        if (s->dirty()) {
+            m_dirty = true;
+            break;
         }
     }
+
     Base::parameters_changed();
 }
 

--- a/src/shapes/cylinder.cpp
+++ b/src/shapes/cylinder.cpp
@@ -281,7 +281,7 @@ public:
 
         Ray3f ray(p + local, -local, 0, Wavelength(0));
 
-        PreliminaryIntersection3f pi = ray_intersect_preliminary(ray, active);
+        PreliminaryIntersection3f pi = ray_intersect_preliminary(ray, 0, active);
         active &= pi.is_valid();
 
         if (dr::none_or<false>(active))
@@ -305,8 +305,8 @@ public:
     std::tuple<FloatP, Point<FloatP, 2>, dr::uint32_array_t<FloatP>,
                dr::uint32_array_t<FloatP>>
     ray_intersect_preliminary_impl(const Ray3fP &ray_,
-                                   dr::mask_t<FloatP> active,
-                                   ScalarIndex /*prim_index*/) const {
+                                   ScalarIndex /*prim_index*/,
+                                   dr::mask_t<FloatP> active) const {
         MI_MASK_ARGUMENT(active);
 
         using Value = std::conditional_t<dr::is_cuda_v<FloatP> || dr::is_diff_v<Float>,
@@ -363,8 +363,8 @@ public:
 
     template <typename FloatP, typename Ray3fP>
     dr::mask_t<FloatP> ray_test_impl(const Ray3fP &ray_,
-                                     dr::mask_t<FloatP> active,
-                                     ScalarIndex /*prim_index*/) const {
+                                     ScalarIndex /*prim_index*/,
+                                     dr::mask_t<FloatP> active) const {
         MI_MASK_ARGUMENT(active);
 
         using Value = std::conditional_t<dr::is_cuda_v<FloatP> || dr::is_diff_v<Float>,
@@ -466,7 +466,7 @@ public:
                    the traced ray, we first recompute the intersection distance
                    in a differentiable way (w.r.t. to the cylindrical parameters) and
                    then compute the corresponding point along the ray. */
-                si.t = dr::replace_grad(si.t, ray_intersect_preliminary(ray, active).t);
+                si.t = dr::replace_grad(si.t, ray_intersect_preliminary(ray, 0, active).t);
                 si.p = ray(si.t);
                 local = to_object.transform_affine(si.p);
             }

--- a/src/shapes/cylinder.cpp
+++ b/src/shapes/cylinder.cpp
@@ -305,7 +305,8 @@ public:
     std::tuple<FloatP, Point<FloatP, 2>, dr::uint32_array_t<FloatP>,
                dr::uint32_array_t<FloatP>>
     ray_intersect_preliminary_impl(const Ray3fP &ray_,
-                                   dr::mask_t<FloatP> active) const {
+                                   dr::mask_t<FloatP> active,
+                                   ScalarIndex /*prim_index*/) const {
         MI_MASK_ARGUMENT(active);
 
         using Value = std::conditional_t<dr::is_cuda_v<FloatP> || dr::is_diff_v<Float>,
@@ -362,7 +363,8 @@ public:
 
     template <typename FloatP, typename Ray3fP>
     dr::mask_t<FloatP> ray_test_impl(const Ray3fP &ray_,
-                                     dr::mask_t<FloatP> active) const {
+                                     dr::mask_t<FloatP> active,
+                                     ScalarIndex /*prim_index*/) const {
         MI_MASK_ARGUMENT(active);
 
         using Value = std::conditional_t<dr::is_cuda_v<FloatP> || dr::is_diff_v<Float>,

--- a/src/shapes/disk.cpp
+++ b/src/shapes/disk.cpp
@@ -193,7 +193,7 @@ public:
 
         Ray3f ray(p + m_frame.n, -m_frame.n, 0, Wavelength(0));
 
-        PreliminaryIntersection3f pi = ray_intersect_preliminary(ray, active);
+        PreliminaryIntersection3f pi = ray_intersect_preliminary(ray, 0, active);
         active &= pi.is_valid();
 
         if (dr::none_or<false>(active))
@@ -217,8 +217,8 @@ public:
     std::tuple<FloatP, Point<FloatP, 2>, dr::uint32_array_t<FloatP>,
                dr::uint32_array_t<FloatP>>
     ray_intersect_preliminary_impl(const Ray3fP &ray_,
-                                   dr::mask_t<FloatP> active,
-                                   ScalarIndex /*prim_index*/) const {
+                                   ScalarIndex /*prim_index*/,
+                                   dr::mask_t<FloatP> active) const {
         Transform<Point<FloatP, 4>> to_object;
         if constexpr (!dr::is_jit_v<FloatP>)
             to_object = m_to_object.scalar();
@@ -239,8 +239,8 @@ public:
 
     template <typename FloatP, typename Ray3fP>
     dr::mask_t<FloatP> ray_test_impl(const Ray3fP &ray_,
-                                     dr::mask_t<FloatP> active,
-                                     ScalarIndex /*prim_index*/) const {
+                                     ScalarIndex /*prim_index*/,
+                                     dr::mask_t<FloatP> active) const {
         MI_MASK_ARGUMENT(active);
 
         Transform<Point<FloatP, 4>> to_object;
@@ -303,7 +303,7 @@ public:
                    the traced ray, we first recompute the intersection distance
                    in a differentiable way (w.r.t. to the disk parameters) and
                    then compute the corresponding point along the ray. */
-                PreliminaryIntersection3f pi_d = ray_intersect_preliminary(ray, active);
+                PreliminaryIntersection3f pi_d = ray_intersect_preliminary(ray, 0, active);
                 si.t = dr::replace_grad(pi.t, pi_d.t);
                 si.p = ray(si.t);
                 prim_uv = dr::replace_grad(pi.prim_uv, pi_d.prim_uv);

--- a/src/shapes/disk.cpp
+++ b/src/shapes/disk.cpp
@@ -85,6 +85,7 @@ public:
                    mark_dirty, get_children_string, parameters_grad_enabled)
     MI_IMPORT_TYPES()
 
+    using typename Base::ScalarIndex;
     using typename Base::ScalarSize;
 
     Disk(const Properties &props) : Base(props) {
@@ -216,7 +217,8 @@ public:
     std::tuple<FloatP, Point<FloatP, 2>, dr::uint32_array_t<FloatP>,
                dr::uint32_array_t<FloatP>>
     ray_intersect_preliminary_impl(const Ray3fP &ray_,
-                                   dr::mask_t<FloatP> active) const {
+                                   dr::mask_t<FloatP> active,
+                                   ScalarIndex /*prim_index*/) const {
         Transform<Point<FloatP, 4>> to_object;
         if constexpr (!dr::is_jit_v<FloatP>)
             to_object = m_to_object.scalar();
@@ -237,7 +239,8 @@ public:
 
     template <typename FloatP, typename Ray3fP>
     dr::mask_t<FloatP> ray_test_impl(const Ray3fP &ray_,
-                                     dr::mask_t<FloatP> active) const {
+                                     dr::mask_t<FloatP> active,
+                                     ScalarIndex /*prim_index*/) const {
         MI_MASK_ARGUMENT(active);
 
         Transform<Point<FloatP, 4>> to_object;

--- a/src/shapes/instance.cpp
+++ b/src/shapes/instance.cpp
@@ -122,8 +122,8 @@ public:
     std::tuple<FloatP, Point<FloatP, 2>, dr::uint32_array_t<FloatP>,
                dr::uint32_array_t<FloatP>>
     ray_intersect_preliminary_impl(const Ray3fP &ray,
-                                   dr::mask_t<FloatP> active,
-                                   ScalarIndex /*prim_index*/) const {
+                                   ScalarIndex /*prim_index*/,
+                                   dr::mask_t<FloatP> active) const {
         MI_MASK_ARGUMENT(active);
         if constexpr (!dr::is_array_v<FloatP>) {
             return m_shapegroup->ray_intersect_preliminary_scalar(m_to_object.scalar().transform_affine(ray));
@@ -134,8 +134,8 @@ public:
 
     template <typename FloatP, typename Ray3fP>
     dr::mask_t<FloatP> ray_test_impl(const Ray3fP &ray, 
-                                     dr::mask_t<FloatP> active,
-                                     ScalarIndex /*prim_index*/) const {
+                                     ScalarIndex /*prim_index*/,
+                                     dr::mask_t<FloatP> active) const {
         MI_MASK_ARGUMENT(active);
 
         if constexpr (!dr::is_array_v<FloatP>) {

--- a/src/shapes/instance.cpp
+++ b/src/shapes/instance.cpp
@@ -57,6 +57,7 @@ public:
     MI_IMPORT_TYPES(BSDF)
 
     using typename Base::ScalarSize;
+    using typename Base::ScalarIndex;
     using ShapeGroup_ = ShapeGroup<Float, Spectrum>;
 
     Instance(const Properties &props) : Base(props) {
@@ -121,7 +122,8 @@ public:
     std::tuple<FloatP, Point<FloatP, 2>, dr::uint32_array_t<FloatP>,
                dr::uint32_array_t<FloatP>>
     ray_intersect_preliminary_impl(const Ray3fP &ray,
-                                   dr::mask_t<FloatP> active) const {
+                                   dr::mask_t<FloatP> active,
+                                   ScalarIndex /*prim_index*/) const {
         MI_MASK_ARGUMENT(active);
         if constexpr (!dr::is_array_v<FloatP>) {
             return m_shapegroup->ray_intersect_preliminary_scalar(m_to_object.scalar().transform_affine(ray));
@@ -131,7 +133,9 @@ public:
     }
 
     template <typename FloatP, typename Ray3fP>
-    dr::mask_t<FloatP> ray_test_impl(const Ray3fP &ray, dr::mask_t<FloatP> active) const {
+    dr::mask_t<FloatP> ray_test_impl(const Ray3fP &ray, 
+                                     dr::mask_t<FloatP> active,
+                                     ScalarIndex /*prim_index*/) const {
         MI_MASK_ARGUMENT(active);
 
         if constexpr (!dr::is_array_v<FloatP>) {

--- a/src/shapes/rectangle.cpp
+++ b/src/shapes/rectangle.cpp
@@ -179,7 +179,7 @@ public:
 
         Ray3f ray(p + m_frame.n, -m_frame.n, 0, Wavelength(0));
 
-        PreliminaryIntersection3f pi = ray_intersect_preliminary(ray, active);
+        PreliminaryIntersection3f pi = ray_intersect_preliminary(ray, 0, active);
         active &= pi.is_valid();
 
         if (dr::none_or<false>(active))
@@ -203,8 +203,8 @@ public:
     std::tuple<FloatP, Point<FloatP, 2>, dr::uint32_array_t<FloatP>,
                dr::uint32_array_t<FloatP>>
     ray_intersect_preliminary_impl(const Ray3fP &ray_,
-                                   dr::mask_t<FloatP> active,
-                                   ScalarIndex /*prim_index*/) const {
+                                   ScalarIndex /*prim_index*/,
+                                   dr::mask_t<FloatP> active) const {
         Transform<Point<FloatP, 4>> to_object;
         if constexpr (!dr::is_jit_v<FloatP>)
             to_object = m_to_object.scalar();
@@ -227,8 +227,8 @@ public:
 
     template <typename FloatP, typename Ray3fP>
     dr::mask_t<FloatP> ray_test_impl(const Ray3fP &ray_,
-                                     dr::mask_t<FloatP> active,
-                                     ScalarIndex /*prim_index*/) const {
+                                     ScalarIndex /*prim_index*/,
+                                     dr::mask_t<FloatP> active) const {
         MI_MASK_ARGUMENT(active);
 
         Transform<Point<FloatP, 4>> to_object;
@@ -293,7 +293,7 @@ public:
                    the traced ray, we first recompute the intersection distance
                    in a differentiable way (w.r.t. to the rectangle parameters)
                    and then compute the corresponding point along the ray. */
-                PreliminaryIntersection3f pi_d = ray_intersect_preliminary(ray, active);
+                PreliminaryIntersection3f pi_d = ray_intersect_preliminary(ray, 0, active);
                 si.t = dr::replace_grad(pi.t, pi_d.t);
                 si.p = ray(si.t);
                 prim_uv = dr::replace_grad(pi.prim_uv, pi_d.prim_uv);

--- a/src/shapes/rectangle.cpp
+++ b/src/shapes/rectangle.cpp
@@ -87,6 +87,7 @@ public:
     MI_IMPORT_TYPES()
 
     using typename Base::ScalarSize;
+    using typename Base::ScalarIndex;
 
     Rectangle(const Properties &props) : Base(props) {
         if (props.get<bool>("flip_normals", false))
@@ -202,7 +203,8 @@ public:
     std::tuple<FloatP, Point<FloatP, 2>, dr::uint32_array_t<FloatP>,
                dr::uint32_array_t<FloatP>>
     ray_intersect_preliminary_impl(const Ray3fP &ray_,
-                                   dr::mask_t<FloatP> active) const {
+                                   dr::mask_t<FloatP> active,
+                                   ScalarIndex /*prim_index*/) const {
         Transform<Point<FloatP, 4>> to_object;
         if constexpr (!dr::is_jit_v<FloatP>)
             to_object = m_to_object.scalar();
@@ -225,7 +227,8 @@ public:
 
     template <typename FloatP, typename Ray3fP>
     dr::mask_t<FloatP> ray_test_impl(const Ray3fP &ray_,
-                                     dr::mask_t<FloatP> active) const {
+                                     dr::mask_t<FloatP> active,
+                                     ScalarIndex /*prim_index*/) const {
         MI_MASK_ARGUMENT(active);
 
         Transform<Point<FloatP, 4>> to_object;

--- a/src/shapes/sdfgrid.cpp
+++ b/src/shapes/sdfgrid.cpp
@@ -109,7 +109,6 @@ public:
     using InputTexture3f = dr::Texture<InputFloat, 3>;
     using InputPoint3f   = Point<InputFloat, 3>;
     using InputTensorXf  = dr::Tensor<DynamicBuffer<InputFloat>>;
-    using InputSpectrum  = dr::replace_scalar_t<Spectrum, float>;
 
     using typename Base::ScalarIndex;
     using typename Base::ScalarSize;
@@ -132,7 +131,7 @@ public:
             fs::path file_path = fs->resolve(props.string("filename"));
             if (!fs::exists(file_path))
                 Log(Error, "\"%s\": file does not exist!", file_path);
-            VolumeGrid<InputFloat, InputSpectrum> vol_grid(file_path);
+            VolumeGrid<float, Color<float, 3>> vol_grid(file_path);
             ScalarVector3i res = vol_grid.size();
             size_t shape[4]    = { (size_t) res.z(), (size_t) res.y(),
                                    (size_t) res.x(), 1 };

--- a/src/shapes/sdfgrid.cpp
+++ b/src/shapes/sdfgrid.cpp
@@ -1,3 +1,5 @@
+#include <drjit/tensor.h>
+#include <drjit/texture.h>
 #include <mitsuba/core/fwd.h>
 #include <mitsuba/core/math.h>
 #include <mitsuba/core/properties.h>
@@ -8,11 +10,13 @@
 #include <mitsuba/render/fwd.h>
 #include <mitsuba/render/interaction.h>
 #include <mitsuba/render/sdf.h>
-#include <drjit/tensor.h>
-#include <drjit/texture.h>
+
+#if defined(MI_ENABLE_EMBREE)
+#include <embree3/rtcore.h>
+#endif
 
 #if defined(MI_ENABLE_CUDA)
-    #include "optix/sdfgrid.cuh"
+#include "optix/sdfgrid.cuh"
 #endif
 
 NAMESPACE_BEGIN(mitsuba)
@@ -49,6 +53,7 @@ public:
                    mark_dirty, get_children_string, parameters_grad_enabled)
     MI_IMPORT_TYPES()
 
+    using typename Base::ScalarIndex;
     using typename Base::ScalarSize;
 
     SDFGrid(const Properties &props) : Base(props) {
@@ -61,23 +66,26 @@ public:
             m_normal_method = Falcao;
         else
             Throw("Invalid normals mode \"%s\", must be one of: \"analytic\", "
-                  "\"smooth\" or \"falcao\"!", normals_mode_str);
+                  "\"smooth\" or \"falcao\"!",
+                  normals_mode_str);
 
         m_watertight = props.get<bool>("watertight", true);
 
-        std::string interpolation_mode_str = props.string("interpolation", "linear");
+        std::string interpolation_mode_str =
+            props.string("interpolation", "linear");
         if (interpolation_mode_str == "cubic") {
             m_interpolation = Cubic;
-            NotImplementedError("Soon"); //FIXME: remove
+            NotImplementedError("Soon"); // FIXME: remove
         } else if (interpolation_mode_str == "linear")
             m_interpolation = Linear;
         else
             Throw("Invalid interpolation mode \"%s\", must be one of: "
-                  "\"linear\" or \"cubic\"!", interpolation_mode_str);
+                  "\"linear\" or \"cubic\"!",
+                  interpolation_mode_str);
 
         float grid_data[8] = { -1.f, -1.f, -1.f, -1.f, -1.f, -1.f, -1.f, -1.f };
-        size_t shape[4] = {2, 2, 2, 1};
-        TensorXf grid = TensorXf(grid_data, 4, shape);
+        size_t shape[4]    = { 2, 2, 2, 1 };
+        TensorXf grid      = TensorXf(grid_data, 4, shape);
         m_grid_texture = Texture3f(grid, true, false, dr::FilterMode::Linear,
                                    dr::WrapMode::Clamp);
 
@@ -86,14 +94,13 @@ public:
     }
 
     ~SDFGrid() {
-#if defined(MI_ENABLE_CUDA)
-        jit_free(m_optix_bboxes);
-        jit_free(m_optix_voxel_indices);
-#endif
+        jit_free(m_bboxes);
+        jit_free(m_voxel_indices);
     }
 
     void update() {
-        auto [S, Q, T] = dr::transform_decompose(m_to_world.scalar().matrix, 25);
+        auto [S, Q, T] =
+            dr::transform_decompose(m_to_world.scalar().matrix, 25);
         if (dr::abs(Q[0]) > 1e-6f || dr::abs(Q[1]) > 1e-6f ||
             dr::abs(Q[2]) > 1e-6f || dr::abs(Q[3] - 1) > 1e-6f)
             Log(Warn, "'to_world' transform shouldn't perform any rotations, "
@@ -101,18 +108,37 @@ public:
                       "instead!");
 
         m_to_object = m_to_world.value().inverse();
+
+        if constexpr (!dr::is_cuda_v<Float>) {
+            m_host_grid_data = m_grid_texture.tensor().data();
+        }
+
+        jit_free(m_bboxes);
+        jit_free(m_voxel_indices);
+        std::tie(m_bboxes, m_voxel_indices, m_filled_voxel_count) =
+            build_bboxes();
+        if (m_filled_voxel_count == 0) {
+            Throw("SDFGrid should at least have one non-empty voxel!");
+        }
+
         mark_dirty();
-   }
+    }
 
     void traverse(TraversalCallback *callback) override {
         Base::traverse(callback);
-        callback->put_parameter("to_world", *m_to_world.ptr(), ParamFlags::Differentiable | ParamFlags::Discontinuous);
-        callback->put_parameter("grid", m_grid_texture.tensor(), ParamFlags::Differentiable | ParamFlags::Discontinuous);
-        callback->put_parameter("watertight", m_watertight, +ParamFlags::NonDifferentiable);
+        callback->put_parameter("to_world", *m_to_world.ptr(),
+                                ParamFlags::Differentiable |
+                                    ParamFlags::Discontinuous);
+        callback->put_parameter("grid", m_grid_texture.tensor(),
+                                ParamFlags::Differentiable |
+                                    ParamFlags::Discontinuous);
+        callback->put_parameter("watertight", m_watertight,
+                                +ParamFlags::NonDifferentiable);
     }
 
     void parameters_changed(const std::vector<std::string> &keys) override {
-        if (keys.empty() || string::contains(keys, "to_world")  || string::contains(keys, "grid")) {
+        if (keys.empty() || string::contains(keys, "to_world") ||
+            string::contains(keys, "grid")) {
             // Ensure previous ray-tracing operation are fully evaluated before
             // modifying the scalar values of the fields in this class
             if constexpr (dr::is_jit_v<Float>)
@@ -122,15 +148,14 @@ public:
             m_to_world = m_to_world.value();
 
             m_grid_texture.set_tensor(m_grid_texture.tensor());
+
             update();
         }
 
         Base::parameters_changed();
     }
 
-    ScalarSize primitive_count() const override {
-        return m_filled_voxel_count;
-    }
+    ScalarSize primitive_count() const override { return m_filled_voxel_count; }
 
     ScalarBoundingBox3f bbox() const override {
         ScalarBoundingBox3f bbox;
@@ -146,6 +171,14 @@ public:
         bbox.expand(to_world.transform_affine(ScalarPoint3f(1.f, 1.f, 1.f)));
 
         return bbox;
+    }
+
+    ScalarBoundingBox3f bbox(ScalarIndex index) const override {
+        if (jit_malloc_type(m_bboxes) != AllocType::Host)
+            NotImplementedError("bbox(ScalarIndex index)");
+
+        ScalarBoundingBox3f *bboxes = (ScalarBoundingBox3f *) m_bboxes;
+        return bboxes[index];
     }
 
     Float surface_area() const override {
@@ -167,12 +200,12 @@ public:
         return ps;
     }
 
-    Float pdf_position(const PositionSample3f & /*ps*/, Mask active) const override {
+    Float pdf_position(const PositionSample3f & /*ps*/,
+                       Mask active) const override {
         // TODO: area emitter
         MI_MASK_ARGUMENT(active);
         return 0;
     }
-
 
     SurfaceInteraction3f eval_parameterization(const Point2f &uv,
                                                uint32_t ray_flags,
@@ -197,30 +230,33 @@ public:
     std::tuple<FloatP, Point<FloatP, 2>, dr::uint32_array_t<FloatP>,
                dr::uint32_array_t<FloatP>>
     ray_intersect_preliminary_impl(const Ray3fP &ray_,
-                                   dr::mask_t<FloatP> active) const {
-        MI_MASK_ARGUMENT(active);
-        (void) ray_;
-        // TODO: embree || differentiable
-        return { dr::select(active, 0, dr::Infinity<FloatP>),
-                 Point<FloatP, 2>(0, 0), ((uint32_t) -1), 0 };
+                                   dr::mask_t<FloatP> active,
+                                   ScalarIndex prim_index) const {
+
+        auto [hit, t, uv, shape_index, p] =
+            ray_intersect_preliminary_common_impl<FloatP>(ray_, active,
+                                                          prim_index);
+        return { t, uv, shape_index, p };
     }
 
     template <typename FloatP, typename Ray3fP>
     dr::mask_t<FloatP> ray_test_impl(const Ray3fP &ray_,
-                                     dr::mask_t<FloatP> active) const {
-        MI_MASK_ARGUMENT(active);
-        (void) ray_;
-        // TODO: embree || differentiable
-        return active;
+                                     dr::mask_t<FloatP> active,
+                                     ScalarIndex prim_index) const {
+
+        auto [hit, t, uv, shape_index, p] =
+            ray_intersect_preliminary_common_impl<FloatP>(ray_, active,
+                                                          prim_index);
+        return hit;
     }
 
     MI_SHAPE_DEFINE_RAY_INTERSECT_METHODS()
 
-    SurfaceInteraction3f compute_surface_interaction(const Ray3f &ray,
-                                                     const PreliminaryIntersection3f &pi,
-                                                     uint32_t ray_flags,
-                                                     uint32_t recursion_depth,
-                                                     Mask active) const override {
+    SurfaceInteraction3f
+    compute_surface_interaction(const Ray3f &ray,
+                                const PreliminaryIntersection3f &pi,
+                                uint32_t ray_flags, uint32_t recursion_depth,
+                                Mask active) const override {
         MI_MASK_ARGUMENT(active);
         constexpr bool IsDiff = dr::is_diff_v<Float>;
 
@@ -233,11 +269,12 @@ public:
         bool detach_shape = has_flag(ray_flags, RayFlags::DetachShape);
         bool follow_shape = has_flag(ray_flags, RayFlags::FollowShape);
 
-        Transform4f to_world = m_to_world.value();
+        Transform4f to_world  = m_to_world.value();
         Transform4f to_object = m_to_object.value();
 
         // TODO: Make sure this is the proper way to detach dr::Texture objects
-        dr::suspend_grad<Float> scope(detach_shape, to_world, to_object, m_grid_texture.tensor().array());
+        dr::suspend_grad<Float> scope(detach_shape, to_world, to_object,
+                                      m_grid_texture.tensor().array());
 
         if constexpr (IsDiff) {
             if (follow_shape) {
@@ -247,9 +284,10 @@ public:
                    in local space and transform it back in world space to get a
                    point rigidly attached to the shape's motion, including
                    translation, scaling and rotation. */
-                Point3f local_p = dr::detach(to_object.transform_affine(ray(pi.t)));
+                Point3f local_p =
+                    dr::detach(to_object.transform_affine(ray(pi.t)));
                 Vector3f local_grad = dr::detach(sdf_grad(local_p));
-                Normal3f local_n = dr::normalize(local_grad);
+                Normal3f local_n    = dr::normalize(local_grad);
                 Ray3f local_ray = dr::detach(to_object.transform_affine(ray));
 
                 /* Note: Only when applying a motion to the entire shape is the
@@ -260,12 +298,14 @@ public:
                 // Capture gradients of `m_grid_texture`
                 Float sdf_value;
                 m_grid_texture.eval(rescale_point(local_p), &sdf_value);
-                Point3f local_motion = sdf_value * (-local_n) / dr::dot(local_n, local_grad);
+                Point3f local_motion =
+                    sdf_value * (-local_n) / dr::dot(local_n, local_grad);
                 local_p = dr::replace_grad(local_p, local_motion);
 
                 // Capture gradients of `m_to_world`
                 si.p = to_world.transform_affine(local_p);
-                si.t = dr::sqrt(dr::squared_norm(si.p - ray.o) / dr::squared_norm(ray.d));
+                si.t = dr::sqrt(dr::squared_norm(si.p - ray.o) /
+                                dr::squared_norm(ray.d));
             } else {
                 /* To ensure that the differential interaction point stays along
                    the traced ray, we first recompute the intersection distance
@@ -273,7 +313,8 @@ public:
                    then compute the corresponding point along the ray. (Instead
                    of computing an intersection with the SDF, we compute an
                    intersection with the tangent plane.) */
-                Point3f local_p = dr::detach(to_object.transform_affine(ray(pi.t)));
+                Point3f local_p =
+                    dr::detach(to_object.transform_affine(ray(pi.t)));
                 Ray3f local_ray = dr::detach(to_object.transform_affine(ray));
 
                 /// Differntiable tangent plane normal
@@ -286,7 +327,8 @@ public:
                 // Capture gradients of `m_grid_texture`
                 Float sdf_value;
                 m_grid_texture.eval(rescale_point(local_p), &sdf_value);
-                Float t_diff = sdf_value / dr::dot(dr::detach(local_n), -local_ray.d);
+                Float t_diff =
+                    sdf_value / dr::dot(dr::detach(local_n), -local_ray.d);
                 t_diff = dr::replace_grad(pi.t, t_diff);
                 // Capture gradients of `m_to_world`
                 Point3f p = to_world.transform_affine(local_ray(t_diff));
@@ -302,7 +344,9 @@ public:
         si.t = dr::select(active, si.t, dr::Infinity<Float>);
 
         Vector3f grad = sdf_grad(m_to_object.value().transform_affine(si.p));
-        si.n = dr::normalize(m_to_world.value().transform_affine(Normal3f(grad)));
+
+        si.n =
+            dr::normalize(m_to_world.value().transform_affine(Normal3f(grad)));
 
         if (likely(has_flag(ray_flags, RayFlags::ShadingFrame))) {
             switch (m_normal_method) {
@@ -310,17 +354,19 @@ public:
                     si.sh_frame.n = si.n;
                     break;
                 case Smooth:
-                    si.sh_frame.n = smooth(m_to_object.value().transform_affine(si.p));
+                    si.sh_frame.n =
+                        smooth(m_to_object.value().transform_affine(si.p));
                     break;
                 case Falcao:
-                    si.sh_frame.n = falcao(m_to_object.value().transform_affine(si.p));
+                    si.sh_frame.n =
+                        falcao(m_to_object.value().transform_affine(si.p));
                     break;
                 default:
                     Throw("Unknown normal computation.");
             }
         }
 
-        si.uv = Point2f(0.f, 0.f);
+        si.uv    = Point2f(0.f, 0.f);
         si.dp_du = Vector3f(0.f);
         si.dp_dv = Vector3f(0.f);
         si.dn_du = si.dn_dv = dr::zeros<Vector3f>();
@@ -345,7 +391,8 @@ public:
            Graphics Techniques (JCGT), vol. 11, no. 3, 94-113, 2022
         */
         auto shape = m_grid_texture.tensor().shape();
-        Vector3f resolution = Vector3f(shape[2] - 1, shape[1] - 1, shape[0] - 1);
+        Vector3f resolution =
+            Vector3f(shape[2] - 1, shape[1] - 1, shape[0] - 1);
         Point3f scaled_p = p * resolution;
 
         Point3i v000 = Point3i(round(scaled_p)) + Vector3i(-1, -1, -1);
@@ -368,19 +415,27 @@ public:
         Bool s011 = !dr::any(v011 < 0);
         Bool s111 = !dr::any(v111 < 0);
 
-        Vector3f n000 = dr::select(s000, dr::normalize(voxel_grad(p, v000)), Vector3f(0.f));
-        Vector3f n100 = dr::select(s100, dr::normalize(voxel_grad(p, v100)), Vector3f(0.f));
-        Vector3f n010 = dr::select(s010, dr::normalize(voxel_grad(p, v010)), Vector3f(0.f));
-        Vector3f n110 = dr::select(s110, dr::normalize(voxel_grad(p, v110)), Vector3f(0.f));
-        Vector3f n001 = dr::select(s001, dr::normalize(voxel_grad(p, v001)), Vector3f(0.f));
-        Vector3f n101 = dr::select(s101, dr::normalize(voxel_grad(p, v101)), Vector3f(0.f));
-        Vector3f n011 = dr::select(s011, dr::normalize(voxel_grad(p, v011)), Vector3f(0.f));
-        Vector3f n111 = dr::select(s111, dr::normalize(voxel_grad(p, v111)), Vector3f(0.f));
+        Vector3f n000 =
+            dr::select(s000, dr::normalize(voxel_grad(p, v000)), Vector3f(0.f));
+        Vector3f n100 =
+            dr::select(s100, dr::normalize(voxel_grad(p, v100)), Vector3f(0.f));
+        Vector3f n010 =
+            dr::select(s010, dr::normalize(voxel_grad(p, v010)), Vector3f(0.f));
+        Vector3f n110 =
+            dr::select(s110, dr::normalize(voxel_grad(p, v110)), Vector3f(0.f));
+        Vector3f n001 =
+            dr::select(s001, dr::normalize(voxel_grad(p, v001)), Vector3f(0.f));
+        Vector3f n101 =
+            dr::select(s101, dr::normalize(voxel_grad(p, v101)), Vector3f(0.f));
+        Vector3f n011 =
+            dr::select(s011, dr::normalize(voxel_grad(p, v011)), Vector3f(0.f));
+        Vector3f n111 =
+            dr::select(s111, dr::normalize(voxel_grad(p, v111)), Vector3f(0.f));
 
         Vector3f diff = scaled_p - Vector3f(v111) + Vector3f(0.5);
-        Float& u = diff[0];
-        Float& v = diff[1];
-        Float& w = diff[2];
+        Float &u      = diff[0];
+        Float &v      = diff[1];
+        Float &w      = diff[2];
         if (u_ptr)
             u = *u_ptr;
         if (v_ptr)
@@ -403,9 +458,10 @@ public:
         w = dr::select(invalid_z_0, 1, w);
         w = dr::select(invalid_z_1, 0, w);
 
-        Normal3f n =
-            (1 - w) * ((1 - v) * ((1 - u) * n000 + u * n100) + v * ((1 - u) * n010 + u * n110)) +
-                  w * ((1 - v) * ((1 - u) * n001 + u * n101) + v * ((1 - u) * n011 + u * n111));
+        Normal3f n = (1 - w) * ((1 - v) * ((1 - u) * n000 + u * n100) +
+                                v * ((1 - u) * n010 + u * n110)) +
+                     w * ((1 - v) * ((1 - u) * n001 + u * n101) +
+                          v * ((1 - u) * n011 + u * n111));
 
         return n;
     };
@@ -415,14 +471,14 @@ public:
         return dr::normalize(m_to_world.value().transform_affine(Normal3f(n)));
     }
 
-    Matrix3f smooth_hessian(const Point3f& p) const override {
-        Float one = 1;
+    Matrix3f smooth_hessian(const Point3f &p) const override {
+        Float one  = 1;
         Float zero = 0;
 
-        Normal3f n1vw = smooth_sh(p, &one,    nullptr, nullptr);
-        Normal3f n0vw = smooth_sh(p, &zero,   nullptr, nullptr);
-        Normal3f nu1w = smooth_sh(p, nullptr, &one,    nullptr);
-        Normal3f nu0w = smooth_sh(p, nullptr, &zero,   nullptr);
+        Normal3f n1vw = smooth_sh(p, &one, nullptr, nullptr);
+        Normal3f n0vw = smooth_sh(p, &zero, nullptr, nullptr);
+        Normal3f nu1w = smooth_sh(p, nullptr, &one, nullptr);
+        Normal3f nu0w = smooth_sh(p, nullptr, &zero, nullptr);
         Normal3f nuv1 = smooth_sh(p, nullptr, nullptr, &one);
         Normal3f nuv0 = smooth_sh(p, nullptr, nullptr, &zero);
 
@@ -455,35 +511,28 @@ public:
         if constexpr (dr::is_cuda_v<Float>) {
             // TODO: more efficient memory allocations
             if (!m_optix_data_ptr)
-                m_optix_data_ptr = jit_malloc(AllocType::Device, sizeof(OptixSDFGridData));
-            if (m_optix_bboxes)
-                jit_free(m_optix_bboxes);
-            if (m_optix_voxel_indices)
-                jit_free(m_optix_voxel_indices);
-
-            std::tie(m_optix_bboxes, m_optix_voxel_indices, m_filled_voxel_count) = build_bboxes();
-            if (m_filled_voxel_count == 0)
-                Throw("SDFGrid should at least have one non-empty voxel!");
+                m_optix_data_ptr =
+                    jit_malloc(AllocType::Device, sizeof(OptixSDFGridData));
 
             size_t resolution[3] = { m_grid_texture.tensor().shape()[2],
                                      m_grid_texture.tensor().shape()[1],
                                      m_grid_texture.tensor().shape()[0] };
 
-            OptixSDFGridData data = { (size_t*) m_optix_voxel_indices,
+            OptixSDFGridData data = { (size_t *) m_voxel_indices,
                                       resolution[0],
                                       resolution[1],
                                       resolution[2],
                                       m_grid_texture.tensor().array().data(),
                                       m_to_object.scalar(),
-                                      m_watertight
-            };
-            jit_memcpy(JitBackend::CUDA, m_optix_data_ptr, &data, sizeof(OptixSDFGridData));
+                                      m_watertight };
+            jit_memcpy(JitBackend::CUDA, m_optix_data_ptr, &data,
+                       sizeof(OptixSDFGridData));
         }
     }
 
     void optix_build_input(OptixBuildInput &build_input) const override {
         build_input.type = OPTIX_BUILD_INPUT_TYPE_CUSTOM_PRIMITIVES;
-        build_input.customPrimitiveArray.aabbBuffers   = &m_optix_bboxes;
+        build_input.customPrimitiveArray.aabbBuffers   = &m_bboxes;
         build_input.customPrimitiveArray.numPrimitives = m_filled_voxel_count;
         build_input.customPrimitiveArray.strideInBytes = 6 * sizeof(float);
         build_input.customPrimitiveArray.flags         = optix_geometry_flags;
@@ -494,7 +543,8 @@ public:
     std::string to_string() const override {
         std::ostringstream oss;
         oss << "SDFgrid[" << std::endl
-            << "  to_world = " << string::indent(m_to_world, 13) << "," << std::endl
+            << "  to_world = " << string::indent(m_to_world, 13) << ","
+            << std::endl
             << "  " << string::indent(get_children_string()) << std::endl
             << "]";
         return oss.str();
@@ -502,13 +552,272 @@ public:
 
     MI_DECLARE_CLASS()
 private:
+    /// Shared implementation for ray_intersect_preliminary_impl and
+    /// ray_test_impl
+    template <typename FloatP, typename Ray3fP>
+    std::tuple<dr::mask_t<FloatP>, FloatP, Point<FloatP, 2>,
+               dr::uint32_array_t<FloatP>, dr::uint32_array_t<FloatP>>
+        MI_INLINE ray_intersect_preliminary_common_impl(
+            const Ray3fP &ray_, dr::mask_t<FloatP> active,
+            ScalarIndex prim_index) const {
+        MI_MASK_ARGUMENT(active);
+
+        // The current implementation doesn't support JIT types so don't try to
+        // use this in for instance compute_surface_interaction
+        if constexpr (dr::is_jit_v<FloatP>)
+            NotImplementedError("ray_intersect_preliminary_common_impl");
+
+        Transform<Point<FloatP, 4>> to_object = m_to_object.scalar();
+        Ray3fP ray = to_object.transform_affine(ray_);
+
+        auto shape = m_grid_texture.tensor().shape();
+
+        uint32_t voxel_index     = m_voxel_indices[prim_index];
+        ScalarVector3u voxel_pos = to_voxel_position(voxel_index);
+
+        // Find boxel AABB in object space
+        ScalarBoundingBox3f bbox_local;
+        {
+            ScalarPoint3f bbox_min =
+                ScalarPoint3f(voxel_pos.x(), voxel_pos.y(), voxel_pos.z());
+            ScalarPoint3f bbox_max = bbox_min + ScalarPoint3f(1.f, 1.f, 1.f);
+            ScalarPoint3f grid_resolution(1.f / (shape[2] - 1),
+                                          1.f / (shape[1] - 1),
+                                          1.f / (shape[0] - 1));
+            bbox_min *= grid_resolution;
+            bbox_max *= grid_resolution;
+            bbox_local.expand(bbox_min);
+            bbox_local.expand(bbox_max);
+        }
+
+        // To determine voxel intersection, we need both near and far AABB
+        // intersections
+        auto [bbox_hit, t_beg, t_end] = bbox_local.ray_intersect(ray);
+
+        // Convert ray to voxel-space [0, 1] x [0, 1] x [0, 1]
+        {
+            ScalarMatrix4f m{};
+            m[0][0] = (float) (shape[2] - 1);
+            m[0][1] = 0.f;
+            m[0][2] = 0.f;
+            m[0][3] = 0.f;
+
+            m[1][0] = 0.f;
+            m[1][1] = (float) (shape[1] - 1);
+            m[1][2] = 0.f;
+            m[1][3] = 0.f;
+
+            m[2][0] = 0.f;
+            m[2][1] = 0.f;
+            m[2][2] = (float) (shape[0] - 1);
+            m[2][3] = 0.f;
+
+            m[3][0] = -1.f * (float) voxel_pos.x();
+            m[3][1] = -1.f * (float) voxel_pos.y();
+            m[3][2] = -1.f * (float) voxel_pos.z();
+            m[3][3] = 1.f;
+
+            auto to_voxel = ScalarTransform4f(m);
+
+            ray = to_voxel.transform_affine(ray);
+        }
+
+        /**
+           Voxel intersection expressed as solution of cubic polynomial:
+
+           Herman Hansson-Söderlund, Alex Evans, and Tomas Akenine-Möller, Ray
+           Tracing of Signed Distance Function Grids, Journal of Computer
+           Graphics Techniques (JCGT), vol. 11, no. 3, 94-113, 2022
+        */
+        FloatP c0;
+        FloatP c1;
+        FloatP c2;
+        FloatP c3;
+        {
+            ScalarVector3u v000 = voxel_pos;
+            ScalarVector3u v100 = v000 + ScalarVector3u(1, 0, 0);
+            ScalarVector3u v010 = v000 + ScalarVector3u(0, 1, 0);
+            ScalarVector3u v110 = v000 + ScalarVector3u(1, 1, 0);
+            ScalarVector3u v001 = v000 + ScalarVector3u(0, 0, 1);
+            ScalarVector3u v101 = v000 + ScalarVector3u(1, 0, 1);
+            ScalarVector3u v011 = v000 + ScalarVector3u(0, 1, 1);
+            ScalarVector3u v111 = v000 + ScalarVector3u(1, 1, 1);
+
+            float s000 = m_host_grid_data[to_voxel_index(v000)];
+            float s100 = m_host_grid_data[to_voxel_index(v100)];
+            float s010 = m_host_grid_data[to_voxel_index(v010)];
+            float s110 = m_host_grid_data[to_voxel_index(v110)];
+            float s001 = m_host_grid_data[to_voxel_index(v001)];
+            float s101 = m_host_grid_data[to_voxel_index(v101)];
+            float s011 = m_host_grid_data[to_voxel_index(v011)];
+            float s111 = m_host_grid_data[to_voxel_index(v111)];
+
+            FloatP o_x = ray.o.x();
+            FloatP o_y = ray.o.y();
+            FloatP o_z = ray.o.z();
+            FloatP d_x = ray.d.x();
+            FloatP d_y = ray.d.y();
+            FloatP d_z = ray.d.z();
+
+            FloatP a  = s101 - s001;
+            FloatP k0 = s000;
+            FloatP k1 = s100 - s000;
+            FloatP k2 = s010 - s000;
+            FloatP k3 = s110 - s010 - k1;
+            FloatP k4 = k0 - s001;
+            FloatP k5 = k1 - a;
+            FloatP k6 = k2 - (s011 - s001);
+            FloatP k7 = k3 - (s111 - s011 - a);
+            FloatP m0 = o_x * o_y;
+            FloatP m1 = d_x * d_y;
+            FloatP m2 = dr::fmadd(o_x, d_y, o_y * d_x);
+            FloatP m3 = dr::fmadd(k5, o_z, -k1);
+            FloatP m4 = dr::fmadd(k6, o_z, -k2);
+            FloatP m5 = dr::fmadd(k7, o_z, -k3);
+
+            c0 = dr::fmadd(k4, o_z, -k0) +
+                 dr::fmadd(o_x, m3, dr::fmadd(o_y, m4, m0 * m5));
+            c1 = dr::fmadd(d_x, m3, d_y * m4) + m2 * m5 +
+                 d_z * (k4 + dr::fmadd(k5, o_x, dr::fmadd(k6, o_y, k7 * m0)));
+            c2 = dr::fmadd(
+                m1, m5,
+                d_z * (dr::fmadd(k5, d_x, dr::fmadd(k6, d_y, k7 * m2))));
+            c3 = k7 * m1 * d_z;
+        }
+
+        auto [hit, t] = sdf_solve_cubic(t_beg, t_end, c3, c2, c1, c0);
+
+        if (m_watertight) {
+            FloatP eval_sdf             = -(c3 * t_beg * t_beg * t_beg +
+                                c2 * t_beg * t_beg + c1 * t_beg + c0);
+            dr::masked(t, eval_sdf < 0) = t_beg;
+            hit                         = hit || eval_sdf < 0;
+        }
+
+        active = active && bbox_hit && hit && t >= 0.f && t <= ray.maxt;
+
+        return { active, dr::select(active, t, dr::Infinity<FloatP>),
+                 Point<FloatP, 2>(0, 0), ((uint32_t) -1), prim_index };
+    }
+
+    /* \brief Solve cubic polynomial that gives solution to voxel intersection
+     *
+     *  M ARMITT, G., K LEER , A., WALD , I., AND F RIEDRICH , H.
+     *  2004. Fast and accurate ray-voxel intersection techniques for
+     *  iso-surface ray tracing.
+     */
+    template <typename FloatP>
+    MI_INLINE std::tuple<dr::mask_t<FloatP>, FloatP>
+    sdf_solve_cubic(FloatP t_beg, FloatP t_end, FloatP c3, FloatP c2, FloatP c1,
+                    FloatP c0) const {
+
+        using MaskP = dr::mask_t<FloatP>;
+
+        auto [has_derivative_roots, root_0, root_1] =
+            math::solve_quadratic(c3 * 3, c2 * 2, c1);
+
+        auto eval_sdf_t = [&](FloatP t_) -> FloatP {
+            return -(c3 * t_ * t_ * t_ + c2 * t_ * t_ + c1 * t_ + c0);
+        };
+
+        auto numerical_solve = [&](FloatP t_near, FloatP t_far, FloatP f_near,
+                                   FloatP f_far) -> FloatP {
+            static constexpr uint32_t num_solve_max_iter = 50;
+            static constexpr float num_solve_epsilon     = 0.004f;
+
+            FloatP t   = 0;
+            FloatP f_t = 0;
+
+            uint32_t i = 0;
+            MaskP done = false;
+            while (!dr::all(done)) {
+                t   = t_near + (t_far - t_near) * (-f_near / (f_far - f_near));
+                f_t = eval_sdf_t(t);
+                FloatP condition = f_t * f_near;
+                t_far            = dr::select(condition <= 0, t, t_far);
+                f_far            = dr::select(condition <= 0, f_t, f_far);
+
+                t_near = dr::select(condition > 0, t, t_near);
+                f_near = dr::select(condition > 0, f_t, f_near);
+                done   = (dr::abs(f_t) < num_solve_epsilon) ||
+                       (num_solve_max_iter < ++i);
+            }
+
+            return t;
+        };
+
+        FloatP t_near = t_beg;
+        FloatP t_far  = t_end;
+
+        FloatP f_root_0 = eval_sdf_t(root_0);
+        FloatP f_root_1 = eval_sdf_t(root_1);
+
+        MaskP root_0_valid = t_near <= root_0 && root_0 <= t_far;
+
+        dr::masked(t_far, has_derivative_roots && root_0_valid &&
+                              eval_sdf_t(t_beg) * f_root_0 <= 0) = root_0;
+        dr::masked(t_near, has_derivative_roots && root_0_valid &&
+                               eval_sdf_t(t_beg) * f_root_0 > 0) = root_0;
+
+        MaskP root_1_valid = t_near <= root_1 && root_1 <= t_far;
+
+        dr::masked(t_far, has_derivative_roots && root_1_valid &&
+                              eval_sdf_t(t_near) * f_root_1 <= 0) = root_1;
+        dr::masked(t_near, has_derivative_roots && root_1_valid &&
+                               eval_sdf_t(t_near) * f_root_1 > 0) = root_1;
+
+        FloatP f_near = eval_sdf_t(t_near);
+        FloatP f_far  = eval_sdf_t(t_far);
+
+        MaskP active = f_near * f_far <= 0;
+
+        FloatP t =
+            dr::select(active, numerical_solve(t_near, t_far, f_near, f_far),
+                       dr::Infinity<Float>);
+
+        return { active, t };
+    }
+
+    /* \brief Given an index of the flat SDFGrid data (voxel corners), return
+     * the associated voxel position
+     */
+    MI_INLINE ScalarVector3u to_voxel_position(uint32_t index) const {
+        auto shape = m_grid_texture.tensor().shape();
+        // Data is packed [Z, Y, X, C]
+        uint32_t shape_v[3] = { (uint32_t) shape[2], (uint32_t) shape[1],
+                                (uint32_t) shape[0] };
+
+        uint32_t resolution_x = shape_v[2] - 1;
+        uint32_t resolution_y = shape_v[1] - 1;
+
+        uint32_t x = index % resolution_x;
+        uint32_t y = ((index - x) / resolution_y) % resolution_y;
+        uint32_t z =
+            (index - x - y * resolution_x) / (resolution_x * resolution_y);
+
+        return { x, y, z };
+    }
+
+    /* \brief Given a voxel position, returns the corresponding voxel index
+     * relative to the flat array of SDFGrid data. In particular, the returned
+     * index maps to the bottom-left corner of the associated voxel
+     */
+    MI_INLINE ScalarIndex to_voxel_index(const ScalarVector3u &v) const {
+        auto shape = m_grid_texture.tensor().shape();
+        // Data is packed [Z, Y, X, C]
+        uint32_t shape_v[3] = { (uint32_t) shape[2], (uint32_t) shape[1],
+                                (uint32_t) shape[0] };
+
+        return v.z() * shape_v[1] * shape_v[0] + v.y() * shape_v[0] + v.x();
+    }
+
     /* \brief Offsets and rescales an point in [0, 1] x [0, 1] x [0, 1] to
      * its corresponding point in the texture. This is usually necessary because
      * dr::Texture objects assume that the value of a pixel is positionned in
      * the middle of the pixel. For a 3D grid, this means that values are not
      * at the corners, but in the middle of the voxels.
      */
-    MI_INLINE Point3f rescale_point(const Point3f& p) const {
+    MI_INLINE Point3f rescale_point(const Point3f &p) const {
         auto shape = m_grid_texture.tensor().shape();
         // TODO: save inv_shape to memory?
         Vector3f inv_shape(1.f / shape[2], 1.f / shape[1], 1.f / shape[0]);
@@ -516,35 +825,60 @@ private:
     }
 
     /* \brief Only computes AABBs for voxel that contain a surface in it.
-     * Returns a device pointer to the array of AABBs, a device pointer to
-     * an array of voxel indices of the former AABBs and the count of voxels with
-     * surface in them.
+     * Returns a pointer to the array of AABBs, a pointer to an array of voxel
+     * indices of the former AABBs and the count of voxels with surface in them.
+     *
+     * Depending on the variant used, the pointer returned is either host or
+     * device visible
      */
-    std::tuple<void*, void*, size_t> build_bboxes() {
-        auto shape = m_grid_texture.tensor().shape();
+    std::tuple<void*, size_t*, size_t> build_bboxes() {
+        auto shape         = m_grid_texture.tensor().shape();
         size_t shape_v[3]  = { shape[2], shape[1], shape[0] };
-        float shape_rcp[3] = { 1.f / (shape[0] - 1), 1.f / (shape[1] - 1), 1.f / (shape[2] - 1) };
-        size_t max_voxel_count = (shape[0] - 1) * (shape[1] - 1) * (shape[2] - 1);
+        float shape_rcp[3] = { 1.f / (shape[0] - 1), 1.f / (shape[1] - 1),
+                               1.f / (shape[2] - 1) };
+        size_t max_voxel_count =
+            (shape[0] - 1) * (shape[1] - 1) * (shape[2] - 1);
         ScalarTransform4f to_world = m_to_world.scalar();
 
-        float *grid = (float *) jit_malloc_migrate(
-            m_grid_texture.tensor().array().data(), AllocType::Host, false);
-        jit_sync_thread();
+        float* grid = nullptr;
 
-        size_t count = 0;
-        optix::BoundingBox3f* aabbs = new optix::BoundingBox3f[max_voxel_count]();
-        size_t* voxel_indices = new size_t[max_voxel_count]();
+        if constexpr (dr::is_cuda_v<Float>) {
+            grid = (float *) jit_malloc_migrate(
+                m_grid_texture.tensor().array().data(), AllocType::Host, false);
+            jit_sync_thread();
+        } else {
+            grid = m_grid_texture.tensor().array().data();
+        }
+
+        using BoundingBoxType =
+            typename std::conditional<dr::is_cuda_v<Float>,
+                                      optix::BoundingBox3f,
+                                      ScalarBoundingBox3f>::type;
+
+        size_t count           = 0;
+        BoundingBoxType* aabbs = (BoundingBoxType *) jit_malloc(
+            AllocType::Host, sizeof(BoundingBoxType) * max_voxel_count);
+        size_t* voxel_indices = (size_t *) jit_malloc(
+            AllocType::Host, sizeof(size_t) * max_voxel_count);
         for (size_t z = 0; z < shape[0] - 1; ++z) {
-            for (size_t y = 0; y < shape[1] - 1 ; ++y) {
+            for (size_t y = 0; y < shape[1] - 1; ++y) {
                 for (size_t x = 0; x < shape[2] - 1; ++x) {
-                    size_t v000 = (x + 0) + (y + 0) * shape_v[0] + (z + 0) * shape_v[0] * shape_v[1];
-                    size_t v100 = (x + 1) + (y + 0) * shape_v[0] + (z + 0) * shape_v[0] * shape_v[1];
-                    size_t v010 = (x + 0) + (y + 1) * shape_v[0] + (z + 0) * shape_v[0] * shape_v[1];
-                    size_t v110 = (x + 1) + (y + 1) * shape_v[0] + (z + 0) * shape_v[0] * shape_v[1];
-                    size_t v001 = (x + 0) + (y + 0) * shape_v[0] + (z + 1) * shape_v[0] * shape_v[1];
-                    size_t v101 = (x + 1) + (y + 0) * shape_v[0] + (z + 1) * shape_v[0] * shape_v[1];
-                    size_t v011 = (x + 0) + (y + 1) * shape_v[0] + (z + 1) * shape_v[0] * shape_v[1];
-                    size_t v111 = (x + 1) + (y + 1) * shape_v[0] + (z + 1) * shape_v[0] * shape_v[1];
+                    size_t v000 = (x + 0) + (y + 0) * shape_v[0] +
+                                  (z + 0) * shape_v[0] * shape_v[1];
+                    size_t v100 = (x + 1) + (y + 0) * shape_v[0] +
+                                  (z + 0) * shape_v[0] * shape_v[1];
+                    size_t v010 = (x + 0) + (y + 1) * shape_v[0] +
+                                  (z + 0) * shape_v[0] * shape_v[1];
+                    size_t v110 = (x + 1) + (y + 1) * shape_v[0] +
+                                  (z + 0) * shape_v[0] * shape_v[1];
+                    size_t v001 = (x + 0) + (y + 0) * shape_v[0] +
+                                  (z + 1) * shape_v[0] * shape_v[1];
+                    size_t v101 = (x + 1) + (y + 0) * shape_v[0] +
+                                  (z + 1) * shape_v[0] * shape_v[1];
+                    size_t v011 = (x + 0) + (y + 1) * shape_v[0] +
+                                  (z + 1) * shape_v[0] * shape_v[1];
+                    size_t v111 = (x + 1) + (y + 1) * shape_v[0] +
+                                  (z + 1) * shape_v[0] * shape_v[1];
 
                     float f000 = grid[v000];
                     float f100 = grid[v100];
@@ -562,55 +896,81 @@ private:
 
                     ScalarBoundingBox3f bbox;
                     bbox.expand(to_world.transform_affine(ScalarPoint3f(
-                        (x + 0) * shape_rcp[2], (y + 0) * shape_rcp[1], (z + 0) * shape_rcp[0])));
+                        (x + 0) * shape_rcp[2], (y + 0) * shape_rcp[1],
+                        (z + 0) * shape_rcp[0])));
                     bbox.expand(to_world.transform_affine(ScalarPoint3f(
-                        (x + 1) * shape_rcp[2], (y + 0) * shape_rcp[1], (z + 0) * shape_rcp[0])));
+                        (x + 1) * shape_rcp[2], (y + 0) * shape_rcp[1],
+                        (z + 0) * shape_rcp[0])));
                     bbox.expand(to_world.transform_affine(ScalarPoint3f(
-                        (x + 0) * shape_rcp[2], (y + 1) * shape_rcp[1], (z + 0) * shape_rcp[0])));
+                        (x + 0) * shape_rcp[2], (y + 1) * shape_rcp[1],
+                        (z + 0) * shape_rcp[0])));
                     bbox.expand(to_world.transform_affine(ScalarPoint3f(
-                        (x + 1) * shape_rcp[2], (y + 1) * shape_rcp[1], (z + 0) * shape_rcp[0])));
+                        (x + 1) * shape_rcp[2], (y + 1) * shape_rcp[1],
+                        (z + 0) * shape_rcp[0])));
                     bbox.expand(to_world.transform_affine(ScalarPoint3f(
-                        (x + 1) * shape_rcp[2], (y + 0) * shape_rcp[1], (z + 1) * shape_rcp[0])));
+                        (x + 1) * shape_rcp[2], (y + 0) * shape_rcp[1],
+                        (z + 1) * shape_rcp[0])));
                     bbox.expand(to_world.transform_affine(ScalarPoint3f(
-                        (x + 1) * shape_rcp[2], (y + 0) * shape_rcp[1], (z + 1) * shape_rcp[0])));
+                        (x + 1) * shape_rcp[2], (y + 0) * shape_rcp[1],
+                        (z + 1) * shape_rcp[0])));
                     bbox.expand(to_world.transform_affine(ScalarPoint3f(
-                        (x + 0) * shape_rcp[2], (y + 1) * shape_rcp[1], (z + 1) * shape_rcp[0])));
+                        (x + 0) * shape_rcp[2], (y + 1) * shape_rcp[1],
+                        (z + 1) * shape_rcp[0])));
                     bbox.expand(to_world.transform_affine(ScalarPoint3f(
-                        (x + 1) * shape_rcp[2], (y + 1) * shape_rcp[1], (z + 1) * shape_rcp[0])));
+                        (x + 1) * shape_rcp[2], (y + 1) * shape_rcp[1],
+                        (z + 1) * shape_rcp[0])));
 
                     size_t voxel_index =
                         (x + 0) + (y + 0) * (shape_v[0] - 1) +
                         (z + 0) * (shape_v[0] - 1) * (shape_v[1] - 1);
+
                     voxel_indices[count] = voxel_index;
-                    aabbs[count] = optix::BoundingBox3f(bbox);
+                    aabbs[count]         = BoundingBoxType(bbox);
 
                     count++;
                 }
             }
         }
 
-        jit_free(grid);
+        void* aabbs_ptr           = nullptr;
+        size_t* voxel_indices_ptr = nullptr;
 
-        //TODO: async memcpy
-        void *aabbs_ptr = jit_malloc(AllocType::Device, sizeof(optix::BoundingBox3f) * count);
-        jit_memcpy(JitBackend::CUDA, aabbs_ptr, aabbs, sizeof(optix::BoundingBox3f) * count);
+        if constexpr (dr::is_cuda_v<Float>) {
+            // TODO: async memcpy
+            aabbs_ptr = jit_malloc(AllocType::Device,
+                                   sizeof(optix::BoundingBox3f) * count);
+            jit_memcpy(JitBackend::CUDA, aabbs_ptr, aabbs,
+                       sizeof(optix::BoundingBox3f) * count);
 
-        void *voxel_indices_ptr = jit_malloc(AllocType::Device, sizeof(size_t) * count);
-        jit_memcpy(JitBackend::CUDA, voxel_indices_ptr, voxel_indices, sizeof(size_t) * count);
+            voxel_indices_ptr = (size_t *) jit_malloc(AllocType::Device,
+                                                      sizeof(size_t) * count);
+            jit_memcpy(JitBackend::CUDA, voxel_indices_ptr, voxel_indices,
+                       sizeof(size_t) * count);
 
-        return {aabbs_ptr, voxel_indices_ptr, count};
+            jit_free(aabbs);
+            jit_free(voxel_indices);
+            jit_free(grid);
+
+        } else {
+            // Our initial allocations were host-visible, so just reuse these
+            aabbs_ptr         = aabbs;
+            voxel_indices_ptr = voxel_indices;
+        }
+
+        return { aabbs_ptr, voxel_indices_ptr, count };
     }
 
     /// Computes the gradient for a specific gradient
-    Vector3f voxel_grad(const Point3f& p, const Point3i& voxel_index) const {
+    Vector3f voxel_grad(const Point3f &p, const Point3i &voxel_index) const {
         auto shape = m_grid_texture.tensor().shape();
-        Vector3f resolution = Vector3f(shape[2] - 1, shape[1] - 1, shape[0] - 1);
+        Vector3f resolution =
+            Vector3f(shape[2] - 1, shape[1] - 1, shape[0] - 1);
 
         Float f[6];
         Point3f query;
 
         Point3f voxel_size = 1.f / resolution;
-        Point3f p000 = Point3f(voxel_index) * voxel_size;
+        Point3f p000       = Point3f(voxel_index) * voxel_size;
 
         query = rescale_point(Point3f(p000[0] + voxel_size[0], p[1], p[2]));
         m_grid_texture.eval(query, &f[0]);
@@ -624,7 +984,7 @@ private:
 
         query = rescale_point(Point3f(p[0], p[1], p000[2] + voxel_size[2]));
         m_grid_texture.eval(query, &f[4]);
-        query = rescale_point(Point3f(p[0], p[1], p000[2] ));
+        query = rescale_point(Point3f(p[0], p[1], p000[2]));
         m_grid_texture.eval(query, &f[5]);
 
         Float dx = f[0] - f[1]; // f(1, y, z) - f(0, y, z)
@@ -634,16 +994,17 @@ private:
         return Vector3f(dx, dy, dz);
     }
 
-    Vector3f sdf_grad(const Point3f& p) const {
+    Vector3f sdf_grad(const Point3f &p) const {
         auto shape = m_grid_texture.tensor().shape();
-        Vector3f resolution = Vector3f(shape[2] - 1, shape[1] - 1, shape[0] - 1);
+        Vector3f resolution =
+            Vector3f(shape[2] - 1, shape[1] - 1, shape[0] - 1);
         Point3i min_voxel_index(p * resolution);
 
         return voxel_grad(p, min_voxel_index);
     }
 
     /// Very efficient normals (faceted appearance)
-    Normal3f falcao(const Point3f& point) const {
+    Normal3f falcao(const Point3f &point) const {
         // FALCÃO , P., 2008. Implicit function to distance function.
         // URL: https://www.pouet.net/topic.php?which=5604&page=3#c233266.
 
@@ -654,16 +1015,20 @@ private:
         Vector3f epsilon =
             0.1f * Vector3f(1.f / shape[2], 1.f / shape[1], 1.f / shape[0]);
 
-        auto v = [&](const Point3f& p){
+        auto v = [&](const Point3f &p) {
             Float out;
             m_grid_texture.eval(rescale_point(p), &out);
             return out;
         };
 
-        Point3f p1(point.x() + epsilon.x(), point.y() - epsilon.y(), point.z() - epsilon.z());
-        Point3f p2(point.x() - epsilon.x(), point.y() - epsilon.y(), point.z() + epsilon.z());
-        Point3f p3(point.x() - epsilon.x(), point.y() + epsilon.y(), point.z() - epsilon.z());
-        Point3f p4(point.x() + epsilon.x(), point.y() + epsilon.y(), point.z() + epsilon.z());
+        Point3f p1(point.x() + epsilon.x(), point.y() - epsilon.y(),
+                   point.z() - epsilon.z());
+        Point3f p2(point.x() - epsilon.x(), point.y() - epsilon.y(),
+                   point.z() + epsilon.z());
+        Point3f p3(point.x() - epsilon.x(), point.y() + epsilon.y(),
+                   point.z() - epsilon.z());
+        Point3f p4(point.x() + epsilon.x(), point.y() + epsilon.y(),
+                   point.z() + epsilon.z());
 
         Float v1 = v(p1);
         Float v2 = v(p2);
@@ -692,12 +1057,20 @@ private:
         Cubic,
     };
 
-#if defined(MI_ENABLE_CUDA)
-    void* m_optix_bboxes = nullptr;
-    void* m_optix_voxel_indices = nullptr;
-#endif
     // TODO: Store inverse shape using `rcp`
     Texture3f m_grid_texture;
+
+    // Weak pointer to underlying grid texture data. Only used for llvm/scalar
+    // variants. We store this because during raytracing, we don't want to call
+    // Texture3f::tensor().data() which internally calls jit_var_ptr and is
+    // guarded by a global state lock
+    float* m_host_grid_data = nullptr;
+
+    // Depending on variant, host or device visible stores of non-empty voxel
+    // bboxes and correspondingand indices
+    void* m_bboxes          = nullptr;
+    size_t* m_voxel_indices = nullptr;
+
     bool m_watertight;
     size_t m_filled_voxel_count = 0;
     NormalMethod m_normal_method;

--- a/src/shapes/sdfgrid.cpp
+++ b/src/shapes/sdfgrid.cpp
@@ -59,7 +59,7 @@ SDF Grid (:monosp:`sdfgrid`)
 
 .. subfigstart::
 .. subfigure:: ../../resources/data/docs/images/render/shape_sdfgrid.jpg
-   :caption: Basic example using the default smooth method for computing normals
+   :caption: Basic example
 .. subfigure:: ../../resources/data/docs/images/render/shape_sdfgrid_analytic.jpg 
    :caption: An SDF grid using the analytic method for computing normals
 .. subfigend::
@@ -77,7 +77,7 @@ selected as the default approach to ensure continuity across grid cells.
    - An SDF grid shape does not emit UV coordinates for texturing.
 
 
-The following XML snippet showcases a simple example of a SDF Grid:
+The following XML snippet showcases a simple example of an SDF Grid:
 
 .. tabs::
     .. code-tab:: xml

--- a/src/shapes/sphere.cpp
+++ b/src/shapes/sphere.cpp
@@ -117,6 +117,7 @@ public:
     MI_IMPORT_TYPES()
 
     using typename Base::ScalarSize;
+    using typename Base::ScalarIndex;
 
     Sphere(const Properties &props) : Base(props) {
         /// Are the sphere normals pointing inwards? default: no
@@ -344,7 +345,8 @@ public:
     std::tuple<FloatP, Point<FloatP, 2>, dr::uint32_array_t<FloatP>,
                dr::uint32_array_t<FloatP>>
     ray_intersect_preliminary_impl(const Ray3fP &ray,
-                                   dr::mask_t<FloatP> active) const {
+                                   dr::mask_t<FloatP> active,
+                                   ScalarIndex /*prim_index*/) const {
         MI_MASK_ARGUMENT(active);
         using Value = std::conditional_t<dr::is_cuda_v<FloatP> || dr::is_diff_v<Float>,
                                          dr::float32_array_t<FloatP>,
@@ -413,7 +415,8 @@ public:
 
     template <typename FloatP, typename Ray3fP>
     dr::mask_t<FloatP> ray_test_impl(const Ray3fP &ray,
-                                     dr::mask_t<FloatP> active) const {
+                                     dr::mask_t<FloatP> active,
+                                     ScalarIndex /*prim_index*/) const {
         MI_MASK_ARGUMENT(active);
 
         using Value = std::conditional_t<dr::is_cuda_v<FloatP> || dr::is_diff_v<Float>,

--- a/src/shapes/sphere.cpp
+++ b/src/shapes/sphere.cpp
@@ -321,7 +321,7 @@ public:
 
         Ray3f ray(p + local, -local, 0, Wavelength(0));
 
-        PreliminaryIntersection3f pi = ray_intersect_preliminary(ray, active);
+        PreliminaryIntersection3f pi = ray_intersect_preliminary(ray, 0, active);
         active &= pi.is_valid();
 
         if (dr::none_or<false>(active))
@@ -345,8 +345,8 @@ public:
     std::tuple<FloatP, Point<FloatP, 2>, dr::uint32_array_t<FloatP>,
                dr::uint32_array_t<FloatP>>
     ray_intersect_preliminary_impl(const Ray3fP &ray,
-                                   dr::mask_t<FloatP> active,
-                                   ScalarIndex /*prim_index*/) const {
+                                   ScalarIndex /*prim_index*/,
+                                   dr::mask_t<FloatP> active) const {
         MI_MASK_ARGUMENT(active);
         using Value = std::conditional_t<dr::is_cuda_v<FloatP> || dr::is_diff_v<Float>,
                                          dr::float32_array_t<FloatP>,
@@ -415,8 +415,8 @@ public:
 
     template <typename FloatP, typename Ray3fP>
     dr::mask_t<FloatP> ray_test_impl(const Ray3fP &ray,
-                                     dr::mask_t<FloatP> active,
-                                     ScalarIndex /*prim_index*/) const {
+                                     ScalarIndex /*prim_index*/,
+                                     dr::mask_t<FloatP> active) const {
         MI_MASK_ARGUMENT(active);
 
         using Value = std::conditional_t<dr::is_cuda_v<FloatP> || dr::is_diff_v<Float>,
@@ -511,7 +511,7 @@ public:
                    the traced ray, we first recompute the intersection distance
                    in a differentiable way (w.r.t. to the sphere parameters) and
                    then compute the corresponding point along the ray. */
-                si.t = dr::replace_grad(pi.t, ray_intersect_preliminary(ray, active).t);
+                si.t = dr::replace_grad(pi.t, ray_intersect_preliminary(ray, 0, active).t);
                 si.p = ray(si.t);
                 si.sh_frame.n = dr::normalize(si.p - center);
                 local = to_object.transform_affine(si.p);

--- a/src/shapes/tests/test_sdfgrid.py
+++ b/src/shapes/tests/test_sdfgrid.py
@@ -4,7 +4,7 @@ import mitsuba as mi
 
 # TODO: change variants once they're all implemented
 
-def test01_create(variant_cuda_ad_rgb):
+def test01_create(variant_scalar_rgb):
     for normal_method in ["analytic", "smooth", "falcao"]:
         s = mi.load_dict({
             "type" : "sdfgrid",
@@ -13,7 +13,7 @@ def test01_create(variant_cuda_ad_rgb):
         assert s is not None
 
 
-def test02_bbox(variant_cuda_ad_rgb):
+def test02_bbox(variant_scalar_rgb):
     sy = 2.5
     for sx in [1, 2, 4]:
         for translate in [mi.ScalarVector3f([1.3, -3.0, 5]),
@@ -31,7 +31,7 @@ def test02_bbox(variant_cuda_ad_rgb):
             assert dr.allclose(b.max, translate +[sx, sy, 1.0])
 
 
-def test03_parameters_changed(variant_cuda_ad_rgb):
+def test03_parameters_changed(variant_scalar_rgb):
     pytest.importorskip("numpy")
     import numpy as np
 
@@ -54,7 +54,7 @@ def test03_parameters_changed(variant_cuda_ad_rgb):
     assert True
 
 
-def test04_ray_intersect(variant_cuda_ad_rgb):
+def test04_ray_intersect(variants_all_ad_rgb):
     pytest.importorskip("numpy")
     import numpy as np
 
@@ -98,7 +98,7 @@ def test04_ray_intersect(variant_cuda_ad_rgb):
                     assert dr.allclose(si.p, ray.o - mi.Vector3f(0, 0, 2 + y))
 
 
-def test07_differentiable_surface_interaction_ray_forward_follow_shape(variant_cuda_ad_rgb):
+def test07_differentiable_surface_interaction_ray_forward_follow_shape(variants_all_ad_rgb):
     # TODO: remove scenes
 
     dr.set_flag(dr.JitFlag.VCallRecord, False)


### PR DESCRIPTION
This PR adds support for using SDFGrid shapes when targeting llvm/scalar variants. Here, accelerated grid traversal is reliant on Embree

The implementation of voxel intersection handling is based off of the existing CUDA side work, but has been re-expressed to support packet types. Of particular note:

* Embree relies on callbacks to supply custom geometry bboxes per primitive (voxel). This is in contrast to OptiX, where we can immediately supply a single buffer of all bounding boxes. As such, similar to mesh handling, we need to modify the interface of `Shape::ray_intersect_preliminary/Shape::ray_test` to optionally provide a primitive index to determine which voxel the ray is intersecting.
* Similar to the OptiX implementation, we filter out any empty voxels and maintain a mapping from primitive index to the voxel position.
* The sdfgrid tests scope have been extended to test all variants

Outstanding things left:

- [X] Remove references to cubic interpolation in `SDFGrid` 
- [X] Remove Falcao method for generating normals.
- [X] Fill out documentation for SDFGrid including image examples
- [X] Fix instancing support on CUDA (llvm appears to work)
- [X] Add support for sdf grid data source similar to volume grid
