### PR TITLE
Fix epsilon issue for volpath integrators

### DIFF
--- a/src/integrators/volpath.cpp
+++ b/src/integrators/volpath.cpp
@@ -339,7 +339,8 @@ public:
             return { emitter_val, ds };
         }
 
-        Ray3f ray = ref_interaction.spawn_ray(ds.d);
+        Ray3f ray = ref_interaction.spawn_ray_to(ds.p);
+        Float max_dist = ray.maxt;
 
         // Potentially escaping the medium if this is the current medium's boundary
         if constexpr (std::is_convertible_v<Interaction, SurfaceInteraction3f>)
@@ -356,7 +357,7 @@ public:
         sampler->loop_put(loop);
         loop.init();
         while (loop(dr::detach(active))) {
-            Float remaining_dist = ds.dist * (1.f - math::ShadowEpsilon<Float>) - total_dist;
+            Float remaining_dist = max_dist - total_dist;
             ray.maxt = remaining_dist;
             active &= remaining_dist > 0.f;
             if (dr::none_or<false>(active))

--- a/src/integrators/volpathmis.cpp
+++ b/src/integrators/volpathmis.cpp
@@ -391,7 +391,8 @@ public:
             return { p_over_f_nee, p_over_f_uni, emitter_val, ds};
         }
 
-        Ray3f ray = ref_interaction.spawn_ray(ds.d);
+        Ray3f ray = ref_interaction.spawn_ray_to(ds.p);
+        Float max_dist = ray.maxt;
 
         // Potentially escaping the medium if this is the current medium's boundary
         if constexpr (std::is_convertible_v<Interaction, SurfaceInteraction3f>)
@@ -408,8 +409,7 @@ public:
         sampler->loop_put(loop);
         loop.init();
         while (loop(dr::detach(active))) {
-
-            Float remaining_dist = ds.dist * (1.f - math::ShadowEpsilon<Float>) - total_dist;
+            Float remaining_dist = max_dist - total_dist;
             ray.maxt = remaining_dist;
             active &= remaining_dist > 0.f;
             if (dr::none_or<false>(active))

--- a/src/python/python/ad/integrators/prbvolpath.py
+++ b/src/python/python/ad/integrators/prbvolpath.py
@@ -331,7 +331,8 @@ class PRBVolpathIntegrator(RBIntegrator):
         medium = dr.select(active, medium, dr.zeros(mi.MediumPtr))
         medium[(active_surface & si.is_medium_transition())] = si.target_medium(ds.d)
 
-        ray = ref_interaction.spawn_ray(ds.d)
+        ray = ref_interaction.spawn_ray_to(ds.p)
+        max_dist = mi.Float(ray.maxt)
         total_dist = mi.Float(0.0)
         si = dr.zeros(mi.SurfaceInteraction3f)
         needs_intersection = mi.Bool(True)
@@ -340,7 +341,7 @@ class PRBVolpathIntegrator(RBIntegrator):
                        state=lambda: (sampler, active, medium, ray, total_dist,
                                       needs_intersection, si, transmittance))
         while loop(active):
-            remaining_dist = ds.dist * (1.0 - mi.math.ShadowEpsilon) - total_dist
+            remaining_dist = max_dist - total_dist
             ray.maxt = dr.detach(remaining_dist)
             active &= remaining_dist > 0.0
 


### PR DESCRIPTION
The volpath integrators currently seem to have a small epsilon issue due to the use of `ref_interaction.spawn_ray` instead of `ref_interaction.spawn_ray_to`. The latter computes a better/more generous shadow epsilon. Therefore, replacing this call and the use of the previous shadow epsilon fixes the epsilon issue. 

For renderings showcasing the problem, see #678 (towards the bottom of the thread)