### PR TITLE
Fix to_string in AOV integrator

### DIFF
--- a/src/integrators/aov.cpp
+++ b/src/integrators/aov.cpp
@@ -340,7 +340,7 @@ public:
 
     std::string to_string() const override {
         std::ostringstream oss;
-        oss << "Scene[" << std::endl
+        oss << "AOVIntegrator[" << std::endl
             << "  aovs = " << m_aov_names << "," << std::endl
             << "  integrators = [" << std::endl;
         for (size_t i = 0; i < m_integrators.size(); ++i) {


### PR DESCRIPTION
Fix the `to_string` method of the AOV integrator as it was using the wrong plugin name.