### PR TITLE
Disk: use tighter bounding box

### DIFF
--- a/src/shapes/disk.cpp
+++ b/src/shapes/disk.cpp
@@ -134,15 +134,17 @@ public:
 
 
     ScalarBoundingBox3f bbox() const override {
-        ScalarBoundingBox3f bbox;
         ScalarTransform4f to_world = m_to_world.scalar();
 
-        bbox.expand(to_world.transform_affine(ScalarPoint3f(-1.f, -1.f, 0.f)));
-        bbox.expand(to_world.transform_affine(ScalarPoint3f(-1.f,  1.f, 0.f)));
-        bbox.expand(to_world.transform_affine(ScalarPoint3f( 1.f, -1.f, 0.f)));
-        bbox.expand(to_world.transform_affine(ScalarPoint3f( 1.f,  1.f, 0.f)));
+        ScalarPoint3f c = to_world * ScalarPoint3f(0.f, 0.f, 0.f);
+        ScalarVector3f u = to_world * ScalarVector3f(1.f, 0.f, 0.f);
+        ScalarVector3f v = to_world * ScalarVector3f(0.f, 1.f, 0.f);
+        ScalarVector3f e = dr::sqrt(dr::sqr(u) + dr::sqr(v));
 
-        return bbox;
+        return ScalarBoundingBox3f(
+            dr::minimum(c - e, c + e),
+            dr::maximum(c - e, c + e)
+        );
     }
 
     Float surface_area() const override {


### PR DESCRIPTION
<!-- Please add the labels (e.g. bug fix, feature, ..) corresponding to this PR -->

## Description

Currently, the bounding box for a disk is computed as the bounding box of the square that inscribes it. One can however compute a tighter-fitting bounding box such that the disk is always tangent to some of its sides. See [here](https://iquilezles.org/articles/ellipses/) for the derivation.

Note that this implementation is already used for cylinders, that can be similarly bound by the bounding box of the bounding boxes of its endcaps.

## Testing

Tested in `scalar_rgb`, `cuda_ad_rgb` and `llvm_ad_rgb` for 1k random ellipses, resulting in a ~3% performance increase in CUDA mode, and 7% in LLVM mode.
