### PR TITLE
Add `flip_tex_coords` option to `ply` plugin

### DIFF
--- a/src/render/tests/test_mesh.py
+++ b/src/render/tests/test_mesh.py
@@ -1007,4 +1007,47 @@ def test24_texture_attributes(variants_all_rgb):
     assert dr.allclose(mesh.eval_attribute('attribute_1', si), texture.eval(si))
 
 
+@fresolver_append_path
+def test25_flip_tex_coords_obj(variants_all_rgb, tmp_path):
+    mesh = mi.load_dict({
+        'type': 'obj',
+        'filename': 'resources/data/tests/obj/rectangle_uv.obj',
+        'flip_tex_coords': False
+    })
+    params = mi.traverse(mesh)
 
+    mesh_flipped = mi.load_dict({
+        'type': 'obj',
+        'filename': 'resources/data/tests/obj/rectangle_uv.obj',
+        'flip_tex_coords': True
+    })
+    params_flipped = mi.traverse(mesh_flipped)
+
+    uv = params['vertex_texcoords'].numpy()
+    uv_flipped = params_flipped['vertex_texcoords'].numpy()
+
+    assert (uv[::2] == uv_flipped[::2]).all()
+    assert (uv[1::2] == 1 - uv_flipped[1::2]).all()
+
+
+@fresolver_append_path
+def test26_flip_tex_coords_ply(variants_all_rgb, tmp_path):
+    mesh = mi.load_dict({
+        'type': 'ply',
+        'filename': 'resources/data/tests/ply/rectangle_uv.ply',
+        'flip_tex_coords': False
+    })
+    params = mi.traverse(mesh)
+
+    mesh_flipped = mi.load_dict({
+        'type': 'ply',
+        'filename': 'resources/data/tests/ply/rectangle_uv.ply',
+        'flip_tex_coords': True
+    })
+    params_flipped = mi.traverse(mesh_flipped)
+
+    uv = params['vertex_texcoords'].numpy()
+    uv_flipped = params_flipped['vertex_texcoords'].numpy()
+
+    assert (uv[::2] == uv_flipped[::2]).all()
+    assert (uv[1::2] == 1 - uv_flipped[1::2]).all()

--- a/src/shapes/obj.cpp
+++ b/src/shapes/obj.cpp
@@ -147,7 +147,7 @@ public:
 
     OBJMesh(const Properties &props) : Base(props) {
         /* Causes all texture coordinates to be vertically flipped.
-           Enabled by default, for consistence with the Mitsuba 1 behavior. */
+           Enabled by default, for consistency with the Mitsuba 1 behavior. */
         bool flip_tex_coords = props.get<bool>("flip_tex_coords", true);
 
         auto fr = Thread::thread()->file_resolver();

--- a/src/shapes/ply.cpp
+++ b/src/shapes/ply.cpp
@@ -33,6 +33,10 @@ PLY (Stanford Triangle Format) mesh loader (:monosp:`ply`)
      discarded and *face normals* will instead be used during rendering.
      This gives the rendered object a faceted appearance. (Default: |false|)
 
+ * - flip_tex_coords
+   - |bool|
+   - Treat the vertical component of the texture as inverted? (Default: |false|)
+
  * - flip_normals
    - |bool|
    - Is the mesh inverted, i.e. should the normal vectors be flipped? (Default:|false|, i.e.
@@ -164,6 +168,9 @@ public:
     PLYMesh(const Properties &props) : Base(props) {
         /// Process vertex/index records in large batches
         constexpr size_t elements_per_packet = 1024;
+
+        /* Causes all texture coordinates to be vertically flipped. */
+        bool flip_tex_coords = props.get<bool>("flip_tex_coords", false);
 
         auto fs = Thread::thread()->file_resolver();
         fs::path file_path = fs->resolve(props.string("filename"));
@@ -305,6 +312,8 @@ public:
                                 target + (m_face_normals
                                               ? sizeof(InputFloat) * 3
                                               : sizeof(InputFloat) * 6));
+                            if (flip_tex_coords)
+                                uv.y() = 1.f - uv.y();
                             dr::store(texcoord_ptr, uv);
                             texcoord_ptr += 2;
                         }


### PR DESCRIPTION
## Description

This PR adds the the option flip UV texture coordinates vertically on the `ply` plugin, similarly to the `obj` plugin.
By default, this option is set to false to guarantee backwards compatibility.

Fixes #814

## Testing

Some basic tests for this functionality were added.