### PR TITLE
Properties: Support TensorXf and Transform3 

### DIFF
--- a/include/mitsuba/core/properties.h
+++ b/include/mitsuba/core/properties.h
@@ -38,22 +38,40 @@ class MI_EXPORT_LIB Properties {
 public:
     /// Supported types of properties
     enum class Type {
-        Bool,              /// Boolean value (true/false)
-        Long,              /// 64-bit signed integer
-        Float,             /// Floating point value
-        Array3f,           /// 3D array
-        Transform,         /// 4x4 transform for homogeneous coordinates
-        AnimatedTransform, /// An animated 4x4 transformation
-        Color,             /// Tristimulus color value
-        String,            /// String
-        NamedReference,    /// Named reference to another named object
-        Object,            /// Arbitrary object
-        Pointer            /// const void* pointer (for internal communication between plugins)
+        /// Boolean value (true/false)
+        Bool,
+        /// 64-bit signed integer
+        Long,
+        /// Floating point value
+        Float,
+        /// 3D array
+        Array3f,
+        /// A tensor of arbitrary shape
+        Tensor,
+        /// 3x3 transform for homogeneous coordinates
+        Transform3f,
+        /// 4x4 transform for homogeneous coordinates
+        Transform4f,
+        /// An animated 4x4 transformation
+        AnimatedTransform,
+        /// Tristimulus color value
+        Color,
+        /// String
+        String,
+        /// Named reference to another named object
+        NamedReference,
+        /// Arbitrary object
+        Object,
+        /// const void* pointer (for internal communication between plugins)
+        Pointer
     };
 
     // Scene parsing in double precision
     using Float = double;
     using Array3f = dr::Array<Float, 3>;
+    // Variant-agnostic handle to TensorXf
+    using TensorHandle = std::shared_ptr<void>;
+
     MI_IMPORT_CORE_TYPES()
 
     /// Construct an empty property container
@@ -195,8 +213,14 @@ public:  // Type-specific getters and setters ----------------------------------
     /// Store a color in the Properties instance
     void set_color(const std::string &name, const Color3f &value, bool error_duplicates = true);
 
+    /// Store a 3x3 homogeneous coordinate transformation in the Properties instance
+    void set_transform3f(const std::string &name, const Transform3f &value, bool error_duplicates = true);
+
     /// Store a 4x4 homogeneous coordinate transformation in the Properties instance
     void set_transform(const std::string &name, const Transform4f &value, bool error_duplicates = true);
+
+    /// Store a tensor handle in the Properties instance
+    void set_tensor_handle(const std::string &name, const TensorHandle &value, bool error_duplicates = true);
 
 #if 0
     /// Store an animated transformation in the Properties instance
@@ -361,6 +385,13 @@ public:  // Type-specific getters and setters ----------------------------------
         return volume<Volume>(name);
     }
 
+    /// Retrieve a tensor
+    template <typename Tensor>
+    Tensor* tensor(const std::string &name) const {
+        TensorHandle handle = get<Properties::TensorHandle>(name);
+        return reinterpret_cast<Tensor*>(handle.get());
+    }
+
 private:
     /// Return a reference to an object for a specific name (return null ref if doesn't exist)
     ref<Object> find_object(const std::string &name) const;
@@ -388,8 +419,11 @@ EXTERN_EXPORT_PROPERTY_ACCESSOR(T(Vector<float, 3>))
 EXTERN_EXPORT_PROPERTY_ACCESSOR(T(Vector<double, 3>))
 EXTERN_EXPORT_PROPERTY_ACCESSOR(T(Color<float, 3>))
 EXTERN_EXPORT_PROPERTY_ACCESSOR(T(Color<double, 3>))
+EXTERN_EXPORT_PROPERTY_ACCESSOR(T(Transform<Point<float, 3>>))
+EXTERN_EXPORT_PROPERTY_ACCESSOR(T(Transform<Point<double, 3>>))
 EXTERN_EXPORT_PROPERTY_ACCESSOR(T(Transform<Point<float, 4>>))
 EXTERN_EXPORT_PROPERTY_ACCESSOR(T(Transform<Point<double, 4>>))
+EXTERN_EXPORT_PROPERTY_ACCESSOR(T(Properties::TensorHandle))
 EXTERN_EXPORT_PROPERTY_ACCESSOR(T(std::string))
 EXTERN_EXPORT_PROPERTY_ACCESSOR(T(ref<Object>))
 #undef T

--- a/include/mitsuba/python/docstr.h
+++ b/include/mitsuba/python/docstr.h
@@ -5851,27 +5851,31 @@ static const char *__doc_mitsuba_Properties_PropertiesPrivate = R"doc()doc";
 
 static const char *__doc_mitsuba_Properties_Type = R"doc(Supported types of properties)doc";
 
-static const char *__doc_mitsuba_Properties_Type_AnimatedTransform = R"doc(4x4 transform for homogeneous coordinates)doc";
+static const char *__doc_mitsuba_Properties_Type_AnimatedTransform = R"doc(An animated 4x4 transformation)doc";
 
-static const char *__doc_mitsuba_Properties_Type_Array3f = R"doc(Floating point value)doc";
+static const char *__doc_mitsuba_Properties_Type_Array3f = R"doc(3D array)doc";
 
-static const char *__doc_mitsuba_Properties_Type_Bool = R"doc()doc";
+static const char *__doc_mitsuba_Properties_Type_Bool = R"doc(Boolean value (true/false))doc";
 
-static const char *__doc_mitsuba_Properties_Type_Color = R"doc(An animated 4x4 transformation)doc";
+static const char *__doc_mitsuba_Properties_Type_Color = R"doc(Tristimulus color value)doc";
 
-static const char *__doc_mitsuba_Properties_Type_Float = R"doc(64-bit signed integer)doc";
+static const char *__doc_mitsuba_Properties_Type_Float = R"doc(Floating point value)doc";
 
-static const char *__doc_mitsuba_Properties_Type_Long = R"doc(Boolean value (true/false))doc";
+static const char *__doc_mitsuba_Properties_Type_Long = R"doc(64-bit signed integer)doc";
 
-static const char *__doc_mitsuba_Properties_Type_NamedReference = R"doc(String)doc";
+static const char *__doc_mitsuba_Properties_Type_NamedReference = R"doc(Named reference to another named object)doc";
 
-static const char *__doc_mitsuba_Properties_Type_Object = R"doc(Named reference to another named object)doc";
+static const char *__doc_mitsuba_Properties_Type_Object = R"doc(Arbitrary object)doc";
 
-static const char *__doc_mitsuba_Properties_Type_Pointer = R"doc(Arbitrary object)doc";
+static const char *__doc_mitsuba_Properties_Type_Pointer = R"doc(const void* pointer (for internal communication between plugins))doc";
 
-static const char *__doc_mitsuba_Properties_Type_String = R"doc(Tristimulus color value)doc";
+static const char *__doc_mitsuba_Properties_Type_String = R"doc(String)doc";
 
-static const char *__doc_mitsuba_Properties_Type_Transform = R"doc(3D array)doc";
+static const char *__doc_mitsuba_Properties_Type_Tensor = R"doc(A tensor of arbitrary shape)doc";
+
+static const char *__doc_mitsuba_Properties_Type_Transform3f = R"doc(3x3 transform for homogeneous coordinates)doc";
+
+static const char *__doc_mitsuba_Properties_Type_Transform4f = R"doc(4x4 transform for homogeneous coordinates)doc";
 
 static const char *__doc_mitsuba_Properties_as_string = R"doc(Return one of the parameters (converting it to a string if necessary))doc";
 
@@ -5977,8 +5981,14 @@ static const char *__doc_mitsuba_Properties_set_pointer = R"doc(Store an arbitra
 
 static const char *__doc_mitsuba_Properties_set_string = R"doc(Store a string in the Properties instance)doc";
 
+static const char *__doc_mitsuba_Properties_set_tensor_handle = R"doc(Store a tensor handle in the Properties instance)doc";
+
 static const char *__doc_mitsuba_Properties_set_transform =
 R"doc(Store a 4x4 homogeneous coordinate transformation in the Properties
+instance)doc";
+
+static const char *__doc_mitsuba_Properties_set_transform3f =
+R"doc(Store a 3x3 homogeneous coordinate transformation in the Properties
 instance)doc";
 
 static const char *__doc_mitsuba_Properties_string = R"doc(Retrieve a string value)doc";

--- a/include/mitsuba/render/volumegrid.h
+++ b/include/mitsuba/render/volumegrid.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <drjit/tensor.h>
+
 #include <mitsuba/core/bbox.h>
 #include <mitsuba/core/properties.h>
 #include <mitsuba/core/spectrum.h>

--- a/src/core/bitmap.cpp
+++ b/src/core/bitmap.cpp
@@ -968,6 +968,13 @@ void Bitmap::read_exr(Stream *stream) {
                 for (size_t j = 0; j < 4; ++j)
                     M(i, j) = v->value().x[i][j];
             m_metadata.set_transform(name, Transform4f(M));
+        } else if (type_name == "m33f") {
+            auto v = static_cast<const Imf::M33fAttribute *>(attr);
+            Matrix3f M;
+            for (size_t i = 0; i < 3; ++i)
+                for (size_t j = 0; j < 3; ++j)
+                    M(i, j) = v->value().x[i][j];
+            m_metadata.set_transform3f(name, Transform3f(M));
         }
     }
 
@@ -1336,7 +1343,14 @@ void Bitmap::write_exr(Stream *stream, int quality) const {
                         Imath::V3f((float) val.x(), (float) val.y(), (float) val.z())));
                 }
                 break;
-            case Type::Transform: {
+            case Type::Transform3f: {
+                   Matrix3f val = metadata.get<ScalarTransform3f>(*it).matrix;
+                    header.insert(it->c_str(), Imf::M33fAttribute(Imath::M33f(
+                        (float) val(0, 0), (float) val(0, 1), (float) val(0, 2), 
+                        (float) val(1, 0), (float) val(1, 1), (float) val(1, 2),
+                        (float) val(2, 0), (float) val(2, 1), (float) val(2, 2))));
+                } break;
+            case Type::Transform4f: {
                     Matrix4f val = metadata.get<ScalarTransform4f>(*it).matrix;
                     header.insert(it->c_str(), Imf::M44fAttribute(Imath::M44f(
                         (float) val(0, 0), (float) val(0, 1),

--- a/src/core/properties.cpp
+++ b/src/core/properties.cpp
@@ -9,6 +9,8 @@
 #include <sstream>
 #include <cstring>
 
+#include <drjit/tensor.h>
+
 #include <mitsuba/core/logger.h>
 #include <mitsuba/core/properties.h>
 #include <mitsuba/core/transform.h>
@@ -16,10 +18,12 @@
 
 NAMESPACE_BEGIN(mitsuba)
 
-using Float       = typename Properties::Float;
-using Color3f     = typename Properties::Color3f;
-using Array3f     = typename Properties::Array3f;
-using Transform4f = typename Properties::Transform4f;
+using Float         = typename Properties::Float;
+using Color3f       = typename Properties::Color3f;
+using Array3f       = typename Properties::Array3f;
+using Transform3f   = typename Properties::Transform3f;
+using Transform4f   = typename Properties::Transform4f;
+using TensorHandle  = typename Properties::TensorHandle;
 
 using VariantType = variant<
     bool,
@@ -27,7 +31,9 @@ using VariantType = variant<
     Float,
     Array3f,
     std::string,
+    Transform3f,
     Transform4f,
+    TensorHandle,
     Color3f,
     NamedReference,
     ref<Object>,
@@ -82,6 +88,23 @@ T get_impl(const Iterator &it) {
     return (T const &) it->second.data;
 }
 
+
+/**
+ * \brief Specialization to gracefully handle if user supplies either a 3x3 or 4x4 transform.
+ * Historically, we didn't directly support Transform3 properties so want to maintain 
+ * backwards compatibility
+ */
+template<>
+Transform3f get_impl<Transform3f, Transform4f>(const Iterator &it) {
+    if (!it->second.data.template is<Transform3f>() && !it->second.data.template is<Transform4f>())
+        Throw("The property \"%s\" has the wrong type (expected <%s> or <%s>, is <%s>)",
+              it->first, typeid(Transform3f).name(), typeid(Transform4f).name(), it->second.data.type().name());
+    it->second.queried = true;
+    if (it->second.data.template is<Transform4f>())
+        return ((Transform4f const &)it->second.data).extract();
+    return (Transform3f const &) it->second.data;
+}
+
 template <typename T>
 T get_routing(const Iterator &it) {
     if constexpr (dr::is_static_array_v<T>) {
@@ -92,6 +115,13 @@ T get_routing(const Iterator &it) {
         else
             return (T) get_impl<Array3f>(it);
     }
+
+    if constexpr (std::is_same_v<T, TensorHandle>)
+        return get_impl<TensorHandle>(it);
+
+    if constexpr (std::is_same_v<T, Transform<Point<float, 3>>> ||
+                  std::is_same_v<T, Transform<Point<double, 3>>>)
+        return (T) get_impl<Transform3f, Transform4f>(it);
 
     if constexpr (std::is_same_v<T, Transform<Point<float, 4>>> ||
                   std::is_same_v<T, Transform<Point<double, 4>>>)
@@ -171,7 +201,9 @@ T Properties::get(const std::string &name, const T &def_val) const {
 
 DEFINE_PROPERTY_SETTER(bool,         set_bool)
 DEFINE_PROPERTY_SETTER(int64_t,      set_long)
+DEFINE_PROPERTY_SETTER(Transform3f,  set_transform3f)
 DEFINE_PROPERTY_SETTER(Transform4f,  set_transform)
+DEFINE_PROPERTY_SETTER(TensorHandle, set_tensor_handle)
 DEFINE_PROPERTY_SETTER(Color3f,      set_color)
 DEFINE_PROPERTY_ACCESSOR(std::string,    string,  set_string,          string)
 DEFINE_PROPERTY_ACCESSOR(NamedReference, ref,     set_named_reference, named_reference)
@@ -210,7 +242,9 @@ namespace {
         Type operator()(const Float &) { return Type::Float; }
         Type operator()(const Array3f &) { return Type::Array3f; }
         Type operator()(const std::string &) { return Type::String; }
-        Type operator()(const Transform4f &) { return Type::Transform; }
+        Type operator()(const Transform3f &) { return Type::Transform3f; }
+        Type operator()(const Transform4f &) { return Type::Transform4f; }
+        Type operator()(const TensorHandle &) { return Type::Tensor; }
         Type operator()(const Color3f &) { return Type::Color; }
         Type operator()(const NamedReference &) { return Type::NamedReference; }
         Type operator()(const ref<Object> &) { return Type::Object; }
@@ -226,7 +260,9 @@ namespace {
         void operator()(const Float &f) { os << f; }
         void operator()(const Array3f &t) { os << t; }
         void operator()(const std::string &s) { os << "\"" << s << "\""; }
+        void operator()(const Transform3f &t) { os << t; }
         void operator()(const Transform4f &t) { os << t; }
+        void operator()(const TensorHandle &t) { os << t.get(); }
         void operator()(const Color3f &t) { os << t; }
         void operator()(const NamedReference &nr) { os << "\"" << (const std::string &) nr << "\""; }
         void operator()(const ref<Object> &o) { os << o->to_string(); }
@@ -531,8 +567,11 @@ EXPORT_PROPERTY_ACCESSOR(T(Vector<float, 3>))
 EXPORT_PROPERTY_ACCESSOR(T(Vector<double, 3>))
 EXPORT_PROPERTY_ACCESSOR(T(Color<float, 3>))
 EXPORT_PROPERTY_ACCESSOR(T(Color<double, 3>))
+EXPORT_PROPERTY_ACCESSOR(T(Transform<Point<float, 3>>))
+EXPORT_PROPERTY_ACCESSOR(T(Transform<Point<double, 3>>))
 EXPORT_PROPERTY_ACCESSOR(T(Transform<Point<float, 4>>))
 EXPORT_PROPERTY_ACCESSOR(T(Transform<Point<double, 4>>))
+EXPORT_PROPERTY_ACCESSOR(T(Properties::TensorHandle))
 EXPORT_PROPERTY_ACCESSOR(T(std::string))
 EXPORT_PROPERTY_ACCESSOR(T(ref<Object>))
 #if defined(__APPLE__)

--- a/src/core/python/xml_v.cpp
+++ b/src/core/python/xml_v.cpp
@@ -1,3 +1,4 @@
+#include <drjit/tensor.h>
 #include <mitsuba/core/filesystem.h>
 #include <mitsuba/core/fresolver.h>
 #include <mitsuba/core/xml.h>
@@ -294,6 +295,7 @@ void parse_dictionary(DictParseContext &ctx,
         SET_PROPS(py::str, std::string, set_string);
         SET_PROPS(ScalarColor3f, ScalarColor3f, set_color);
         SET_PROPS(ScalarArray3f, ScalarArray3f, set_array3f);
+        SET_PROPS(ScalarTransform3f, ScalarTransform3f, set_transform3f);
         SET_PROPS(ScalarTransform4f, ScalarTransform4f, set_transform);
 
         if (key.find('.') != std::string::npos) {
@@ -365,6 +367,12 @@ void parse_dictionary(DictParseContext &ctx,
         // Try to cast to Array3f (list, tuple, numpy.array, ...)
         try {
             props.set_array3f(key, value.template cast<Properties::Array3f>());
+            continue;
+        } catch (const pybind11::cast_error &) { }
+
+        // Try to cast to TensorXf
+        try {
+            props.set_tensor_handle(key, std::make_shared<TensorXf>(value.template cast<TensorXf>()));
             continue;
         } catch (const pybind11::cast_error &) { }
 

--- a/src/core/tests/test_properties.py
+++ b/src/core/tests/test_properties.py
@@ -194,3 +194,38 @@ def test10_animated_transforms(variant_scalar_rgb):
     assert type(p["trafo"]) is mi.Transform4d
     assert type(p["atrafo"]) is mi.AnimatedTransform
 
+def test10_transforms3(variant_scalar_rgb):
+    p = mi.Properties()
+    p["transform"] = mi.ScalarTransform3d.translate([2,4])
+
+    assert type(p["transform"] is mi.ScalarTransform3d)
+
+def test11_tensor(variant_scalar_rgb):
+    props = mi.Properties()
+
+    # Check copy is set to properties
+    a = dr.zeros(mi.TensorXf, shape = [30, 30, 30])
+    props['foo'] = a
+    a = None
+    assert props['foo'].shape == (30, 30, 30)
+
+    # Check temporary can be set
+    props['moo'] =  dr.zeros(mi.TensorXf, shape = [30, 30, 30])
+    assert props['moo'].shape == (30, 30, 30)
+
+    # Check numpy
+    import numpy as np
+    props['goo'] = np.zeros((2, 3, 4))
+    assert props['goo'].shape == (2, 3, 4)
+
+def test11_tensor_cuda(variant_cuda_ad_rgb):
+    # Check tensor flow
+    pytest.importorskip("tensorflow")
+    props['boo'] = tf.constant([[1, 2], [3, 4]])
+    assert props['boo'].shape == (2, 2)
+
+    # Check PyTorch
+    pytest.importorskip("torch")
+    import torch
+    props['goo'] = torch.zeros(2, 3, 4)
+    assert props['goo'].shape == (2, 3, 4)

--- a/src/shapes/sdfgrid.cpp
+++ b/src/shapes/sdfgrid.cpp
@@ -157,6 +157,18 @@ public:
             m_grid_texture = InputTexture3f(
                 InputTensorXf(vol_grid.data(), 4, shape), true, true,
                 dr::FilterMode::Linear, dr::WrapMode::Clamp);
+        } else if (props.has_property("grid")) {
+            TensorXf* tensor = props.tensor<TensorXf>("grid");
+            if (tensor->ndim() != 4)
+                Throw(
+                    "SDF grid tensor has dimension %lu, expected 4",
+                    tensor->ndim());
+            if (tensor->shape(3) != 1)
+                Throw(
+                    "SDF grid shape at index 3 is %lu, expected 1",
+                    tensor->shape(3));
+            m_grid_texture = InputTexture3f(*tensor, true, true,
+                dr::FilterMode::Linear, dr::WrapMode::Clamp);
         } else {
             InputFloat default_data[8] = { -1.f, -1.f, -1.f, -1.f,
                                            -1.f, -1.f, -1.f, -1.f };

--- a/src/textures/bitmap.cpp
+++ b/src/textures/bitmap.cpp
@@ -117,12 +117,13 @@ public:
     MI_IMPORT_TYPES(Texture)
 
     BitmapTexture(const Properties &props) : Texture(props) {
-        m_transform = props.get<ScalarTransform4f>("to_uv", ScalarTransform4f())
-                          .extract();
+        m_transform = props.get<ScalarTransform3f>("to_uv", ScalarTransform3f());
         if (m_transform != ScalarTransform3f())
             dr::make_opaque(m_transform);
 
-        ref<Bitmap> bitmap;
+        ref<Bitmap> bitmap = nullptr;
+        TensorXf* tensor = nullptr;
+
         if (props.has_property("bitmap")) {
             // Creates a Bitmap texture directly from an existing Bitmap object
             if (props.has_property("filename"))
@@ -134,13 +135,21 @@ public:
             if (!b)
                 Throw("Property \"bitmap\" must be a Bitmap instance.");
             bitmap = b;
-        } else {
+        } else if (props.has_property("filename")) {
             // Creates a Bitmap texture by loading an image from the filesystem
             FileResolver* fs = Thread::thread()->file_resolver();
             fs::path file_path = fs->resolve(props.string("filename"));
             m_name = file_path.filename().string();
             Log(Debug, "Loading bitmap texture from \"%s\" ..", m_name);
             bitmap = new Bitmap(file_path);
+        } else if (props.has_property("data")) {
+            tensor = props.tensor<TensorXf>("data");
+            if (tensor->ndim() != 3)
+                Throw("Bitmap raw tensor has dimension %lu, expected 3", tensor->ndim());
+
+            const size_t channel_count = tensor->shape(2);
+            if (channel_count != 1 && channel_count != 3)
+                Throw("Unsupported tensor channel count: %d (expected 1 or 3)", channel_count);
         }
 
         std::string filter_mode_str = props.string("filter_type", "bilinear");
@@ -165,103 +174,133 @@ public:
             Throw("Invalid wrap mode \"%s\", must be one of: \"repeat\", "
                   "\"mirror\", or \"clamp\"!", wrap_mode_str);
 
-        /* Convert to linear RGB float bitmap, will be converted
-           into spectral profile coefficients below (in place) */
-        Bitmap::PixelFormat pixel_format = bitmap->pixel_format();
-        switch (pixel_format) {
-            case Bitmap::PixelFormat::Y:
-            case Bitmap::PixelFormat::YA:
-                pixel_format = Bitmap::PixelFormat::Y;
-                break;
-
-            case Bitmap::PixelFormat::RGB:
-            case Bitmap::PixelFormat::RGBA:
-            case Bitmap::PixelFormat::XYZ:
-            case Bitmap::PixelFormat::XYZA:
-                pixel_format = Bitmap::PixelFormat::RGB;
-                break;
-
-            default:
-                Throw("The texture needs to have a known pixel "
-                      "format (Y[A], RGB[A], XYZ[A] are supported).");
-        }
-
         /* Should Mitsuba disable transformations to the stored color data?
            (e.g. sRGB to linear, spectral upsampling, etc.) */
         m_raw = props.get<bool>("raw", false);
-        if (m_raw) {
-            /* Don't undo gamma correction in the conversion below.
-               This is needed, e.g., for normal maps. */
-            bitmap->set_srgb_gamma(false);
-        }
-
         m_accel = props.get<bool>("accel", true);
 
-        // Convert the image into the working floating point representation
-        bitmap =
-            bitmap->convert(pixel_format, struct_type_v<ScalarFloat>, false);
+        if (tensor) {
+            Log(Debug, "Loading bitmap texture from tensor...");
+            if (!m_raw)
+                Throw("Bitmap raw property must be true when initializing using tensor data."
+                      "Otherwise use a bitmap object or file if transformation of color data is"
+                      " required.");
+            m_texture = Texture2f(TensorXf(*tensor), m_accel, m_accel, filter_mode, wrap_mode);
+            const size_t pixel_count = tensor->shape(1) * tensor->shape(0);
+            const size_t ch_count = tensor->shape(2);
 
-        if (!dr::all(bitmap->size() == 1) && dr::any(bitmap->size() < 2)) {
-            Log(Warn,
-                "Image must be at least 2x2 pixels in size, up-sampling..");
-            using ReconstructionFilter = Bitmap::ReconstructionFilter;
-            ref<ReconstructionFilter> rfilter =
-                PluginManager::instance()->create_object<ReconstructionFilter>(
-                    Properties("tent"));
+            if (ch_count == 3) {
+                if constexpr (dr::is_dynamic_v<Float>)
+                    m_mean = dr::sum(luminance(dr::unravel<Color3f>(tensor->array()))) / pixel_count;
+                else {
+                    const size_t pixel_count = tensor->shape(0) * tensor->shape(1);
+                    double mean = 0.0;
+                    ScalarFloat* ptr = tensor->data();
+                    for (size_t i = 0; i < pixel_count; ++i) {
+                        ScalarColor3f value = dr::load<ScalarColor3f>(ptr);
+                        mean += (double) luminance(value);
+                        ptr += 3;
+                    }
+                    m_mean = (ScalarFloat)(mean / pixel_count);
+                }
+            }
+            else
+                m_mean = dr::sum(tensor->array()) / pixel_count;
+
+        } else {
+            /* Convert to linear RGB float bitmap, will be converted
+               into spectral profile coefficients below (in place) */
+            Bitmap::PixelFormat pixel_format = bitmap->pixel_format();
+            switch (pixel_format) {
+                case Bitmap::PixelFormat::Y:
+                case Bitmap::PixelFormat::YA:
+                    pixel_format = Bitmap::PixelFormat::Y;
+                    break;
+
+                case Bitmap::PixelFormat::RGB:
+                case Bitmap::PixelFormat::RGBA:
+                case Bitmap::PixelFormat::XYZ:
+                case Bitmap::PixelFormat::XYZA:
+                    pixel_format = Bitmap::PixelFormat::RGB;
+                    break;
+
+                default:
+                    Throw("The texture needs to have a known pixel "
+                          "format (Y[A], RGB[A], XYZ[A] are supported).");
+            }
+
+            if (m_raw) {
+                /* Don't undo gamma correction in the conversion below.
+                   This is needed, e.g., for normal maps. */
+                bitmap->set_srgb_gamma(false);
+            }
+
+            // Convert the image into the working floating point representation
             bitmap =
-                bitmap->resample(dr::maximum(bitmap->size(), 2), rfilter);
-        }
+                bitmap->convert(pixel_format, struct_type_v<ScalarFloat>, false);
 
-        ScalarFloat *ptr = (ScalarFloat *) bitmap->data();
-        size_t pixel_count = bitmap->pixel_count();
-        bool exceed_unit_range = false;
+            if (dr::any(bitmap->size() < 2)) {
+                Log(Warn,
+                    "Image must be at least 2x2 pixels in size, up-sampling..");
+                using ReconstructionFilter = Bitmap::ReconstructionFilter;
+                ref<ReconstructionFilter> rfilter =
+                    PluginManager::instance()->create_object<ReconstructionFilter>(
+                        Properties("tent"));
+                bitmap =
+                    bitmap->resample(dr::maximum(bitmap->size(), 2), rfilter);
+            }
 
-        double mean = 0.0;
-        if (bitmap->channel_count() == 3) {
-            if (is_spectral_v<Spectrum> && !m_raw) {
+            ScalarFloat *ptr = (ScalarFloat *) bitmap->data();
+            size_t pixel_count = bitmap->pixel_count();
+            bool exceed_unit_range = false;
+
+            double mean = 0.0;
+            if (bitmap->channel_count() == 3) {
+                if (is_spectral_v<Spectrum> && !m_raw) {
+                    for (size_t i = 0; i < pixel_count; ++i) {
+                        ScalarColor3f value = dr::load<ScalarColor3f>(ptr);
+                        if (!all(value >= 0 && value <= 1))
+                            exceed_unit_range = true;
+                        value = srgb_model_fetch(value);
+                        mean += (double) srgb_model_mean(value);
+                        dr::store(ptr, value);
+                        ptr += 3;
+                    }
+                } else {
+                    for (size_t i = 0; i < pixel_count; ++i) {
+                        ScalarColor3f value = dr::load<ScalarColor3f>(ptr);
+                        if (!all(value >= 0 && value <= 1))
+                            exceed_unit_range = true;
+                        mean += (double) luminance(value);
+                        ptr += 3;
+                    }
+                }
+            } else if (bitmap->channel_count() == 1) {
                 for (size_t i = 0; i < pixel_count; ++i) {
-                    ScalarColor3f value = dr::load<ScalarColor3f>(ptr);
-                    if (!all(value >= 0 && value <= 1))
+                    ScalarFloat value = ptr[i];
+                    if (!(value >= 0 && value <= 1))
                         exceed_unit_range = true;
-                    value = srgb_model_fetch(value);
-                    mean += (double) srgb_model_mean(value);
-                    dr::store(ptr, value);
-                    ptr += 3;
+                    mean += (double) value;
                 }
             } else {
-                for (size_t i = 0; i < pixel_count; ++i) {
-                    ScalarColor3f value = dr::load<ScalarColor3f>(ptr);
-                    if (!all(value >= 0 && value <= 1))
-                        exceed_unit_range = true;
-                    mean += (double) luminance(value);
-                    ptr += 3;
-                }
+                Throw("Unsupported channel count: %d (expected 1 or 3)",
+                      bitmap->channel_count());
             }
-        } else if (bitmap->channel_count() == 1) {
-            for (size_t i = 0; i < pixel_count; ++i) {
-                ScalarFloat value = ptr[i];
-                if (!(value >= 0 && value <= 1))
-                    exceed_unit_range = true;
-                mean += (double) value;
-            }
-        } else {
-            Throw("Unsupported channel count: %d (expected 1 or 3)",
-                  bitmap->channel_count());
+
+            if (exceed_unit_range && !m_raw)
+                Log(Warn,
+                    "BitmapTexture: texture named \"%s\" contains pixels that "
+                    "exceed the [0, 1] range!",
+                    m_name);
+
+            m_mean = Float(mean / pixel_count);
+
+            size_t channels = bitmap->channel_count();
+            ScalarVector2i res = ScalarVector2i(bitmap->size());
+            size_t shape[3] = { (size_t) res.y(), (size_t) res.x(), channels };
+            m_texture = Texture2f(TensorXf(bitmap->data(), 3, shape), m_accel,
+                                  m_accel, filter_mode, wrap_mode);
         }
-
-        if (exceed_unit_range && !m_raw)
-            Log(Warn,
-                "BitmapTexture: texture named \"%s\" contains pixels that "
-                "exceed the [0, 1] range!",
-                m_name);
-
-        m_mean = Float(mean / pixel_count);
-
-        size_t channels = bitmap->channel_count();
-        ScalarVector2i res = ScalarVector2i(bitmap->size());
-        size_t shape[3] = { (size_t) res.y(), (size_t) res.x(), channels };
-        m_texture = Texture2f(TensorXf(bitmap->data(), 3, shape), m_accel,
-                              m_accel, filter_mode, wrap_mode);
     }
 
     void traverse(TraversalCallback *callback) override {

--- a/src/textures/checkerboard.cpp
+++ b/src/textures/checkerboard.cpp
@@ -58,7 +58,7 @@ public:
     Checkerboard(const Properties &props) : Texture(props) {
         m_color0 = props.texture<Texture>("color0", .4f);
         m_color1 = props.texture<Texture>("color1", .2f);
-        m_transform = props.get<ScalarTransform4f>("to_uv", ScalarTransform4f()).extract();
+        m_transform = props.get<ScalarTransform3f>("to_uv", ScalarTransform3f());
     }
 
     void traverse(TraversalCallback *callback) override {

--- a/src/textures/tests/test_bitmap.py
+++ b/src/textures/tests/test_bitmap.py
@@ -230,3 +230,21 @@ def test05_eval_spectral(variants_vec_backends_once_spectral):
     expected = 0.5394
     assert dr.allclose(expected, spec, atol=1e-04)
     assert dr.allclose(expected, mono, atol=1e-04)
+
+
+def test06_tensor_load(variants_all_rgb):
+    bitmap = mi.load_dict({
+        'type' : 'bitmap',
+        'data' : dr.ones(mi.TensorXf, shape = [30, 30, 3]),
+        'raw' : True
+    })
+
+    assert dr.allclose(bitmap.mean(), 1.0);
+
+    bitmap = mi.load_dict({
+        'type' : 'bitmap',
+        'data' : dr.full(mi.TensorXf, 3.0, shape = [30, 30, 3]),
+        'raw' : True
+    })
+
+    assert dr.allclose(bitmap.mean(), 3.0);

--- a/src/textures/tests/test_volume.py
+++ b/src/textures/tests/test_volume.py
@@ -52,3 +52,16 @@ def test03_eval_3(variants_vec_backends_once_rgb, tmpdir):
     ref_values = mi.Color3f([0.9, 0.0, 0.0], [0.4, 0.0, 0.0], [0.2, 0.0, 0.0])
     assert dr.allclose(texture.eval_3(si), ref_values)
     assert dr.allclose(texture.max(), 0.9)
+
+
+def test04_load_tensor(variants_vec_backends_once):
+    grid = dr.full(mi.TensorXf, 0.9, [3, 3, 3])
+    grid[:, 0, :] = 0.0
+    texture = mi.load_dict({
+        'type': 'volume',
+        'volume': {'type': 'gridvolume', 'data': grid},
+    })
+    si = dr.zeros(mi.SurfaceInteraction3f)
+    si.p = mi.Point3f([0.4, 0.4, 0.3], [0.5, 0.0, -0.5], [0.5, 0.4, 0.5])
+    assert dr.allclose(dr.mean(texture.eval(si)), [0.9, 0.0, 0.0])
+    assert dr.allclose(texture.max(), 0.9)


### PR DESCRIPTION
<!-- Please add the labels (e.g. bug fix, feature, ..) corresponding to this PR -->

## Description

1. Currently, plugin parameters that were of type `Transform3f` such as `to_uv` transforms, could only accept `mi.Properties` of type `Transform4f` and then we would have to extract down to the corresponding 3x3 transform. This change allows a user to directly set a `Transform3` e.g.
```
bsdf = mi.load_dict("bsdf": {
  "type": "diffuse",
  "reflectance": {
      "type": "checkerboard",
      "color0": rho0,
      "color1": rho1,
      "to_uv": mi.ScalarTransform3f.scale(2)
  },
})
```
Note, to maintain backwards compatibility, `props.get<ScalarTransform3f>` can still handle if the supplied transform is 4x4

2.  `mi.TensorXf` can now also be set in properties, meaning that in Python, plugin TensorXf parameters can be supplied during construction i.e.

```
my_plugin = mi.load_dict({"type : "plugin",  "some_tensor" : mi.TensorXf(array, shape) })
```
Additionally, all the implicit numpy, Tensorflow, PyTorch etc. conversions will still work in this context.

Note, that this change simply provides the necessary support within the Properties. It's up to the individual plugins themselves to modify the constructors to fetch and load the tensor instance

## Testing

Adding some additional tests in `test_properties.py`