### PR TITLE
Check that dict keys do not contains . character

### DIFF
--- a/include/mitsuba/core/string.h
+++ b/include/mitsuba/core/string.h
@@ -138,7 +138,7 @@ inline bool replace_inplace(std::string &str, const std::string &source,
 
 /// Remove leading and trailing characters
 extern MI_EXPORT_LIB std::string trim(const std::string &s,
-                                        const std::string &whitespace = " \t");
+                                      const std::string &whitespace = " \t");
 
 /// Check if a list of keys contains a specific key
 extern MI_EXPORT_LIB bool contains(const std::vector<std::string> &keys, const std::string &key);

--- a/src/core/python/xml_v.cpp
+++ b/src/core/python/xml_v.cpp
@@ -189,7 +189,7 @@ ref<Object> create_texture_from(const py::dict &dict, bool within_emitter) {
     if (type == "rgb") {
         if (dict.size() != 2) {
             Throw("'rgb' dictionary should always contain 2 entries "
-                    "('type' and 'value'), got %u.", dict.size());
+                  "('type' and 'value'), got %u.", dict.size());
         }
         // Read info from the dictionary
         Properties::Color3f color(0.f);
@@ -206,7 +206,7 @@ ref<Object> create_texture_from(const py::dict &dict, bool within_emitter) {
     } else if (type == "spectrum") {
         if (dict.size() != 2) {
             Throw("'spectrum' dictionary should always contain 2 "
-                    "entries ('type' and 'value'), got %u.", dict.size());
+                  "entries ('type' and 'value'), got %u.", dict.size());
         }
         // Read info from the dictionary
         Properties::Float const_value(1);
@@ -295,6 +295,12 @@ void parse_dictionary(DictParseContext &ctx,
         SET_PROPS(ScalarColor3f, ScalarColor3f, set_color);
         SET_PROPS(ScalarArray3f, ScalarArray3f, set_array3f);
         SET_PROPS(ScalarTransform4f, ScalarTransform4f, set_transform);
+
+        if (key.find('.') != std::string::npos) {
+            Throw("The object key '%s' contains a '.' character, which is "
+                  "already used as a delimiter in the object path in the scene."
+                  " Please use '_' instead.", key);
+        }
 
         // Parse nested dictionary
         if (py::isinstance<py::dict>(value)) {


### PR DESCRIPTION
It is important to prevent users from using the `.` character in scene object's names, as this character is already used as path separator (e.g. in `mi.traverse()`). This PR adds a simple check for this in the `mi.load_dict()` routine, suggesting the user to use `_` instead.