### PR TITLE
Fix mi.cornell_box when no variant is set

### DIFF
--- a/src/python/python/util.py
+++ b/src/python/python/util.py
@@ -566,7 +566,7 @@ def cornell_box():
     '''
     Returns a dictionary containing a description of the Cornell Box scene.
     '''
-    T = mi.ScalarTransform4f
+    T = mi.scalar_rgb.Transform4f
     return {
         'type': 'scene',
         'integrator': {


### PR DESCRIPTION
It can be useful to instanciate a Cornell box dictionnary without setting a Mitsuba variant. E.g. see the following code:

```python
import mitsuba as mi
d = mi.scalar_rgb.cornell_box()
...
```

For this to work, we should avoid using type aliases from `mi` directly. This PR removes the usage of the type alias for `ScalarTransform4f` to make this work.