### PR TITLE
Add support for hide_emitters in python integrators

### DIFF
--- a/src/python/python/ad/integrators/direct_reparam.py
+++ b/src/python/python/ad/integrators/direct_reparam.py
@@ -137,13 +137,20 @@ class DirectReparamIntegrator(ADIntegrator):
         pi = scene.ray_intersect_preliminary(ray_reparam, active)
         si = pi.compute_surface_interaction(ray_reparam)
 
+        active_next = mi.Bool(active)
+
+        # Hide the environment emitter if necessary
+        if self.hide_emitters:
+            active_next &= si.is_valid()
+
         # Differentiable evaluation of intersected emitter / envmap
-        L += si.emitter(scene).eval(si)
+        L += si.emitter(scene).eval(si, active_next)
 
         # ------------------ Emitter sampling -------------------
 
         # Should we continue tracing to reach one more vertex?
-        active_next = si.is_valid()
+        active_next &= si.is_valid()
+
         # Get the BSDF. Potentially computes texture-space differentials.
         bsdf = si.bsdf(ray_reparam)
 

--- a/src/python/python/ad/integrators/prb.py
+++ b/src/python/python/ad/integrators/prb.py
@@ -104,10 +104,11 @@ class PRBIntegrator(RBIntegrator):
         loop.set_max_iterations(self.max_depth)
 
         while loop(active):
+            active_next = mi.Bool(active)
+
             # Compute a surface interaction that tracks derivatives arising
             # from differentiable shape parameters (position, normals, etc.)
             # In primal mode, this is just an ordinary ray tracing operation.
-
             with dr.resume_grad(when=not primal):
                 si = scene.ray_intersect(ray,
                                          ray_flags=mi.RayFlags.All,
@@ -118,6 +119,10 @@ class PRBIntegrator(RBIntegrator):
 
             # ---------------------- Direct emission ----------------------
 
+            # Hide the environment emitter if necessary
+            if self.hide_emitters:
+                active_next &= ~(dr.eq(depth, 0) & ~si.is_valid())
+
             # Compute MIS weight for emitter sample from previous bounce
             ds = mi.DirectionSample3f(scene, si=si, ref=prev_si)
 
@@ -127,12 +132,12 @@ class PRBIntegrator(RBIntegrator):
             )
 
             with dr.resume_grad(when=not primal):
-                Le = β * mis * ds.emitter.eval(si)
+                Le = β * mis * ds.emitter.eval(si, active_next)
 
             # ---------------------- Emitter sampling ----------------------
 
             # Should we continue tracing to reach one more vertex?
-            active_next = (depth + 1 < self.max_depth) & si.is_valid()
+            active_next &= (depth + 1 < self.max_depth) & si.is_valid()
 
             # Is emitter sampling even possible on the current vertex?
             active_em = active_next & mi.has_flag(bsdf.flags(), mi.BSDFFlags.Smooth)

--- a/src/python/python/ad/integrators/prbvolpath.py
+++ b/src/python/python/ad/integrators/prbvolpath.py
@@ -68,10 +68,6 @@ class PRBVolpathIntegrator(RBIntegrator):
     """
     def __init__(self, props=mi.Properties()):
         super().__init__(props)
-        self.max_depth = props.get('max_depth', -1)
-        self.rr_depth = props.get('rr_depth', 5)
-        self.hide_emitters = props.get('hide_emitters', False)
-
         self.use_nee = False
         self.nee_handle_homogeneous = False
         self.handle_null_scattering = False


### PR DESCRIPTION
This PR adds support to hide directly visible emitters to all Python integrators. This uses the already existing `hide_emitters` property parsed in all integrator's constructor.