### PR TITLE
Add eval_3 to srgb plugin

### DIFF
--- a/src/spectra/srgb.cpp
+++ b/src/spectra/srgb.cpp
@@ -85,7 +85,10 @@ public:
 
     Color3f eval_3(const SurfaceInteraction3f &/*si*/, Mask active) const override {
         MI_MASKED_FUNCTION(ProfilerPhase::TextureEvaluate, active);
-        return m_value;
+        if constexpr (is_monochromatic_v<Spectrum>)
+            return Color3f(m_value[0]);
+        else
+            return m_value;
     }
 
     Float eval_1(const SurfaceInteraction3f & /*it*/, Mask active) const override {

--- a/src/spectra/srgb.cpp
+++ b/src/spectra/srgb.cpp
@@ -83,6 +83,11 @@ public:
             return m_value;
     }
 
+    Color3f eval_3(const SurfaceInteraction3f &/*si*/, Mask active) const override {
+        MI_MASKED_FUNCTION(ProfilerPhase::TextureEvaluate, active);
+        return m_value;
+    }
+
     Float eval_1(const SurfaceInteraction3f & /*it*/, Mask active) const override {
         MI_MASKED_FUNCTION(ProfilerPhase::TextureEvaluate, active);
         return mean();


### PR DESCRIPTION
This PR adds a straightforward implementation of `SRGBSpectrum::eval_3()`.