### PR TITLE
Fix incorrect log output in `chi2.py` (pdf_min)

### DIFF
--- a/src/python/python/chi2.py
+++ b/src/python/python/chi2.py
@@ -226,7 +226,7 @@ class ChiSquareTest:
         pdf_min = dr.min(self.pdf) / self.sample_count
         if not pdf_min[0] >= 0:
             self._log('Failure: Encountered a cell with a '
-                      'negative PDF value: %f' % pdf_min)
+                      'negative PDF value: %f' % pdf_min[0])
             self.fail = True
 
         self.pdf_sum = dr.sum(self.pdf) / self.sample_count


### PR DESCRIPTION
## Description

This PR fixes the following type error when `pdf_min` is negative in Chi2 test:
```TypeError: must be real number, not drjit.llvm.ad.Float```

This change is consistent with `pdf_sum` syntax. 

## Testing

<!-- Please describe the tests that you added to verify your changes. -->

## Checklist

<!-- Please make sure to complete this checklist before requesting a review. -->

- [N/A ] My code follows the [style guidelines](https://mitsuba.readthedocs.io/en/latest/src/developer_guide.html#coding-style) of this project
- [N/A] My changes generate no new warnings
- [N/A] My code also compiles for `cuda_*` and `llvm_*` variants. If you can't test this, please leave below
- [N/A] I have commented my code
- [N/A] I have made corresponding changes to the documentation
- [N/A] I have added tests that prove my fix is effective or that my feature works
- [N/A] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 3 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba/blob/master/LICENSE)