### PR TITLE
Envmap: do not assume alignment in RGB mode

### DIFF
--- a/src/emitters/tests/test_envmap.py
+++ b/src/emitters/tests/test_envmap.py
@@ -116,3 +116,22 @@ def test03_load_bitmap(variants_all_rgb):
     w2 = emitter_2.eval(si)
 
     assert dr.allclose(w1, w2, rtol=1e-3)
+
+
+def test04_parameters_changed(variants_all):
+    import numpy as np
+
+    n_channels = mi.Spectrum.Size
+    bitmap = mi.Bitmap(np.zeros((191, 23, n_channels), dtype=np.float32))
+    emitter = mi.load_dict({
+        "type" : "envmap",
+        "bitmap" : bitmap
+    })
+
+    params = mi.traverse(emitter)
+    shape = dr.shape(params['data'])
+    params['data'] = dr.ones(mi.TensorXf, shape=shape)
+    params.update()
+
+    params = mi.traverse(emitter)
+    assert dr.allclose(params['data'], 1)


### PR DESCRIPTION
## Description

The `envmap` plugin used to always use 4 channels regardless of the color mode. When updating the luminance map in `parameters_changed()`, aligned stores and loads were used, which was fine.

However, the envmap can now use 3 channel data in RGB mode (https://github.com/mitsuba-renderer/mitsuba3/commit/820c38e575b5e9e45fa89e046871c88a20181ef1), so the alignment assumption no longer holds.

This PR switches to unaligned loads and stores when the envmap data uses 3 channels.

## Testing

Added a simple test which triggers `Envmap::parameters_changed()`. When unconditionally assuming alignment, this test crashes in RGB modes.

## Checklist

- [x] My code follows the [style guidelines](https://mitsuba.readthedocs.io/en/latest/src/developer_guide.html#coding-style) of this project
- [x] My changes generate no new warnings
- [x] My code also compiles for `cuda_*` and `llvm_*` variants. If you can't test this, please leave below
- [ ] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 3 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba/blob/master/LICENSE)