### PR TITLE
Scene: Update bounding box when relevant params changed

### DIFF
--- a/src/render/scene.cpp
+++ b/src/render/scene.cpp
@@ -369,6 +369,10 @@ MI_VARIANT void Scene<Float, Spectrum>::parameters_changed(const std::vector<std
             accel_parameters_changed_gpu();
         else
             accel_parameters_changed_cpu();
+
+        m_bbox = {};
+        for (auto &s : m_shapes)
+            m_bbox.expand(s->bbox());
     }
 
     // Check whether any shape parameters have gradient tracking enabled

--- a/src/render/tests/test_scene.py
+++ b/src/render/tests/test_scene.py
@@ -246,3 +246,21 @@ def test09_test_emitter_sampling_weight_update(variants_all_backends_once):
     assert dr.allclose(scene.pdf_emitter(0), pdf[0])
     assert dr.allclose(scene.pdf_emitter(1), pdf[1])
     assert dr.allclose(scene.pdf_emitter(2), pdf[2])
+
+
+def test10_test_scene_bbox_update(variant_scalar_rgb):
+    scene = mi.load_dict({
+        'type': 'scene',
+        "sphere" : {
+            "type" : "sphere"
+        }
+    })
+
+    bbox = scene.bbox()
+    params = mi.traverse(scene)
+    offset = [-1, -1, -1]
+    params['sphere.to_world'] = mi.Transform4f.translate(offset)
+    params.update()
+
+    expected = mi.BoundingBox3f(bbox.min + offset, bbox.max + offset)
+    assert expected == scene.bbox()


### PR DESCRIPTION
## Description

Motivated by #461, in the event that the underlying accel structure needs to be recomputed, we similarly need to recompute corresponding scene bounding box 

## Testing

Added a small test in `test_scene`
