### PR TITLE
irradiancemeter: check if m_shape is set

### DIFF
--- a/src/sensors/irradiancemeter.cpp
+++ b/src/sensors/irradiancemeter.cpp
@@ -68,6 +68,10 @@ public:
         if (m_film->rfilter()->radius() > .5f + math::RayEpsilon<Float>)
             Log(Warn, "This sensor should only be used with a reconstruction filter"
                "of radius 0.5 or lower (e.g. default 'box' filter)");
+
+        if (!m_shape) {
+            Throw("The irradiance meter must be defined as a child object to a shape in a scene.");
+        }
     }
 
     std::pair<RayDifferential3f, Spectrum>


### PR DESCRIPTION
When the irradiancemeter is instantiated on it's own instead of as a child of a shape, mitsuba runs into a segmentation fault. Introducing a simple check in the constructor makes sure that the scene format is valid and the irradiancemeter is used as a child of the shape plugin.