### PR TITLE
AOV Integrator: Fixing up primal render

### DIFF
--- a/src/integrators/tests/test_aov.py
+++ b/src/integrators/tests/test_aov.py
@@ -147,3 +147,32 @@ def test04_check_aov_correct(variants_all_rgb):
 
     # Check z-pos
     assert(dr.allclose(image[:,:, -1:].array, [plane_offset] * image_dim))
+
+
+def test05_check_aov_film(variants_all_rgb):
+    import numpy as np
+    scene = mi.load_file(find_resource('resources/data/scenes/cbox/cbox.xml'))
+
+    path_integrator = mi.load_dict({
+        'type': 'path',
+        'max_depth': 6
+    })
+
+    aov_integrator = mi.load_dict({
+        'type': 'aov',
+        'aovs': 'dd.y:depth,nn:sh_normal',
+        'my_image': path_integrator
+    })
+
+    spp = 16
+
+    film = scene.sensors()[0].film()
+
+    path_integrator.render(scene, seed=0, spp=spp)
+    bitmap_path = film.bitmap(raw=False)
+
+    aovs_image = aov_integrator.render(scene, seed=0, spp=spp)
+    bitmap_aov = film.bitmap(raw=False)
+
+    # Make sure radiance is consistent
+    assert(np.allclose(bitmap_aov.split()[0][1],bitmap_path.split()[0][1]))


### PR DESCRIPTION
Withing the `AOVIntegrator`, partitioning of render calls between AOV and base channels was implemented in #815 . This was motivated by the need to separate how gradients are computed between AOV channels which simply use autodiff and the inner integrators that may invariably have their own handling of `render_forward` and `render_backwards`

However, writing to an underlying film is tightly coupled to an integrator's render call. In particular, the integrator is in effect responsible for initialising the film prior to rendering. With respect to the AOV Integrator, this is problematic because while we want to split our render calls between AOVs and inner integrators for the purposes of differentiation, we concurrently require a single render call that will write both AOV and base channels into our film. This PR is an attempt to address the latter problem.