### PR TITLE
Python bindinds improvements

### DIFF
--- a/include/mitsuba/render/integrator.h
+++ b/include/mitsuba/render/integrator.h
@@ -181,13 +181,13 @@ public:
                             uint32_t spp = 0) {
 
         if (sensor_index >= scene->sensors().size())
-            Throw("SamplingIntegrator::render_forward(): sensor index %i" 
+            Throw("SamplingIntegrator::render_forward(): sensor index %i"
                   "is out of bounds!", sensor_index);
 
         return render_forward(scene,
                               params,
                               scene->sensors()[sensor_index].get(),
-                              seed, 
+                              seed,
                               spp);
     }
 
@@ -272,14 +272,14 @@ public:
                          uint32_t spp = 0) {
 
         if (sensor_index >= scene->sensors().size())
-            Throw("SamplingIntegrator::render_backward(): sensor index %i" 
+            Throw("SamplingIntegrator::render_backward(): sensor index %i"
                   "is out of bounds!", sensor_index);
 
         return render_backward(scene,
                                params,
                                grad_in,
                                scene->sensors()[sensor_index].get(),
-                               seed, 
+                               seed,
                                spp);
     }
 

--- a/src/core/python/drjit_v.cpp
+++ b/src/core/python/drjit_v.cpp
@@ -132,13 +132,10 @@ MI_PY_EXPORT(DrJit) {
         m.attr("UnpolarizedSpectrum") = m.attr("Spectrum");
     }
 
-    // Matrix type aliases
-    for (int dim = 2; dim < 5; ++dim) {
-        std::string name = "Matrix" + std::to_string(dim),
-                    dr_name  = name + "f";
+    auto bind_type_aliases = [&](const std::string &name) {
+        std::string dr_name  = name + "f";
         if constexpr (std::is_same_v<double, ScalarFloat>)
             dr_name += "64";
-
         m.attr((name + "f").c_str()) =
             drjit_variant.attr(dr_name.c_str());
         m.attr(("Scalar" + name + "f").c_str()) =
@@ -151,28 +148,17 @@ MI_PY_EXPORT(DrJit) {
             drjit_variant.attr(dr_name.c_str());
         m.attr(("Scalar" + name + "d").c_str()) =
             drjit_scalar.attr(dr_name.c_str());
-    }
+    };
+
+    // Matrix type aliases
+    for (int dim = 2; dim < 5; ++dim)
+        bind_type_aliases("Matrix" + std::to_string(dim));
+
+    // Complex type aliases
+    bind_type_aliases("Complex2");
 
     // Quaternion type aliases
-    {
-        std::string name = "Quaternion4",
-                    dr_name  = name + "f";
-        if constexpr (std::is_same_v<double, ScalarFloat>)
-            dr_name += "64";
-
-        m.attr((name + "f").c_str()) =
-            drjit_variant.attr(dr_name.c_str());
-        m.attr(("Scalar" + name + "f").c_str()) =
-            drjit_scalar.attr(dr_name.c_str());
-
-        if constexpr (!std::is_same_v<double, ScalarFloat>)
-            dr_name += "64";
-
-        m.attr((name + "d").c_str()) =
-            drjit_variant.attr(dr_name.c_str());
-        m.attr(("Scalar" + name + "d").c_str()) =
-            drjit_scalar.attr(dr_name.c_str());
-    }
+    bind_type_aliases("Quaternion4");
 
     // Tensor type aliases
     if constexpr (std::is_same_v<float, ScalarFloat>)

--- a/src/integrators/aov.cpp
+++ b/src/integrators/aov.cpp
@@ -334,10 +334,8 @@ public:
                             Sensor *sensor,
                             uint32_t seed = 0,
                             uint32_t spp = 0) override {
-
-        TensorXf aovs_grad;
-
         // Perform forward mode propagation just for AOV image
+        TensorXf aovs_grad;
         {
             TensorXf aovs_image = Base::render(scene, sensor, seed, spp);
 
@@ -346,7 +344,7 @@ public:
             size_t num_aovs = m_aov_names.size();
             aovs_image = get_channels_slice(aovs_image, aovs_image.shape(2) - num_aovs, num_aovs);
 
-            // Perform an AD traversal of all registered AD variables that 
+            // Perform an AD traversal of all registered AD variables that
             // influence 'aovs_image' in a differentiable manner
             dr::forward_to(aovs_image.array());
 
@@ -367,8 +365,6 @@ public:
                          Sensor* sensor,
                          uint32_t seed = 0,
                          uint32_t spp = 0) override {
-
-        using Array = typename TensorXf::Array;
         size_t base_ch_count = sensor->film()->base_channels_count();
         auto [image_grads, aovs_grad] = split_channels(base_ch_count, grad_in);
 
@@ -427,7 +423,7 @@ protected:
 
         DynamicBuffer<UInt32> idx = dr::arange<DynamicBuffer<UInt32>>(slice_flat);
         DynamicBuffer<UInt32> pixel_idx = idx / num_channels;
-        DynamicBuffer<UInt32> channel_idx = dr::fmadd(pixel_idx, uint32_t(-(int)num_channels), idx) 
+        DynamicBuffer<UInt32> channel_idx = dr::fmadd(pixel_idx, uint32_t(-(int)num_channels), idx)
             + channel_offset;
 
         auto values_idx = dr::fmadd(pixel_idx, src.shape(2), channel_idx);
@@ -440,7 +436,7 @@ protected:
 
         DynamicBuffer<UInt32> idx = dr::arange<DynamicBuffer<UInt32>>(src_flat);
         DynamicBuffer<UInt32> pixel_idx = idx / src_shape[2];
-        DynamicBuffer<UInt32> dst_channel_idx = dr::fmadd(pixel_idx, uint32_t(-(int)src_shape[2]), idx) 
+        DynamicBuffer<UInt32> dst_channel_idx = dr::fmadd(pixel_idx, uint32_t(-(int)src_shape[2]), idx)
             + dst_channel_offset;
 
         uint32_t num_dst_channels = dst.shape(2);
@@ -453,7 +449,7 @@ protected:
     }
 
     /// Combine inner integrator images and AOVS image
-    TensorXf merge_channels(const std::vector<TensorXf>& inner_images, 
+    TensorXf merge_channels(const std::vector<TensorXf>& inner_images,
                             const TensorXf& aovs_image) const {
         using Array = typename TensorXf::Array;
 

--- a/src/render/integrator.cpp
+++ b/src/render/integrator.cpp
@@ -47,7 +47,6 @@ Integrator<Float, Spectrum>::render_forward(Scene* scene,
                                             Sensor *sensor,
                                             uint32_t seed,
                                             uint32_t spp) {
-
     // Recorded loops cannot be differentiated, so let's disable them
     dr::scoped_set_flag scope(JitFlag::LoopRecord, false);
 

--- a/src/render/python/fresnel_v.cpp
+++ b/src/render/python/fresnel_v.cpp
@@ -1,3 +1,4 @@
+#include <mitsuba/render/ior.h>
 #include <mitsuba/render/fresnel.h>
 #include <mitsuba/python/python.h>
 
@@ -25,5 +26,13 @@ MI_PY_EXPORT(fresnel) {
          py::overload_cast<const Vector3f &, const Normal3f &, Float, Float>(&refract<Float>),
          "wi"_a, "m"_a, "cos_theta_t"_a, "eta_ti"_a, D(refract, 2))
     .def("fresnel_diffuse_reflectance", &fresnel_diffuse_reflectance<Float>,
-         "eta"_a, D(fresnel_diffuse_reflectance));
+         "eta"_a, D(fresnel_diffuse_reflectance))
+    .def("lookup_ior",
+         [](const Properties &props, const std::string& name, py::object def) {
+            if (py::isinstance<py::float_>(def))
+                return lookup_ior(props, name, def.template cast<Properties::Float>());
+            return lookup_ior(props, name, def.template cast<std::string>());
+         },
+         "properties"_a, "name"_a, "default"_a,
+         "Lookup IOR value in table.");
 }


### PR DESCRIPTION
This PR brings the following improvement to the Python bindings of Mitsuba:

a. Add bindings for the `lookup_ior` routine
b. Binds aliases for the `ComplexNf` Dr.Jit types
c. Fix bindings of the `TraverseCallback::put_parameter` function in order to be able to call `put_parameter` from Python on a `TraverseCallback` class defined in C++.
d. Fix the `Integrator::render_forward` and `Integrator::render_backward` bindings to properly handle the `params` arguments.