### PR TITLE
Fix normalmap

### DIFF
--- a/src/bsdfs/normalmap.cpp
+++ b/src/bsdfs/normalmap.cpp
@@ -118,9 +118,10 @@ public:
                                              const Point2f &sample2,
                                              Mask active) const override {
         // Sample nested BSDF with perturbed shading frame
+        auto [ perturbed_frame_wrt_si, perturbed_frame_wrt_world ] = frame(si, active);
         SurfaceInteraction3f perturbed_si(si);
-        perturbed_si.sh_frame = frame(si, active);
-        perturbed_si.wi = perturbed_si.to_local(si.wi);
+        perturbed_si.sh_frame = perturbed_frame_wrt_world;
+        perturbed_si.wi       = perturbed_frame_wrt_si.to_local(si.wi);
         auto [bs, weight] = m_nested_bsdf->sample(ctx, perturbed_si,
                                                   sample1, sample2, active);
         active &= dr::any(dr::neq(unpolarized_spectrum(weight), 0.f));
@@ -128,9 +129,10 @@ public:
             return { bs, 0.f };
 
         // Transform sampled 'wo' back to original frame and check orientation
-        Vector3f perturbed_wo = perturbed_si.to_world(bs.wo);
+        Vector3f perturbed_wo = perturbed_frame_wrt_si.to_world(bs.wo);
         active &= Frame3f::cos_theta(bs.wo) *
                   Frame3f::cos_theta(perturbed_wo) > 0.f;
+        bs.pdf = dr::select(active, bs.pdf, 0.f);
         bs.wo = perturbed_wo;
 
         return { bs, weight & active };
@@ -140,10 +142,11 @@ public:
     Spectrum eval(const BSDFContext &ctx, const SurfaceInteraction3f &si,
                   const Vector3f &wo, Mask active) const override {
         // Evaluate nested BSDF with perturbed shading frame
+        auto [ perturbed_frame_wrt_si, perturbed_frame_wrt_world ] = frame(si, active);
         SurfaceInteraction3f perturbed_si(si);
-        perturbed_si.sh_frame = frame(si, active);
-        perturbed_si.wi       = perturbed_si.to_local(si.wi);
-        Vector3f perturbed_wo = perturbed_si.to_local(wo);
+        perturbed_si.sh_frame = perturbed_frame_wrt_world;
+        perturbed_si.wi       = perturbed_frame_wrt_si.to_local(si.wi);
+        Vector3f perturbed_wo = perturbed_frame_wrt_si.to_local(wo);
 
         active &= Frame3f::cos_theta(wo) *
                   Frame3f::cos_theta(perturbed_wo) > 0.f;
@@ -155,10 +158,11 @@ public:
     Float pdf(const BSDFContext &ctx, const SurfaceInteraction3f &si,
               const Vector3f &wo, Mask active) const override {
         // Evaluate nested BSDF with perturbed shading frame
+        auto [ perturbed_frame_wrt_si, perturbed_frame_wrt_world ] = frame(si, active);
         SurfaceInteraction3f perturbed_si(si);
-        perturbed_si.sh_frame = frame(si, active);
-        perturbed_si.wi       = perturbed_si.to_local(si.wi);
-        Vector3f perturbed_wo = perturbed_si.to_local(wo);
+        perturbed_si.sh_frame = perturbed_frame_wrt_world;
+        perturbed_si.wi       = perturbed_frame_wrt_si.to_local(si.wi);
+        Vector3f perturbed_wo = perturbed_frame_wrt_si.to_local(wo);
 
         active &= Frame3f::cos_theta(wo) *
                   Frame3f::cos_theta(perturbed_wo) > 0.f;
@@ -173,10 +177,11 @@ public:
         MI_MASKED_FUNCTION(ProfilerPhase::BSDFEvaluate, active);
 
         // Evaluate nested BSDF with perturbed shading frame
+        auto [ perturbed_frame_wrt_si, perturbed_frame_wrt_world ] = frame(si, active);
         SurfaceInteraction3f perturbed_si(si);
-        perturbed_si.sh_frame = frame(si, active);
-        perturbed_si.wi       = perturbed_si.to_local(si.wi);
-        Vector3f perturbed_wo = perturbed_si.to_local(wo);
+        perturbed_si.sh_frame = perturbed_frame_wrt_world;
+        perturbed_si.wi       = perturbed_frame_wrt_si.to_local(si.wi);
+        Vector3f perturbed_wo = perturbed_frame_wrt_si.to_local(wo);
 
         active &= Frame3f::cos_theta(wo) *
                   Frame3f::cos_theta(perturbed_wo) > 0.f;
@@ -185,14 +190,23 @@ public:
         return { value & active, dr::select(active, pdf, 0.f) };
     }
 
-    Frame3f frame(const SurfaceInteraction3f &si, Mask active) const {
+    /** \brief Compute the perturbation due to the normal map relative to \c si.sh_frame,
+     * as well as the full \c sh_frame of the perturbation in the world coordinate system.
+     */
+    std::pair<Frame3f, Frame3f> frame(const SurfaceInteraction3f &si, Mask active) const {
         Normal3f n = dr::fmadd(m_normalmap->eval_3(si, active), 2, -1.f);
 
-        Frame3f result;
-        result.n = dr::normalize(n);
-        result.s = dr::normalize(dr::fnmadd(result.n, dr::dot(result.n, si.dp_du), si.dp_du));
-        result.t = dr::cross(result.n, result.s);
-        return result;
+        Frame3f frame_wrt_si;
+        frame_wrt_si.n = dr::normalize(n);
+        frame_wrt_si.s = dr::normalize(dr::fnmadd(frame_wrt_si.n, frame_wrt_si.n.x(), ScalarVector3f(1, 0, 0)));
+        frame_wrt_si.t = dr::cross(frame_wrt_si.n, frame_wrt_si.s);
+
+        Frame3f frame_wrt_world;
+        frame_wrt_world.n = si.to_world(frame_wrt_si.n);
+        frame_wrt_world.s = si.to_world(frame_wrt_si.s);
+        frame_wrt_world.t = si.to_world(frame_wrt_si.t);
+
+        return { frame_wrt_si, frame_wrt_world };
     }
 
     Spectrum eval_diffuse_reflectance(const SurfaceInteraction3f &si,

--- a/src/bsdfs/tests/test_normalmap.py
+++ b/src/bsdfs/tests/test_normalmap.py
@@ -1,0 +1,107 @@
+import pytest
+import drjit as dr
+import mitsuba as mi
+import numpy as np
+
+def test01_empty(variants_vec_backends_once_rgb):
+    raw_bsdf : mi.BSDF = mi.load_dict({
+        'type': 'roughconductor',
+        'distribution': 'ggx',
+        'alpha_u': 0.2,
+        'alpha_v': 0.05,
+        'material': 'Al'
+    })
+    normalmap_bsdf : mi.BSDF = mi.load_dict(
+    {
+        'type': 'normalmap',
+        'normalmap': {
+            'type': 'srgb',
+            'color': [ 0.5, 0.5, 1.0 ]
+        },
+        'nested_bsdf': raw_bsdf
+    })
+
+    rng : mi.Sampler = mi.load_dict({
+        'type': 'ldsampler'
+    })
+    rng.seed(0, 1024)
+    sample1 = rng.next_1d()
+    sample2 = rng.next_2d()
+
+    si = mi.SurfaceInteraction3f()
+    si.sh_frame = mi.Frame3f(mi.Vector3f(1, 1, 1))
+    si.wi = mi.Vector3f(0, 0, 1)
+
+    bs_ref, weight_ref = raw_bsdf.sample(mi.BSDFContext(), si, sample1, sample2)
+    bs_test, weight_test = normalmap_bsdf.sample(mi.BSDFContext(), si, sample1, sample2)
+
+    # ignore quantities for zero-weight samples!
+    bs_ref.wo[dr.all(dr.eq(weight_ref, 0))] = 0
+    bs_test.wo[dr.all(dr.eq(weight_test, 0))] = 0
+    bs_ref.pdf[dr.all(dr.eq(weight_ref, 0))] = 0
+    bs_test.pdf[dr.all(dr.eq(weight_test, 0))] = 0
+
+    assert dr.allclose(bs_ref.wo, bs_test.wo)
+    assert dr.allclose(bs_ref.pdf, bs_test.pdf)
+    assert dr.allclose(weight_ref, weight_test)
+
+def test02_tilted(variants_vec_backends_once_rgb):
+    # Construct a "local" frame representing a normal perturbation
+    sin_theta = 0.5
+    cos_theta = 0.5*dr.sqrt(3)
+    s = mi.ScalarVector3f(cos_theta, 0, -sin_theta)
+    t = mi.ScalarVector3f(0, 1, 0)
+    n = mi.ScalarVector3f(sin_theta, 0, cos_theta)
+    normal_frame = mi.Frame3f(s, t, n)
+    raw_bsdf : mi.BSDF = mi.load_dict({
+        'type': 'roughconductor',
+        'distribution': 'ggx',
+        'alpha_u': 0.2,
+        'alpha_v': 0.05,
+        'material': 'Al'
+    })
+    perturbed_bsdf : mi.BSDF = mi.load_dict(
+    {
+        'type': 'normalmap',
+        'normalmap': {
+            'type': 'srgb',
+            'color': n * 0.5 + 0.5
+        },
+        'nested_bsdf': raw_bsdf
+    })
+
+    rng : mi.Sampler = mi.load_dict({
+        'type': 'ldsampler'
+    })
+    rng.seed(0, 1024)
+    sample1 = rng.next_1d()
+    sample2 = rng.next_2d()
+
+    si_original = mi.SurfaceInteraction3f()
+    si_original.sh_frame = mi.Frame3f(mi.Vector3f(1, 1, 1))
+    si_original.wi = mi.Vector3f(0, 0, 1)
+
+    si_perturbed = mi.SurfaceInteraction3f()
+    si_perturbed.sh_frame = mi.Frame3f(si_original.to_world(normal_frame.s), si_original.to_world(normal_frame.t), si_original.to_world(normal_frame.n))
+    si_perturbed.wi = normal_frame.to_local(si_original.wi)
+
+    bs_raw, weight_raw = raw_bsdf.sample(mi.BSDFContext(), si_perturbed, sample1, sample2)
+    bs_test, weight_test = perturbed_bsdf.sample(mi.BSDFContext(), si_original, sample1, sample2)
+
+    # move raw wo to into the perturbed normal frame
+    wo_raw = normal_frame.to_world(bs_raw.wo)
+    wo_test = bs_test.wo
+
+    # mask invalid "raw" samples with inconsistent surface orientations
+    bs_raw.pdf[wo_raw.z * bs_raw.wo.z <= 0] = 0
+    weight_raw[wo_raw.z * bs_raw.wo.z <= 0] = 0
+
+    # ignore quantities for zero-weight samples!
+    wo_raw[dr.all(dr.eq(weight_raw, 0))] = 0
+    wo_test[dr.all(dr.eq(weight_test, 0))] = 0
+    bs_raw.pdf[dr.all(dr.eq(weight_raw, 0))] = 0
+    bs_test.pdf[dr.all(dr.eq(weight_test, 0))] = 0
+
+    assert dr.allclose(wo_raw, wo_test, atol=1e-4)
+    assert dr.allclose(bs_raw.pdf, bs_test.pdf, atol=1e-4)
+    assert dr.allclose(weight_raw, weight_test, atol=2e-4)


### PR DESCRIPTION
<!-- Please add the labels (e.g. bug fix, feature, ..) corresponding to this PR -->

## Description

The shading frame in the `normalmap` BSDF was not computed correctly.
The shading frame-local normal was used in conjunction with the world-space `dp_du` to construct the perturbed shading frame.
The shading frame in turn was interpreted as the "shading frame in world space", as well as the relative transformation between the original shading frame and the perturbed one...

## Testing

<!-- Please describe the tests that you added to verify your changes. -->
`resources/data/tests/scenes/git/test_normalmap_roughconductor_path.xml` has been added in my fork of the [mitsuba-data repository](https://github.com/tomix1024/mitsuba-data) to verify the changes.
**(But this probably does not really count here, does it?)**
The improved correctness relative to the previous implementation can be seen if the normal-mapped rendering is compared to a not normal-mapped rendering.

I have added `src/bsdfs/tests/test_normalmap.py`, that verifies that sampling from a normal-mapped BSDF is the same as sampling from the nested BSDF with an appropriately rotated surface interaction.

## Checklist

<!-- Please make sure to complete this checklist before requesting a review. -->

- [x] My code follows the [style guidelines](https://mitsuba.readthedocs.io/en/latest/src/developer_guide.html#coding-style) of this project
- [x] My changes generate no new warnings
- [x] My code also compiles for `cuda_*` and `llvm_*` variants. If you can't test this, please leave below
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 3 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba/blob/master/LICENSE)