### PR TITLE
Mask BSDF: fix sampling weight to get correct gradients

### DIFF
--- a/src/bsdfs/mask.cpp
+++ b/src/bsdfs/mask.cpp
@@ -147,14 +147,15 @@ public:
         bs.sampled_component = null_index;
         bs.sampled_type      = +BSDFFlags::Null;
         bs.pdf               = 1.f - opacity;
-        result               = 1.f;
+        result               = (1.f - opacity) / dr::detach(1.f - opacity);
 
         Mask nested_mask = active && sample1 < opacity;
         if (dr::any_or<true>(nested_mask)) {
             sample1 /= opacity;
             auto tmp                = m_nested_bsdf->sample(ctx, si, sample1, sample2, nested_mask);
             dr::masked(bs, nested_mask) = tmp.first;
-            dr::masked(result, nested_mask) = tmp.second;
+            dr::masked(result, nested_mask) = tmp.second * opacity / dr::detach(opacity);
+            dr::masked(bs.pdf, nested_mask) *= opacity;
         }
 
         return { bs, result };


### PR DESCRIPTION
## Description

The opacity texture of the `Mask` BSDF should be differentiable. However, the current implementation does not allow to get correct gradients. This is due to ignoring the sampling weight introduced by the discrete decision to either go through the surface or reflect. For forward rendering, this is perfectly fine, since this weight is always 1. However, this weight is important to get correct derivatives.

The code below generates a forward derivative both with AD and FD to illustrate the issue.

```python
import mitsuba as mi
mi.set_variant('cuda_ad_rgb')
from mitsuba.scalar_rgb import Transform4f as T
import drjit as dr

scene = mi.load_dict({
    'type': 'scene',
    'integrator': {
        'type': 'path',
    },
    'sensor': {
        'type': 'perspective',
        'fov': 45,
        'to_world': T.look_at(origin=[0, 0, 3], target=[0, 0, 0], up=[0, 1, 0]),
        'film': {
            'type': 'hdrfilm',
            'width': 512,
            'height': 512,
        },
    },
    'plane': {
        'type': 'rectangle',
        'to_world': T.rotate((0, 0, 1), 180),
        'bsdf': {
            'type': 'mask',
            'material': {
                'type': 'diffuse',
                'reflectance': {
                    'type': 'rgb',
                    'value': [0.01, 0.5, 0.1],
                },
            },
            'opacity': {
                'type': 'bitmap',
                'filename': 'resources/data/common/textures/leaf_mask.png',
                'wrap_mode': 'clamp',
            }
        }
    },
    'emitter': {
        'type': 'envmap',
        'filename': 'tutorials/scenes/textures/envmap.exr',
    }
})

params = mi.traverse(scene)

a = mi.Float(0.5)
key = 'plane.bsdf.opacity.data'
opacity = mi.TensorXf(params[key])
eps = 1e-3

params[key] = opacity * (a + eps)
params.update()
img1 = mi.render(scene, params=params, seed=0, spp=8192)

params[key] = opacity * (a - eps)
params.update()
img0 = mi.render(scene, params=params, seed=0, spp=8192)

grad_fd = (img1 - img0) / (2 * eps)
mi.Bitmap(grad_fd).write("grad_fd.exr")

dr.enable_grad(a)
params[key] = opacity * a
params.update()
img = mi.render(scene, params=params, seed=0, spp=256)
dr.forward(a)

mi.Bitmap(dr.grad(img)).write("grad_ad.exr")
mi.Bitmap(img).write("primal.exr")

```

Finite differences produce a gradient images that looks like this: 
![grad_fd](https://github.com/mitsuba-renderer/mitsuba3/assets/40777524/17ec13a6-6043-4d25-8444-6aeac0fd9aef)

While forward-mode AD gives a very different result:
![grad_ad_broken](https://github.com/mitsuba-renderer/mitsuba3/assets/40777524/ab3aed2a-5921-4ddd-b075-22b4cbfb19eb)

With the changes in this PR, we get the right derivatives:
![grad_ad_fix](https://github.com/mitsuba-renderer/mitsuba3/assets/40777524/c6ee8ea8-1215-4fc8-b6bf-e0b4e85db9da)

All three images are generated from tev in diff mode with the same exposure level.
