### PR TITLE
WIP: fix kernel cache miss due to changing film crop_size, crop_offset

### DIFF
--- a/src/render/integrator.cpp
+++ b/src/render/integrator.cpp
@@ -423,7 +423,8 @@ SamplingIntegrator<Float, Spectrum>::render_sample(const Scene *scene,
 
     Vector2f sample_pos   = pos + sampler->next_2d(active),
              adjusted_pos = dr::fmadd(sample_pos, scale, offset);
-
+    dr::make_opaque(sample_pos, adjusted_pos);
+    
     Point2f aperture_sample(.5f);
     if (sensor->needs_aperture_sample())
         aperture_sample = sampler->next_2d(active);

--- a/src/render/integrator.cpp
+++ b/src/render/integrator.cpp
@@ -290,13 +290,13 @@ SamplingIntegrator<Float, Spectrum>::render(Scene *scene,
 
         // Compute the position on the image plane
         Vector2u pos;
-        pos.y() = idx / film_size[0];
-        pos.x() = dr::fnmadd(film_size[0], pos.y(), idx);
+        pos.y() = idx / dr::opaque<UInt32>(film_size[0]);
+        pos.x() = dr::fnmadd(dr::opaque<UInt32>(film_size[0]), pos.y(), idx);
 
         if (film->sample_border())
-            pos -= film->rfilter()->border_size();
+	    pos -= dr::opaque<Vector2u>(film->rfilter()->border_size());
 
-        pos += film->crop_offset();
+        pos += dr::opaque<Vector2u>(film->crop_offset());
 
         // Scale factor that will be applied to ray differentials
         ScalarFloat diff_scale_factor = dr::rsqrt((ScalarFloat) spp);
@@ -422,9 +422,8 @@ SamplingIntegrator<Float, Spectrum>::render_sample(const Scene *scene,
                    offset = -ScalarVector2f(film->crop_offset()) * scale;
 
     Vector2f sample_pos   = pos + sampler->next_2d(active),
-             adjusted_pos = dr::fmadd(sample_pos, scale, offset);
-    dr::make_opaque(sample_pos, adjusted_pos);
-    
+      adjusted_pos = dr::fmadd(sample_pos, dr::opaque<Vector2f>(scale), dr::opaque<Vector2f>(offset));
+
     Point2f aperture_sample(.5f);
     if (sensor->needs_aperture_sample())
         aperture_sample = sampler->next_2d(active);

--- a/src/sensors/perspective.cpp
+++ b/src/sensors/perspective.cpp
@@ -190,9 +190,9 @@ public:
         m_image_rect.expand(Point2f(pmax.x(), pmax.y()) / pmax.z());
         m_normalization = 1.f / m_image_rect.volume();
         m_needs_sample_3 = false;
-
+	m_scaled_principal_point_offset = m_film->size() * m_principal_point_offset / m_film->crop_size();
         dr::make_opaque(m_camera_to_sample, m_sample_to_camera, m_dx, m_dy, m_x_fov,
-                        m_image_rect, m_normalization, m_principal_point_offset);
+                        m_image_rect, m_normalization, m_principal_point_offset, m_scaled_principal_point_offset);
     }
 
     std::pair<Ray3f, Spectrum> sample_ray(Float time, Float wavelength_sample,
@@ -209,13 +209,10 @@ public:
         ray.time = time;
         ray.wavelengths = wavelengths;
 
-        Vector2f scaled_principal_point_offset =
-            m_film->size() * m_principal_point_offset / m_film->crop_size();
-
         // Compute the sample position on the near plane (local camera space).
         Point3f near_p = m_sample_to_camera *
-                         Point3f(position_sample.x() + scaled_principal_point_offset.x(),
-                                 position_sample.y() + scaled_principal_point_offset.y(),
+                         Point3f(position_sample.x() + m_scaled_principal_point_offset.x(),
+                                 position_sample.y() + m_scaled_principal_point_offset.y(),
                                  0.f);
 
         // Convert into a normalized ray direction; adjust the ray interval accordingly.
@@ -246,13 +243,10 @@ public:
         ray.time = time;
         ray.wavelengths = wavelengths;
 
-        Vector2f scaled_principal_point_offset =
-            m_film->size() * m_principal_point_offset / m_film->crop_size();
-
         // Compute the sample position on the near plane (local camera space).
         Point3f near_p = m_sample_to_camera *
-                         Point3f(position_sample.x() + scaled_principal_point_offset.x(),
-                                 position_sample.y() + scaled_principal_point_offset.y(),
+                         Point3f(position_sample.x() + m_scaled_principal_point_offset.x(),
+                                 position_sample.y() + m_scaled_principal_point_offset.y(),
                                  0.f);
 
         // Convert into a normalized ray direction; adjust the ray interval accordingly.
@@ -290,12 +284,9 @@ public:
         if (dr::none_or<false>(active))
             return { ds, dr::zeros<Spectrum>() };
 
-        Vector2f scaled_principal_point_offset =
-            m_film->size() * m_principal_point_offset / m_film->crop_size();
-
         Point3f screen_sample = m_camera_to_sample * ref_p;
-        ds.uv = Point2f(screen_sample.x() - scaled_principal_point_offset.x(),
-                        screen_sample.y() - scaled_principal_point_offset.y());
+        ds.uv = Point2f(screen_sample.x() - m_scaled_principal_point_offset.x(),
+                        screen_sample.y() - m_scaled_principal_point_offset.y());
         active &= (ds.uv.x() >= 0) && (ds.uv.x() <= 1) && (ds.uv.y() >= 0) &&
                   (ds.uv.y() <= 1);
         if (dr::none_or<false>(active))
@@ -409,6 +400,7 @@ private:
     Float m_x_fov;
     Vector3f m_dx, m_dy;
     Vector2f m_principal_point_offset;
+    Vector2f m_scaled_principal_point_offset;
 };
 
 MI_IMPLEMENT_CLASS_VARIANT(PerspectiveCamera, ProjectiveCamera)


### PR DESCRIPTION
<!-- Please add the labels (e.g. bug fix, feature, ..) corresponding to this PR -->

## Description

Work in progress. Since I won't be able to work on this for a while, I decide to open a PR for results I have so far. Hopefully it will be useful. Feel free to take over.

Current PR only fixes kernel cache miss in perspective.cpp and integrator.cpp, which seem to eliminate most kernel cache miss in render. render_backward still incur kernel cache miss likely due to imageblock.

Fixes #908 

## Testing

<!-- Please describe the tests that you added to verify your changes. -->

## Checklist

<!-- Please make sure to complete this checklist before requesting a review. -->

- [ ] My code follows the [style guidelines](https://mitsuba.readthedocs.io/en/latest/src/developer_guide.html#coding-style) of this project
- [ ] My changes generate no new warnings
- [ ] My code also compiles for `cuda_*` and `llvm_*` variants. If you can't test this, please leave below
- [ ] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 3 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba/blob/master/LICENSE)