### PR TITLE
Fix a bug: unable to get SGGX "S" parameters because of type error

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -23,8 +23,8 @@ jobs:
   build_wheels:
     strategy:
       matrix:
-        os: [ubuntu-20.04, windows-latest, macos-latest]
-        python: [cp38, cp39, cp310, cp311]
+        os: [ubuntu-20.04]
+        python: [cp38]
         cibw-arch: [x86_64, arm64]
         exclude:
           - os: ubuntu-20.04

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -23,8 +23,8 @@ jobs:
   build_wheels:
     strategy:
       matrix:
-        os: [ubuntu-20.04]
-        python: [cp38]
+        os: [ubuntu-20.04, windows-latest, macos-latest]
+        python: [cp38, cp39, cp310, cp311]
         cibw-arch: [x86_64, arm64]
         exclude:
           - os: ubuntu-20.04

--- a/src/phase/sggx.cpp
+++ b/src/phase/sggx.cpp
@@ -69,7 +69,7 @@ public:
     }
 
     void traverse(TraversalCallback *callback) override {
-        callback->put_parameter("S", m_ndf_params, +ParamFlags::Differentiable);
+        callback->put_object("S", m_ndf_params.get(), +ParamFlags::Differentiable);
     }
 
     MI_INLINE


### PR DESCRIPTION
<!-- bug fix -->

## Description

Fix a bug: unable to get SGGX "S" parameters because of type error
change get_parameters to get_object in SGGX because the parameters are stored in a volume.
It's a one line change of code.

Fixes # unable to get SGGX "S" parameters because of type error
`key = 'object.interior_medium.phase_function.S'
print(params[key])`
This line of code will cause error that get_property is not working with the specific type.

## Testing

`key = 'object.interior_medium.phase_function.S.data'
print(params[key])`

## Checklist

<!-- Please make sure to complete this checklist before requesting a review. -->

- [x] My code follows the [style guidelines](https://mitsuba.readthedocs.io/en/latest/src/developer_guide.html#coding-style) of this project
- [x] My changes generate no new warnings
- [x] My code also compiles for `cuda_*` and `llvm_*` variants. If you can't test this, please leave below
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 3 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba/blob/master/LICENSE)