### PR TITLE
[bugfix] Add UTF-8 encoding to file read/write in test_tutorials.py

### DIFF
--- a/src/render/tests/test_tutorials.py
+++ b/src/render/tests/test_tutorials.py
@@ -21,7 +21,7 @@ def run_notebook(notebook_path, tmp_dir=None):
     if tmp_dir is None:
         tmp_dir = dirname(notebook_path)
 
-    with open(notebook_path) as f:
+    with open(notebook_path, encoding='utf-8') as f:
         nb = nbformat.read(f, as_version=4)
 
     # Check the variants required in this notebook are enabled, otherwise skip
@@ -37,7 +37,7 @@ def run_notebook(notebook_path, tmp_dir=None):
     proc.preprocess(nb, {'metadata': {'path': dirname(notebook_path)}})
     output_path = join(tmp_dir, '{}_all_output.ipynb'.format(nb_name))
 
-    with open(output_path, mode='wt') as f:
+    with open(output_path, mode='wt', encoding='utf-8') as f:
         nbformat.write(nb, f)
 
     return nb


### PR DESCRIPTION
## Description

Tests for tutorials/jupyter notebooks don't work on Windows because the file read/write doesn't explicitly specify the encoding of the notebooks which under linux/mac os defaults to utf-8, but a different encoding under Windows (cp1252 I think).

This PR fixes the encoding choice and avoids the `UnicodeDecodeError`/`UnicodeEncodeError` that occurs on Windows when running notebook tests.

## Checklist

- [x] My code follows the [style guidelines](https://mitsuba.readthedocs.io/en/latest/src/developer_guide.html#coding-style) of this project
- [x] My changes generate no new warnings
- [x] My code also compiles for `cuda_*` and `llvm_*` variants. If you can't test this, please leave below
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 3 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba/blob/master/LICENSE)