### PR TITLE
Add mitsuba suffix to OpenEXR library dependencies

### DIFF
--- a/ext/CMakeLists.txt
+++ b/ext/CMakeLists.txt
@@ -200,7 +200,7 @@ set_property(TARGET
   IexMath IlmThread Half Iex Imath IlmImf IexMath
   PROPERTY PUBLIC_HEADER "")
 
-foreach(X IN LISTS IexMath IlmThread Half Iex Imath IlmImf IexMath IlmImfUtil)
+foreach(X IexMath IlmThread Half Iex Imath IlmImf IexMath IlmImfUtil)
     set_property(TARGET ${X} PROPERTY OUTPUT_NAME "${X}-mitsuba")
 endforeach()
 

--- a/ext/CMakeLists.txt
+++ b/ext/CMakeLists.txt
@@ -200,6 +200,10 @@ set_property(TARGET
   IexMath IlmThread Half Iex Imath IlmImf IexMath
   PROPERTY PUBLIC_HEADER "")
 
+foreach(X IN LISTS IexMath IlmThread Half Iex Imath IlmImf IexMath IlmImfUtil)
+    set_property(TARGET ${X} PROPERTY OUTPUT_NAME "${X}-mitsuba")
+endforeach()
+
 set(OPENEXR_INCLUDE_DIRS
   ${CMAKE_CURRENT_SOURCE_DIR}/openexr/IlmBase/Imath
   ${CMAKE_CURRENT_SOURCE_DIR}/openexr/IlmBase/Imath

--- a/ext/CMakeLists.txt
+++ b/ext/CMakeLists.txt
@@ -201,7 +201,7 @@ set_property(TARGET
   PROPERTY PUBLIC_HEADER "")
 
 foreach(X IexMath IlmThread Half Iex Imath IlmImf IexMath IlmImfUtil)
-    set_property(TARGET ${X} PROPERTY OUTPUT_NAME "${X}-mitsuba")
+  set_property(TARGET ${X} PROPERTY OUTPUT_NAME "${X}-mitsuba")
 endforeach()
 
 set(OPENEXR_INCLUDE_DIRS


### PR DESCRIPTION
This is motivated by DLL import failures reported when using the mitsuba-blender addon - specifically when attempting to import mitsuba within the embedded Python interpreter in Blender 3.5+ on Windows (see [here](https://github.com/mitsuba-renderer/mitsuba-blender/issues/61)).

The underlying issue is that as of Blender 3.5, OpenEXR dependencies (among others) for the executable moved from being linked statically to dynamically. More importantly, these shared libraries are bundled as a side-by-side assembly which overrides the default DLL search order on Windows. Moreover, once a DLL with the same module name is already loaded in memory, the system uses the loaded DLL, no matter which directory it is in.

Ultimately this is problematic for Mitsuba currently as Blender 3.5+ is targeting OpenEXR v3 and Mitsuba is currently on 2.5. Regardless of the version mismatch, we want to always guarantee that the `mitsuba.dll` does use the accompanying built OpenEXR dependencies rather than anything externally. So by renaming the output of the built OpenEXR dll's with a `-mitsuba` suffix we can bypass this issue.

I've built and tested on Windows locally to confirm that this change does indeed fix the linked issue.
