### PR TITLE
Ensure correct rotation of backfacing retarders

### DIFF
--- a/src/bsdfs/retarder.cpp
+++ b/src/bsdfs/retarder.cpp
@@ -111,13 +111,15 @@ public:
             UnpolarizedSpectrum delta = dr::deg_to_rad(m_delta->eval(si, active));
 
             // Approximate angle-of-incidence behaviour with a cosine falloff
-            delta *= dr::abs(Frame3f::cos_theta(si.wi));
+            Float cos_theta = Frame3f::cos_theta(si.wi);
+            delta *= dr::abs(cos_theta);
 
             // Get standard Mueller matrix for a linear polarizer.
             Spectrum M = mueller::linear_retarder(delta);
 
-            // Rotate optical element by specified angle
-            M = mueller::rotated_element(theta, M);
+            /* Rotate optical element by specified angle. The angle is flipped if
+               the element is intersected from the backside. */
+            M = mueller::rotated_element(dr::sign(cos_theta) * theta, M);
 
             /* The `forward` direction here is always along the direction that
                light travels. This is needed for the coordinate system rotation
@@ -161,13 +163,15 @@ public:
             UnpolarizedSpectrum delta = dr::deg_to_rad(m_delta->eval(si, active));
 
             // Approximate angle-of-incidence behaviour with a cosine falloff
-            delta *= dr::abs(Frame3f::cos_theta(si.wi));
+            Float cos_theta = Frame3f::cos_theta(si.wi);
+            delta *= dr::abs(cos_theta);
 
             // Get standard Mueller matrix for a linear polarizer.
             Spectrum M = mueller::linear_retarder(delta);
 
-            // Rotate optical element by specified angle
-            M = mueller::rotated_element(theta, M);
+            /* Rotate optical element by specified angle. The angle is flipped if
+               the element is intersected from the backside. */
+            M = mueller::rotated_element(dr::sign(cos_theta) * theta, M);
 
             /* The `forward` direction here is always along the direction that
                light travels. This is needed for the coordinate system rotation


### PR DESCRIPTION
Hi,

I think there is a small bug in the retarder implementation. If a retarder is rotated, the rotation's sign should be flipped if the retarder is viewed from the reverse direction.

This is necessary to ensure the following physical property: If a retarder is rotated 45 degrees, it will convert linearly vertically polarized light to left circularly polarized light in one direction. In the opposite direction, it should be doing the reverse, which is currently not the case.

Intuitively, it also makes sense that a clockwise rotation on one side would be a counterclockwise rotation on the other side.

The fix is easy, but I would like to have confirmation from someone else to make sure this is really the right thing here.




