### PR TITLE
reparam: pass wavelengths to aux_rays

### DIFF
--- a/src/python/python/ad/reparam.py
+++ b/src/python/python/ad/reparam.py
@@ -85,8 +85,8 @@ def _sample_warp_field(scene: mi.Scene,
     aux_ray = mi.Ray3f(
         o = ray.o,
         d = ray_frame.to_world(omega_local),
-        time = ray.time)
-    aux_ray.wavelengths = ray.wavelengths
+        time = ray.time,
+        wavelengths = ray.wavelengths)
 
     # Compute an intersection that follows the intersected shape. For example,
     # a perturbation of the translation parameter will propagate to 'si.p'.

--- a/src/python/python/ad/reparam.py
+++ b/src/python/python/ad/reparam.py
@@ -86,6 +86,7 @@ def _sample_warp_field(scene: mi.Scene,
         o = ray.o,
         d = ray_frame.to_world(omega_local),
         time = ray.time)
+    aux_ray.wavelengths = ray.wavelengths
 
     # Compute an intersection that follows the intersected shape. For example,
     # a perturbation of the translation parameter will propagate to 'si.p'.


### PR DESCRIPTION
<!-- Please add the labels (e.g. bug fix, feature, ..) corresponding to this PR -->

## Description

When using spectral mode with the prb_reparam integrator, an exception is thrown:

```RuntimeError: jit_var_wrap_vcall(): invoked with an uninitialized variable!```

By passing wavelengths to the aux_rays in reparam.py _sample_warp_field(...) this issue can be solved (although the wavelengths are not required by the algorithm itself):

```
aux_ray = mi.Ray3f(
  o = ray.o,
  d = ray_frame.to_world(omega_local),
  time = ray.time)
aux_ray.wavelengths = ray.wavelengths
```

## Testing

No tests included - generally tests should cover prb_reparam in spectral mode. 

## Checklist

<!-- Please make sure to complete this checklist before requesting a review. -->

- [x] My code follows the [style guidelines](https://mitsuba.readthedocs.io/en/latest/src/developer_guide.html#coding-style) of this project
- [x] My changes generate no new warnings
- [x] My code also compiles for `cuda_*` and `llvm_*` variants. If you can't test this, please leave below
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 3 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba/blob/master/LICENSE)