### PR TITLE
Fix version checks in BlenderMesh plugin

### DIFF
--- a/include/mitsuba/core/util.h
+++ b/include/mitsuba/core/util.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <mitsuba/mitsuba.h>
+#include <mitsuba/core/string.h>
+#include <mitsuba/core/logger.h>
 #include <tinyformat.h>
 #include <sstream>
 #include <string>
@@ -47,6 +49,53 @@ extern MI_EXPORT_LIB std::string info_copyright();
 
 /// Return human-readable information about the enabled processor features
 extern MI_EXPORT_LIB std::string info_features();
+
+struct Version {
+    unsigned int major, minor, patch;
+
+    Version() = default;
+
+    Version(int major, int minor, int patch)
+        : major(major), minor(minor), patch(patch) { }
+
+    Version(const char *value) {
+        auto list = string::tokenize(value, " .");
+        if (list.size() != 3)
+            Throw("Version number must consist of three period-separated parts!");
+        major = std::stoul(list[0]);
+        minor = std::stoul(list[1]);
+        patch = std::stoul(list[2]);
+    }
+
+    bool operator==(const Version &v) const {
+        return std::tie(major, minor, patch) == std::tie(v.major, v.minor, v.patch);
+    }
+
+    bool operator!=(const Version &v) const {
+        return std::tie(major, minor, patch) != std::tie(v.major, v.minor, v.patch);
+    }
+
+    bool operator<(const Version &v) const {
+        return std::tie(major, minor, patch) < std::tie(v.major, v.minor, v.patch);
+    }
+
+    bool operator<=(const Version &v) const {
+        return std::tie(major, minor, patch) <= std::tie(v.major, v.minor, v.patch);
+    }
+
+    bool operator>(const Version &v) const {
+        return std::tie(major, minor, patch) > std::tie(v.major, v.minor, v.patch);
+    }
+
+    bool operator>=(const Version &v) const {
+        return std::tie(major, minor, patch) >= std::tie(v.major, v.minor, v.patch);
+    }
+
+    friend std::ostream &operator<<(std::ostream &os, const Version &v) {
+        os << v.major << "." << v.minor << "." << v.patch;
+        return os;
+    }
+};
 
 NAMESPACE_END(util)
 NAMESPACE_END(mitsuba)

--- a/src/core/xml.cpp
+++ b/src/core/xml.cpp
@@ -35,49 +35,13 @@
 NAMESPACE_BEGIN(mitsuba)
 NAMESPACE_BEGIN(xml)
 
+using Version = util::Version;
+
 // Set of supported XML tags
 enum class Tag {
     Boolean, Integer, Float, String, Point, Vector, Spectrum, RGB,
     Transform, Translate, Matrix, Rotate, Scale, LookAt, Object,
     NamedReference, Include, Alias, Default, Resource, Invalid
-};
-
-struct Version {
-    unsigned int major, minor, patch;
-
-    Version() = default;
-
-    Version(int major, int minor, int patch)
-        : major(major), minor(minor), patch(patch) { }
-
-    Version(const char *value) {
-        auto list = string::tokenize(value, " .");
-        if (list.size() != 3)
-            Throw("Version number must consist of three period-separated parts!");
-        major = std::stoul(list[0]);
-        minor = std::stoul(list[1]);
-        patch = std::stoul(list[2]);
-    }
-
-    bool operator==(const Version &v) const {
-        return std::tie(major, minor, patch) ==
-               std::tie(v.major, v.minor, v.patch);
-    }
-
-    bool operator!=(const Version &v) const {
-        return std::tie(major, minor, patch) !=
-               std::tie(v.major, v.minor, v.patch);
-    }
-
-    bool operator<(const Version &v) const {
-        return std::tie(major, minor, patch) <
-               std::tie(v.major, v.minor, v.patch);
-    }
-
-    friend std::ostream &operator<<(std::ostream &os, const Version &v) {
-        os << v.major << "." << v.minor << "." << v.patch;
-        return os;
-    }
 };
 
 // Check if the name corresponds to an unbounded spectrum property which require


### PR DESCRIPTION
This PR fixes the Blender version checks in the `BlenderMesh` plugin. More specifically, the current checks assume there is no major version greater than 3, which isn't the case anymore with the "soon-to-be-released" Blender v4.0.

This patch reuses the `Version` class implemented in `xml.cpp`, now moved to `util.h`, to perform the checks.