### PR TITLE
[Feature] Expose principal point offsets in Sensor traverse mechanism

### DIFF
--- a/src/sensors/perspective.cpp
+++ b/src/sensors/perspective.cpp
@@ -58,6 +58,7 @@ Perspective pinhole camera (:monosp:`perspective`)
  * - principal_point_offset_x, principal_point_offset_y
    - |float|
    - Specifies the position of the camera's principal point relative to the center of the film.
+   - |exposed|, |differentiable|, |discontinuous|
 
  * - srf
    - |spectrum|
@@ -153,8 +154,10 @@ public:
 
     void traverse(TraversalCallback *callback) override {
         Base::traverse(callback);
-        callback->put_parameter("x_fov",     m_x_fov,          ParamFlags::Differentiable | ParamFlags::Discontinuous);
-        callback->put_parameter("to_world", *m_to_world.ptr(), ParamFlags::Differentiable | ParamFlags::Discontinuous);
+        callback->put_parameter("x_fov",                    m_x_fov,                      ParamFlags::Differentiable | ParamFlags::Discontinuous);
+        callback->put_parameter("principal_point_offset_x", m_principal_point_offset.x(), ParamFlags::Differentiable | ParamFlags::Discontinuous);
+        callback->put_parameter("principal_point_offset_y", m_principal_point_offset.y(), ParamFlags::Differentiable | ParamFlags::Discontinuous);
+        callback->put_parameter("to_world",                *m_to_world.ptr(),             ParamFlags::Differentiable | ParamFlags::Discontinuous);
     }
 
     void parameters_changed(const std::vector<std::string> &keys) override {


### PR DESCRIPTION
## Description

This PR simply exposes the principal point offsets through the traverse mechanism of the perspective Sensor. The motivation for doing this is to be able to convert back and forth between camera representations with as little loss in translation as possible.

## Testing

N/A

## Checklist

- [x] My code follows the [style guidelines](https://mitsuba.readthedocs.io/en/latest/src/developer_guide.html#coding-style) of this project
- [x] My changes generate no new warnings
- [x] My code also compiles for `cuda_*` and `llvm_*` variants. If you can't test this, please leave below
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works (N/A)
- [x] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 3 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba/blob/master/LICENSE)