### PR TITLE
[bug fix] `pplastic.eval` for `TransportMode.Importance`

### DIFF
--- a/src/bsdfs/pplastic.cpp
+++ b/src/bsdfs/pplastic.cpp
@@ -330,7 +330,8 @@ public:
                 // Refract outside
                 Normal3f n(0.f, 0.f, 1.f);
                 Float inv_eta = dr::rcp(m_eta);
-                Float cos_theta_t_i = std::get<1>(fresnel(cos_theta_i, m_eta));
+                Float cos_theta_i_hat = ctx.mode == TransportMode::Radiance ? cos_theta_i : cos_theta_o;
+                Float cos_theta_t_i = std::get<1>(fresnel(cos_theta_i_hat, m_eta));
                 Vector3f wi_hat_p = -refract(wi_hat, cos_theta_t_i, inv_eta);
                 Spectrum Ti = mueller::specular_transmission(dr::abs(Frame3f::cos_theta(wi_hat_p)), inv_eta);
 


### PR DESCRIPTION
<!-- Please add the labels (e.g. bug fix, feature, ..) corresponding to this PR -->

## Description

Previous version of `PolarizedPlastic::eval` had produced wrong values for `mi.TransportMode.Importance` flag and polarized variants.
The issue has been fixed in this PR by just two lines.

## Testing

I'm not sure my testing code consists of preferable usage of Mitsuba 3, so I'm attaching the testing code here rather than creating a testing file in the repo.

Testing code: with correct implementation of `pplastic` pBSDF, its result under unpolarized variant should be equal to the (0,0) entry of the result under polarized variant.
```
import numpy as np
import drjit as dr
import mitsuba as mi
mi.set_variant('cuda_rgb_polarized')

def example_wiwo():
    theta = np.linspace(1e-4, np.pi-1e-4, 10)
    phi = np.linspace(1e-4, 2*np.pi - 1e-4, 10)
    thetai, phii, thetao, phio = np.meshgrid(theta, phi, theta, phi, indexing='ij')

    sini = np.sin(thetai)
    sino = np.sin(thetao)

    wi = np.stack([np.cos(phii)*sini, np.sin(phii)*sini, np.cos(thetai)], axis=-1).reshape(-1, 3)
    wo = np.stack([np.cos(phio)*sino, np.sin(phio)*sino, np.cos(thetao)], axis=-1).reshape(-1, 3)
    # print(f"{type(wi) = }, {dr.shape(wi) = }")
    return wi, wo

wi_np, wo_np = example_wiwo()
for mode in [mi.TransportMode.Radiance, mi.TransportMode.Importance]:
    print(f"\n# {mode}")
    res_list = []
    for variant in ['cuda_rgb', 'cuda_rgb_polarized']:    
        mi.set_variant(variant)
        
        wi_mi = mi.Vector3f(wi_np); wo_mi = mi.Vector3f(wo_np)
        bsdf = mi.load_dict({'type': 'pplastic'})

        si = mi.SurfaceInteraction3f()
        si.wi = wi_mi
        bsdf_res = bsdf.eval(mi.BSDFContext(mode),
                            si, wo_mi)
        res_list.append(bsdf_res)
    print(f"{dr.allclose(res_list[0], res_list[1][0,0]) = }")
    diff = (res_list[0] - res_list[1][0,0]).numpy()
    print(f"{diff.min() = }, {diff.max() = }")
    print(f"{np.sqrt(np.square(diff).mean() )=}") # RMSE
```

The result ***BEFORE*** modifying code was as follows:
```
# TransportMode.Radiance
dr.allclose(res_list[0], res_list[1][0,0]) = True
diff.min() = -3.7252903e-08, diff.max() = 1.4901161e-07
np.sqrt(np.square(diff).mean() )=2.3844331e-08

# TransportMode.Importance
dr.allclose(res_list[0], res_list[1][0,0]) = False
diff.min() = -0.009225626, diff.max() = 0.033938695
np.sqrt(np.square(diff).mean() )=0.0059159775
```
which produces a failed assertion for `mi.TransportMode.Importance`.

However, ***AFTER*** modifying code (this PR) gives:
```
# TransportMode.Radiance
dr.allclose(res_list[0], res_list[1][0,0]) = True
diff.min() = -3.7252903e-08, diff.max() = 1.4901161e-07
np.sqrt(np.square(diff).mean() )=2.3844331e-08

# TransportMode.Importance
dr.allclose(res_list[0], res_list[1][0,0]) = True
diff.min() = -4.4703484e-08, diff.max() = 4.4703484e-08
np.sqrt(np.square(diff).mean() )=1.0366235e-08
```
## Checklist

<!-- Please make sure to complete this checklist before requesting a review. -->

- [x] My code follows the [style guidelines](https://mitsuba.readthedocs.io/en/latest/src/developer_guide.html#coding-style) of this project
- [x] My changes generate no new warnings
- [x] My code also compiles for `cuda_*` and `llvm_*` variants. If you can't test this, please leave below
- [ ] I have commented my code
- [ ] I have made corresponding changes to the documentation
(since It is just two lines.)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 3 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba/blob/master/LICENSE)