### PR TITLE
Add support for AOVs to Python AD integrators.

### DIFF
--- a/src/python/python/ad/integrators/common.py
+++ b/src/python/python/ad/integrators/common.py
@@ -74,13 +74,14 @@ class ADIntegrator(mi.CppADIntegrator):
             ray, weight, pos = self.sample_rays(scene, sensor, sampler)
 
             # Launch the Monte Carlo sampling process in primal mode
-            L, valid, _ = self.sample(
+            L, valid, aovs, _ = self.sample(
                 mode=dr.ADMode.Primal,
                 scene=scene,
                 sampler=sampler,
                 ray=ray,
                 depth=mi.UInt32(0),
                 δL=None,
+                δaovs=None,
                 state_in=None,
                 active=mi.Bool(True)
             )
@@ -97,6 +98,7 @@ class ADIntegrator(mi.CppADIntegrator):
                 value=L * weight,
                 weight=1.0,
                 alpha=dr.select(valid, mi.Float(1), mi.Float(0)),
+                aovs=aovs,
                 wavelengths=ray.wavelengths
             )
 
@@ -131,7 +133,7 @@ class ADIntegrator(mi.CppADIntegrator):
             ray, weight, pos = self.sample_rays(scene, sensor, sampler)
 
             with dr.resume_grad():
-                L, valid, _ = self.sample(
+                L, valid, aovs, _ = self.sample(
                     mode=dr.ADMode.Forward,
                     scene=scene,
                     sampler=sampler,
@@ -148,6 +150,7 @@ class ADIntegrator(mi.CppADIntegrator):
                     value=L * weight,
                     weight=1,
                     alpha=dr.select(valid, mi.Float(1), mi.Float(0)),
+                    aovs=aovs,
                     wavelengths=ray.wavelengths
                 )
 
@@ -183,7 +186,7 @@ class ADIntegrator(mi.CppADIntegrator):
             ray, weight, pos = self.sample_rays(scene, sensor, sampler)
 
             with dr.resume_grad():
-                L, valid, _ = self.sample(
+                L, valid, aovs, _ = self.sample(
                     mode=dr.ADMode.Backward,
                     scene=scene,
                     sampler=sampler,
@@ -203,6 +206,7 @@ class ADIntegrator(mi.CppADIntegrator):
                     value=L * weight,
                     weight=1,
                     alpha=dr.select(valid, mi.Float(1), mi.Float(0)),
+                    aovs=aovs,
                     wavelengths=ray.wavelengths
                 )
 
@@ -372,6 +376,7 @@ class ADIntegrator(mi.CppADIntegrator):
                        value: mi.Spectrum,
                        weight: mi.Float,
                        alpha: mi.Float,
+                       aovs: Sequence[mi.Float],
                        wavelengths: mi.Spectrum):
         '''Helper function to splat values to a imageblock'''
         if (dr.all(mi.has_flag(film.flags(), mi.FilmFlags.Special))):
@@ -382,13 +387,18 @@ class ADIntegrator(mi.CppADIntegrator):
             block.put(pos, aovs)
             del aovs
         else:
-            block.put(
-                pos=pos,
-                wavelengths=wavelengths,
-                value=value,
-                weight=weight,
-                alpha=alpha
-            )
+            if mi.is_spectral:
+                rgb = mi.spectrum_to_srgb(value, wavelengths)
+            elif mi.is_monochromatic:
+                rgb = value.x
+            else:
+                rgb = value
+            if mi.has_flag(film.flags(), mi.FilmFlags.Alpha):
+                aovs = [rgb.x, rgb.y, rgb.z, alpha, weight] + aovs
+            else:
+                aovs = [rgb.x, rgb.y, rgb.z, weight] + aovs
+            block.put(pos, aovs)
+
 
     def sample(self,
                mode: dr.ADMode,
@@ -397,8 +407,9 @@ class ADIntegrator(mi.CppADIntegrator):
                ray: mi.Ray3f,
                depth: mi.UInt32,
                δL: Optional[mi.Spectrum],
+               δaovs: Optional[mi.Spectrum],
                state_in: Any,
-               active: mi.Bool) -> Tuple[mi.Spectrum, mi.Bool]:
+               active: mi.Bool) -> Tuple[mi.Spectrum, mi.Bool, List[mi.Float]]:
         """
         This function does the main work of differentiable rendering and
         remains unimplemented here. It is provided by subclasses of the
@@ -465,6 +476,12 @@ class ADIntegrator(mi.CppADIntegrator):
         Output ``valid`` (``mi.Bool``):
             Indicates whether the rays intersected a surface, which can be used
             to compute an alpha channel.
+
+        Output ``aovs`` (``List[mi.Float]``):
+            Integrators may return one or more arbitrary output variables (AOVs).
+            The implementation has to guarantee that the number of returned AOVs
+            matches the length of self.aov_names().
+
         """
 
         raise Exception('RBIntegrator does not provide the sample() method. '
@@ -555,7 +572,7 @@ class RBIntegrator(ADIntegrator):
             ray, weight, pos = self.sample_rays(scene, sensor, sampler)
 
             # Launch the Monte Carlo sampling process in primal mode (1)
-            L, valid, state_out = self.sample(
+            L, valid, aovs, state_out = self.sample(
                 mode=dr.ADMode.Primal,
                 scene=scene,
                 sampler=sampler.clone(),
@@ -567,13 +584,14 @@ class RBIntegrator(ADIntegrator):
             )
 
             # Launch the Monte Carlo sampling process in forward mode (2)
-            δL, valid_2, state_out_2 = self.sample(
+            δL, valid_2, δaovs, state_out_2 = self.sample(
                 mode=dr.ADMode.Forward,
                 scene=scene,
                 sampler=sampler,
                 ray=ray,
                 depth=mi.UInt32(0),
                 δL=None,
+                δaovs=None,
                 state_in=state_out,
                 active=mi.Bool(True)
             )
@@ -590,6 +608,7 @@ class RBIntegrator(ADIntegrator):
                 value=δL * weight,
                 weight=1.0,
                 alpha=dr.select(valid_2, mi.Float(1), mi.Float(0)),
+                aovs=[δaov * weight for δaov in δaovs],
                 wavelengths=ray.wavelengths
             )
 
@@ -597,8 +616,8 @@ class RBIntegrator(ADIntegrator):
             film.put_block(block)
 
             # Explicitly delete any remaining unused variables
-            del sampler, ray, weight, pos, L, valid, δL, valid_2, params, \
-                state_out, state_out_2, block
+            del sampler, ray, weight, pos, L, valid, aovs, δL, δaovs, \
+                valid_2, params, state_out, state_out_2, block
 
             # Probably a little overkill, but why not.. If there are any
             # DrJit arrays to be collected by Python's cyclic GC, then
@@ -682,7 +701,8 @@ class RBIntegrator(ADIntegrator):
 
             def splatting_and_backward_gradient_image(value: mi.Spectrum,
                                                       weight: mi.Float,
-                                                      alpha: mi.Float):
+                                                      alpha: mi.Float,
+                                                      aovs: Sequence[mi.Float]):
                 '''
                 Backward propagation of the gradient image through the sample
                 splatting and weight division steps.
@@ -699,6 +719,7 @@ class RBIntegrator(ADIntegrator):
                     value=value,
                     weight=weight,
                     alpha=alpha,
+                    aovs=aovs,
                     wavelengths=ray.wavelengths
                 )
 
@@ -721,45 +742,53 @@ class RBIntegrator(ADIntegrator):
                 with dr.suspend_grad(pos, ray, weight):
                     L = dr.full(mi.Spectrum, 1.0, dr.width(ray))
                     dr.enable_grad(L)
-
+                    aovs = []
+                    for _ in self.aov_names():
+                        aov = dr.ones(mi.Float, dr.width(ray))
+                        dr.enable_grad(aov)
+                        aovs.append(aov)
                     splatting_and_backward_gradient_image(
                         value=L * weight,
                         weight=1.0,
-                        alpha=1.0
+                        alpha=1.0,
+                        aovs=[aov * weight for aov in aovs]
                     )
 
                     δL = dr.grad(L)
+                    δaovs = dr.grad(aovs)
 
             # Clear the dummy data splatted on the film above
             film.clear()
 
             # Launch the Monte Carlo sampling process in primal mode (1)
-            L, valid, state_out = self.sample(
+            L, valid, aovs, state_out = self.sample(
                 mode=dr.ADMode.Primal,
                 scene=scene,
                 sampler=sampler.clone(),
                 ray=ray,
                 depth=mi.UInt32(0),
                 δL=None,
+                δaovs=None,
                 state_in=None,
                 active=mi.Bool(True)
             )
 
             # Launch Monte Carlo sampling in backward AD mode (2)
-            L_2, valid_2, state_out_2 = self.sample(
+            L_2, valid_2, aovs_2, state_out_2 = self.sample(
                 mode=dr.ADMode.Backward,
                 scene=scene,
                 sampler=sampler,
                 ray=ray,
                 depth=mi.UInt32(0),
                 δL=δL,
+                δaovs=δaovs,
                 state_in=state_out,
                 active=mi.Bool(True)
             )
 
             # We don't need any of the outputs here
-            del L_2, valid_2, state_out, state_out_2, δL, \
-                ray, weight, pos, sampler
+            del L_2, valid_2, aovs_2, state_out, state_out_2, \
+                δL, δaovs, ray, weight, pos, sampler
 
             gc.collect()
 
@@ -952,7 +981,7 @@ class PSIntegrator(ADIntegrator):
                 ray, weight, pos = self.sample_rays(scene, sensor, sampler)
 
                 # Launch the Monte Carlo sampling process in differentiable mode
-                L, valid, _ = self.sample(
+                L, valid, aovs, _ = self.sample(
                     mode     = mode,
                     scene    = scene,
                     sampler  = sampler,
@@ -973,6 +1002,7 @@ class PSIntegrator(ADIntegrator):
                 value=L * weight,
                 weight=1.0,
                 alpha=dr.select(valid, mi.Float(1), mi.Float(0)),
+                aovs=[aov * weight for aov in aovs],
                 wavelengths=ray.wavelengths
             )
 
@@ -1225,11 +1255,12 @@ class PSIntegrator(ADIntegrator):
                ray: mi.Ray3f,
                depth: mi.UInt32,
                δL: Optional[mi.Spectrum],
+               δaovs: Optional[mi.Spectrum],
                state_in: Any,
                active: mi.Bool,
                project: bool = False,
                si_shade: Optional[mi.SurfaceInteraction3f] = None
-    ) -> Tuple[mi.Spectrum, mi.Bool, Any]:
+    ) -> Tuple[mi.Spectrum, mi.Bool, List[mi.Float], Any]:
         """
         See ADIntegrator.sample() for a description of this function's purpose.
 
@@ -1258,6 +1289,11 @@ class PSIntegrator(ADIntegrator):
         Output ``valid`` (``mi.Bool``):
             Indicates whether the rays intersected a surface, which can be used
             to compute an alpha channel.
+
+        Output ``aovs`` (``Sequence[mi.Float]``):
+            Integrators may return one or more arbitrary output variables (AOVs).
+            The implementation has to guarantee that the number of returned AOVs
+            matches the length of self.aov_names().
 
         Output ``seedray`` / ``state_out`` (``any``):
             If ``project`` is true, the integrator returns the seed rays to be

--- a/src/python/python/ad/integrators/direct_projective.py
+++ b/src/python/python/ad/integrators/direct_projective.py
@@ -115,7 +115,7 @@ class DirectProjectiveIntegrator(PSIntegrator):
                project: bool = False,
                si_shade: Optional[mi.SurfaceInteraction3f] = None,
                **kwargs # Absorbs unused arguments
-    ) -> Tuple[mi.Spectrum, mi.Bool, Any]:
+    ) -> Tuple[mi.Spectrum, mi.Bool, List[mi.Float], Any]:
         """
         See ``PSIntegrator.sample()`` for a description of this interface and
         the role of the various parameters and return values.
@@ -253,7 +253,7 @@ class DirectProjectiveIntegrator(PSIntegrator):
 
                 guide_seed = [dr.detach(ray_seed), active_guide | mask_replace]
 
-        return L, active, guide_seed if project else None
+        return L, active, [], guide_seed if project else None
 
 
     def sample_radiance_difference(self, scene, ss, curr_depth, sampler, active):
@@ -282,7 +282,7 @@ class DirectProjectiveIntegrator(PSIntegrator):
 
             # ----------- Estimate the radiance of the background -----------
             ray_bg = ss.spawn_ray()
-            radiance_bg, _, _ = self.sample(
+            radiance_bg, _, _, _ = self.sample(
                 dr.ADMode.Primal, scene, sampler, ray_bg, curr_depth, None, None, active, False, None)
 
             # ----------- Estimate the radiance of the foreground -----------
@@ -327,7 +327,7 @@ class DirectProjectiveIntegrator(PSIntegrator):
             si_fg.wi[wrong_side] = si_fg.to_local(-ss.d)
 
             # Estimate the radiance starting from the surface interaction
-            radiance_fg, _, _ = self.sample(
+            radiance_fg, _, _, _ = self.sample(
                 dr.ADMode.Primal, scene, sampler, ray_bg, curr_depth, None, None, active, False, si_fg)
 
         else:

--- a/src/python/python/ad/integrators/prb.py
+++ b/src/python/python/ad/integrators/prb.py
@@ -65,8 +65,7 @@ class PRBIntegrator(RBIntegrator):
                state_in: Optional[mi.Spectrum],
                active: mi.Bool,
                **kwargs # Absorbs unused arguments
-    ) -> Tuple[mi.Spectrum,
-               mi.Bool, mi.Spectrum]:
+    ) -> Tuple[mi.Spectrum, mi.Bool, List[mi.Float], mi.Spectrum]:
         """
         See ``ADIntegrator.sample()`` for a description of this interface and
         the role of the various parameters and return values.
@@ -253,6 +252,7 @@ class PRBIntegrator(RBIntegrator):
         return (
             L if primal else δL, # Radiance/differential radiance
             dr.neq(depth, 0),    # Ray validity flag for alpha blending
+            [],                  # Empty typle of AOVs
             L                    # State for the differential phase
         )
 

--- a/src/python/python/ad/integrators/prb_basic.py
+++ b/src/python/python/ad/integrators/prb_basic.py
@@ -52,8 +52,7 @@ class BasicPRBIntegrator(RBIntegrator):
                state_in: Optional[mi.Spectrum],
                active: mi.Bool,
                **kwargs # Absorbs unused arguments
-    ) -> Tuple[mi.Spectrum,
-               mi.Bool, mi.Spectrum]:
+    ) -> Tuple[mi.Spectrum, mi.Bool, List[mi.Float], mi.Spectrum]:
         """
         See ``ADIntegrator.sample()`` for a description of this interface and
         the role of the various parameters and return values.
@@ -161,6 +160,7 @@ class BasicPRBIntegrator(RBIntegrator):
         return (
             L if primal else δL, # Radiance/differential radiance
             dr.neq(depth, 0),    # Ray validity flag for alpha blending
+            [],                  # Empty typle of AOVs
             L                    # State the for differential phase
         )
 

--- a/src/python/python/ad/integrators/prb_projective.py
+++ b/src/python/python/ad/integrators/prb_projective.py
@@ -134,7 +134,7 @@ class PathProjectiveIntegrator(PSIntegrator):
                project: bool = False,
                si_shade: Optional[mi.SurfaceInteraction3f] = None,
                **kwargs # Absorbs unused arguments
-    ) -> Tuple[mi.Spectrum, mi.Bool, Any]:
+    ) -> Tuple[mi.Spectrum, mi.Bool, List[mi.Float], Any]:
         """
         See ``PSIntegrator.sample()`` for a description of this interface and
         the role of the various parameters and return values.
@@ -375,6 +375,7 @@ class PathProjectiveIntegrator(PSIntegrator):
         return (
             L if primal else δL, # Radiance/differential radiance
             dr.neq(depth, 0),    # Ray validity flag for alpha blending
+            [],                  # Empty tuple of AOVs.
                                  # Seed rays, or the state for the differential phase
             [dr.detach(ray_seed), active_seed] if project else L
         )
@@ -392,7 +393,7 @@ class PathProjectiveIntegrator(PSIntegrator):
             ss.p + (1 + dr.max(dr.abs(ss.p))) * (ss.d * ss.offset + ss.n * mi.math.ShapeEpsilon),
             ss.d
         )
-        radiance_bg, _, _ = self.sample(
+        radiance_bg, _, _, _ = self.sample(
             dr.ADMode.Primal, scene, sampler, ray_bg, curr_depth, None, None, active, False, None)
 
         # ----------- Estimate the radiance of the foreground -----------
@@ -430,7 +431,7 @@ class PathProjectiveIntegrator(PSIntegrator):
 
         # Call `sample()` to estimate the radiance starting from the surface
         # interaction
-        radiance_fg, _, _ = self.sample(
+        radiance_fg, _, _, _ = self.sample(
             dr.ADMode.Primal, scene, sampler, ray_bg, curr_depth, None, None, active, False, si_fg)
 
         # Compute the radiance difference

--- a/src/python/python/ad/integrators/prbvolpath.py
+++ b/src/python/python/ad/integrators/prbvolpath.py
@@ -97,8 +97,7 @@ class PRBVolpathIntegrator(RBIntegrator):
                state_in: Optional[mi.Spectrum],
                active: mi.Bool,
                **kwargs # Absorbs unused arguments
-    ) -> Tuple[mi.Spectrum,
-               mi.Bool, mi.Spectrum]:
+    ) -> Tuple[mi.Spectrum, mi.Bool, List[mi.Float], mi.Spectrum]:
         self.prepare_scene(scene)
 
         if mode == dr.ADMode.Forward:
@@ -331,7 +330,7 @@ class PRBVolpathIntegrator(RBIntegrator):
                 medium[has_medium_trans] = si.target_medium(ray.d)
                 active &= (active_surface | active_medium)
 
-        return L if is_primal else δL, valid_ray, L
+        return L if is_primal else δL, valid_ray, [], L
 
     def sample_emitter(self, mei, si, active_medium, active_surface, scene, sampler, medium, channel,
                        active, adj_emitted=None, δL=None, mode=None):

--- a/src/python/python/ad/projective.py
+++ b/src/python/python/ad/projective.py
@@ -189,7 +189,7 @@ class ProjectiveDetail():
 
         # Call sample() to get the seed rays
         ray, _, _ = parent.sample_rays(scene, sensor, sampler)
-        _, _, (ray_seed, active) = parent.sample(
+        _, _, _, (ray_seed, active) = parent.sample(
             mode     = dr.ADMode.Primal,
             scene    = scene,
             sampler  = sampler,


### PR DESCRIPTION
## Description
 PR to add AOV support to Python AD integrators. The motivation for this is to be able to output arbitrary auxiliary values from Python AD integrators. This can be useful to add additional supervision, e.g., to segmentation masks for inverse rendering.

## Testing

<!-- Please describe the tests that you added to verify your changes. -->

## Checklist

<!-- Please make sure to complete this checklist before requesting a review. -->

- [x] My code follows the [style guidelines](https://mitsuba.readthedocs.io/en/latest/src/developer_guide.html#coding-style) of this project
- [x] My changes generate no new warnings
- [x] My code also compiles for `cuda_*` and `llvm_*` variants. If you can't test this, please leave below
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 3 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba/blob/master/LICENSE)