### PR TITLE
Add DEPENDS for copy-targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -489,9 +489,9 @@ endif()
 
 # Copy shared libraries to Python folders (no rpath on Windows)
 if (MSVC AND MI_ENABLE_PYTHON)
-  add_custom_target(copy-targets ALL)
-
   set(COPY_TARGETS mitsuba ${MI_DEPEND} ${MI_PLUGIN_TARGETS})
+  add_custom_target(copy-targets ALL DEPENDS ${COPY_TARGETS})
+
   foreach(target ${COPY_TARGETS})
     get_target_property(TARGET_FOLDER ${target} FOLDER)
     if (TARGET_FOLDER STREQUAL "drjit")


### PR DESCRIPTION
<!-- Please add the labels (e.g. bug fix, feature, ..) corresponding to this PR -->

## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Add `DEPENDS` for `copy-targets` so that `build/Release/python/mitsuba/plugins` syncs with `build/Release/plugins`.

## Testing

<!-- Please describe the tests that you added to verify your changes. -->

None for `CMakeLists.txt` changes.

## Checklist

<!-- Please make sure to complete this checklist before requesting a review. -->

- [x] My code follows the [style guidelines](https://mitsuba.readthedocs.io/en/latest/src/developer_guide.html#coding-style) of this project
- [x] My changes generate no new warnings
- [x] My code also compiles for `cuda_*` and `llvm_*` variants. If you can't test this, please leave below
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 3 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba/blob/master/LICENSE)