### PR TITLE
Handle BSDF evaluation singularities (polarized variants)

### DIFF
--- a/include/mitsuba/render/mueller.h
+++ b/include/mitsuba/render/mueller.h
@@ -347,10 +347,10 @@ MuellerMatrix rotate_stokes_basis(const Vector3 &forward,
  *      Direction of travel for input Stokes vector (normalized)
  *
  * \param out_basis_current
- *      Current (normalized) input Stokes basis. Must be orthogonal to \c out_forward.
+ *      Current (normalized) output Stokes basis. Must be orthogonal to \c out_forward.
  *
  * \param out_basis_target
- *      Target (normalized) input Stokes basis. Must be orthogonal to \c out_forward.
+ *      Target (normalized) output Stokes basis. Must be orthogonal to \c out_forward.
  *
  * \return
  *      New Mueller matrix that operates from \c in_basis_target to \c out_basis_target.

--- a/src/bsdfs/conductor.cpp
+++ b/src/bsdfs/conductor.cpp
@@ -284,8 +284,15 @@ public:
             /* The Stokes reference frame vector of this matrix lies perpendicular
                to the plane of reflection. */
             Vector3f n(0, 0, 1);
-            Vector3f s_axis_in  = dr::normalize(dr::cross(n, -wo_hat)),
-                     s_axis_out = dr::normalize(dr::cross(n, wi_hat));
+            Vector3f s_axis_in  = dr::cross(n, -wo_hat);
+            Vector3f s_axis_out = dr::cross(n, wi_hat);
+
+            // Singularity when the input & output are collinear with the normal
+            Mask collinear = dr::all(dr::eq(s_axis_in, Vector3f(0)));
+            s_axis_in  = dr::select(collinear, Vector3f(1, 0, 0),
+                                               dr::normalize(s_axis_in));
+            s_axis_out = dr::select(collinear, Vector3f(1, 0, 0),
+                                               dr::normalize(s_axis_out));
 
             /* Rotate in/out reference vector of `value` s.t. it aligns with the
                implicit Stokes bases of -wo_hat & wi_hat. */

--- a/src/bsdfs/dielectric.cpp
+++ b/src/bsdfs/dielectric.cpp
@@ -315,8 +315,15 @@ public:
             /* The Stokes reference frame vector of this matrix lies perpendicular
                to the plane of reflection. */
             Vector3f n(0, 0, 1);
-            Vector3f s_axis_in  = dr::normalize(dr::cross(n, -wo_hat)),
-                     s_axis_out = dr::normalize(dr::cross(n, wi_hat));
+            Vector3f s_axis_in  = dr::cross(n, -wo_hat);
+            Vector3f s_axis_out = dr::cross(n, wi_hat);
+
+            // Singularity when the input & output are collinear with the normal
+            Mask collinear = dr::all(dr::eq(s_axis_in, Vector3f(0)));
+            s_axis_in  = dr::select(collinear, Vector3f(1, 0, 0),
+                                               dr::normalize(s_axis_in));
+            s_axis_out = dr::select(collinear, Vector3f(1, 0, 0),
+                                               dr::normalize(s_axis_out));
 
             /* Rotate in/out reference vector of `weight` s.t. it aligns with the
                implicit Stokes bases of -wo_hat & wi_hat. */

--- a/src/bsdfs/roughconductor.cpp
+++ b/src/bsdfs/roughconductor.cpp
@@ -285,8 +285,15 @@ public:
 
             /* The Stokes reference frame vector of this matrix lies perpendicular
                to the plane of reflection. */
-            Vector3f s_axis_in  = dr::normalize(dr::cross(m, -wo_hat)),
-                     s_axis_out = dr::normalize(dr::cross(m, wi_hat));
+            Vector3f s_axis_in  = dr::cross(m, -wo_hat);
+            Vector3f s_axis_out = dr::cross(m, wi_hat);
+
+            // Singularity when the input & output are collinear with the normal
+            Mask collinear = dr::all(dr::eq(s_axis_in, Vector3f(0)));
+            s_axis_in  = dr::select(collinear, Vector3f(1, 0, 0),
+                                               dr::normalize(s_axis_in));
+            s_axis_out = dr::select(collinear, Vector3f(1, 0, 0),
+                                               dr::normalize(s_axis_out));
 
             /* Rotate in/out reference vector of F s.t. it aligns with the implicit
                Stokes bases of -wo_hat & wi_hat. */
@@ -355,8 +362,15 @@ public:
 
             /* The Stokes reference frame vector of this matrix lies perpendicular
                to the plane of reflection. */
-            Vector3f s_axis_in  = dr::normalize(dr::cross(H, -wo_hat)),
-                     s_axis_out = dr::normalize(dr::cross(H, wi_hat));
+            Vector3f s_axis_in  = dr::cross(H, -wo_hat);
+            Vector3f s_axis_out = dr::cross(H, wi_hat);
+
+            // Singularity when the input & output are collinear with the normal
+            Mask collinear = dr::all(dr::eq(s_axis_in, Vector3f(0)));
+            s_axis_in  = dr::select(collinear, Vector3f(1, 0, 0),
+                                               dr::normalize(s_axis_in));
+            s_axis_out = dr::select(collinear, Vector3f(1, 0, 0),
+                                               dr::normalize(s_axis_out));
 
             /* Rotate in/out reference vector of F s.t. it aligns with the implicit
                Stokes bases of -wo_hat & wi_hat. */
@@ -470,8 +484,15 @@ public:
 
             /* The Stokes reference frame vector of this matrix lies perpendicular
                to the plane of reflection. */
-            Vector3f s_axis_in  = dr::normalize(dr::cross(H, -wo_hat)),
-                     s_axis_out = dr::normalize(dr::cross(H, wi_hat));
+            Vector3f s_axis_in  = dr::cross(H, -wo_hat);
+            Vector3f s_axis_out = dr::cross(H, wi_hat);
+
+            // Singularity when the input & output are collinear with the normal
+            Mask collinear = dr::all(dr::eq(s_axis_in, Vector3f(0)));
+            s_axis_in  = dr::select(collinear, Vector3f(1, 0, 0),
+                                               dr::normalize(s_axis_in));
+            s_axis_out = dr::select(collinear, Vector3f(1, 0, 0),
+                                               dr::normalize(s_axis_out));
 
             /* Rotate in/out reference vector of F s.t. it aligns with the implicit
                Stokes bases of -wo_hat & wi_hat. */


### PR DESCRIPTION
We would create undefined `(NaN`) Stokes basis vectors. In particular, this would happen when the normal is collinear with the incident/outgoing direction. 

## Description

For the `conductor`, `dielectric` and `roughconductor` plugins, this issue would only happen in the case of retroreflection. The normal (or microfacet normal) is collinear with both the incident and outgoing direction. In such cases, we can arbitrarily pick the Fresnel perpendicular component to be any vector perpendicular to the normal. It would not break any physical constraints or conventions needed by the internal Mueller matrices.
Note: one could maybe pick the Stoke's basis such that it matches the "implicit" local frame and therefore avoid a few operations, I don't believe it is worth the additional code complexity.

For the `pplastic` either the incidient or outoing direction could be collinear with the surface normal, they must therefore be handled distinctly.

Fixes #757, #957