### PR TITLE
Fix SGGX Python bindings

### DIFF
--- a/src/render/python/microflake_v.cpp
+++ b/src/render/python/microflake_v.cpp
@@ -4,21 +4,37 @@
 MI_PY_EXPORT(MicroflakeDistribution) {
     MI_PY_IMPORT_TYPES()
 
-    m.def("sggx_sample",
-          py::overload_cast<const Frame3f&,
-                            const Point2f&,
-                            const dr::Array<Float, 6>&>(sggx_sample<Float>),
-          "sh_frame"_a, "sample"_a, "s"_a, D(sggx_sample));
+    m.def(
+        "sggx_sample",
+        [](const Frame3f &frame, const Point2f &sample,
+           const std::array<Float, 6> &s) {
+            dr::Array<Float, 6> s_drjit_array(s[0], s[1], s[2], s[3], s[4], s[5]);
+            return sggx_sample(frame, sample, s_drjit_array);
+        },
+        "sh_frame"_a, "sample"_a, "s"_a, D(sggx_sample));
 
-    m.def("sggx_sample",
-          py::overload_cast<const Vector3f&,
-                            const Point2f&,
-                            const dr::Array<Float, 6>&>(sggx_sample<Float>),
-          "sh_frame"_a, "sample"_a, "s"_a, D(sggx_sample));
+    m.def(
+        "sggx_sample",
+        [](const Vector3f &wi, const Point2f &sample,
+           const std::array<Float, 6> &s) {
+            dr::Array<Float, 6> s_drjit_array(s[0], s[1], s[2], s[3], s[4], s[5]);
+            return sggx_sample(wi, sample, s_drjit_array);
+        },
+        "wi"_a, "sample"_a, "s"_a, D(sggx_sample));
 
-    m.def("sggx_pdf", &sggx_pdf<Float>,
-          "wm"_a, "s"_a, D(sggx_pdf));
+    m.def(
+        "sggx_pdf",
+        [](const Vector3f &wm, const std::array<Float, 6> &s) {
+            dr::Array<Float, 6> s_drjit_array(s[0], s[1], s[2], s[3], s[4], s[5]);
+            return sggx_pdf(wm, s_drjit_array);
+        },
+        "wm"_a, "s"_a, D(sggx_pdf));
 
-    m.def("sggx_projected_area", &sggx_projected_area<Float>,
-          "wi"_a, "s"_a, D(sggx_projected_area));
+    m.def(
+        "sggx_projected_area",
+        [](const Vector3f &wi, const std::array<Float, 6> &s) {
+            dr::Array<Float, 6> s_drjit_array(s[0], s[1], s[2], s[3], s[4], s[5]);
+            return sggx_projected_area(wi, s_drjit_array);
+        },
+        "wi"_a, "s"_a, D(sggx_projected_area));
 }

--- a/src/render/tests/test_microflake.py
+++ b/src/render/tests/test_microflake.py
@@ -4,10 +4,10 @@ import drjit as dr
 import pytest
 
 
-@pytest.mark.parametrize("alpha", [[1, 1, 1], [1, 0.1, 0.5]])
+@pytest.mark.parametrize("s_diagonal", [[1, 1, 1], [1, 0.1, 0.5]])
 @pytest.mark.parametrize("angle", [dr.pi / 4, dr.pi / 2])
-def test01_sampling(variants_vec_backends_once, alpha, angle):
-    s = alpha + [0, 0, 0]
+def test01_sampling(variants_vec_backends_once, s_diagonal, angle):
+    s = s_diagonal + [0, 0, 0]
     w_i = dr.normalize(mi.Vector3f(0, dr.sin(angle), dr.cos(angle)))
 
     def sample_fun(sample):
@@ -19,11 +19,10 @@ def test01_sampling(variants_vec_backends_once, alpha, angle):
 
     chi2 = mi.chi2.ChiSquareTest(
         domain=mi.chi2.SphericalDomain(),
-        sample_func=lambda *args: sample_fun(*args),
-        pdf_func=lambda *args: pdf_fun(*args),
+        sample_func=sample_fun,
+        pdf_func=pdf_fun,
         sample_dim=2,
         res=128,
         ires=32
     )
-
     assert chi2.run()

--- a/src/render/tests/test_microflake.py
+++ b/src/render/tests/test_microflake.py
@@ -1,0 +1,29 @@
+import mitsuba as mi
+import drjit as dr
+
+import pytest
+
+
+@pytest.mark.parametrize("alpha", [[1, 1, 1], [1, 0.1, 0.5]])
+@pytest.mark.parametrize("angle", [dr.pi / 4, dr.pi / 2])
+def test01_sampling(variants_vec_backends_once, alpha, angle):
+    s = alpha + [0, 0, 0]
+    w_i = dr.normalize(mi.Vector3f(0, dr.sin(angle), dr.cos(angle)))
+
+    def sample_fun(sample):
+        return mi.sggx_sample(w_i, sample, s)
+
+    def pdf_fun(w_n):
+        n_dot_wi = dr.maximum(0, dr.dot(w_n, w_i))
+        return n_dot_wi * mi.sggx_pdf(w_n, s) / mi.sggx_projected_area(w_i, s)
+
+    chi2 = mi.chi2.ChiSquareTest(
+        domain=mi.chi2.SphericalDomain(),
+        sample_func=lambda *args: sample_fun(*args),
+        pdf_func=lambda *args: pdf_fun(*args),
+        sample_dim=2,
+        res=128,
+        ires=32
+    )
+
+    assert chi2.run()


### PR DESCRIPTION
Hi,

The SGGX Python bindings currently expect a dr::Array<Float, 6>, which we don't actually bind to Python. I am not sure if this was always the case, or maybe the Vector6f bindings were removed. In either case, we probably do not want to bind Vector6f.

This PR changes the SGGX functions to expect an std::array<Float, 6> instead. It also adds a Python-side test of the sampling and PDF evaluation, which ensures that those bindings will not break easily.