### PR TITLE
Fix use-after-free and memory leak

### DIFF
--- a/include/mitsuba/core/argparser.h
+++ b/include/mitsuba/core/argparser.h
@@ -89,6 +89,12 @@ public:
     };
 
 public:
+
+    ~ArgParser() {
+        for (Arg *arg : m_args)
+            delete arg;
+    }
+
     /**
      * \brief Register a new argument with the given prefix
      *

--- a/src/render/scene_optix.inl
+++ b/src/render/scene_optix.inl
@@ -553,11 +553,6 @@ MI_VARIANT void Scene<Float, Spectrum>::accel_release_gpu() {
         // Ensure all ray tracing kernels are terminated before releasing the scene
         dr::sync_thread();
 
-        /* Decrease the reference count of the IAS handle variable. This will
-           trigger the release of the OptiX acceleration data structure if no
-           ray tracing calls are pending. */
-        m_accel_handle = 0;
-
         OptixSceneState *s = (OptixSceneState *) m_accel;
 
         if (s->own_sbt) {
@@ -567,6 +562,11 @@ MI_VARIANT void Scene<Float, Spectrum>::accel_release_gpu() {
             (void) UInt32::steal(s->sbt_jit_index);
         }
         m_accel = nullptr;
+
+        /* Decrease the reference count of the IAS handle variable. This will
+           trigger the release of the OptiX acceleration data structure if no
+           ray tracing calls are pending. */
+        m_accel_handle = 0;
     }
 }
 


### PR DESCRIPTION
Fixes two bugs found using AddressSanitizer, using the methodology described in: https://github.com/mitsuba-renderer/drjit-core/pull/78.