### PR TITLE
Fix splat to block in mono mode

### DIFF
--- a/src/python/python/ad/integrators/common.py
+++ b/src/python/python/ad/integrators/common.py
@@ -390,7 +390,7 @@ class ADIntegrator(mi.CppADIntegrator):
             if mi.is_spectral:
                 rgb = mi.spectrum_to_srgb(value, wavelengths)
             elif mi.is_monochromatic:
-                rgb = value.x
+                rgb = mi.Color3f(value.x)
             else:
                 rgb = value
             if mi.has_flag(film.flags(), mi.FilmFlags.Alpha):


### PR DESCRIPTION
## Description

When rendering in monochromatic(*_ad_mono) mode using AD Integrators, a bug occurs related to splatting values onto the Image block.

Reproducer:
```
import sys
sys.path.insert(0, "./build/python")

import mitsuba as mi
import drjit as dr

mi.set_variant('cuda_ad_mono')

scene = mi.load_dict({
    "type": "scene",
    "integrator": {
        "type": "prb_basic"
    },
    "sensor": {
        "type": "perspective",
        "film": {
            "type": "hdrfilm",
            "pixel_format": "luminance",
        }
    }
})

mi.render(scene)
```

Error message:

```
Traceback (most recent call last):
  File "/home/ln/Desktop/mitsuba3/test.py", line 23, in <module>
    mi.render(scene)
  File "/home/ln/Desktop/mitsuba3/./build/python/mitsuba/python/util.py", line 522, in render
    return dr.custom(_RenderOp, scene, sensor, params, integrator,
  File "/home/ln/Desktop/mitsuba3/./build/python/drjit/router.py", line 5776, in custom
    output = inst.eval(**{ k: _dr.detach(v) for k, v in kwargs.items() })
  File "/home/ln/Desktop/mitsuba3/./build/python/mitsuba/python/util.py", line 377, in eval
    return self.integrator.render(
  File "/home/ln/Desktop/mitsuba3/./build/python/mitsuba/python/ad/integrators/common.py", line 96, in render
    ADIntegrator._splat_to_block(
  File "/home/ln/Desktop/mitsuba3/./build/python/mitsuba/python/ad/integrators/common.py", line 399, in _splat_to_block
    aovs = [rgb.x, rgb.y, rgb.z, weight] + aovs
AttributeError: 'drjit.cuda.ad.Float' object has no attribute 'x'
```

## Checklist

- [x] My code follows the [style guidelines](https://mitsuba.readthedocs.io/en/latest/src/developer_guide.html#coding-style) of this project
- [x] My changes generate no new warnings
- [x] My code also compiles for `cuda_*` and `llvm_*` variants. If you can't test this, please leave below
- [ ] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 3 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba/blob/master/LICENSE)