### PR TITLE
Intrusive counting and plugin trampolines

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -290,6 +290,7 @@ add_subdirectory(ext)
 # Always add the include directories for tinyformat, Dr.Jit and Eigen
 include_directories(include
   ${TINYFORMAT_INCLUDE_DIRS}
+  ${NANOBIND_INCLUDE_DIRS}
   ${CMAKE_CURRENT_BINARY_DIR}/include
 )
 

--- a/ext/CMakeLists.txt
+++ b/ext/CMakeLists.txt
@@ -336,6 +336,12 @@ mark_as_advanced(
 unset(CMAKE_CXX_STANDARD CACHE)
 
 # ----------------------------------------------------------
+#  Nanobind headers
+# ----------------------------------------------------------
+
+set(NANOBIND_INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/nanobind/include PARENT_SCOPE)
+
+# ----------------------------------------------------------
 #  Hide a few more settings that aren't relevant for users
 # ----------------------------------------------------------
 

--- a/include/mitsuba/render/bsdf.h
+++ b/include/mitsuba/render/bsdf.h
@@ -267,6 +267,9 @@ class MI_EXPORT_LIB BSDF : public Object {
 public:
     MI_IMPORT_TYPES(Texture)
 
+    /// Virtual destructor
+    virtual ~BSDF();
+
     /**
      * \brief Importance sample the BSDF model
      *
@@ -592,12 +595,10 @@ public:
     //! @}
     // -----------------------------------------------------------------------
 
-
     MI_DECLARE_CLASS()
+
 protected:
     BSDF(const Properties &props);
-public:
-    virtual ~BSDF();
 
 protected:
     /// Combined flags for all components of this BSDF.

--- a/src/core/bitmap.cpp
+++ b/src/core/bitmap.cpp
@@ -808,9 +808,10 @@ void Bitmap::write(Stream *stream, FileFormat format, int quality) const {
 
 void Bitmap::write_async(const fs::path &path, FileFormat format, int quality) const {
     this->inc_ref();
-    Task *task = dr::do_async([path, format, quality, this](){
+    Task *task = dr::do_async([path, format, quality, this]() {
         write(path, format, quality);
-        this->dec_ref();
+        if (this->dec_ref())
+            delete this;
     });
     Thread::register_task(task);
 }

--- a/src/core/object.cpp
+++ b/src/core/object.cpp
@@ -2,18 +2,9 @@
 #include <cstdlib>
 #include <cstdio>
 #include <sstream>
+#include <nanobind/intrusive/counter.inl>
 
 NAMESPACE_BEGIN(mitsuba)
-
-void Object::dec_ref(bool dealloc) const noexcept {
-    uint32_t ref_count = m_ref_count.fetch_sub(1);
-    if (ref_count <= 0) {
-        fprintf(stderr, "Internal error: Object reference count < 0!\n");
-        abort();
-    } else if (ref_count == 1 && dealloc) {
-        delete this;
-    }
-}
 
 std::vector<ref<Object>> Object::expand() const {
     return { };
@@ -32,8 +23,6 @@ std::string Object::to_string() const {
     oss << class_()->name() << "[" << (void *) this << "]";
     return oss.str();
 }
-
-Object::~Object() { }
 
 std::ostream& operator<<(std::ostream &os, const Object *object) {
     os << ((object != nullptr) ? object->to_string() : "nullptr");

--- a/src/core/python/CMakeLists.txt
+++ b/src/core/python/CMakeLists.txt
@@ -33,7 +33,7 @@ set(CORE_PY_SRC
 #  ${CMAKE_CURRENT_SOURCE_DIR}/fresolver.cpp
 #  ${CMAKE_CURRENT_SOURCE_DIR}/logger.cpp
 #  ${CMAKE_CURRENT_SOURCE_DIR}/mmap.cpp
-#  ${CMAKE_CURRENT_SOURCE_DIR}/object.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/object.cpp
 #  ${CMAKE_CURRENT_SOURCE_DIR}/progress.cpp
 #  ${CMAKE_CURRENT_SOURCE_DIR}/rfilter.cpp
 #  ${CMAKE_CURRENT_SOURCE_DIR}/stream.cpp

--- a/src/core/python/object.cpp
+++ b/src/core/python/object.cpp
@@ -39,24 +39,28 @@ MI_PY_EXPORT(Object) {
             return cast_object(pmgr.create_object(props, class_));
         }, D(PluginManager, create_object));
 
-    py::class_<Object, ref<Object>>(m, "Object", D(Object))
-        .def(py::init<>(), D(Object, Object))
-        .def(py::init<const Object &>(), D(Object, Object, 2))
+    nb::class_<Object>(
+            m, "Object",
+            nb::intrusive_ptr<Object>(
+                [](Object *o, PyObject *po) noexcept { o->set_self_py(po); }),
+            D(Object)
+        )
+        .def(nb::init<>(), D(Object, Object))
+        .def(nb::init<const Object &>(), D(Object, Object, 2))
         .def_method(Object, id)
         .def_method(Object, set_id, "id"_a)
-        .def_method(Object, ref_count)
         .def_method(Object, inc_ref)
-        .def_method(Object, dec_ref, "dealloc"_a = true)
-        .def("expand", [](const Object &o) -> py::list {
+        .def_method(Object, dec_ref)
+        .def("expand", [](const Object &o) -> nb::list {
             auto result = o.expand();
-            py::list l;
+            nb::list l;
             for (Object *o2: result)
                 l.append(cast_object(o2));
             return l;
         }, D(Object, expand))
         .def_method(Object, traverse, "cb"_a)
-        .def_method(Object, parameters_changed, "keys"_a = py::list())
-        .def_property_readonly("ptr", [](Object *self) { return (uintptr_t) self; })
-        .def("class_", &Object::class_, py::return_value_policy::reference, D(Object, class))
+        .def_method(Object, parameters_changed, "keys"_a = nb::list())
+        .def_prop_ro("ptr", [](Object *self) { return (uintptr_t) self; })
+        .def("class_", &Object::class_, nb::rv_policy::copy, D(Object, class))
         .def("__repr__", &Object::to_string, D(Object, to_string));
 }

--- a/src/python/main.cpp
+++ b/src/python/main.cpp
@@ -9,7 +9,7 @@
 // core
 //MI_PY_DECLARE(atomic);
 //MI_PY_DECLARE(filesystem);
-//MI_PY_DECLARE(Object);
+MI_PY_DECLARE(Object);
 MI_PY_DECLARE(Cast);
 //MI_PY_DECLARE(Struct);
 //MI_PY_DECLARE(Appender);
@@ -73,6 +73,18 @@ NB_MODULE(mitsuba_ext, m) {
     m.attr("MI_ENABLE_EMBREE") = false;
 #endif
 
+    // Initialize reference counting hooks for mitsuba::Object
+    nb::intrusive_init(
+        [](PyObject *o) noexcept {
+            nb::gil_scoped_acquire guard;
+            Py_INCREF(o);
+        },
+        [](PyObject *o) noexcept {
+            nb::gil_scoped_acquire guard;
+            Py_DECREF(o);
+        }
+    );
+
 //    m.def("set_log_level", [](mitsuba::LogLevel level) {
 //
 //        if (!Thread::thread()->logger()) {
@@ -115,7 +127,7 @@ NB_MODULE(mitsuba_ext, m) {
 //    // Register python modules
 //    MI_PY_IMPORT(atomic);
 //    MI_PY_IMPORT(filesystem);
-//    MI_PY_IMPORT(Object);
+    MI_PY_IMPORT(Object);
     MI_PY_IMPORT(Cast);
 //    MI_PY_IMPORT(Struct);
 //    MI_PY_IMPORT(Appender);

--- a/src/python/main.cpp
+++ b/src/python/main.cpp
@@ -31,7 +31,7 @@ MI_PY_DECLARE(Cast);
 //MI_PY_DECLARE(util);
 
 // render
-//MI_PY_DECLARE(BSDFContext);
+MI_PY_DECLARE(BSDFContext);
 //MI_PY_DECLARE(EmitterExtras);
 //MI_PY_DECLARE(RayFlags);
 //MI_PY_DECLARE(MicrofacetType);
@@ -148,7 +148,7 @@ NB_MODULE(mitsuba_ext, m) {
 //    MI_PY_IMPORT(Timer);
 //    MI_PY_IMPORT(util);
 //
-//    MI_PY_IMPORT(BSDFContext);
+    MI_PY_IMPORT(BSDFContext);
 //    MI_PY_IMPORT(EmitterExtras);
 //    MI_PY_IMPORT(RayFlags);
 //    MI_PY_IMPORT(MicrofacetType);

--- a/src/python/main_v.cpp
+++ b/src/python/main_v.cpp
@@ -129,6 +129,7 @@ NB_MODULE(MODULE_NAME, m) {
     m.attr("__name__") = "mitsuba." DRJIT_TOSTRING(MI_VARIANT_NAME);
 
     MI_PY_IMPORT_TYPES()
+
 //
 //    // Create sub-modules
 //    py::module math    = create_submodule(m, "math"),

--- a/src/python/main_v.cpp
+++ b/src/python/main_v.cpp
@@ -86,8 +86,8 @@ MI_PY_DECLARE(xml);
 //MI_PY_DECLARE(quad);
 //
 //// render
-//MI_PY_DECLARE(BSDFSample);
-//MI_PY_DECLARE(BSDF);
+MI_PY_DECLARE(BSDFSample);
+MI_PY_DECLARE(BSDF);
 //MI_PY_DECLARE(Emitter);
 //MI_PY_DECLARE(Endpoint);
 //MI_PY_DECLARE(Film);
@@ -194,8 +194,8 @@ NB_MODULE(MODULE_NAME, m) {
 //    MI_PY_IMPORT(PositionSample);
 //    MI_PY_IMPORT(SilhouetteSample);
 //    MI_PY_IMPORT(DirectionSample);
-//    MI_PY_IMPORT(BSDFSample);
-//    MI_PY_IMPORT(BSDF);
+    MI_PY_IMPORT(BSDFSample);
+    MI_PY_IMPORT(BSDF);
 //    MI_PY_IMPORT(Film);
 //    MI_PY_IMPORT(fresnel);
 //    MI_PY_IMPORT(ImageBlock);

--- a/src/render/bsdf.cpp
+++ b/src/render/bsdf.cpp
@@ -7,12 +7,12 @@
 NAMESPACE_BEGIN(mitsuba)
 
 MI_VARIANT BSDF<Float, Spectrum>::BSDF(const Properties &props)
-    : m_flags(+BSDFFlags::Empty), m_id(props.id()) { 
+    : m_flags(+BSDFFlags::Empty), m_id(props.id()) {
     if constexpr (dr::is_jit_v<Float>)
         jit_registry_put(dr::backend_v<Float>, "mitsuba::BSDF", this);
 }
 
-MI_VARIANT BSDF<Float, Spectrum>::~BSDF() { 
+MI_VARIANT BSDF<Float, Spectrum>::~BSDF() {
     if constexpr (dr::is_jit_v<Float>)
         jit_registry_remove(this);
 }

--- a/src/render/python/CMakeLists.txt
+++ b/src/render/python/CMakeLists.txt
@@ -1,5 +1,5 @@
-#set(RENDER_PY_V_SRC
-#  ${CMAKE_CURRENT_SOURCE_DIR}/bsdf_v.cpp
+set(RENDER_PY_V_SRC
+  ${CMAKE_CURRENT_SOURCE_DIR}/bsdf_v.cpp
 #  ${CMAKE_CURRENT_SOURCE_DIR}/emitter_v.cpp
 #  ${CMAKE_CURRENT_SOURCE_DIR}/endpoint_v.cpp
 #  ${CMAKE_CURRENT_SOURCE_DIR}/film_v.cpp
@@ -23,12 +23,12 @@
 #  ${CMAKE_CURRENT_SOURCE_DIR}/volume_v.cpp
 #  ${CMAKE_CURRENT_SOURCE_DIR}/volumegrid_v.cpp
 #  ${CMAKE_CURRENT_SOURCE_DIR}/signal.h
-#  PARENT_SCOPE
-#)
-#
-#set(RENDER_PY_SRC
+  PARENT_SCOPE
+)
+
+set(RENDER_PY_SRC
 #  ${CMAKE_CURRENT_SOURCE_DIR}/emitter.cpp
-#  ${CMAKE_CURRENT_SOURCE_DIR}/bsdf.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/bsdf.cpp
 #  ${CMAKE_CURRENT_SOURCE_DIR}/shape.cpp
 #  ${CMAKE_CURRENT_SOURCE_DIR}/interaction.cpp
 #  ${CMAKE_CURRENT_SOURCE_DIR}/microfacet.cpp
@@ -36,5 +36,5 @@
 #  ${CMAKE_CURRENT_SOURCE_DIR}/sensor.cpp
 #  ${CMAKE_CURRENT_SOURCE_DIR}/spiral.cpp
 #  ${CMAKE_CURRENT_SOURCE_DIR}/film.cpp
-#  PARENT_SCOPE
-#)
+  PARENT_SCOPE
+)

--- a/src/render/python/bsdf.cpp
+++ b/src/render/python/bsdf.cpp
@@ -2,46 +2,49 @@
 #include <mitsuba/render/shape.h>
 #include <mitsuba/core/properties.h>
 #include <mitsuba/python/python.h>
+#include <nanobind/stl/string.h>
 
 MI_PY_EXPORT(BSDFContext) {
-    py::enum_<TransportMode>(m, "TransportMode", D(TransportMode))
-        .def_value(TransportMode, Radiance)
-        .def_value(TransportMode, Importance);
+    //nb::enum_<TransportMode>(m, "TransportMode", D(TransportMode))
+    //    .def_value(TransportMode, Radiance)
+    //    .def_value(TransportMode, Importance);
 
-    auto e = py::enum_<BSDFFlags>(m, "BSDFFlags", D(BSDFFlags))
-        .def_value(BSDFFlags, Empty)
-        .def_value(BSDFFlags, Null)
-        .def_value(BSDFFlags, DiffuseReflection)
-        .def_value(BSDFFlags, DiffuseTransmission)
-        .def_value(BSDFFlags, GlossyReflection)
-        .def_value(BSDFFlags, GlossyTransmission)
-        .def_value(BSDFFlags, DeltaReflection)
-        .def_value(BSDFFlags, DeltaTransmission)
-        .def_value(BSDFFlags, Anisotropic)
-        .def_value(BSDFFlags, SpatiallyVarying)
-        .def_value(BSDFFlags, NonSymmetric)
-        .def_value(BSDFFlags, FrontSide)
-        .def_value(BSDFFlags, BackSide)
-        .def_value(BSDFFlags, Reflection)
-        .def_value(BSDFFlags, Transmission)
-        .def_value(BSDFFlags, Diffuse)
-        .def_value(BSDFFlags, Glossy)
-        .def_value(BSDFFlags, Smooth)
-        .def_value(BSDFFlags, Delta)
-        .def_value(BSDFFlags, Delta1D)
-        .def_value(BSDFFlags, All);
+    //auto e = nb::enum_<BSDFFlags>(m, "BSDFFlags", D(BSDFFlags))
+    //    .def_value(BSDFFlags, Empty)
+    //    .def_value(BSDFFlags, Null)
+    //    .def_value(BSDFFlags, DiffuseReflection)
+    //    .def_value(BSDFFlags, DiffuseTransmission)
+    //    .def_value(BSDFFlags, GlossyReflection)
+    //    .def_value(BSDFFlags, GlossyTransmission)
+    //    .def_value(BSDFFlags, DeltaReflection)
+    //    .def_value(BSDFFlags, DeltaTransmission)
+    //    .def_value(BSDFFlags, Anisotropic)
+    //    .def_value(BSDFFlags, SpatiallyVarying)
+    //    .def_value(BSDFFlags, NonSymmetric)
+    //    .def_value(BSDFFlags, FrontSide)
+    //    .def_value(BSDFFlags, BackSide)
+    //    .def_value(BSDFFlags, Reflection)
+    //    .def_value(BSDFFlags, Transmission)
+    //    .def_value(BSDFFlags, Diffuse)
+    //    .def_value(BSDFFlags, Glossy)
+    //    .def_value(BSDFFlags, Smooth)
+    //    .def_value(BSDFFlags, Delta)
+    //    .def_value(BSDFFlags, Delta1D)
+    //    .def_value(BSDFFlags, All);
 
-    MI_PY_DECLARE_ENUM_OPERATORS(BSDFFlags, e)
+    //MI_PY_DECLARE_ENUM_OPERATORS(BSDFFlags, e)
 
-    py::class_<BSDFContext>(m, "BSDFContext", D(BSDFContext))
-        .def(py::init<TransportMode>(),
-            "mode"_a = TransportMode::Radiance, D(BSDFContext, BSDFContext))
-        .def(py::init<TransportMode, uint32_t, uint32_t>(),
-            "mode"_a, "type_mask"_a, "component"_a, D(BSDFContext, BSDFContext, 2))
-        .def_method(BSDFContext, reverse)
-        .def_method(BSDFContext, is_enabled, "type"_a, "component"_a = 0)
-        .def_field(BSDFContext, mode,      D(BSDFContext, mode))
-        .def_field(BSDFContext, type_mask, D(BSDFContext, type_mask))
-        .def_field(BSDFContext, component, D(BSDFContext, component))
+    nb::class_<BSDFContext>(m, "BSDFContext", D(BSDFContext))
+        //FIXME: remove this constructor
+        .def("__init__", [](BSDFContext *ctx) { new (ctx) BSDFContext(TransportMode::Radiance);})
+        //.def(nb::init<TransportMode>(),
+        //    "mode"_a = TransportMode::Radiance, D(BSDFContext, BSDFContext))
+        //.def(nb::init<TransportMode, uint32_t, uint32_t>(),
+        //    "mode"_a, "type_mask"_a, "component"_a, D(BSDFContext, BSDFContext, 2))
+        //.def_method(BSDFContext, reverse)
+        //.def_method(BSDFContext, is_enabled, "type"_a, "component"_a = 0)
+        //.def_field(BSDFContext, mode,      D(BSDFContext, mode))
+        //.def_field(BSDFContext, type_mask, D(BSDFContext, type_mask))
+        //.def_field(BSDFContext, component, D(BSDFContext, component))
         .def_repr(BSDFContext);
 }

--- a/src/render/python/bsdf_v.cpp
+++ b/src/render/python/bsdf_v.cpp
@@ -2,6 +2,9 @@
 #include <mitsuba/render/shape.h>
 #include <mitsuba/core/properties.h>
 #include <mitsuba/python/python.h>
+#include <nanobind/trampoline.h>
+#include <nanobind/stl/string.h>
+#include <drjit/python.h>
 
 MI_PY_EXPORT(BSDFSample) {
     MI_PY_IMPORT_TYPES()
@@ -9,15 +12,15 @@ MI_PY_EXPORT(BSDFSample) {
     m.def("has_flag", [](uint32_t flags, BSDFFlags f) { return has_flag(flags, f); });
     m.def("has_flag", [](UInt32   flags, BSDFFlags f) { return has_flag(flags, f); });
 
-    auto bs = py::class_<BSDFSample3f>(m, "BSDFSample3f", D(BSDFSample3))
-        .def(py::init<>())
-        .def(py::init<const Vector3f &>(), "wo"_a, D(BSDFSample3, BSDFSample3))
-        .def(py::init<const BSDFSample3f &>(), "bs"_a, "Copy constructor")
-        .def_readwrite("wo", &BSDFSample3f::wo, D(BSDFSample3, wo))
-        .def_readwrite("pdf", &BSDFSample3f::pdf, D(BSDFSample3, pdf))
-        .def_readwrite("eta", &BSDFSample3f::eta, D(BSDFSample3, eta))
-        .def_readwrite("sampled_type", &BSDFSample3f::sampled_type, D(BSDFSample3, sampled_type))
-        .def_readwrite("sampled_component", &BSDFSample3f::sampled_component, D(BSDFSample3, sampled_component))
+    auto bs = nb::class_<BSDFSample3f>(m, "BSDFSample3f", D(BSDFSample3))
+        .def(nb::init<>())
+        .def(nb::init<const Vector3f &>(), "wo"_a, D(BSDFSample3, BSDFSample3))
+        .def(nb::init<const BSDFSample3f &>(), "bs"_a, "Copy constructor")
+        .def_rw("wo", &BSDFSample3f::wo, D(BSDFSample3, wo))
+        .def_rw("pdf", &BSDFSample3f::pdf, D(BSDFSample3, pdf))
+        .def_rw("eta", &BSDFSample3f::eta, D(BSDFSample3, eta))
+        .def_rw("sampled_type", &BSDFSample3f::sampled_type, D(BSDFSample3, sampled_type))
+        .def_rw("sampled_component", &BSDFSample3f::sampled_component, D(BSDFSample3, sampled_component))
         .def_repr(BSDFSample3f);
 
     MI_PY_DRJIT_STRUCT(bs, BSDFSample3f, wo, pdf, eta, sampled_type, sampled_component);
@@ -27,6 +30,7 @@ MI_PY_EXPORT(BSDFSample) {
 MI_VARIANT class PyBSDF : public BSDF<Float, Spectrum> {
 public:
     MI_IMPORT_TYPES(BSDF)
+    NB_TRAMPOLINE(BSDF, 12);
 
     PyBSDF(const Properties &props) : BSDF(props) { }
 
@@ -35,21 +39,21 @@ public:
            Float sample1, const Point2f &sample2,
            Mask active) const override {
         using Return = std::pair<BSDFSample3f, Spectrum>;
-        PYBIND11_OVERRIDE_PURE(Return, BSDF, sample, ctx, si, sample1, sample2, active);
+        NB_OVERRIDE_PURE(sample, ctx, si, sample1, sample2, active);
     }
 
     Spectrum eval(const BSDFContext &ctx,
                   const SurfaceInteraction3f &si,
                   const Vector3f &wo,
                   Mask active) const override {
-        PYBIND11_OVERRIDE_PURE(Spectrum, BSDF, eval, ctx, si, wo, active);
+        NB_OVERRIDE_PURE(eval, ctx, si, wo, active);
     }
 
     Float pdf(const BSDFContext &ctx,
               const SurfaceInteraction3f &si,
               const Vector3f &wo,
               Mask active) const override {
-        PYBIND11_OVERRIDE_PURE(Float, BSDF, pdf, ctx, si, wo, active);
+        NB_OVERRIDE_PURE(pdf, ctx, si, wo, active);
     }
 
     std::pair<Spectrum, Float> eval_pdf(const BSDFContext &ctx,
@@ -57,40 +61,40 @@ public:
               const Vector3f &wo,
               Mask active) const override {
         using Return = std::pair<Spectrum, Float>;
-        PYBIND11_OVERRIDE(Return, BSDF, eval_pdf, ctx, si, wo, active);
+        NB_OVERRIDE(eval_pdf, ctx, si, wo, active);
     }
 
     Spectrum eval_diffuse_reflectance(const SurfaceInteraction3f &si,
                                       Mask active) const override {
-        PYBIND11_OVERRIDE(Spectrum, BSDF, eval_diffuse_reflectance, si, active);
+        NB_OVERRIDE(eval_diffuse_reflectance, si, active);
     }
 
     Mask has_attribute(const std::string &name, Mask active) const override {
-        PYBIND11_OVERRIDE(Mask, BSDF, has_attribute, name, active);
+        NB_OVERRIDE(has_attribute, name, active);
     }
 
     UnpolarizedSpectrum eval_attribute(const std::string &name, const SurfaceInteraction3f &si, Mask active) const override {
-        PYBIND11_OVERRIDE(UnpolarizedSpectrum, BSDF, eval_attribute, name, si, active);
+        NB_OVERRIDE(eval_attribute, name, si, active);
     }
 
     Float eval_attribute_1(const std::string &name, const SurfaceInteraction3f &si, Mask active) const override {
-        PYBIND11_OVERRIDE(Float, BSDF, eval_attribute_1, name, si, active);
+        NB_OVERRIDE(eval_attribute_1, name, si, active);
     }
 
     Color3f eval_attribute_3(const std::string &name, const SurfaceInteraction3f &si, Mask active) const override {
-        PYBIND11_OVERRIDE(Color3f, BSDF, eval_attribute_3, name, si, active);
+        NB_OVERRIDE(eval_attribute_3, name, si, active);
     }
 
     std::string to_string() const override {
-        PYBIND11_OVERRIDE_PURE(std::string, BSDF, to_string,);
+        NB_OVERRIDE_PURE(to_string);
     }
 
     void traverse(TraversalCallback *cb) override {
-        PYBIND11_OVERRIDE(void, BSDF, traverse, cb);
+        NB_OVERRIDE(traverse, cb);
     }
 
     void parameters_changed(const std::vector<std::string> &keys) override {
-        PYBIND11_OVERRIDE(void, BSDF, parameters_changed, keys);
+        NB_OVERRIDE(parameters_changed, keys);
     }
 
     using BSDF::m_flags;
@@ -163,9 +167,6 @@ template <typename Ptr, typename Cls> void bind_bsdf_generic(Cls &cls) {
         .def("needs_differentials",
              [](Ptr bsdf) { return bsdf->needs_differentials(); },
              D(BSDF, needs_differentials));
-
-    if constexpr (dr::is_array_v<Ptr>)
-        bind_drjit_ptr_array(cls);
 }
 
 MI_PY_EXPORT(BSDF) {
@@ -173,29 +174,29 @@ MI_PY_EXPORT(BSDF) {
     using PyBSDF = PyBSDF<Float, Spectrum>;
 
     auto bsdf = MI_PY_TRAMPOLINE_CLASS(PyBSDF, BSDF, Object)
-        .def(py::init<const Properties&>(), "props"_a)
-        .def("flags", py::overload_cast<size_t, Mask>(&BSDF::flags, py::const_),
+        .def(nb::init<const Properties&>(), "props"_a)
+        .def("flags", nb::overload_cast<size_t, Mask>(&BSDF::flags, nb::const_),
             "index"_a, "active"_a = true, D(BSDF, flags, 2))
         .def_method(BSDF, component_count, "active"_a = true)
         .def_method(BSDF, id)
-        .def_property("m_flags",
+        .def_prop_rw("m_flags",
             [](PyBSDF &bsdf){ return bsdf.m_flags; },
             [](PyBSDF &bsdf, uint32_t flags){
                 bsdf.m_flags = flags;
             }
         )
-        .def_readwrite("m_components", &PyBSDF::m_components)
-        .def("__repr__", &BSDF::to_string);
+        .def_field(PyBSDF, m_components, D(BSDF, m_components))
+        .def("__repr__", &BSDF::to_string, D(BSDF, to_string));
 
     bind_bsdf_generic<BSDF *>(bsdf);
 
     if constexpr (dr::is_array_v<BSDFPtr>) {
-        py::object dr       = py::module_::import("drjit"),
+        nb::object dr       = nb::module_::import_("drjit"),
                    dr_array = dr.attr("ArrayBase");
 
-        py::class_<BSDFPtr> cls(m, "BSDFPtr", dr_array);
-        bind_bsdf_generic<BSDFPtr>(cls);
-        pybind11_type_alias<UInt32, dr::replace_scalar_t<UInt32, BSDFFlags>>();
+        dr::ArrayBinding b;
+        auto bsdf_ptr = dr::bind_array_t<BSDFPtr>(b, m, "BSDFPtr");
+        bind_bsdf_generic<BSDFPtr>(bsdf_ptr);
     }
 
     MI_PY_REGISTER_OBJECT("register_bsdf", BSDF)


### PR DESCRIPTION
I've tried to remove all of the mechanical search&replace changes, and put them in other commits. 

The changes in this PR should exclusively hold what is necessary to introduce intrusive counters in `mitsuba::Object` and bindings for the `BSDF` plugins. 

I've tested the trampolines "manually": custom BSDF types get properly deleted when exiting the interpreter or if explicitly deleted before that with `del my_bsdf_instance`. 

Notes: 
* I've opted to keep our own `ref` rather than replacing it with the one from `nanobind`, as their interfaces are slightly different (one allows implicit casts to `T*`, the other doesn't, and a few other things). This isn't crucial by any means, and we can still change it down the line. FWIW, I actually started doing this first and stopped after about 2 hours of refactoring -- the codebase is scattered with these implicit casts currently.
* All plugin destructors must be `public virtual` now. More precisely, any type which inherits from `Object` must have thos specifiers.
* This isn't directly related to this PR, hence it being in a separate commit, but the new shutdown routine can be found here: https://github.com/mitsuba-renderer/mitsuba3/commit/3063431cb028659939b227a34330221882b52f9d. In short, we should now be able to fully rely on the `atexit` behaviour to cleanup our static datatstructures.