### PR TITLE
Fix Properties::SortKey operator for large integers

### DIFF
--- a/src/core/properties.cpp
+++ b/src/core/properties.cpp
@@ -8,6 +8,7 @@
 #include <map>
 #include <sstream>
 #include <cstring>
+#include <climits>
 
 #include <drjit/tensor.h>
 
@@ -59,10 +60,11 @@ struct SortKey {
 
         if (std::isdigit(*a_ptr) && std::isdigit(*b_ptr)) {
             char *a_end, *b_end;
-            long l1 = std::strtol(a_ptr, &a_end, 10);
-            long l2 = std::strtol(b_ptr, &b_end, 10);
+            long long l1 = std::strtoll(a_ptr, &a_end, 10);
+            long long l2 = std::strtoll(b_ptr, &b_end, 10);
             if (a_end == (a.c_str() + a.size()) &&
-                b_end == (b.c_str() + b.size()))
+                b_end == (b.c_str() + b.size()) &&
+                l1 != LLONG_MAX && l2 != LLONG_MAX)
                 return l1 < l2;
         }
 
@@ -91,7 +93,7 @@ T get_impl(const Iterator &it) {
 
 /**
  * \brief Specialization to gracefully handle if user supplies either a 3x3 or 4x4 transform.
- * Historically, we didn't directly support Transform3 properties so want to maintain 
+ * Historically, we didn't directly support Transform3 properties so want to maintain
  * backwards compatibility
  */
 template<>

--- a/src/core/tests/test_properties.py
+++ b/src/core/tests/test_properties.py
@@ -228,3 +228,15 @@ def test11_tensor_cuda(variant_cuda_ad_rgb):
     torch = pytest.importorskip("torch")
     props['goo'] = torch.zeros(2, 3, 4)
     assert props['goo'].shape == (2, 3, 4)
+
+def test12_large_integer_keys(variant_scalar_rgb):
+    key1 = '5c930abab5cb692464249420000000000000000000000004'
+    key2 = '5c930abab5cb692464249420000000000000000000000001'
+
+    props = mi.Properties()
+    props[key1] = 4.0
+    props[key2] = 8.0
+
+    assert len(props.property_names()) == 2
+    assert props[key1] == 4.0
+    assert props[key2] == 8.0


### PR DESCRIPTION
The current implementation of the key comparison operator in `Properties` assumes that integers found in keys fit in a 32 bits integer. When working with large scenes exported from Blender, it is often the case for object names to contain larger integers. This results in Mitsuba complaining about missing or duplicated keys.

This patch fixes this issue by performing a proper comparison for integers that fit in 64 bits, and otherwise falling back onto the string comparison.