### PR TITLE
Fix reference counting of OptiX shader binding table

### DIFF
--- a/src/render/scene_optix.inl
+++ b/src/render/scene_optix.inl
@@ -30,12 +30,11 @@ struct OptixSceneState {
     OptixAccelData accel;
     OptixTraversableHandle ias_handle = 0ull;
     struct InstanceData {
-        void* buffer = nullptr;             // Device-visible storage for IAS 
-        void* inputs = nullptr;             // Device-visible storage for OptixInstance array
+        void* buffer = nullptr;  // Device-visible storage for IAS
+        void* inputs = nullptr;  // Device-visible storage for OptixInstance array
     } ias_data;
     size_t config_index;
     uint32_t sbt_jit_index;
-    bool own_sbt;
 };
 
 /**
@@ -357,9 +356,11 @@ MI_VARIANT void Scene<Float, Spectrum>::accel_init_gpu(const Properties &props) 
             jit_optix_update_sbt(s2.sbt_jit_index, &s2.sbt);
 
             memcpy(&s.sbt, &s2.sbt, sizeof(OptixShaderBindingTable));
+
             s.sbt_jit_index = s2.sbt_jit_index;
+            jit_var_inc_ref(s.sbt_jit_index);
+
             s.config_index = s2.config_index;
-            s.own_sbt = false;
         } else {
             // =====================================================
             //  Initialize OptiX configuration
@@ -425,7 +426,6 @@ MI_VARIANT void Scene<Float, Spectrum>::accel_init_gpu(const Properties &props) 
                 jit_malloc_migrate(s.sbt.hitgroupRecordBase, AllocType::Device, 1);
 
             s.sbt_jit_index = jit_optix_configure_sbt(&s.sbt, config.pipeline_jit_index);
-            s.own_sbt = true;
         }
 
         // =====================================================
@@ -555,12 +555,11 @@ MI_VARIANT void Scene<Float, Spectrum>::accel_release_gpu() {
 
         OptixSceneState *s = (OptixSceneState *) m_accel;
 
-        if (s->own_sbt) {
-            /* This will decrease the reference count of the shader binding table
-               JIT variable which might trigger the release of the OptiX SBT if
-               no ray tracing calls are pending. */
-            (void) UInt32::steal(s->sbt_jit_index);
-        }
+        /* This will decrease the reference count of the shader binding table
+            JIT variable which might trigger the release of the OptiX SBT if
+            no ray tracing calls are pending. */
+        (void) UInt32::steal(s->sbt_jit_index);
+
         m_accel = nullptr;
 
         /* Decrease the reference count of the IAS handle variable. This will


### PR DESCRIPTION
This patch attempts to fix a reference counting issue with OptiX's shader binding tables shared between scenes.

More specifically, this issue arises when a mesh is shared in between two scenes, with the `eval_parameterization()` being used on that mesh. When the first scene is deleted, it will free the shader binding table used in `eval_parameterization()` which we might want to use with the second scene. See the pseudo code below to illustrate this example:

```python
shape = ...

scene1 = mi.load_dict({ 'type': 'scene', 'shape': shape })

a = scene1.ray_intersect(...)
b = shape.eval_parameterization()
dr.eval(a, b)

del scene1

scene2 = mi.load_dict({ 'type': 'scene', 'shape': shape })

a = scene2.ray_intersect(...)
b = shape.eval_parameterization()
dr.eval(a, b)
```

Unfortunately this patch doesn't solve all possible issues. When a Mesh is shared in between multiple scenes, it should ideally have a parameterization nested scene per parent scene, to make sure `eval_parameterization` and `scene->ray_tracing()` can take place within the same megakernel.

Any thoughts?