### PR TITLE
Fix Properties::SortKey trailing zeros

### DIFF
--- a/src/core/properties.cpp
+++ b/src/core/properties.cpp
@@ -65,7 +65,7 @@ struct SortKey {
             if (a_end == (a.c_str() + a.size()) &&
                 b_end == (b.c_str() + b.size()) &&
                 l1 != LLONG_MAX && l2 != LLONG_MAX &&
-                !((l1 == l2) && (a.size() != b.size()))) // catch trailing zeros case (e.g. 001 vs 01))
+                !((l1 == l2) && (a.size() != b.size()))) // catch leading zeros case (e.g. 001 vs 01))
                 return l1 < l2;
         }
 

--- a/src/core/properties.cpp
+++ b/src/core/properties.cpp
@@ -64,7 +64,8 @@ struct SortKey {
             long long l2 = std::strtoll(b_ptr, &b_end, 10);
             if (a_end == (a.c_str() + a.size()) &&
                 b_end == (b.c_str() + b.size()) &&
-                l1 != LLONG_MAX && l2 != LLONG_MAX)
+                l1 != LLONG_MAX && l2 != LLONG_MAX &&
+                !((l1 == l2) && (a.size() != b.size()))) // catch trailing zeros case (e.g. 001 vs 01))
                 return l1 < l2;
         }
 

--- a/src/core/tests/test_properties.py
+++ b/src/core/tests/test_properties.py
@@ -240,3 +240,15 @@ def test12_large_integer_keys(variant_scalar_rgb):
     assert len(props.property_names()) == 2
     assert props[key1] == 4.0
     assert props[key2] == 8.0
+
+def test13_trailing_zeros_keys(variant_scalar_rgb):
+    key1 = 'aa_1'
+    key2 = 'aa_0001'
+
+    props = mi.Properties()
+    props[key1] = 4.0
+    props[key2] = 8.0
+
+    assert len(props.property_names()) == 2
+    assert props[key1] == 4.0
+    assert props[key2] == 8.0


### PR DESCRIPTION
This PR is fixing another edge case in `Properties::SortKey`: when the key's numerical suffixes compile to the same value, but have a different number of trailing zeros, the operator should fallback to the string comparison.

For instance, currently the following two keys can be used together in a `props`: `key_001` and `key_01`.

I also added a unit test that covers this edge case.