### PR TITLE
Allow zero-initializations of `Mesh` objects wrapping an `Emitter` or `Sensor`

### DIFF
--- a/include/mitsuba/render/mesh.h
+++ b/include/mitsuba/render/mesh.h
@@ -19,7 +19,7 @@ public:
     MI_IMPORT_TYPES()
     MI_IMPORT_BASE(Shape, m_to_world, mark_dirty, m_emitter, m_sensor, m_bsdf,
                    m_interior_medium, m_exterior_medium, m_is_instance,
-                   m_discontinuity_types, m_shape_type)
+                   m_discontinuity_types, m_shape_type, m_initialized)
 
     // Mesh is always stored in single precision
     using InputFloat = float;
@@ -34,12 +34,24 @@ public:
     using typename Base::ScalarIndex;
     using typename Base::Index;
 
-    /// Create a new mesh with the given vertex and face data structures
+    /** \brief Creates a zero-initialized mesh with the given vertex and face
+     * counts
+     *
+     * The vertex and face buffers can be filled using the ``mi.traverse``
+     * mechanism. When initializing these buffers through another method, an
+     * explicit call to \ref initialize must be made once all buffers are
+     * filled.
+     */
     Mesh(const std::string &name, ScalarSize vertex_count,
          ScalarSize face_count, const Properties &props = Properties(),
          bool has_vertex_normals = false, bool has_vertex_texcoords = false);
 
-    /// Must be called at the end of the constructor of Mesh plugins
+    /** \brief Must be called once at the end of the construction of a Mesh
+     *
+     * This method computes internal data structures and notifies the parent
+     * sensor or emitter (if there is one) that this instance is their internal
+     * shape.
+     */
     void initialize() override;
 
     // =========================================================================

--- a/include/mitsuba/render/shape.h
+++ b/include/mitsuba/render/shape.h
@@ -982,6 +982,9 @@ protected:
 protected:
     /// True if the shape's geometry has changed
     bool m_dirty = true;
+
+    /// True if the shape has called iniatlize() at least once
+    bool m_initialized = false;
 };
 
 // -----------------------------------------------------------------------

--- a/src/render/mesh.cpp
+++ b/src/render/mesh.cpp
@@ -52,8 +52,6 @@ Mesh<Float, Spectrum>::Mesh(const std::string &name, ScalarSize vertex_count,
         m_vertex_normals = dr::zeros<FloatStorage>(m_vertex_count * 3);
     if (has_vertex_texcoords)
         m_vertex_texcoords = dr::zeros<FloatStorage>(m_vertex_count * 2);
-
-    initialize();
 }
 
 MI_VARIANT
@@ -89,8 +87,6 @@ MI_VARIANT void Mesh<Float, Spectrum>::traverse(TraversalCallback *callback) {
     // We arbitrarily chose to show all attributes as being differentiable here.
     for (auto &[name, attribute]: m_mesh_attributes)
         callback->put_parameter(name, attribute.buf, +ParamFlags::Differentiable);
-
-
 }
 
 MI_VARIANT void Mesh<Float, Spectrum>::parameters_changed(const std::vector<std::string> &keys) {
@@ -157,6 +153,9 @@ MI_VARIANT void Mesh<Float, Spectrum>::parameters_changed(const std::vector<std:
         m_faces_ptr = m_faces.data();
 #endif
         mark_dirty();
+
+        if (!m_initialized)
+            Base::initialize();
     }
 
     Base::parameters_changed();

--- a/src/render/shape.cpp
+++ b/src/render/shape.cpp
@@ -634,6 +634,8 @@ MI_VARIANT void Shape<Float, Spectrum>::initialize() {
         m_emitter->set_shape(this);
     if (m_sensor)
         m_sensor->set_shape(this);
+
+    m_initialized = true;
 }
 
 MI_VARIANT


### PR DESCRIPTION
--- Fairly straightforward PR, want to check the CI ---

## Description

Removes a problematic call to `Mesh::initialize` when using meshes' zero-initializer.

This call serves to notify the emitter or sensor of the shape that is wrapping them. However if called during construction of the mesh, the child plugin is not aware that it's parent is still empty2. This PR fixes this issue by moving the initialization to the `parameters_changed` method, which is expected to be used to fill the mesh's buffers in any case.

In addition, some emitters/sensors might expect to be notified every time the shape they are enclosed is modified. This can happen both through the `parameters_changed` interface or when `set_shape` happens. With this PR, both cases are covered.

Fixes #1089