### PR TITLE
[Feature] Add setpath for fish shell

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -225,11 +225,20 @@ if (NOT SKBUILD)
       configure_file(${CMAKE_CURRENT_SOURCE_DIR}/resources/setpath.sh
                      ${CMAKE_CURRENT_BINARY_DIR}/setpath.sh @ONLY)
       install(FILES ${CMAKE_CURRENT_BINARY_DIR}/setpath.sh DESTINATION ".")
+
+      configure_file(${CMAKE_CURRENT_SOURCE_DIR}/resources/setpath.fish
+                     ${CMAKE_CURRENT_BINARY_DIR}/setpath.fish @ONLY)
+      install(FILES ${CMAKE_CURRENT_BINARY_DIR}/setpath.fish DESTINATION ".")
   else()
       configure_file(${CMAKE_CURRENT_SOURCE_DIR}/resources/setpath.sh
                      ${CMAKE_CURRENT_BINARY_DIR}/resources/setpath.sh @ONLY)
       install(FILES ${CMAKE_CURRENT_BINARY_DIR}/setpath.sh DESTINATION ".")
       ro_copy(${CMAKE_CURRENT_BINARY_DIR}/resources/setpath.sh setpath.sh)
+
+      configure_file(${CMAKE_CURRENT_SOURCE_DIR}/resources/setpath.fish
+                     ${CMAKE_CURRENT_BINARY_DIR}/resources/setpath.fish @ONLY)
+      install(FILES ${CMAKE_CURRENT_BINARY_DIR}/setpath.fish DESTINATION ".")
+      ro_copy(${CMAKE_CURRENT_BINARY_DIR}/resources/setpath.fish setpath.fish)
 
       configure_file(${CMAKE_CURRENT_SOURCE_DIR}/resources/setpath.bat
                      ${CMAKE_CURRENT_BINARY_DIR}/resources/setpath.bat @ONLY)

--- a/docs/src/developer_guide/compiling.rst
+++ b/docs/src/developer_guide/compiling.rst
@@ -245,7 +245,7 @@ Now, compilation should be as simple as running the following from inside the
 Running Mitsuba
 ---------------
 
-Once Mitsuba is compiled, run the ``setpath.sh/.bat/.ps1`` script in your build
+Once Mitsuba is compiled, run the ``setpath.sh/setpath.fish/.bat/.ps1`` script in your build
 directory to configure environment variables (``PATH/PYTHONPATH``) that are
 required to run Mitsuba.
 
@@ -253,6 +253,9 @@ required to run Mitsuba.
 
     # On Linux / Mac OS
     source setpath.sh
+
+    # For fish shell
+    source setpath.fish
 
     # On Windows (cmd)
     C:/.../mitsuba3/build/Release> setpath

--- a/resources/setpath.fish
+++ b/resources/setpath.fish
@@ -1,0 +1,32 @@
+# This script adds Mitsuba and the Python bindings to the shell's search
+# path. It must be executed via the 'source' command so that it can modify
+# the relevant environment variables.
+
+set MI_DIR ""
+set MI_VARIANTS "@MI_VARIANT_NAMES_STR@"
+
+if [ "$FISH_VERSION" ]
+    if string match -q -- "source" (status current-command)
+        set MI_DIR (dirname (realpath (status current-filename)))
+    end
+end
+
+if not string length -q -- $MI_DIR
+    echo "This script must be executed via the 'source' command, i.e.:"
+    echo "\$ source" (status current-filename)
+    exit 0
+end
+
+set -gx PYTHONPATH $MI_DIR/python $PYTHONPATH
+set -gx PATH $MI_DIR $PATH
+
+# Completions
+complete -c mitsuba -s h -l help -d "Print a short help text and exit"
+complete -c mitsuba -s m -l mode --no-files -ra $MI_VARIANTS -d "Request a specific mode/variant of the renderer"
+complete -c mitsuba -s v -l verbose -d "Be more verbose"
+complete -c mitsuba -s t -l threads -d "Render with the specified number of threads"
+complete -c mitsuba -s D -l define -d "Define a constant that can be referenced"
+complete -c mitsuba -s s -l sensor -d "Index of the sensor to render with"
+complete -c mitsuba -s u -l update -d "Update the scene's XML description to the latest version"
+complete -c mitsuba -s a -l append -d "Add one or more entries to the resource search path"
+complete -c mitsuba -s o -l output -d "Write the output image to a file"


### PR DESCRIPTION
<!-- Please add the labels (e.g. bug fix, feature, ..) corresponding to this PR -->

## Description

This PR adds setpath functionality for the fish shell.

## Testing

Local tests on Linux with fish shell.

## Checklist

<!-- Please make sure to complete this checklist before requesting a review. -->

- [x] My code follows the [style guidelines](https://mitsuba.readthedocs.io/en/latest/src/developer_guide.html#coding-style) of this project
- [x] My changes generate no new warnings
- [x] My code also compiles for `cuda_*` and `llvm_*` variants. If you can't test this, please leave below
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 3 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba/blob/master/LICENSE)