### PR TITLE
Fix `measuredpolarized` in JIT modes

### DIFF
--- a/src/bsdfs/measured_polarized.cpp
+++ b/src/bsdfs/measured_polarized.cpp
@@ -113,6 +113,7 @@ public:
 
     MeasuredPolarized(const Properties &props) : Base(props) {
         m_flags = BSDFFlags::GlossyReflection | BSDFFlags::FrontSide;
+        dr::set_attr(this, "flags", m_flags);
         m_components.push_back(m_flags);
 
         m_alpha_sample = props.get<ScalarFloat>("alpha_sample", 0.1f);


### PR DESCRIPTION
<!-- Please add the labels (e.g. bug fix, feature, ..) corresponding to this PR -->

## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

The plugin `measured_polarized` did not work in JIT variants. The problem was that its flags were not set with Dr. Jit. I fixed it by adding the corresponding line in the constructor. This is a fix to the issue #694.

## Testing

I made a scene with light green silicone composed by a plane, sphere and a light source. I rendered it with the `scalar_spectral_polarized`, `llvm_spectral_polarized` and `cuda_spectral_polarized` modes. The final RGB files are the following
![scalar exr](https://github.com/mitsuba-renderer/mitsuba3/assets/24795695/28ab7a23-e84e-4ebd-85f7-b1689cdb7d8e)
![llvm exr](https://github.com/mitsuba-renderer/mitsuba3/assets/24795695/d8ad17e8-1eca-4f48-9df2-0fbe326baa59)
![cuda exr](https://github.com/mitsuba-renderer/mitsuba3/assets/24795695/9aca8a85-2f2c-4e8e-846d-8caed26718fb)

Scene file:
```
<scene version="3.0.0">
    <default name="spp" value="1024"/>
    <default name="res" value="256"/>

    <integrator type="stokes">
        <integrator type='path'>
        </integrator>
    </integrator>

    <sensor type="perspective" id="sensor">
        <string name="fov_axis" value="smaller"/>
        <float name="near_clip" value="0.01"/>
        <float name="far_clip" value="1000"/>
        <float name="focus_distance" value="1000"/>
        <float name="fov" value="39.3077"/>
        <transform name="to_world">
            <lookat origin="0, 0, 4"
                    target="0, 0, 0"
                    up    ="0, 1  0"/>
        </transform>
        <sampler type="independent">
            <integer name="sample_count" value="$spp"/>
        </sampler>
        <film type="hdrfilm">
            <integer name="width"  value="$res"/>
            <integer name="height" value="$res"/>
            <rfilter type="gaussian"/>
        </film>
    </sensor>

    <!-- BSDFs -->

    <bsdf type="measured_polarized" id="metal">
        <string name="filename" value="pbrdf_data/22_lightgreen_silicon_inpainted.pbsdf"/>
        <float name="alpha_sample" value="0.10"/>
    </bsdf>
   

    <bsdf type="diffuse" id="white">
    </bsdf>

    <!-- Light -->

    <shape type="obj" id="light">
        <string name="filename" value="meshes/cbox_luminaire.obj"/>
        <transform name="to_world">
            <translate x="0" y="-0.01" z="0.75"/>
            <scale value="10"/>
        </transform>

        <ref id="white"/>
        <emitter type="area">
            <rgb name="radiance" value="25.0"/>
        </emitter>
    </shape>

    <!-- Shapes -->

    <shape type="obj" id="floor">
        <string name="filename" value="meshes/cbox_floor.obj"/>
        <ref id="metal"/>
    </shape>

    <shape type="sphere">
        <ref id="metal"/>
        <point name="center" value="-0.0, -0.0, -0.5"/>
        <float name="radius" value="0.5"/>
    </shape>
</scene>
```

## Checklist

<!-- Please make sure to complete this checklist before requesting a review. -->

- [x] My code follows the [style guidelines](https://mitsuba.readthedocs.io/en/latest/src/developer_guide.html#coding-style) of this project
- [x] My changes generate no new warnings
- [x] My code also compiles for `cuda_*` and `llvm_*` variants. If you can't test this, please leave below
- [x] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 3 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba/blob/master/LICENSE)