### PR TITLE
Docs: update recommended Clang version

### DIFF
--- a/docs/src/developer_guide/compiling.rst
+++ b/docs/src/developer_guide/compiling.rst
@@ -117,7 +117,7 @@ To fetch all dependencies and Clang, enter the following commands on Ubuntu:
 .. code-block:: bash
 
     # Install recent versions build tools, including Clang and libc++ (Clang's C++ library)
-    sudo apt install clang-10 libc++-10-dev libc++abi-10-dev cmake ninja-build
+    sudo apt install clang-15 libc++-15-dev libc++abi-15-dev cmake ninja-build
 
     # Install libraries for image I/O
     sudo apt install libpng-dev libjpeg-dev
@@ -141,7 +141,7 @@ CMake will always use the correct compiler.
 
 .. code-block:: bash
 
-    export CC=clang-10 export CXX=clang++-10
+    export CC=clang-15 export CXX=clang++-15
 
 If you installed another version of Clang, the version suffix of course has to
 be adjusted. Now, compilation should be as simple as running the following from


### PR DESCRIPTION
Hi,

@jhoydis pointed out recently that the current build guide's instructions:

```bash
sudo apt install clang-10 libc++-10-dev libc++abi-10-dev cmake ninja-build
```

no longer work on e.g. Ubuntu 22.04 (and most likely more recent versions as well), because the `libc++-10-dev` and `libc++abi-10-dev` packages no longer exist.

I understand that Clang 10 is used in the CI and it makes sense to recommend the same compiler version that is tested, but since it's not working anymore, would switching to Clang 15 in the docs be okay?