### PR TITLE
[bug fix] issue #1168 by adding eval_null_transmission to trampoline class

### DIFF
--- a/src/render/python/bsdf_v.cpp
+++ b/src/render/python/bsdf_v.cpp
@@ -65,6 +65,11 @@ public:
         PYBIND11_OVERRIDE(Spectrum, BSDF, eval_diffuse_reflectance, si, active);
     }
 
+    Spectrum eval_null_transmission(const SurfaceInteraction3f &si,
+                                      Mask active) const override {
+        PYBIND11_OVERRIDE(Spectrum, BSDF, eval_null_transmission, si, active);
+    }
+
     Mask has_attribute(const std::string &name, Mask active) const override {
         PYBIND11_OVERRIDE(Mask, BSDF, has_attribute, name, active);
     }


### PR DESCRIPTION
[bug fix] for issue #1168

## Description

This small contribution fixes an issue I had as suggested by @merlinND.

Fixes #1168 

## Testing

I verified that eval_null_transmission is called as expected after the fix and that my python BSDF (see #1168) behaves exactly the same as the reference C++ plugin.

## Checklist

<!-- Please make sure to complete this checklist before requesting a review. -->

- [x] My code follows the [style guidelines](https://mitsuba.readthedocs.io/en/latest/src/developer_guide.html#coding-style) of this project
- [x] My changes generate no new warnings
- [x] My code also compiles for `cuda_*` and `llvm_*` variants. If you can't test this, please leave below
- [x] I have commented my code: not necessary
- [x] I have made corresponding changes to the documentation: not necessary
- [ ] I have added tests that prove my fix is effective or that my feature works: I verified that it fixes the problem I had
- [x] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 3 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba/blob/master/LICENSE)