### PR TITLE
Fix for sampling_weight emitter attribute

### DIFF
--- a/src/render/emitter.cpp
+++ b/src/render/emitter.cpp
@@ -8,6 +8,7 @@ NAMESPACE_BEGIN(mitsuba)
 MI_VARIANT Emitter<Float, Spectrum>::Emitter(const Properties &props)
     : Base(props) {
         m_sampling_weight = props.get<ScalarFloat>("sampling_weight", 1.0f);
+        dr::set_attr(this, "sampling_weight", m_sampling_weight);
     }
 MI_VARIANT Emitter<Float, Spectrum>::~Emitter() { }
 
@@ -20,6 +21,7 @@ MI_VARIANT
 void Emitter<Float, Spectrum>::parameters_changed(const std::vector<std::string> &keys) {
     set_dirty(true);
     Base::parameters_changed(keys);
+    dr::set_attr(this, "sampling_weight", m_sampling_weight);
 }
 
 MI_IMPLEMENT_CLASS_VARIANT(Emitter, Endpoint, "emitter")


### PR DESCRIPTION
Hi,
We encountered a small bug in the emitter plugin that caused the sampling_weight attribute to not be updated when it was changed in the scene parameters. Calling `dr::set_attr(this, "sampling_weight", m_sampling_weight)` in the constructor and `parameters_changed` seems to fix the issue.
Below is a small reproducer of the issue in case it helps. Just change `num_emitters` to 1 or 12, the outputs should be identical:

```python
import matplotlib.pyplot as plt
import mitsuba as mi
import numpy as np
import drjit as dr

mi.set_variant('llvm_ad_rgb')

from mitsuba import ScalarTransform4f as T
 
# Changing this to num_emitters = 1 should give the same result as num_emitters = 12
num_emitters = 12

sensor = {
    'type': 'perspective',
    'fov': 39.3077,
    'to_world': T.look_at(origin=[0, -4, 0], target=[0, 0, 0], up=[0, 0, 1]),
    'sampler': {'type': 'independent', 'sample_count': 16},
    'film': {
        'type': 'hdrfilm',
        'width': 256,
        'height': 256,
        'pixel_format': 'rgb',
    },
}

scene_dict = {
    'type': 'scene',
    'head': {
        'type': 'sphere',
        'to_world': (
            T.scale(0.5).translate([0, 1.5, 0])
        ),
        'bsdf': {
            'type': 'diffuse',
        },
    },
    'sensor': sensor,
}

emitter_radiance = 100.0

for i in range(num_emitters):
  rotation = i * 360.0 / num_emitters
  scene_dict[f'emitter_{i:03d}'] = {
      'type': 'sphere',
      'emitter': {
          'type': 'area',
          'radiance': {
              'type': 'rgb',
              'value': emitter_radiance,
          },
      },
      'to_world': T.rotate([0, 1, 0], rotation).translate([0, 0, 1]).scale(0.1),
  }

scene = mi.load_dict(scene_dict)

params = mi.traverse(scene)

def switch_on_emitter(emitter_idx):
  for e_idx in range(num_emitters):
    if e_idx == emitter_idx:
      params['emitter_' + f'{e_idx:03d}' + '.emitter.sampling_weight'] = 1.0
      params['emitter_' + f'{e_idx:03d}' + '.emitter.radiance.value'] = emitter_radiance
    else:
      params['emitter_' + f'{e_idx:03d}' + '.emitter.sampling_weight'] = 0.0
      params['emitter_' + f'{e_idx:03d}' + '.emitter.radiance.value'] = 0.0

  params.update()

if(num_emitters != 1):
  switch_on_emitter(0)

integrator = mi.load_dict({
  'type': 'direct',
  'emitter_samples': 1,
  'bsdf_samples': 1,
})

image = mi.render(scene, integrator=integrator)

plt.imshow(image)
```
Best,
Philippe