### PR TITLE
MergeShape: add to registry upon construction

### DIFF
--- a/src/shapes/merge.cpp
+++ b/src/shapes/merge.cpp
@@ -11,6 +11,11 @@ public:
     MI_IMPORT_TYPES(BSDF, Medium, Emitter, Sensor, Mesh)
 
     MergeShape(const Properties &props) {
+        // Note: we are *not* calling the `Shape` constructor as we do not
+        // want to accept various properties such as `to_world`.
+        if constexpr (dr::is_jit_v<Float>)
+            jit_registry_put(dr::backend_v<Float>, "mitsuba::Shape", this);
+
         std::unordered_map<Key, ref<Mesh>, key_hasher> tbl;
         size_t visited = 0, ignored = 0;
         Timer timer;

--- a/src/shapes/tests/test_merge.py
+++ b/src/shapes/tests/test_merge.py
@@ -1,0 +1,97 @@
+import mitsuba as mi
+
+from mitsuba.scalar_rgb.test.util import fresolver_append_path
+
+
+def example_mesh(**kwargs):
+    return {
+        "type" : "ply",
+        "filename" : "resources/data/tests/ply/triangle.ply",
+        "face_normals" : True,
+        **kwargs
+    }
+
+
+@fresolver_append_path
+def test01_merge_single_shape(variants_all_backends_once):
+    # One shape on its own, no BSDF
+    m = mi.load_dict({
+        "type": "merge",
+        "child1": example_mesh(),
+    })
+    assert isinstance(m, mi.Mesh)
+
+    # One shape in a scene, no BSDF
+    m = mi.load_dict({
+        "type": "scene",
+        "parent": {
+            "type": "merge",
+            "child1": example_mesh(),
+        },
+    })
+    assert len(m.shapes()) == 1
+
+    # One shape in a scene, with a BSDF
+    m = mi.load_dict({
+        "type": "scene",
+        "parent": {
+            "type": "merge",
+            "child1": example_mesh(bsdf={ "type": "diffuse" }),
+        },
+    })
+    assert len(m.shapes()) == 1
+
+    # Non-mesh --> should be just passed through
+    m = mi.load_dict({
+        "type": "merge",
+        "child1": {
+            "type": "sphere",
+        },
+    })
+    assert isinstance(m, mi.Shape)
+
+
+@fresolver_append_path
+def test02_two_shapes(variants_all_rgb):
+    # No BSDF --> doesn't merge
+    m = mi.load_dict({
+        "type": "merge",
+        "child1": example_mesh(),
+        "child2": example_mesh(),
+    })
+    assert len(m) == 2
+
+    # No BSDF --> doesn't merge
+    m = mi.load_dict({
+        "type": "merge",
+        "child1": example_mesh(bsdf={ "type": "diffuse" }),
+        "child2": example_mesh(),
+    })
+    assert len(m) == 2
+
+    # Same BSDF: merge
+    m = mi.load_dict({
+        "type": "scene",
+        "bsdf1": { "type": "diffuse" },
+        "parent": {
+            "type": "merge",
+            "child1": example_mesh(bsdf={ "type": "ref", "id": "bsdf1" }),
+            "child2": example_mesh(bsdf={ "type": "ref", "id": "bsdf1" }),
+        }
+    })
+    assert len(m.shapes()) == 1
+
+    # Non-mesh --> doesn't merge
+    m = mi.load_dict({
+        "type": "scene",
+        "bsdf1": { "type": "diffuse" },
+        "parent": {
+            "type": "merge",
+            "child1": example_mesh(bsdf={ "type": "ref", "id": "bsdf1" }),
+            "child2": {
+                "type": "sphere",
+                "bsdf": { "type": "ref", "id": "bsdf1" }
+            },
+        }
+    })
+    assert len(m.shapes()) == 2


### PR DESCRIPTION
<!-- Please add the labels (e.g. bug fix, feature, ..) corresponding to this PR -->

## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->
Without this change, any inclusion of `merge` in a scene would crash at the `jit_registry_remove(this)` call in the destructor of `MergeShape`, due to the missing `jit_registry_put()` call.

I checked all other plugins that should be included in the registry,. Since they all call their `Base` constructor, they shouldn't have this issue.

## Testing

Add basic unit tests, since this plugin was never instantiated in the test suite.

## Checklist

<!-- Please make sure to complete this checklist before requesting a review. -->

- [x] My code follows the [style guidelines](https://mitsuba.readthedocs.io/en/latest/src/developer_guide.html#coding-style) of this project
- [x] My changes generate no new warnings
- [x] My code also compiles for `cuda_*` and `llvm_*` variants. If you can't test this, please leave below
- [x] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 3 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba/blob/master/LICENSE)