### PR TITLE
More Mitsuba Python stubs improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,7 +106,7 @@ endif()
 
 if (NOT EXISTS ${CMAKE_CURRENT_BINARY_DIR}/mitsuba.conf)
   # Default: only scalar modes (RGB, Spectral)
-  set(MI_DEFAULT_VARIANTS "scalar_rgb;scalar_spectral;cuda_ad_rgb;llvm_ad_rgb;llvm_ad_spectral_polarized" CACHE STRING "Default Mitsuba variants that should be included if no mitsuba.conf file exists")
+  set(MI_DEFAULT_VARIANTS "scalar_rgb;scalar_spectral;cuda_ad_rgb;llvm_ad_rgb;llvm_ad_spectral" CACHE STRING "Default Mitsuba variants that should be included if no mitsuba.conf file exists")
   mark_as_advanced(MI_DEFAULT_VARIANTS)
   foreach(TMP ${MI_DEFAULT_VARIANTS})
     string(APPEND INSERT_CONFIGURATIONS_HERE "\"${TMP}\", ")

--- a/resources/variant-stub.cmake
+++ b/resources/variant-stub.cmake
@@ -1,10 +1,17 @@
 # Syntax:  cmake -P variant-stub.cmake <input> <output>
-# Applies some post-cleanup on generated Mitsuba Python stubs
+# Applies post-cleanup of generated Mitsuba Python stubs
+# Will delete input after writing output
 
 file(READ ${CMAKE_ARGV3} FILE_CONTENTS)
 string(REPLACE "drjit.llvm" "drjit.auto" FILE_CONTENTS "${FILE_CONTENTS}")
 string(REPLACE "drjit.cuda" "drjit.auto" FILE_CONTENTS "${FILE_CONTENTS}")
 string(REPLACE "types.CapsuleType" "object" FILE_CONTENTS "${FILE_CONTENTS}")
+string(REPLACE "filesystem.path" "str" FILE_CONTENTS "${FILE_CONTENTS}")
+string(REPLACE "scalar_rgb." "" FILE_CONTENTS "${FILE_CONTENTS}")
+string(REPLACE "class Properties(_Properties)" "class Properties" FILE_CONTENTS "${FILE_CONTENTS}")
+string(REPLACE "_Properties" "Properties" FILE_CONTENTS "${FILE_CONTENTS}")
+string(REGEX REPLACE "[\n ]+python\\.[^-\\s]+ as python\\.[^-\\s]+," "" FILE_CONTENTS "${FILE_CONTENTS}")
+string(REGEX REPLACE "import mitsuba as [a-z_]+" "" FILE_CONTENTS "${FILE_CONTENTS}")
 
 file(WRITE "${CMAKE_ARGV4}" "${FILE_CONTENTS}")
-
+file(REMOVE "${CMAKE_ARGV3}")

--- a/src/core/python/object_v.cpp
+++ b/src/core/python/object_v.cpp
@@ -54,7 +54,7 @@ public:
 /// FIXME: casted return should use rv_policy::reference_interal
 #define GET_PROPERTY_T(T)                                                      \
     if (strcmp(type.name(), typeid(T).name()) == 0)                            \
-      return nb::cast((T *) ptr);
+      return nb::cast((T *) ptr, parent);
 
 /// Implementation detail of mitsuba.set_property
 #define SET_PROPERTY_T(T)                                                      \

--- a/src/core/python/object_v.cpp
+++ b/src/core/python/object_v.cpp
@@ -54,7 +54,7 @@ public:
 /// FIXME: casted return should use rv_policy::reference_interal
 #define GET_PROPERTY_T(T)                                                      \
     if (strcmp(type.name(), typeid(T).name()) == 0)                            \
-      return nb::cast((T *) ptr, parent);
+      return nb::cast((T *) ptr, nb::rv_policy::reference_internal, parent);
 
 /// Implementation detail of mitsuba.set_property
 #define SET_PROPERTY_T(T)                                                      \

--- a/src/core/python/spline_v.cpp
+++ b/src/core/python/spline_v.cpp
@@ -5,6 +5,7 @@
 #include <nanobind/ndarray.h>
 #include <nanobind/stl/pair.h>
 #include <nanobind/stl/tuple.h>
+#include <nanobind/stl/vector.h>
 
 template<typename Float_>
 void bind_spline(nb::module_ &m) {

--- a/src/core/python/thread.cpp
+++ b/src/core/python/thread.cpp
@@ -92,7 +92,7 @@ MI_PY_EXPORT(Thread) {
        .def_method(Thread, is_critical)
        .def_method(Thread, set_name)
        .def_method(Thread, name)
-       .def_method(Thread, thread_id)
+       .def_static_method(Thread, thread_id)
        .def_method(Thread, logger)
        .def_method(Thread, set_logger)
        .def_method(Thread, set_file_resolver)

--- a/src/core/python/transform_v.cpp
+++ b/src/core/python/transform_v.cpp
@@ -36,7 +36,6 @@ void bind_transform3(nb::module_ &m, const char *name) {
         })
         .def(nb::init<Matrix3f>(), D(Transform, Transform))
         .def(nb::init<Matrix3f, Matrix3f>(), "Initialize from a matrix and its inverse transpose")
-        .def("has_scale", &Transform3f::has_scale, D(Transform, has_scale))
         /// Operators
         .def(nb::self == nb::self)
         .def(nb::self != nb::self)
@@ -114,7 +113,6 @@ void bind_transform4(nb::module_ &m, const char *name) {
         .def(nb::init<Matrix4f>(), D(Transform, Transform))
         .def(nb::init<Matrix4f, Matrix4f>(), "Initialize from a matrix and its inverse transpose")
         .def("translation", &Transform4f::translation, D(Transform, translation))
-        .def("has_scale", &Transform4f::has_scale, D(Transform, has_scale))
         .def("extract", &Transform4f::template extract<3>, D(Transform, extract))
         /// Operators
         .def(nb::self == nb::self)

--- a/src/core/tests/test_python.py
+++ b/src/core/tests/test_python.py
@@ -11,16 +11,16 @@ def test01_import_mitsuba_variants():
 
     # Importing specific variant
     mi_var = _import(f'mitsuba.{variant}')
-    assert mi_var.__name__ == f"mitsuba.{variant}"
+    assert mi_var.__name__ == f"mitsuba"
 
     # Should be able to access the variants from mitsuba itself
     mi_var2 = getattr(mi, variant)
-    assert mi_var2.__name__ == f"mitsuba.{variant}"
+    assert mi_var2.__name__ == f"mitsuba"
 
     # Change the current variant
     mi.set_variant('scalar_rgb')
     assert mi.variant() == 'scalar_rgb'
-    assert mi_var.__name__ == f"mitsuba.{variant}"
+    assert mi_var.__name__ == f"mitsuba"
 
 
 def test02_import_submodules():

--- a/src/emitters/tests/test_spot.py
+++ b/src/emitters/tests/test_spot.py
@@ -13,8 +13,6 @@ spectrum_dicts = {
     }
 }
 
-mi.set_variant('scalar_rgb')
-
 lookat_transforms = [
     mi.scalar_rgb.ScalarTransform4f().look_at([0, 1, 0], [0, 0, 0], [1, 0, 0]),
     mi.scalar_rgb.ScalarTransform4f().look_at([0, 0, 1], [0, 0, 0], [0, -1, 0])

--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -164,20 +164,6 @@ endif()
 add_custom_target(mitsuba-copy-python-src ALL DEPENDS ${MI_COPY_FILES})
 set_target_properties(mitsuba-copy-python-src PROPERTIES FOLDER python)
 
-# ----------------------------------------------------------
-#   Copy targets for python (no rpath on Windows)
-# ----------------------------------------------------------
-
-if (MSVC)
-  # This target is dependent on the root CMakeLists.txt target `copy-targets`
-  add_custom_target(copy-targets-python ALL)
-  set_target_properties(copy-targets-python PROPERTIES FOLDER python)
-endif()
-
-# ----------------------------------------------------------
-#   Generate type information stubs (mitsuba)
-# ----------------------------------------------------------
-
 set(MI_ALL_VARIANTS "")
 
 foreach (MI_VARIANT ${MI_VARIANTS})
@@ -186,16 +172,37 @@ foreach (MI_VARIANT ${MI_VARIANTS})
   list(APPEND MI_ALL_VARIANTS ${MI_VARIANT_NAME})
 endforeach()
 
+set(MI_STUB_DEPENDS mitsuba_alias mitsuba_ext mitsuba-copy-python-src ${MI_ALL_VARIANTS})
+
+# ----------------------------------------------------------
+#   Copy targets for python (no rpath on Windows)
+# ----------------------------------------------------------
+
+if (MSVC)
+  # This target is dependent on the root CMakeLists.txt target `copy-targets`
+  add_custom_target(copy-targets-python ALL)
+  set_target_properties(copy-targets-python PROPERTIES FOLDER python)
+
+  list(APPEND MI_STUB_DEPENDS copy-targets-python)
+endif()
+
+# ----------------------------------------------------------
+#   Generate type information stubs (mitsuba)
+# ----------------------------------------------------------
+
 set(STUB_ARGS
   PYTHON_PATH ${MI_BINARY_DIR}/python
   PATTERN_FILE ${CMAKE_CURRENT_SOURCE_DIR}/stubs.pat
-  DEPENDS mitsuba mitsuba_ext ${MI_ALL_VARIANTS}
+  DEPENDS ${MI_STUB_DEPENDS}
 )
 
 # The sanitizers require preloading shared libraries into Python, and that
 # doesn't play well with stub generation. Disable stubs if sanitizers are
 # enabled.
 if (NOT (MI_SANITIZE_ADDRESS OR MI_SANITIZE_MEMORY))
+
+  set(MI_STUB_SUBMODULES "math" "quad" "spline" "mueller" "warp" "misc"
+                         "python.ad" "python.chi2" "python.math_py" "python.util" "python.xml")
 
   nanobind_add_stub(
     mitsuba-stub
@@ -213,12 +220,34 @@ if (NOT (MI_SANITIZE_ADDRESS OR MI_SANITIZE_MEMORY))
       ${MI_BINARY_DIR}/python/mitsuba/__init__.pyi
   )
 
+  set(MI_STUB_TARGET_DEPS
+    ${MI_BINARY_DIR}/python/mitsuba/__init__.pyi
+    ${MI_BINARY_DIR}/python/mitsuba/py.typed)
+
+  foreach (value ${MI_STUB_SUBMODULES})
+    string(REPLACE "." "/" value_path ${value})
+    nanobind_add_stub(
+      mitsuba-stub-${value}
+      MODULE mitsuba.mitsuba_stubs.${value}
+      OUTPUT ${MI_BINARY_DIR}/python/mitsuba/${value_path}_stubs.pyi
+      ${STUB_ARGS}
+    )
+
+    add_custom_command(
+      OUTPUT ${MI_BINARY_DIR}/python/mitsuba/${value_path}.pyi
+      DEPENDS ${MI_BINARY_DIR}/python/mitsuba/${value_path}_stubs.pyi
+      COMMAND cmake -P ${CMAKE_CURRENT_SOURCE_DIR}/../../resources/variant-stub.cmake
+        ${MI_BINARY_DIR}/python/mitsuba/${value_path}_stubs.pyi
+        ${MI_BINARY_DIR}/python/mitsuba/${value_path}.pyi
+    )
+
+    list(APPEND MI_STUB_TARGET_DEPS ${MI_BINARY_DIR}/python/mitsuba/${value_path}.pyi)
+  endforeach()
+
   add_custom_target(
     mitsuba-stubs
     ALL
-    DEPENDS
-    ${MI_BINARY_DIR}/python/mitsuba/__init__.pyi
-    ${MI_BINARY_DIR}/python/mitsuba/py.typed
+    DEPENDS ${MI_STUB_TARGET_DEPS}
   )
 
 endif()

--- a/src/python/main_v.cpp
+++ b/src/python/main_v.cpp
@@ -120,27 +120,23 @@ using Caster = nb::object(*)(mitsuba::Object *);
 Caster cast_object = nullptr;
 
 NB_MODULE(MI_VARIANT_NAME, m) {
-    // Temporarily change the module name (for pydoc)
-    m.attr("__name__") = "mitsuba." DRJIT_TOSTRING(MI_VARIANT_NAME);
+    m.attr("__name__") = "mitsuba";
 
     // Create sub-modules
-    nb::module_ math =
-        m.def_submodule("math", "Mathematical routines, special functions, "
-                                "etc.");
-    nb::module_ spline =
-        m.def_submodule("spline", "Functions for evaluating and sampling "
-                                  "Catmull-Rom splines");
-    nb::module_ warp =
-        m.def_submodule("warp", "Common warping techniques that map from "
-                                "the unit square to other domains, such as "
-                                "spheres, hemispheres, etc.");
-    nb::module_ quad =
-        m.def_submodule("quad", "Functions for numerical quadrature");
-    nb::module_ mueller =
-        m.def_submodule("mueller", "Routines to manipulate Mueller matrices "
-                                   "for polarized rendering.");
+    // Don't use nb::def_submodule because of namespace collisions
+    // create_submodule will always create a new module
+    nb::module_ math    = create_submodule(m, "math"),
+                spline  = create_submodule(m, "spline"),
+                warp    = create_submodule(m, "warp"),
+                quad    = create_submodule(m, "quad"),
+                mueller = create_submodule(m, "mueller");
 
-    m.attr("__name__") = "mitsuba";
+    math.doc()    = "Mathematical routines, special functions, etc.";
+    spline.doc()  = "Functions for evaluating and sampling Catmull-Rom splines";
+    warp.doc()    = "Common warping techniques that map from the unit square to other "
+                    "domains, such as spheres, hemispheres, etc.";
+    quad.doc()    = "Functions for numerical quadrature";
+    mueller.doc() = "Routines to manipulate Mueller matrices for polarized rendering.";
 
     // FIXME: we don't really need a list of casters
     /// Initialize the list of casters
@@ -249,7 +245,4 @@ NB_MODULE(MI_VARIANT_NAME, m) {
     paths.append(nb::str(mi_dir));
     paths.append(nb::str(mi_py_dir));
     m.attr("__path__") = paths;
-
-    // Change module name back to correct value
-    m.attr("__name__") = "mitsuba." DRJIT_TOSTRING(MI_VARIANT_NAME);
 }

--- a/src/python/mitsuba_stubs/__init__.py
+++ b/src/python/mitsuba_stubs/__init__.py
@@ -43,3 +43,11 @@ except ImportError:
                        'Mitsuba.')
 
 sys.modules[__name__] = sys.modules['mitsuba']
+sys.modules[__name__ +'.math']      = mi.math
+sys.modules[__name__ +'.spline']    = mi.spline
+sys.modules[__name__ +'.warp']      = mi.warp
+sys.modules[__name__ +'.quad']      = mi.quad
+sys.modules[__name__ +'.mueller']   = mi.mueller
+sys.modules[__name__ +'.misc']      = mi.misc
+sys.modules[__name__ +'.python']    = mi.python
+

--- a/src/python/stubs.pat
+++ b/src/python/stubs.pat
@@ -35,30 +35,107 @@ casters:
 
 .*\.DRJIT_STRUCT:
 
-Scalar.*:
+mitsuba.__prefix__:
+    from .python import (
+        ad as ad,
+        chi2 as chi2,
+        math_py as math_py,
+        util as util,
+        xml as xml
+    )
 
-# Type alias but specific to variant we used to generate stub
-UnpolarizedSpectrum:
-Spectrum:
+    _UnpolarizedSpectrumCp: TypeAlias = Union['UnpolarizedSpectrum', 'drjit.auto.ad._FloatCp', 'drjit.scalar._ArrayXfCp', 'drjit.auto._ArrayXfCp', 'drjit.auto.ad._ArrayXf16Cp']
+
+    _Spectrum_vtCp: TypeAlias = Union['Spectrum_vt', '_UnpolarizedSpectrumCp', 'drjit.scalar._ArrayXfCp', 'drjit.auto._ArrayXfCp', 'drjit.auto.ad._ArrayXf16Cp']
+
+    _SpectrumCp: TypeAlias = Union['Spectrum', '_Spectrum_vtCp', 'drjit.scalar._ArrayXfCp', 'drjit.auto._ArrayXfCp', 'drjit.auto.ad._ArrayXf16Cp']
+
+    class Spectrum_vt(drjit.ArrayBase['Spectrum_vt', '_Spectrum_vtCp', UnpolarizedSpectrum, '_UnpolarizedSpectrumCp', UnpolarizedSpectrum, 'Spectrum_vt', drjit.auto.ad.ArrayXb]):
+        pass
+
+    class Spectrum(drjit.ArrayBase['Spectrum', '_SpectrumCp', Spectrum_vt, '_Spectrum_vtCp', Spectrum_vt, drjit.auto.ad.ArrayXf, drjit.auto.ad.ArrayXb]):
+        pass
+
+    class UnpolarizedSpectrum(drjit.ArrayBase['UnpolarizedSpectrum', '_UnpolarizedSpectrumCp', drjit.auto.ad.Float, 'drjit.auto.ad._FloatCp', drjit.auto.ad.Float, 'UnpolarizedSpectrum', drjit.auto.ad.ArrayXb]):
+        pass
+
+Bitmap.__eq__:
+Bitmap.__ne__:
+
+BoundingBox2f.__eq__:
+BoundingBox2f.__ne__:
+
+BoundingBox3f.__eq__:
+BoundingBox3f.__ne__:
+
+BoundingSphere3f.__eq__:
+BoundingSphere3f.__ne__:
+
+DirectionSample3f.__setitem__:
+
+Field.*.__eq__:
+Field.*.__ne__:
+
+Frame.*.__eq__:
+Frame.*.__ne__:
+
+Interaction3f.assign:
+Interaction3f.__setitem__:
+
+MediumInteraction.*.assign:
+
+PositionSample3f.assign:
+PositionSample3f.__setitem__:
+
+Properties.__eq__:
+Properties.__ne__:
+
+Ray.*.__eq__:
+Ray.*.__ne__:
+Ray.*.assign:
+
+RayDifferential.*.__setitem__:
+
+ScalarTransform.*.__eq__:
+ScalarTransform.*.__ne__:
+
+Struct.__eq__:
+Struct.__ne__:
+
+SurfaceInteraction.*.__eq__:
+SurfaceInteraction.*.__ne__:
+
+ScalarPoint.*.__getitem__:
+ScalarPoint.*.__setitem__:
+ScalarPoint.*.__delitem__:
+
+ScalarColor.*.__getitem__:
+ScalarColor.*.__setitem__:
+ScalarColor.*.__delitem__:
+
+ScalarNormal.*.__getitem__:
+ScalarNormal.*.__setitem__:
+ScalarNormal.*.__delitem__:
+
+Transform.*.__eq__:
+Transform.*.__ne__:
+
+Vector.*.__getitem__:
+Vector.*.__setitem__:
+Vector.*.__delitem__:
+
+.*Ptr.Domain:
+.*Ptr.__getitem__:
+.*Ptr.__setitem__:
+.*Ptr.__delitem__:
 
 # Specific to variant we used to generate stub
 is_monochromatic:
 is_polarized:
 is_rgb:
 is_spectral:
-
-mitsuba.__prefix__:
-    class Spectrum(drjit.ArrayBase):
-        pass
-
-    class UnpolarizedSpectrum(drjit.ArrayBase):
-        pass
-
-
-.*Cp:
-_.*Cp:
-
-.*Ptr.Domain:
-.*Ptr.__getitem__:
-.*Ptr.__setitem__:
-.*Ptr.__delitem__:
+UnpolarizedSpectrum:
+Spectrum:
+_UnpolarizedSpectrumCp:
+_SpectrumCp:
+_Spectrum_vtCp:

--- a/src/render/python/emitter_v.cpp
+++ b/src/render/python/emitter_v.cpp
@@ -164,8 +164,6 @@ MI_PY_EXPORT(Emitter) {
         .def_rw("m_needs_sample_3", &PyEmitter::m_needs_sample_3)
         .def_field(PyEmitter, m_flags, D(Emitter, m_flags));
 
-    bind_emitter_generic<Emitter *>(emitter);
-
     if constexpr (dr::is_array_v<EmitterPtr>) {
         dr::ArrayBinding b;
         auto emitter_ptr = dr::bind_array_t<EmitterPtr>(b, m, "EmitterPtr");

--- a/src/render/python/sensor_v.cpp
+++ b/src/render/python/sensor_v.cpp
@@ -166,9 +166,6 @@ MI_PY_EXPORT(Sensor) {
 
     auto sensor = MI_PY_TRAMPOLINE_CLASS(PySensor, Sensor, Endpoint)
         .def(nb::init<const Properties&>())
-        .def("sample_ray_differential", &Sensor::sample_ray_differential,
-             "time"_a, "sample1"_a, "sample2"_a, "sample3"_a, "active"_a = true,
-             D(Sensor, sample_ray_differential))
         .def_method(Sensor, shutter_open)
         .def_method(Sensor, shutter_open_time)
         .def_method(Sensor, needs_aperture_sample)


### PR DESCRIPTION
- Going through `pyright` output to identity some legitimate issues with the bindings, primarily with repeated bindings.
- For the variant submodules, including them in the top-level namespace so that the relative imports in the stubs are variant agnostic.
- Attempt to express `Spectrum` and `UnpolarizedSpectrum` in a variant-agnostic way that still provides some specificity as a templated `dr.ArrayBase` type
- Generating stubs for native and Python submodules