### PR TITLE
Fix Python ScopedThreadEnvironment

### DIFF
--- a/src/core/python/thread.cpp
+++ b/src/core/python/thread.cpp
@@ -112,6 +112,7 @@ MI_PY_EXPORT(Thread) {
                                             D(ScopedSetThreadEnvironment))
         .def(nb::init<const ThreadEnvironment &>())
         .def("__enter__", &PyScopedSetThreadEnvironment::enter)
-        .def("__exit__", &PyScopedSetThreadEnvironment::exit);
+        .def("__exit__", &PyScopedSetThreadEnvironment::exit,
+             "exc_type"_a.none(), "exc_val"_a.none(), "exc_tb"_a.none());
 }
 

--- a/src/core/tests/test_thread.py
+++ b/src/core/tests/test_thread.py
@@ -1,0 +1,7 @@
+import pytest
+import mitsuba as mi
+
+def test01_use_scoped_thread_environment(variant_scalar_rgb):
+    environment = mi.ThreadEnvironment()
+    with mi.ScopedSetThreadEnvironment(environment):
+        mi.Log(mi.LogLevel.Info, "Log from a thread environment.")


### PR DESCRIPTION
This fixes #1263. The issue was the missing "_a.none()" annotation for Nanobind. The naming of the parameters to `__exit__` follows what Dr.Jit itself uses. I also added a new test that covers that at least using a thread environment does not fail. 