### PR TITLE
SceneParameter: fix update parameters

### DIFF
--- a/src/core/python/object_v.cpp
+++ b/src/core/python/object_v.cpp
@@ -101,6 +101,18 @@ MI_PY_EXPORT(Object) {
         },
         "ptr"_a, "type"_a, "value"_a);
 
+    m.def(
+        "set_property",
+        [](nb::handle dst, nb::handle src) {
+            nb::handle h = dst.type();
+            if (nb::type_check(h)) {
+                nb::inst_replace_copy(dst, h(src));
+                return;
+            }
+            Throw("set_property(): Target property type isn't a nanobind type!");
+        },
+        "dst"_a, "src"_a);
+
     if constexpr (dr::is_array_v<ObjectPtr>) {
         dr::ArrayBinding b;
         auto object_ptr = dr::bind_array_t<ObjectPtr>(b, m, "ObjectPtr");

--- a/src/python/python/util.py
+++ b/src/python/python/util.py
@@ -73,9 +73,9 @@ class SceneParameters(Mapping):
 
         if value_type is None:
             try:
-                cur.assign(value)
-            except AttributeError as e:
-                if "has no attribute 'assign'" in str(e):
+                self.set_property(cur, value)
+            except Exception as e:
+                if "Target property type isn't a nanobind type" in str(e):
                     mi.Log(
                         mi.LogLevel.Warn,
                         f"Parameter '{key}' cannot be modified! This usually "


### PR DESCRIPTION
For custom Python plugins that expose modifiable parameters, updating these values through the use of `mi.traverse` required the use of `assign` to enable updating of the underlying cpp data. i.e. we can propagate the modifications to the actual plugin parameters.

For this particular case, we instead rely on nanobind's `nb::inst_replace_copy` function to perform the same functionality.

The behaviour updating parameters of cpp plugins remains unchanged.  