### PR TITLE
More robust shutdown

### DIFF
--- a/src/core/class.cpp
+++ b/src/core/class.cpp
@@ -1,6 +1,6 @@
 #include <mitsuba/core/class.h>
 #include <mitsuba/core/logger.h>
-#include <map>
+#include <unordered_map>
 #include <iostream>
 
 NAMESPACE_BEGIN(mitsuba)
@@ -13,7 +13,7 @@ void cleanup();
 NAMESPACE_END(detail)
 NAMESPACE_END(xml)
 
-static std::map<std::string, Class *> *__classes;
+static std::unordered_map<std::string, Class *> *__classes;
 bool Class::m_is_initialized = false;
 const Class *m_class = nullptr;
 
@@ -34,9 +34,13 @@ Class::Class(const std::string &name, const std::string &parent, const std::stri
         m_alias = name;
 
     if (!__classes)
-        __classes = new std::map<std::string, Class *>();
+        __classes = new std::unordered_map<std::string, Class *>();
 
-    (*__classes)[key(name, variant)] = this;
+    std::string class_key = key(name, variant);
+    if ((*__classes).find(class_key) != (*__classes).end())
+        delete (*__classes)[class_key];
+
+    (*__classes)[class_key] = this;
 
     // Register classes that declare an alias for use in the XML parser
     if (!alias.empty())

--- a/src/python/alias.cpp
+++ b/src/python/alias.cpp
@@ -201,6 +201,9 @@ NB_MODULE(mitsuba_alias, m) {
     atexit.attr("register")(nb::cpp_function([]() {
         curr_variant.reset();
 
+        PyDict_Clear(mi_dict);
+        mi_dict = nullptr;
+
         if (variant_modules) {
             Py_DECREF(variant_modules);
             variant_modules = nullptr; 

--- a/src/python/main.cpp
+++ b/src/python/main.cpp
@@ -167,6 +167,17 @@ NB_MODULE(mitsuba_ext, m) {
         }
         Class::static_remove_functors();
         StructConverter::static_shutdown();
+
+        /* When the main thread's lifetime was shared with Python, it would be
+         * detected as a nanbonid leak as the last reference is held by C++.
+         * Calling `Thread::static_shutdown()` deletes this last reference,
+         * however the main thread is still needed to clean up other parts of
+         * the system. The solution is therefore to temporarily clean it up
+         * and then re-build it such that Python can no longer track it. */
+        if(Thread::thread()->self_py()) {
+            Thread::static_shutdown();
+            Thread::static_initialization();
+        }
     }));
 
     /* Callback function cleanup static data strucutres, this should be called

--- a/src/python/main.cpp
+++ b/src/python/main.cpp
@@ -166,9 +166,7 @@ NB_MODULE(mitsuba_ext, m) {
             Thread::wait_for_tasks();
         }
         Class::static_remove_functors();
-        Logger::static_shutdown();
         StructConverter::static_shutdown();
-        Thread::static_shutdown();
     }));
 
     /* Callback function cleanup static data strucutres, this should be called
@@ -176,6 +174,8 @@ NB_MODULE(mitsuba_ext, m) {
     nanobind_module_def_mitsuba_ext.m_free = [](void *) {
         Profiler::static_shutdown();
         Bitmap::static_shutdown();
+        Logger::static_shutdown();
+        Thread::static_shutdown();
         Class::static_shutdown();
         Jit::static_shutdown();
     };

--- a/src/render/emitter.cpp
+++ b/src/render/emitter.cpp
@@ -7,10 +7,10 @@ NAMESPACE_BEGIN(mitsuba)
 
 MI_VARIANT Emitter<Float, Spectrum>::Emitter(const Properties &props)
     : Base(props) {
+        m_sampling_weight = props.get<ScalarFloat>("sampling_weight", 1.0f);
+
         if constexpr (dr::is_jit_v<Float>)
             jit_registry_put(dr::backend_v<Float>, "mitsuba::Emitter", this);
-
-        m_sampling_weight = props.get<ScalarFloat>("sampling_weight", 1.0f);
     }
 
 MI_VARIANT Emitter<Float, Spectrum>::~Emitter() { 

--- a/src/render/medium.cpp
+++ b/src/render/medium.cpp
@@ -16,9 +16,6 @@ MI_VARIANT Medium<Float, Spectrum>::Medium() :
 }
 
 MI_VARIANT Medium<Float, Spectrum>::Medium(const Properties &props) : m_id(props.id()) {
-    if constexpr (dr::is_jit_v<Float>)
-        jit_registry_put(dr::backend_v<Float>, "mitsuba::Medium", this);
-
     for (auto &[name, obj] : props.objects(false)) {
         auto *phase = dynamic_cast<PhaseFunction *>(obj.get());
         if (phase) {
@@ -35,6 +32,9 @@ MI_VARIANT Medium<Float, Spectrum>::Medium(const Properties &props) : m_id(props
     }
 
     m_sample_emitters = props.get<bool>("sample_emitters", true);
+
+    if constexpr (dr::is_jit_v<Float>)
+        jit_registry_put(dr::backend_v<Float>, "mitsuba::Medium", this);
 }
 
 MI_VARIANT Medium<Float, Spectrum>::~Medium() {

--- a/src/render/python/integrator_v.cpp
+++ b/src/render/python/integrator_v.cpp
@@ -175,7 +175,8 @@ protected:
 };
 
 MI_IMPLEMENT_CLASS_VARIANT(CppADIntegrator, SamplingIntegrator)
-MI_INSTANTIATE_CLASS(CppADIntegrator)
+
+template class CppADIntegrator<MI_VARIANT_FLOAT, MI_VARIANT_SPECTRUM>;
 
 MI_VARIANT class PyADIntegrator : public CppADIntegrator<Float, Spectrum> {
 public:

--- a/src/render/sensor.cpp
+++ b/src/render/sensor.cpp
@@ -12,9 +12,6 @@ NAMESPACE_BEGIN(mitsuba)
 // =============================================================================
 
 MI_VARIANT Sensor<Float, Spectrum>::Sensor(const Properties &props) : Base(props) {
-    if constexpr (dr::is_jit_v<Float>)
-        jit_registry_put(dr::backend_v<Float>, "mitsuba::Sensor", this);
-
     m_shutter_open      = props.get<ScalarFloat>("shutter_open", 0.f);
     m_shutter_open_time = props.get<ScalarFloat>("shutter_close", 0.f) - m_shutter_open;
 
@@ -68,12 +65,15 @@ MI_VARIANT Sensor<Float, Spectrum>::Sensor(const Properties &props) : Base(props
 
     if (has_flag(m_film->flags(), FilmFlags::Spectral)) {
         if (m_srf != nullptr) {
-            Throw("Sensor(): Spectral response function defined previously in sensor,"
+            Throw("Sensor(): Spectral response function defined previously in sensor, "
                   "but another was found in film.");
         } else {
             m_srf = m_film->sensor_response_function();
         }
     }
+
+    if constexpr (dr::is_jit_v<Float>)
+        jit_registry_put(dr::backend_v<Float>, "mitsuba::Sensor", this);
 }
 
 MI_VARIANT Sensor<Float, Spectrum>::~Sensor() {

--- a/src/render/shape.cpp
+++ b/src/render/shape.cpp
@@ -19,9 +19,6 @@
 NAMESPACE_BEGIN(mitsuba)
 
 MI_VARIANT Shape<Float, Spectrum>::Shape(const Properties &props) : m_id(props.id()) {
-    if constexpr (dr::is_jit_v<Float>)
-        jit_registry_put(dr::backend_v<Float>, "mitsuba::Shape", this);
-
     m_to_world =
         (ScalarTransform4f) props.get<ScalarTransform4f>("to_world", ScalarTransform4f());
     m_to_object = m_to_world.scalar().inverse();
@@ -73,6 +70,9 @@ MI_VARIANT Shape<Float, Spectrum>::Shape(const Properties &props) : m_id(props.i
     }
 
     m_silhouette_sampling_weight = props.get<ScalarFloat>("silhouette_sampling_weight", 1.0f);
+
+    if constexpr (dr::is_jit_v<Float>)
+        jit_registry_put(dr::backend_v<Float>, "mitsuba::Shape", this);
 }
 
 MI_VARIANT Shape<Float, Spectrum>::~Shape() {

--- a/src/render/shapegroup.cpp
+++ b/src/render/shapegroup.cpp
@@ -5,9 +5,6 @@
 NAMESPACE_BEGIN(mitsuba)
 
 MI_VARIANT ShapeGroup<Float, Spectrum>::ShapeGroup(const Properties &props) {
-    if constexpr (dr::is_jit_v<Float>)
-        jit_registry_put(dr::backend_v<Float>, "mitsuba::ShapeGroup", this);
-
     m_id = props.id();
 
 #if !defined(MI_ENABLE_EMBREE)
@@ -81,6 +78,9 @@ MI_VARIANT ShapeGroup<Float, Spectrum>::ShapeGroup(const Properties &props) {
             dr::load<DynamicBuffer<UInt32>>(data.get(), m_shapes.size());
     }
 #endif
+
+    if constexpr (dr::is_jit_v<Float>)
+        jit_registry_put(dr::backend_v<Float>, "mitsuba::ShapeGroup", this);
 }
 
 MI_VARIANT ShapeGroup<Float, Spectrum>::~ShapeGroup() {

--- a/src/sensors/tests/test_thinlens.py
+++ b/src/sensors/tests/test_thinlens.py
@@ -230,7 +230,7 @@ def test05_spectrum_sampling(variants_vec_spectral):
         "aperture_radius": 1.0,
     })
     wavelengths, _ =  camera.sample_wavelengths(dr.zeros(mi.SurfaceInteraction3f), mi.Float([0.1, 0.4, 0.9]))
-    assert (dr.all_nested((wavelengths >= mi.MI_CIE_MIN) & (wavelengths <= mi.MI_CIE_MAX)))
+    assert dr.all((wavelengths >= mi.MI_CIE_MIN) & (wavelengths <= mi.MI_CIE_MAX), axis=None)
 
     # Check custom SRF wavelength sampling
     camera = mi.load_dict({
@@ -242,7 +242,7 @@ def test05_spectrum_sampling(variants_vec_spectral):
         }
     })
     wavelengths, _ =  camera.sample_wavelengths(dr.zeros(mi.SurfaceInteraction3f), mi.Float([0.1, 0.4, 0.9]))
-    assert (dr.all_nested((wavelengths >= 1200) & (wavelengths <= 1400)))
+    assert dr.all((wavelengths >= 1200) & (wavelengths <= 1400), axis=None)
 
     # Check error if double SRF is defined
     with pytest.raises(RuntimeError, match=r'Sensor\(\)'):

--- a/src/shapes/merge.cpp
+++ b/src/shapes/merge.cpp
@@ -13,9 +13,6 @@ public:
     MergeShape(const Properties &props) {
         // Note: we are *not* calling the `Shape` constructor as we do not
         // want to accept various properties such as `to_world`.
-        if constexpr (dr::is_jit_v<Float>)
-            jit_registry_put(dr::backend_v<Float>, "mitsuba::Shape", this);
-
         std::unordered_map<Key, ref<Mesh>, key_hasher> tbl;
         size_t visited = 0, ignored = 0;
         Timer timer;
@@ -54,6 +51,9 @@ public:
 
         Log(Info, "Collapsed %zu into %zu meshes. (took %s, %zu objects ignored)",
             visited, tbl.size(), util::time_string((float) timer.value()), ignored);
+
+        if constexpr (dr::is_jit_v<Float>)
+            jit_registry_put(dr::backend_v<Float>, "mitsuba::Shape", this);
     }
 
     std::vector<ref<Object>> expand() const override {


### PR DESCRIPTION
## Description
Fixes unexpected segfaults or faulty logs during the Python session shutdown.

This was mostly due to an incorrect order in the shutdown routines and some of them not being triggered due to dangling references. In particular, a `PyModuleDef`'s `m_free` attribute will not be called if there are still some references to the module. 

(cc @bathal1)


## Testing

No new tests were added - capturing the corrected behavior is too complex in pytest.