### PR TITLE
Fix unique_ptr type for stream read

### DIFF
--- a/src/core/python/stream.cpp
+++ b/src/core/python/stream.cpp
@@ -47,7 +47,7 @@ MI_PY_EXPORT(Stream) {
             s.write(b.c_str(), b.size());
         }, D(Stream, write))
         .def("read", [](Stream &s, size_t size) {
-            std::unique_ptr<char> tmp(new char[size]);
+            std::unique_ptr<char[]> tmp(new char[size]);
             s.read((void *) tmp.get(), size);
             return nb::bytes(tmp.get(), size);
         }, D(Stream, write))


### PR DESCRIPTION
Minor change to switch to `std::unique_ptr<char[]>` in the stream bindings. The current code produces undefined behavior by using `std::unique_ptr<char> tmp(new char[size]);`. This causes a mismatch between new[] and delete (without []) operators