### PR TITLE
Fix Python bindings for SGGX distribution functions

### DIFF
--- a/include/mitsuba/python/docstr.h
+++ b/include/mitsuba/python/docstr.h
@@ -6472,6 +6472,15 @@ static const char *__doc_mitsuba_Resampler_target_resolution = R"doc(Return the 
 
 static const char *__doc_mitsuba_Resampler_to_string = R"doc(Return a human-readable summary)doc";
 
+static const char *__doc_mitsuba_SGGXPhaseFunctionParams =
+R"doc(The parameters of the SGGX phase function stored as a pair of 3D
+vectors [[S_xx, S_yy, S_zz], [S_xy, S_xz, S_yz]])doc";
+
+static const char *__doc_mitsuba_SGGXPhaseFunctionParams_SGGXPhaseFunctionParams =
+R"doc(Construct from a pair of 3D vectors [S_xx, S_yy, S_zz] and [S_xy,
+S_xz, S_yz] that correspond to the entries of a symmetric positive
+definite 3x3 matrix.)doc";
+
 static const char *__doc_mitsuba_Sampler =
 R"doc(Base class of all sample generators.
 

--- a/include/mitsuba/render/microflake.h
+++ b/include/mitsuba/render/microflake.h
@@ -7,6 +7,45 @@
 NAMESPACE_BEGIN(mitsuba)
 
 /**
+ * \brief The parameters of the SGGX phase function stored as a pair of 
+ * 3D vectors [[S_xx, S_yy, S_zz], [S_xy, S_xz, S_yz]]
+ */
+template <typename Float>
+struct SGGXPhaseFunctionParams {
+    dr::Array<Float, 3> diag;
+    dr::Array<Float, 3> off_diag;
+
+    /**
+     * \brief Construct from a pair of 3D vectors [S_xx, S_yy, S_zz] and 
+     * [S_xy, S_xz, S_yz] that correspond to the entries of a symmetric positive
+     * definite 3x3 matrix.
+     */
+    SGGXPhaseFunctionParams(const dr::Array<Float, 3>& diag, 
+                            const dr::Array<Float, 3>& off_diag) :
+        diag(diag),
+        off_diag(off_diag) {}
+
+    operator const dr::Array<Float, 6>() const { 
+        return { 
+            diag[0], diag[1], diag[2],
+            off_diag[0], off_diag[1], off_diag[2]
+        };
+    }
+
+    DRJIT_STRUCT(SGGXPhaseFunctionParams, diag, off_diag);
+};
+
+/// Return a string representation of SGGXPhaseFunction parameters
+template <typename Float>
+std::ostream &operator<<(std::ostream &os, const SGGXPhaseFunctionParams<Float> &s) {
+    os << "SGGXPhaseFunctionParams[" << std::endl
+       << "  [S_xx, S_yy, S_zz] = " << string::indent(s.diag, 6) << "," << std::endl
+       << "  [S_xy, S_xz, S_yz] = " << string::indent(s.off_diag, 6) << "," << std::endl
+       << "]";
+    return os;
+}
+
+/**
  * \brief Samples the visible normal distribution of the SGGX
  * microflake distribution
  *
@@ -23,11 +62,10 @@ NAMESPACE_BEGIN(mitsuba)
  *      A uniformly distributed 2D sample
  *
  * \param s
- *      The parameters of the SGGX phase function stored as a 6D vector
- *      [S_xx, S_yy, S_zz, S_xy, S_xz, S_yz]. The parameters describe
- *      the entries of a symmetric positive definite 3x3 matrix. The user
- *      needs to ensure that the parameters indeed represent a positive
- *      definite matrix.
+ *      The parameters of the SGGX phase function S_xx, S_yy, S_zz, S_xy, S_xz,
+ *      and S_yz that describe the entries of a symmetric positive definite 3x3
+ *      matrix. The user needs to ensure that the parameters indeed represent a
+ *      positive definite matrix.
  *
  * \return A normal (in world space) sampled from the distribution
  *         of visible normals
@@ -74,11 +112,10 @@ Normal<Float, 3> sggx_sample(const Vector<Float, 3> &wi,
  *      The microflake normal
  *
  * \param s
- *      The parameters of the SGGX phase function stored as a 6D vector
- *      [S_xx, S_yy, S_zz, S_xy, S_xz, S_yz]. The parameters describe
- *      the entries of a symmetric positive definite 3x3 matrix. The user
- *      needs to ensure that the parameters indeed represent a positive
- *      definite matrix.
+ *      The parameters of the SGGX phase function S_xx, S_yy, S_zz, S_xy, S_xz,
+ *      and S_yz that describe the entries of a symmetric positive definite 3x3
+ *      matrix. The user needs to ensure that the parameters indeed represent a
+ *      positive definite matrix.
  *
  * \return The probability of sampling a certain normal
  */
@@ -106,11 +143,10 @@ Float sggx_pdf(const Vector<Float, 3> &wm, const dr::Array<Float, 6> &s) {
  *      A 3D direction
  *
  * \param s
- *      The parameters of the SGGX phase function stored as a 6D vector
- *      [S_xx, S_yy, S_zz, S_xy, S_xz, S_yz]. The parameters describe
- *      the entries of a symmetric positive definite 3x3 matrix. The user
- *      needs to ensure that the parameters indeed represent a positive
- *      definite matrix.
+ *      The parameters of the SGGX phase function S_xx, S_yy, S_zz, S_xy, S_xz,
+ *      and S_yz that describe the entries of a symmetric positive definite 3x3
+ *      matrix. The user needs to ensure that the parameters indeed represent a
+ *      positive definite matrix.
  *
  * \return The projected area of the SGGX microflake distribution
  */

--- a/src/render/python/microflake_v.cpp
+++ b/src/render/python/microflake_v.cpp
@@ -1,24 +1,55 @@
 #include <mitsuba/render/microflake.h>
 #include <mitsuba/python/python.h>
 
+#include <nanobind/stl/string.h>
+#include <nanobind/stl/list.h>
+
 MI_PY_EXPORT(MicroflakeDistribution) {
     MI_PY_IMPORT_TYPES()
 
-    m.def("sggx_sample",
-          nb::overload_cast<const Frame3f&,
-                            const Point2f&,
-                            const dr::Array<Float, 6>&>(sggx_sample<Float>),
-          "sh_frame"_a, "sample"_a, "s"_a, D(sggx_sample));
+    using SGGXParams = SGGXPhaseFunctionParams<Float>;
 
-    m.def("sggx_sample",
-          nb::overload_cast<const Vector3f&,
-                            const Point2f&,
-                            const dr::Array<Float, 6>&>(sggx_sample<Float>),
-          "sh_frame"_a, "sample"_a, "s"_a, D(sggx_sample));
+    MI_PY_CHECK_ALIAS(SGGXParams, "SGGXPhaseFunctionParams") {
+        auto sggx_phase = nb::class_<SGGXParams>(m, "SGGXPhaseFunctionParams")
+            .def(nb::init<const dr::Array<Float, 3>&, const dr::Array<Float, 3>&>(),
+                D(SGGXPhaseFunctionParams, SGGXPhaseFunctionParams))
+            .def(nb::init<const SGGXParams &>(), "Copy constructor")
+            .def("__init__", [](SGGXParams *t, const nb::list &l) {
+                if (l.size() != 6)
+                    nb::raise("Expected list of size 6!");
+                SGGXParams s {
+                    {nb::cast<Float>(l[0]), nb::cast<Float>(l[1]), nb::cast<Float>(l[2])},
+                    {nb::cast<Float>(l[3]), nb::cast<Float>(l[4]), nb::cast<Float>(l[5])}
+                };
+                new (t) SGGXParams(s);
+            })
+            .def_field(SGGXParams, diag)
+            .def_field(SGGXParams, off_diag)
+            .def_repr(SGGXParams);
+        MI_PY_DRJIT_STRUCT(sggx_phase, SGGXParams, diag, off_diag)
 
-    m.def("sggx_pdf", &sggx_pdf<Float>,
-          "wm"_a, "s"_a, D(sggx_pdf));
+        nb::implicitly_convertible<nb::list, SGGXParams>();
+    }
 
-    m.def("sggx_projected_area", &sggx_projected_area<Float>,
-          "wi"_a, "s"_a, D(sggx_projected_area));
+    m.def("sggx_sample", [](const Frame3f& sh_frame,
+                            const Point2f& sample,
+                            const SGGXParams& s) {
+        return sggx_sample<Float>(sh_frame, sample, s);
+    }, "sh_frame"_a, "sample"_a, "s"_a, D(sggx_sample));
+
+    m.def("sggx_sample", [](const Vector3f& sh_frame,
+                            const Point2f& sample,
+                            const SGGXParams& s) {
+        return sggx_sample<Float>(sh_frame, sample, s);
+    }, "sh_frame"_a, "sample"_a, "s"_a, D(sggx_sample));
+
+    m.def("sggx_pdf", [](const Vector<Float, 3> &wm,
+                         const SGGXParams &s) {
+        return sggx_pdf<Float>(wm, s);
+    }, "wm"_a, "s"_a, D(sggx_pdf));
+
+    m.def("sggx_projected_area", [](const Vector<Float, 3> &wi,
+                                    const SGGXParams &s) {
+        return sggx_projected_area<Float>(wi, s);
+    }, "wi"_a, "s"_a, D(sggx_projected_area));
 }

--- a/src/render/tests/test_microflake.py
+++ b/src/render/tests/test_microflake.py
@@ -1,0 +1,16 @@
+import pytest
+import drjit as dr
+import mitsuba as mi
+import numpy as np
+
+def test01_binding_types(variants_all_rgb):
+    x = mi.sggx_sample(mi.Frame3f(1), mi.Point2f(1), mi.SGGXPhaseFunctionParams([1,2,3,4,5,6]))
+    assert type(x) == mi.Normal3f
+    x = mi.sggx_sample(mi.Frame3f(1), mi.Point2f(1), [1,2,3,4,5,6])
+    assert type(x) == mi.Normal3f
+    x = mi.sggx_sample(mi.Vector3f(1), mi.Point2f(1), [1,2,3,4,5,6])
+    assert type(x) == mi.Normal3f
+    x = mi.sggx_pdf(mi.Vector3f(1), [1,2,3,4,5,6])
+    assert type(x) == mi.Float
+    x = mi.sggx_projected_area(mi.Vector3f(1), [1,2,3,4,5,6])
+    assert type(x) == mi.Float


### PR DESCRIPTION
Workaround because `dr.Array6*` bindings don't exist