### PR TITLE
Add Integrator::m_id

### DIFF
--- a/include/mitsuba/render/integrator.h
+++ b/include/mitsuba/render/integrator.h
@@ -344,7 +344,6 @@ protected:
     /// Identifier (if available)
     std::string m_id;
 };
-};
 
 /** \brief Abstract integrator that performs Monte Carlo sampling starting from
  * the sensor

--- a/include/mitsuba/render/integrator.h
+++ b/include/mitsuba/render/integrator.h
@@ -312,6 +312,12 @@ public:
      */
     virtual std::vector<std::string> aov_names() const;
 
+    /// Return a string identifier
+    std::string id() const override { return m_id; }
+
+    /// Set a string identifier
+    void set_id(const std::string& id) override { m_id = id; };
+
     MI_DECLARE_CLASS()
 
 protected:
@@ -334,6 +340,10 @@ protected:
 
     /// Flag for disabling direct visibility of emitters
     bool m_hide_emitters;
+    
+    /// Identifier (if available)
+    std::string m_id;
+};
 };
 
 /** \brief Abstract integrator that performs Monte Carlo sampling starting from

--- a/src/integrators/tests/test_integrators.py
+++ b/src/integrators/tests/test_integrators.py
@@ -1,0 +1,25 @@
+import pytest
+import drjit as dr
+import mitsuba as mi
+
+def test01_trampoline_id(variants_vec_backends_once_rgb):
+    class DummyIntegrator(mi.SamplingIntegrator):
+        def __init__(self, props):
+            mi.SamplingIntegrator.__init__(self, props)
+            self.depth = props['depth']
+
+        def traverse(self, callback):
+            callback.put_parameter('depth', self.depth, mi.ParamFlags.NonDifferentiable)
+
+    mi.register_integrator('dummy_integrator', DummyIntegrator)
+
+    scene_description = mi.cornell_box()
+    del scene_description['integrator']
+    scene_description['my_integrator'] = {
+        'type': 'dummy_integrator',
+        'depth': 3.1
+    }
+    scene = mi.load_dict(scene_description)
+
+    params = mi.traverse(scene)
+    assert 'my_integrator.depth' in params

--- a/src/render/integrator.cpp
+++ b/src/render/integrator.cpp
@@ -20,7 +20,7 @@ NAMESPACE_BEGIN(mitsuba)
 // -----------------------------------------------------------------------------
 
 MI_VARIANT Integrator<Float, Spectrum>::Integrator(const Properties & props)
-    : m_stop(false) {
+    : m_stop(false), m_id(props.id()) {
     m_timeout = props.get<ScalarFloat>("timeout", -1.f);
 
     // Disable direct visibility of emitters if needed


### PR DESCRIPTION
This patch overrides the `Integrator::id()` and `Integrator::set_id()` methods so that the `mi.traverse` can pick up the correct identifier for the custom Python integrators.