### PR TITLE
Fix getting/setting members in trampolined classes

### DIFF
--- a/src/render/python/emitter_v.cpp
+++ b/src/render/python/emitter_v.cpp
@@ -160,8 +160,8 @@ MI_PY_EXPORT(Emitter) {
         .def_method(Emitter, is_environment)
         .def_method(Emitter, sampling_weight)
         .def_method(Emitter, flags, "active"_a = true)
-        .def_rw("m_needs_sample_2", &PyEmitter::m_needs_sample_2)
-        .def_rw("m_needs_sample_3", &PyEmitter::m_needs_sample_3)
+        .def_field(PyEmitter, m_needs_sample_2, D(Endpoint, m_needs_sample_2))
+        .def_field(PyEmitter, m_needs_sample_3, D(Endpoint, m_needs_sample_3))
         .def_field(PyEmitter, m_flags, D(Emitter, m_flags));
 
     if constexpr (dr::is_array_v<EmitterPtr>) {

--- a/src/render/python/film_v.cpp
+++ b/src/render/python/film_v.cpp
@@ -124,7 +124,8 @@ MI_PY_EXPORT(Film) {
                     "normalize"_a = false, "borders"_a = false)
         .def_method(Film, schedule_storage)
         .def_method(Film, sensor_response_function)
-        .def_method(Film, flags);
+        .def_method(Film, flags)
+        .def_field(PyFilm, m_flags, D(Film, m_flags));
 
     MI_PY_REGISTER_OBJECT("register_film", Film)
 }

--- a/src/render/python/medium_v.cpp
+++ b/src/render/python/medium_v.cpp
@@ -101,24 +101,9 @@ MI_PY_EXPORT(Medium) {
         .def(nb::init<const Properties &>(), "props"_a)
         .def_method(Medium, id)
         .def_method(Medium, set_id)
-        .def_prop_rw("m_sample_emitters",
-            [](PyMedium &medium){ return medium.m_sample_emitters; },
-            [](PyMedium &medium, bool value){
-                medium.m_sample_emitters = value;
-            }
-        )
-        .def_prop_rw("m_is_homogeneous",
-            [](PyMedium &medium){ return medium.m_is_homogeneous; },
-            [](PyMedium &medium, bool value){
-                medium.m_is_homogeneous = value;
-            }
-        )
-        .def_prop_rw("m_has_spectral_extinction",
-            [](PyMedium &medium){ return medium.m_has_spectral_extinction; },
-            [](PyMedium &medium, bool value){
-                medium.m_has_spectral_extinction = value;
-            }
-        )
+        .def_field(PyMedium, m_sample_emitters, D(Medium, m_sample_emitters))
+        .def_field(PyMedium, m_is_homogeneous, D(Medium, m_is_homogeneous))
+        .def_field(PyMedium, m_has_spectral_extinction, D(Medium, m_has_spectral_extinction))
         .def("__repr__", &Medium::to_string, D(Medium, to_string));
 
     bind_medium_generic<Medium *>(medium);

--- a/src/render/python/phase_v.cpp
+++ b/src/render/python/phase_v.cpp
@@ -110,12 +110,7 @@ MI_PY_EXPORT(PhaseFunction) {
             .def("flags", nb::overload_cast<size_t, Mask>(&PhaseFunction::flags, nb::const_),
                  "index"_a, "active"_a = true, D(PhaseFunction, flags, 2))
             .def_method(PhaseFunction, id)
-            .def_prop_rw("m_flags",
-                [](PhaseFunction &phase){ return phase.get_flags(); },
-                [](PhaseFunction &phase, uint32_t flags){
-                    phase.set_flags(flags);
-                }
-            )
+            .def_field(PyPhaseFunction, m_flags, D(PhaseFunction, m_flags))
             .def("__repr__", &PhaseFunction::to_string);
 
     bind_phase_generic<PhaseFunction *>(phase);

--- a/src/render/python/sensor_v.cpp
+++ b/src/render/python/sensor_v.cpp
@@ -171,9 +171,9 @@ MI_PY_EXPORT(Sensor) {
         .def_method(Sensor, needs_aperture_sample)
         .def("film", nb::overload_cast<>(&Sensor::film, nb::const_), D(Sensor, film))
         .def("sampler", nb::overload_cast<>(&Sensor::sampler, nb::const_), D(Sensor, sampler))
-        .def_rw("m_needs_sample_2", &PySensor::m_needs_sample_2)
-        .def_rw("m_needs_sample_3", &PySensor::m_needs_sample_3)
-        .def_rw("m_film", &PySensor::m_film);
+        .def_field(PySensor, m_needs_sample_2, D(Endpoint, m_needs_sample_3))
+        .def_field(PySensor, m_needs_sample_3, D(Endpoint, m_needs_sample_3))
+        .def_field(PySensor, m_film);
 
     bind_sensor_generic<Sensor *>(sensor);
 

--- a/src/render/tests/test_emitter.py
+++ b/src/render/tests/test_emitter.py
@@ -28,3 +28,19 @@ def test01_sampling_weight_getter(variants_vec_rgb):
     weight = emitters.sampling_weight()
     assert dr.allclose(weight, [0.1, 0.7, 0.7])
 
+
+def test02_trampoline(variants_vec_backends_once_rgb):
+    class DummyEmitter(mi.Emitter):
+        def __init__(self, props):
+            mi.Emitter.__init__(self, props)
+            self.m_flags = mi.EmitterFlags.SpatiallyVarying
+
+        def to_string(self):
+            return f"DummyEmitter ({self.m_flags})"
+
+    mi.register_emitter('dummy_emitter', DummyEmitter)
+    emitter = mi.load_dict({
+        'type': 'dummy_emitter'
+    })
+
+    assert str(emitter) == "DummyEmitter (16)"

--- a/src/render/tests/test_film.py
+++ b/src/render/tests/test_film.py
@@ -1,0 +1,20 @@
+import pytest
+import drjit as dr
+import mitsuba as mi
+
+
+def test01_trampoline(variants_vec_backends_once_rgb):
+    class DummyFilm(mi.Film):
+        def __init__(self, props):
+            mi.Film.__init__(self, props)
+            self.m_flags = mi.FilmFlags.Special
+
+        def to_string(self):
+            return f"DummyFilm ({self.m_flags})"
+
+    mi.register_film('dummy_film', DummyFilm)
+    film = mi.load_dict({
+        'type': 'dummy_film'
+    })
+
+    assert str(film) == "DummyFilm (4)"

--- a/src/render/tests/test_medium.py
+++ b/src/render/tests/test_medium.py
@@ -1,0 +1,20 @@
+import pytest
+import drjit as dr
+import mitsuba as mi
+
+
+def test01_trampoline(variants_vec_backends_once_rgb):
+    class DummyMedium(mi.Medium):
+        def __init__(self, props):
+            mi.Medium.__init__(self, props)
+            self.m_is_homogeneous = True
+
+        def to_string(self):
+            return f"DummyMedium ({self.m_is_homogeneous})"
+
+    mi.register_medium('dummy_medium', DummyMedium)
+    medium = mi.load_dict({
+        'type': 'dummy_medium'
+    })
+
+    assert str(medium) == "DummyMedium (True)"

--- a/src/render/tests/test_phase.py
+++ b/src/render/tests/test_phase.py
@@ -1,0 +1,20 @@
+import pytest
+import drjit as dr
+import mitsuba as mi
+
+
+def test01_trampoline(variants_vec_backends_once_rgb):
+    class DummyPhaseFunction(mi.PhaseFunction):
+        def __init__(self, props):
+            mi.PhaseFunction.__init__(self, props)
+            self.m_flags = mi.PhaseFunctionFlags.Anisotropic
+
+        def to_string(self):
+            return f"DummyPhaseFunction ({self.m_flags})"
+
+    mi.register_phasefunction('dummy_phase', DummyPhaseFunction)
+    phase = mi.load_dict({
+        'type': 'dummy_phase'
+    })
+
+    assert str(phase) == "DummyPhaseFunction (2)"

--- a/src/render/tests/test_sensor.py
+++ b/src/render/tests/test_sensor.py
@@ -55,3 +55,20 @@ def test02_perspective_projection(variant_scalar_rgb):
                      [0.0, -25.372756958007812, 1.5, 0.0],
                      [0.0, 0.0, 1.010101079940796, -10.1010103225708],
                      [0, 0, 1, 0]]))
+
+
+def test03_trampoline(variants_vec_backends_once_rgb):
+    class DummySensor(mi.Sensor):
+        def __init__(self, props):
+            mi.Sensor.__init__(self, props)
+            self.m_needs_sample_2 = True
+
+        def to_string(self):
+            return f"DummySensor ({self.m_needs_sample_2})"
+
+    mi.register_sensor('dummy_sensor', DummySensor)
+    sensor = mi.load_dict({
+        'type': 'dummy_sensor'
+    })
+
+    assert str(sensor) == "DummySensor (True)"


### PR DESCRIPTION
## Description

Tiny PR which is a follow-up to https://github.com/mitsuba-renderer/mitsuba3/issues/1249
Single commit that changes all trampolined members from properties to fields, or else they would not work.

## Testing

Every single plugin type now has a test that builds a custom plugin through the trampoline mechanism with a minor check on getting/setting attributes.