### PR TITLE
Cut primary visibility silhouettes against view frustum

### DIFF
--- a/src/python/python/ad/integrators/common.py
+++ b/src/python/python/ad/integrators/common.py
@@ -1117,7 +1117,7 @@ class PSIntegrator(ADIntegrator):
             J = self.proj_detail.perspective_sensor_jacobian(sensor, ss)
 
             ΔL = self.proj_detail.eval_primary_silhouette_radiance_difference(
-                scene, sampler, ss, sensor_center, active=active)
+                scene, sampler, ss, sensor, active=active)
             active &= dr.any(ΔL != 0)
 
         # ∂z/∂ⲡ * normal


### PR DESCRIPTION
## Description

Fixes #1233 

Silhouette boundary points that were behind the camera could still be projected onto the film with a valid `ds.uv` coordinate. 

We now check that `ss.p` is within the frustum. Note that this could have been done in `render_primarily_visible_silhouette` too, but it is theoretically more efficient to mask those lanes before we've started measuring the contribution difference along the silhouette (delta L).