### PR TITLE
Ensure external threads always get a Logger and FileResolver

### DIFF
--- a/include/mitsuba/core/thread.h
+++ b/include/mitsuba/core/thread.h
@@ -132,6 +132,9 @@ public:
     /// Return the current thread
     static Thread *thread();
 
+    /// Return whether the current thread data structure has been initialized.
+    static bool has_initialized_thread();
+
     /// Sleep for a certain amount of time (in milliseconds)
     static void sleep(uint32_t ms);
 

--- a/src/core/logger.cpp
+++ b/src/core/logger.cpp
@@ -122,9 +122,8 @@ void Logger::static_initialization() {
 #endif
 }
 
-void Logger::static_shutdown() {
-    Thread::thread()->set_logger(nullptr);
-}
+// Removal of logger from main thread is handled in thread.cpp.
+void Logger::static_shutdown() { }
 
 size_t Logger::appender_count() const {
     return d->appenders.size();

--- a/src/core/tests/test_thread.py
+++ b/src/core/tests/test_thread.py
@@ -2,12 +2,58 @@ import pytest
 import mitsuba as mi
 from threading import Thread
 
+
 def test01_use_scoped_thread_environment(variant_scalar_rgb):
-    def use_scoped_set_thred_env(env):
+    def use_scoped_set_thread_env(env):
         with mi.ScopedSetThreadEnvironment(environment):
-            mi.Log(mi.LogLevel.Info, "Log from a thread environment.")
+            mi.Log(mi.LogLevel.Info, 'Log from a thread environment.')
 
     environment = mi.ThreadEnvironment()
-    thread = Thread(target = use_scoped_set_thred_env, args = (environment, ))
+    thread = Thread(target=use_scoped_set_thread_env, args=(environment, ))
     thread.start()
     thread.join()
+
+
+def test02_log_from_new_thread(variant_scalar_rgb, tmp_path):
+
+    # We use a StreamAppender to capture the output.
+    log_path = tmp_path / 'log.txt'
+    appender = mi.StreamAppender(str(log_path))
+
+    log_str = 'Log from a thread environment.'
+
+    def print_to_log():
+        logger = mi.Thread.thread().logger()
+        assert logger is not None
+        logger.add_appender(appender)
+        mi.set_log_level(mi.LogLevel.Info)
+        mi.Log(mi.LogLevel.Info, log_str)
+
+    thread = Thread(target=print_to_log)
+    thread.start()
+    thread.join()
+
+    log = appender.read_log()
+    assert 'print_to_log' in log
+    assert log_str in log
+
+
+def test03_access_file_resolver_from_new_thread(variant_scalar_rgb):
+    def access_fresolver():
+        fs = mi.Thread.thread().file_resolver()
+        assert fs is not None
+        fs.resolve('./some_path')
+        n_paths = len(fs)
+        fs.prepend('./some_folder')
+        fs.prepend('./some_folder2')
+        assert len(fs) == n_paths + 2
+
+    fs = mi.Thread.thread().file_resolver()
+    n_paths = len(fs)
+
+    thread = Thread(target=access_fresolver)
+    thread.start()
+    thread.join()
+
+    # The original file resolver remains unchanged.
+    assert len(fs) == n_paths

--- a/src/core/thread.cpp
+++ b/src/core/thread.cpp
@@ -186,6 +186,10 @@ Thread* Thread::thread() {
     return self_val;
 }
 
+bool Thread::has_initialized_thread() {
+    return self != nullptr;
+}
+
 bool Thread::is_running() const {
     return d->running;
 }
@@ -558,8 +562,9 @@ void Thread::static_shutdown() {
         }
         thread_registry.clear();
     }
-
-    thread()->d->running = false;
+    main_thread->d->logger    = nullptr;
+    main_thread->d->fresolver = nullptr;
+    main_thread->d->running   = false;
     self = nullptr;
     main_thread = nullptr;
     #if defined(__linux__) || defined(__APPLE__)


### PR DESCRIPTION
This PR ensures that any external thread that is registered with Mitsuba will have a valid logger and file resolver.

The Logger is re-used from the main thread, since it is thread safe. The file resolver is copied, as it is not thread safe, but light weight to copy.

This PR also adds two tests that exercise this newly added / fixed functionality. 