### PR TITLE
Traversable batch sensor

### DIFF
--- a/src/sensors/batch.cpp
+++ b/src/sensors/batch.cpp
@@ -268,6 +268,12 @@ public:
         return result;
     }
 
+    void traverse(TraversalCallback *callback) override {
+        Base::traverse(callback);
+        for(int i = 0; i < m_sensors.size(); i++)
+            callback->put_object("sensor" + std::to_string(i),                    m_sensors.at(i).get(),                      +ParamFlags::NonDifferentiable);
+    }
+
     MI_DECLARE_CLASS()
 private:
     std::vector<ref<Base>> m_sensors;

--- a/src/sensors/batch.cpp
+++ b/src/sensors/batch.cpp
@@ -268,12 +268,6 @@ public:
         return result;
     }
 
-    void traverse(TraversalCallback *callback) override {
-        Base::traverse(callback);
-        for(int i = 0; i < m_sensors.size(); i++)
-            callback->put_object("sensor" + std::to_string(i),                    m_sensors.at(i).get(),                      +ParamFlags::NonDifferentiable);
-    }
-
     MI_DECLARE_CLASS()
 private:
     std::vector<ref<Base>> m_sensors;


### PR DESCRIPTION


## Description

Currently the parametes of child sensors of batch sensors can not be modified because there is no traverse function for the batch sensor. I need this functionality for a project, so I quickly implemented it.
The traverse function iterates the vector of sensor references, calling the appropriate function for pushing the child sensors to the traversal callback with object name "sensor\<NUMBER\>".
I did not test automatic differentiation as I have no usecase at hand where I could really test if my solution works. I do not see a reason why it might break down, but because this is untested, I set the children parameters to nondifferentiable to not create the impression that this is an intended feature.


## Testing

I tested that the child sensor to_world transformations can be changed and fov can be set.
I also ran a test for performance and stability with 100 random sensor transform changes and had no crash or performance degradation.

## Checklist

- [x] My code follows the [style guidelines](https://mitsuba.readthedocs.io/en/latest/src/developer_guide.html#coding-style) of this project
- [x] My changes generate no new warnings
- [x] My code also compiles for `cuda_*` and `llvm_*` variants. If you can't test this, please leave below
- [ ] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 3 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba/blob/master/LICENSE)