### PR TITLE
Add support for Embree's robust intersection flag

### DIFF
--- a/docs/src/plugin_reference.rst
+++ b/docs/src/plugin_reference.rst
@@ -107,3 +107,41 @@ These flags indicate whether the parameter is differentiable or not, or whether 
 discontinuities and thus needs special treatment.
 
 See :py:class:`mitsuba.ParamFlags` for their documentation.
+
+
+Scene-wide attributes
+---------------------
+
+The Scene object exposes scene-wide attributes. Currently, this functionality is
+only used to configure Embree's BVH. In the future, additional settings for the
+BVH behavior might be exposed.
+
+**Embree BVH mode:** We expose a scene-level flag to enable Embree's "robust"
+mode. Enabling this flag makes Embree use slightly slower but more robust ray
+intersection computations. Embree's default "fast" mode can miss ray
+intersections when a ray perfectly hits the edge between two adjacent triangles.
+Enabling the robust intersection mode fixes that in most cases. Note that Embree
+cannot guarantee that all intersections are reported for rays that exactly hit a
+vertex, which is a known limitation.
+
+.. pluginparameters::
+
+ * - embree_use_robust_intersection
+   - :paramtype:`bool`
+   - Whether Embree uses the robust mode flag `RTC_SCENE_FLAG_ROBUST` (Default: |false|).
+
+When creating a scene, the scene-wide attributes can be specified as follows:
+
+.. tabs::
+    .. code-tab:: xml
+
+        <scene version="3.0.0">
+            <boolean name="embree_use_robust_intersection" value="true"/>
+        </scene>
+
+    .. code-tab:: python
+
+        {
+            'type': 'scene',
+            'embree_use_robust_intersection': True,
+        }

--- a/src/render/scene_embree.inl
+++ b/src/render/scene_embree.inl
@@ -112,7 +112,8 @@ Scene<Float, Spectrum>::accel_init_cpu(const Properties &props) {
 
     s.accel = rtcNewScene(embree_device);
     rtcSetSceneBuildQuality(s.accel, RTC_BUILD_QUALITY_HIGH);
-    rtcSetSceneFlags(s.accel, RTC_SCENE_FLAG_NONE);
+    bool use_robust = props.get<bool>("embree_use_robust_intersections", false);
+    rtcSetSceneFlags(s.accel, use_robust ? RTC_SCENE_FLAG_ROBUST : RTC_SCENE_FLAG_NONE);
 
     ScopedPhase phase(ProfilerPhase::InitAccel);
     accel_parameters_changed_cpu();


### PR DESCRIPTION
Embree supports a fast and "robust" ray intersection mode. Mitsuba uses the default, fast mode. This is likely the best choice for general rendering tasks, but can cause issues in certain applications. 

For example, some people use Mitsuba purely to do some specialized ray tracing (for its speed & simplicity). In such cases, the ray tracing might not happen in in a "Monte Carlo setting", and rays may be spawned in a structured way. In that case, it can happen that rays perfectly hit edges between triangles, which is a known failure mode of Embree's fast mode (see also https://github.com/mitsuba-renderer/mitsuba3/issues/1149).

This PR adds support to set the robust mode at runtime using a boolean flag at the scene level. 

This also adds a test for the behavior. The test currently checks both failure and success of the ray tracing. I am not yet 100% sure if the failure will happen on all platforms (due to subtleties in the compilers & math eval) - to be seen once the CI runs.

I also haven't updated the documentation yet. I wasn't sure yet where would be the best place to describe scene level flags.