### PR TITLE
Fix tonemap CLI

### DIFF
--- a/src/python/python/tonemap.py
+++ b/src/python/python/tonemap.py
@@ -2,7 +2,8 @@ if __name__ == '__main__':
     import sys, os
     import argparse
     from concurrent.futures import ThreadPoolExecutor
-    import mitsuba.scalar_rgb as mi
+    import mitsuba as mi
+    mi.set_variant('scalar_rgb')
 
     mi.set_log_level(mi.LogLevel.Info)
     te = mi.ThreadEnvironment()


### PR DESCRIPTION
Fixes a minor issue with the tonemap CLI. The non-variant functions are no longer in the `scalar_rgb` module itself. Therefore, it's better to just set the scalar_rgb variant here explicitly.