### PR TITLE
Avoid always running stub generation

### DIFF
--- a/resources/variant-stub.cmake
+++ b/resources/variant-stub.cmake
@@ -1,6 +1,5 @@
 # Syntax:  cmake -P variant-stub.cmake <input> <output>
 # Applies post-cleanup of generated Mitsuba Python stubs
-# Will delete input after writing output
 
 file(READ ${CMAKE_ARGV3} FILE_CONTENTS)
 string(REPLACE "drjit.llvm" "drjit.auto" FILE_CONTENTS "${FILE_CONTENTS}")
@@ -14,4 +13,3 @@ string(REGEX REPLACE "[\n ]+python\\.[^-\\s]+ as python\\.[^-\\s]+," "" FILE_CON
 string(REGEX REPLACE "import mitsuba as [a-z_]+" "" FILE_CONTENTS "${FILE_CONTENTS}")
 
 file(WRITE "${CMAKE_ARGV4}" "${FILE_CONTENTS}")
-file(REMOVE "${CMAKE_ARGV3}")

--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -207,16 +207,16 @@ if (NOT (MI_SANITIZE_ADDRESS OR MI_SANITIZE_MEMORY))
   nanobind_add_stub(
     mitsuba-stub
     MODULE mitsuba.mitsuba_stubs
-    OUTPUT ${MI_BINARY_DIR}/python/mitsuba/stubs.pyi
+    OUTPUT ${MI_BINARY_DIR}/python/mitsuba/_stubs.pyi
     MARKER_FILE ${MI_BINARY_DIR}/python/mitsuba/py.typed
     ${STUB_ARGS}
   )
 
   add_custom_command(
     OUTPUT ${MI_BINARY_DIR}/python/mitsuba/__init__.pyi
-    DEPENDS ${MI_BINARY_DIR}/python/mitsuba/stubs.pyi
+    DEPENDS ${MI_BINARY_DIR}/python/mitsuba/_stubs.pyi
     COMMAND cmake -P ${CMAKE_CURRENT_SOURCE_DIR}/../../resources/variant-stub.cmake
-      ${MI_BINARY_DIR}/python/mitsuba/stubs.pyi
+      ${MI_BINARY_DIR}/python/mitsuba/_stubs.pyi
       ${MI_BINARY_DIR}/python/mitsuba/__init__.pyi
   )
 
@@ -229,15 +229,15 @@ if (NOT (MI_SANITIZE_ADDRESS OR MI_SANITIZE_MEMORY))
     nanobind_add_stub(
       mitsuba-stub-${value}
       MODULE mitsuba.mitsuba_stubs.${value}
-      OUTPUT ${MI_BINARY_DIR}/python/mitsuba/${value_path}_stubs.pyi
+      OUTPUT ${MI_BINARY_DIR}/python/mitsuba/_${value_path}_stubs.pyi
       ${STUB_ARGS}
     )
 
     add_custom_command(
       OUTPUT ${MI_BINARY_DIR}/python/mitsuba/${value_path}.pyi
-      DEPENDS ${MI_BINARY_DIR}/python/mitsuba/${value_path}_stubs.pyi
+      DEPENDS ${MI_BINARY_DIR}/python/mitsuba/_${value_path}_stubs.pyi
       COMMAND cmake -P ${CMAKE_CURRENT_SOURCE_DIR}/../../resources/variant-stub.cmake
-        ${MI_BINARY_DIR}/python/mitsuba/${value_path}_stubs.pyi
+        ${MI_BINARY_DIR}/python/mitsuba/_${value_path}_stubs.pyi
         ${MI_BINARY_DIR}/python/mitsuba/${value_path}.pyi
     )
 


### PR DESCRIPTION
First pass of stub generation is based on a specific variant so we have variant-specific types in the function signatures (e.g. `dr.llvm.Float`. As with Dr.Jit stub generation, we run a subsequent command to perform some regex manipulation of the stubs to change these types to `auto` (among a few other things).

Originally, the CMake script would delete the intermediary stubs after this regex manipulation. But the result is that the stub generation will be performed for every build which isn't ideal. This PR aims to avoid this.