### PR TITLE
Fix passing sampler state within symbolic control flow

### DIFF
--- a/src/samplers/ldsampler.cpp
+++ b/src/samplers/ldsampler.cpp
@@ -152,11 +152,13 @@ public:
     }
 
     void traverse_1_cb_ro(void *payload, void (*fn)(void *, uint64_t)) const override {
-        dr::traverse_1_fn_ro(m_scramble_seed, payload, fn);
+        auto fields = dr::make_tuple(m_scramble_seed, m_dimension_index);
+        dr::traverse_1_fn_ro(fields, payload, fn);
     }
 
     void traverse_1_cb_rw(void *payload, uint64_t (*fn)(void *, uint64_t)) override {
-        dr::traverse_1_fn_rw(m_scramble_seed, payload, fn);
+        auto fields = dr::tie(m_scramble_seed, m_dimension_index);
+        dr::traverse_1_fn_rw(fields, payload, fn);
     }
 
     std::string to_string() const override {

--- a/src/samplers/multijitter.cpp
+++ b/src/samplers/multijitter.cpp
@@ -171,12 +171,12 @@ public:
     }
 
     void traverse_1_cb_ro(void *payload, void (*fn)(void *, uint64_t)) const override {
-        auto fields = dr::make_tuple(m_rng, m_permutation_seed);
+        auto fields = dr::make_tuple(m_rng, m_dimension_index, m_permutation_seed);
         dr::traverse_1_fn_ro(fields, payload, fn);
     }
 
     void traverse_1_cb_rw(void *payload, uint64_t (*fn)(void *, uint64_t)) override {
-        auto fields = dr::make_tuple(m_rng, m_permutation_seed);
+        auto fields = dr::tie(m_rng, m_dimension_index, m_permutation_seed);
         dr::traverse_1_fn_rw(fields, payload, fn);
     }
 

--- a/src/samplers/orthogonal.cpp
+++ b/src/samplers/orthogonal.cpp
@@ -158,12 +158,12 @@ public:
     }
 
     void traverse_1_cb_ro(void *payload, void (*fn)(void *, uint64_t)) const override {
-        auto fields = dr::make_tuple(m_rng, m_permutation_seed);
+        auto fields = dr::make_tuple(m_rng, m_dimension_index, m_permutation_seed);
         dr::traverse_1_fn_ro(fields, payload, fn);
     }
 
     void traverse_1_cb_rw(void *payload, uint64_t (*fn)(void *, uint64_t)) override {
-        auto fields = dr::make_tuple(m_rng, m_permutation_seed);
+        auto fields = dr::tie(m_rng, m_dimension_index, m_permutation_seed);
         dr::traverse_1_fn_rw(fields, payload, fn);
     }
 

--- a/src/samplers/stratified.cpp
+++ b/src/samplers/stratified.cpp
@@ -158,12 +158,12 @@ public:
     }
 
     void traverse_1_cb_ro(void *payload, void (*fn)(void *, uint64_t)) const override {
-        auto fields = dr::make_tuple(m_rng, m_permutation_seed);
+        auto fields = dr::make_tuple(m_rng, m_dimension_index, m_permutation_seed);
         dr::traverse_1_fn_ro(fields, payload, fn);
     }
 
     void traverse_1_cb_rw(void *payload, uint64_t (*fn)(void *, uint64_t)) override {
-        auto fields = dr::make_tuple(m_rng, m_permutation_seed);
+        auto fields = dr::tie(m_rng, m_dimension_index, m_permutation_seed);
         dr::traverse_1_fn_rw(fields, payload, fn);
     }
 


### PR DESCRIPTION
Fix for #1288 . The reason why the independent sampler was fine was that we only had a single state variable so the interface for passing in the state wasn't affected.

Before and after comparison.

Stratified:
![image](https://github.com/user-attachments/assets/b08d6ed9-556f-4526-a10b-8eff3ea7d17e)

Ldsampler:
![image](https://github.com/user-attachments/assets/46a09352-cc79-45b1-907b-46ebadb9e9f6)

Multijitter:
![image](https://github.com/user-attachments/assets/f3578723-5308-4e6a-9d82-7856a0899c47)

Orthogonal:
![image](https://github.com/user-attachments/assets/f6bedc84-f98b-4b02-a8c7-b98ddbacf849)


