### PR TITLE
CMake stubs: Change post-process command dependency to target-level 

### DIFF
--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -214,7 +214,7 @@ if (NOT (MI_SANITIZE_ADDRESS OR MI_SANITIZE_MEMORY))
 
   add_custom_command(
     OUTPUT ${MI_BINARY_DIR}/python/mitsuba/__init__.pyi
-    DEPENDS ${MI_BINARY_DIR}/python/mitsuba/_stubs.pyi
+    DEPENDS mitsuba-stub
     COMMAND cmake -P ${CMAKE_CURRENT_SOURCE_DIR}/../../resources/variant-stub.cmake
       ${MI_BINARY_DIR}/python/mitsuba/_stubs.pyi
       ${MI_BINARY_DIR}/python/mitsuba/__init__.pyi
@@ -235,7 +235,7 @@ if (NOT (MI_SANITIZE_ADDRESS OR MI_SANITIZE_MEMORY))
 
     add_custom_command(
       OUTPUT ${MI_BINARY_DIR}/python/mitsuba/${value_path}.pyi
-      DEPENDS ${MI_BINARY_DIR}/python/mitsuba/_${value_path}_stubs.pyi
+      DEPENDS mitsuba-stub-${value}
       COMMAND cmake -P ${CMAKE_CURRENT_SOURCE_DIR}/../../resources/variant-stub.cmake
         ${MI_BINARY_DIR}/python/mitsuba/_${value_path}_stubs.pyi
         ${MI_BINARY_DIR}/python/mitsuba/${value_path}.pyi


### PR DESCRIPTION
Motivated by flaky Windows CI, where we appear to be generating stubs twice, in some instances resulting in a race condition.

After stub generation through nanobind, we perform an additional custom command to regex variant specific types to auto. e.g. `dr.llvm.ad.Float` -> `dr.auto.ad.Float`. Change the cmake custom command dependency from the output `.pyi` file to the corresponding stub-gen target that gets created in `nanobind_add_stub`  to ensure correct execution ordering.