### PR TITLE
Allow vectorized vcalls of Mesh methods

### DIFF
--- a/include/mitsuba/python/docstr.h
+++ b/include/mitsuba/python/docstr.h
@@ -4633,6 +4633,8 @@ static const char *__doc_mitsuba_Mesh_face_data_bytes = R"doc()doc";
 
 static const char *__doc_mitsuba_Mesh_face_indices = R"doc(Returns the vertex indices associated with triangle ``index``)doc";
 
+static const char *__doc_mitsuba_Mesh_edge_indices = R"doc(Returns the vertex indices associated with edge ``edge_index`` (0..2) of triangle ``tri_index``.)doc";
+
 static const char *__doc_mitsuba_Mesh_face_normal = R"doc(Returns the normal direction of the face with index ``index``)doc";
 
 static const char *__doc_mitsuba_Mesh_faces_buffer = R"doc(Return face indices buffer)doc";

--- a/include/mitsuba/render/fwd.h
+++ b/include/mitsuba/render/fwd.h
@@ -104,6 +104,7 @@ template <typename Float_, typename Spectrum_> struct RenderAliases {
     using MediumPtr              = dr::replace_scalar_t<Float, const Medium *>;
     using PhaseFunctionPtr       = dr::replace_scalar_t<Float, const PhaseFunction *>;
     using ShapePtr               = dr::replace_scalar_t<Float, const Shape *>;
+    using MeshPtr                = dr::replace_scalar_t<Float, const Mesh *>;
     using SensorPtr              = dr::replace_scalar_t<Float, const Sensor *>;
     using EmitterPtr             = dr::replace_scalar_t<Float, const Emitter *>;
 };
@@ -188,6 +189,7 @@ template <typename Float_, typename Spectrum_> struct RenderAliases {
     using MediumPtr              = typename RenderAliases::MediumPtr;                              \
     using PhaseFunctionPtr       = typename RenderAliases::PhaseFunctionPtr;                       \
     using ShapePtr               = typename RenderAliases::ShapePtr;                               \
+    using MeshPtr                = typename RenderAliases::MeshPtr;                                \
     using EmitterPtr             = typename RenderAliases::EmitterPtr;                             \
     using SensorPtr              = typename RenderAliases::SensorPtr;
 

--- a/include/mitsuba/render/mesh.h
+++ b/include/mitsuba/render/mesh.h
@@ -204,6 +204,15 @@ public:
     /// Recompute the bounding box (e.g. after modifying the vertex positions)
     void recompute_bbox();
 
+    /**
+     * /brief Build directed edge data structure to efficiently access adjacent
+     * edges.
+     *
+     * This is an implementation of the technique described in:
+     * <tt>https://www.graphics.rwth-aachen.de/media/papers/directed.pdf</tt>.
+     */
+    void build_directed_edges();
+
     // =============================================================
     //! @{ \name Shape interface implementation
     // =============================================================
@@ -397,15 +406,6 @@ protected:
      * Thread-safe, since it uses a mutex.
      */
     void build_pmf();
-
-    /**
-     * /brief Build directed edge data structure to efficiently access adjacent
-     * edges.
-     *
-     * This is an implementation of the technique described in:
-     * <tt>https://www.graphics.rwth-aachen.de/media/papers/directed.pdf</tt>.
-     */
-    void build_directed_edges();
 
     /**
      * /brief Precompute the set of edges that could contribute to the indirect

--- a/include/mitsuba/render/mesh.h
+++ b/include/mitsuba/render/mesh.h
@@ -106,6 +106,20 @@ public:
         return dr::gather<Result>(m_faces, index, active);
     }
 
+    /**
+     * Returns the vertex indices associated with edge \c edge_index (0..2)
+     * of triangle \c tri_index.
+     */
+    template <typename Index>
+    MI_INLINE auto edge_indices(Index tri_index, Index edge_index,
+                                dr::mask_t<Index> active = true) const {
+        using UInt32 = dr::uint32_array_t<Index>;
+        return dr::Array<UInt32, 2>(
+            dr::gather<UInt32>(m_faces, 3 * tri_index + edge_index, active),
+            dr::gather<UInt32>(m_faces, 3 * tri_index + (edge_index + 1) % 3, active)
+        );
+    }
+
     /// Returns the world-space position of the vertex with index \c index
     template <typename Index>
     MI_INLINE auto vertex_position(Index index,
@@ -589,6 +603,7 @@ NAMESPACE_END(mitsuba)
 
 DRJIT_CALL_TEMPLATE_INHERITED_BEGIN(mitsuba::Mesh, mitsuba::Shape)
     DRJIT_CALL_METHOD(face_indices)
+    DRJIT_CALL_METHOD(edge_indices)
     DRJIT_CALL_METHOD(vertex_position)
     DRJIT_CALL_METHOD(vertex_normal)
     DRJIT_CALL_METHOD(vertex_texcoord)

--- a/include/mitsuba/render/mesh.h
+++ b/include/mitsuba/render/mesh.h
@@ -581,3 +581,28 @@ protected:
 
 MI_EXTERN_CLASS(Mesh)
 NAMESPACE_END(mitsuba)
+
+
+// -----------------------------------------------------------------------
+//! @{ \name Dr.Jit support for vectorized function calls
+// -----------------------------------------------------------------------
+
+DRJIT_CALL_TEMPLATE_INHERITED_BEGIN(mitsuba::Mesh, mitsuba::Shape)
+    DRJIT_CALL_METHOD(face_indices)
+    DRJIT_CALL_METHOD(vertex_position)
+    DRJIT_CALL_METHOD(vertex_normal)
+    DRJIT_CALL_METHOD(vertex_texcoord)
+    DRJIT_CALL_METHOD(face_normal)
+    DRJIT_CALL_METHOD(opposite_dedge)
+    DRJIT_CALL_METHOD(ray_intersect_triangle)
+
+    DRJIT_CALL_GETTER(vertex_count)
+    DRJIT_CALL_GETTER(face_count)
+    DRJIT_CALL_GETTER(has_vertex_normals)
+    DRJIT_CALL_GETTER(has_vertex_texcoords)
+    DRJIT_CALL_GETTER(has_mesh_attributes)
+    DRJIT_CALL_GETTER(has_face_normals)
+DRJIT_CALL_INHERITED_END(mitsuba::Mesh)
+
+//! @}
+// -----------------------------------------------------------------------

--- a/include/mitsuba/render/shape.h
+++ b/include/mitsuba/render/shape.h
@@ -1109,6 +1109,7 @@ DRJIT_CALL_TEMPLATE_BEGIN(mitsuba::Shape)
     DRJIT_CALL_GETTER(shape_type)
     auto is_emitter() const { return emitter() != nullptr; }
     auto is_sensor() const { return sensor() != nullptr; }
+    auto is_mesh() const { return shape_type() == (uint32_t) mitsuba::ShapeType::Mesh; }
     auto is_medium_transition() const { return interior_medium() != nullptr ||
                                                exterior_medium() != nullptr; }
 DRJIT_CALL_END(mitsuba::Shape)

--- a/src/render/mesh.cpp
+++ b/src/render/mesh.cpp
@@ -1049,7 +1049,9 @@ Mesh<Float, Spectrum>::primitive_silhouette_projection(const Point3f &viewpoint,
     the nearest edge, instead we randomly sample a point on any silhouette edge.
     This ensures that the triangle corners do not receive minimal samples. */
 
-    if (dr::width(m_E2E) == 0) // Shape is not being differentiated
+    // Directed edge data structure was not prepared,
+    // e.g. due to the shape not being differentiated.
+    if (dr::width(m_E2E) == 0)
         return dr::zeros<SilhouetteSample3f>();
 
     Vector3u fi = face_indices(si.prim_index, active);

--- a/src/render/python/shape_v.cpp
+++ b/src/render/python/shape_v.cpp
@@ -327,7 +327,8 @@ MI_PY_EXPORT(Shape) {
              D(Mesh, add_attribute))
 
         .def("recompute_vertex_normals", &Mesh::recompute_vertex_normals)
-        .def("recompute_bbox", &Mesh::recompute_bbox);
+        .def("recompute_bbox", &Mesh::recompute_bbox)
+        .def("build_directed_edges", &Mesh::build_directed_edges);
 
      bind_mesh_generic<Mesh *>(mesh_cls);
 

--- a/src/render/python/shape_v.cpp
+++ b/src/render/python/shape_v.cpp
@@ -243,6 +243,9 @@ template <typename Ptr, typename Cls> void bind_mesh_generic(Cls &cls) {
        .def("face_indices", [](const Ptr m, UInt32 index, Mask active) {
                 return m->face_indices(index, active);
             }, D(Mesh, face_indices), "index"_a, "active"_a = true)
+       .def("edge_indices", [](const Ptr m, UInt32 tri_index, UInt32 edge_index, Mask active) {
+                return m->edge_indices(tri_index, edge_index, active);
+            }, D(Mesh, edge_indices), "tri_index"_a, "edge_index"_a, "active"_a = true)
        .def("vertex_position", [](const Ptr m, UInt32 index, Mask active) {
                 return m->vertex_position(index, active);
             }, D(Mesh, vertex_position), "index"_a, "active"_a = true)

--- a/src/render/python/shape_v.cpp
+++ b/src/render/python/shape_v.cpp
@@ -266,6 +266,11 @@ MI_PY_EXPORT(Shape) {
              "stream"_a, D(Mesh, write_ply, 2))
         .def("add_attribute", &Mesh::add_attribute, "name"_a, "size"_a, "buffer"_a,
              D(Mesh, add_attribute))
+        .def("vertex_positions_buffer", nb::overload_cast<>(&Mesh::vertex_positions_buffer))
+        .def("faces_buffer", nb::overload_cast<>(&Mesh::faces_buffer))
+        .def("face_indices", [](const Mesh &m, UInt32 index, Mask active) {
+                return m.face_indices(index, active);
+             }, D(Mesh, face_indices), "index"_a, "active"_a = true)
         .def("vertex_position", [](const Mesh &m, UInt32 index, Mask active) {
                 return m.vertex_position(index, active);
              }, D(Mesh, vertex_position), "index"_a, "active"_a = true)
@@ -275,9 +280,9 @@ MI_PY_EXPORT(Shape) {
         .def("vertex_texcoord", [](const Mesh &m, UInt32 index, Mask active) {
                 return m.vertex_texcoord(index, active);
              }, D(Mesh, vertex_texcoord), "index"_a, "active"_a = true)
-        .def("face_indices", [](const Mesh &m, UInt32 index, Mask active) {
-                return m.face_indices(index, active);
-             }, D(Mesh, face_indices), "index"_a, "active"_a = true)
+        .def("face_normal", [](const Mesh &m, UInt32 index, Mask active) {
+                return m.face_normal(index, active);
+             }, D(Mesh, face_normal), "index"_a, "active"_a = true)
         .def("ray_intersect_triangle", &Mesh::ray_intersect_triangle,
              "index"_a, "ray"_a, "active"_a = true,
              D(Mesh, ray_intersect_triangle));

--- a/src/render/tests/test_shape.py
+++ b/src/render/tests/test_shape.py
@@ -36,3 +36,15 @@ def test01_ss_repr(variants_vec_backends_once_rgb):
             """
     assert expected.strip() == str(ss)
 
+
+def test02_shape_ptr(variants_vec_backends_once_rgb):
+   scene = mi.load_dict(mi.cornell_box())
+   shapes = scene.shapes_dr()
+
+   shapes_int = dr.reinterpret_array(mi.UInt32, shapes)
+   print(shapes_int)
+   assert isinstance(shapes_int, mi.UInt32)
+
+   shapes_ptr = dr.reinterpret_array(mi.ShapePtr, shapes_int)
+   print(shapes_ptr)
+   assert isinstance(shapes_ptr, mi.ShapePtr)


### PR DESCRIPTION
<!-- Please add the labels (e.g. bug fix, feature, ..) corresponding to this PR -->

## Description

Allows accessing the `Mesh` interface through a new `MeshPtr` type. This will allow users to access the `Mesh` interface through a new `MeshPtr`. Before, it was only accessible on the individual `Mesh` instances (no vectorized calls).

```py
meshes = mi.MeshPtr(si.shape)
# Not strictly needed, the non-mesh pointers are automatically zeroed-out
active &= si.shape.is_mesh() 

n = meshes.face_normal(si.prim_index, active=active)
```

Requires a DrJit-side change to allow `CallSupport<Mesh>`: https://github.com/mitsuba-renderer/drjit/pull/287 

## Testing

Added a unit test that checks the results of the vcall on `MeshPtr` against calls on the individual mesh instances.

## Checklist

<!-- Please make sure to complete this checklist before requesting a review. -->

- [x] My code follows the [style guidelines](https://mitsuba.readthedocs.io/en/latest/src/developer_guide.html#coding-style) of this project
- [ ] My changes generate no new warnings
- [x] My code also compiles for `cuda_*` and `llvm_*` variants. If you can't test this, please leave below
- [x] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 3 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba/blob/master/LICENSE)