### PR TITLE
Change seed function to take drjit type for seed

### DIFF
--- a/include/mitsuba/render/sampler.h
+++ b/include/mitsuba/render/sampler.h
@@ -95,7 +95,7 @@ public:
      * In the context of wavefront ray tracing & dynamic arrays, this function
      * must be called with \c wavefront_size matching the size of the wavefront.
      */
-    virtual void seed(uint32_t seed,
+    virtual void seed(UInt32 seed,
                       uint32_t wavefront_size = (uint32_t) -1);
 
     /**
@@ -143,7 +143,7 @@ protected:
     Sampler(const Sampler&);
 
     /// Generates a array of seeds where the seed values are unique per sequence
-    UInt32 compute_per_sequence_seed(uint32_t seed) const;
+    UInt32 compute_per_sequence_seed(UInt32 seed) const;
     /// Return the index of the current sample
     UInt32 current_sample_index() const;
 
@@ -170,7 +170,7 @@ public:
     MI_IMPORT_TYPES()
     using PCG32 = mitsuba::PCG32<UInt32>;
 
-    void seed(uint32_t seed, uint32_t wavefront_size = (uint32_t) -1) override;
+    void seed(UInt32 seed, uint32_t wavefront_size = (uint32_t) -1) override;
     void schedule_state() override;
     void traverse_1_cb_ro(void *payload, void (*fn)(void *, uint64_t)) const override;
     void traverse_1_cb_rw(void *payload, uint64_t (*fn)(void *, uint64_t)) override;

--- a/src/python/python/ad/integrators/common.py
+++ b/src/python/python/ad/integrators/common.py
@@ -46,7 +46,7 @@ class ADIntegrator(mi.CppADIntegrator):
     def render(self: mi.SamplingIntegrator,
                scene: mi.Scene,
                sensor: Union[int, mi.Sensor] = 0,
-               seed: int = 0,
+               seed: mi.UInt32 = 0,
                spp: int = 0,
                develop: bool = True,
                evaluate: bool = True) -> mi.TensorXf:
@@ -114,7 +114,7 @@ class ADIntegrator(mi.CppADIntegrator):
                        scene: mi.Scene,
                        params: Any,
                        sensor: Union[int, mi.Sensor] = 0,
-                       seed: int = 0,
+                       seed: mi.UInt32 = 0,
                        spp: int = 0) -> mi.TensorXf:
 
         if isinstance(sensor, int):
@@ -167,7 +167,7 @@ class ADIntegrator(mi.CppADIntegrator):
                         params: Any,
                         grad_in: mi.TensorXf,
                         sensor: Union[int, mi.Sensor] = 0,
-                        seed: int = 0,
+                        seed: mi.UInt32 = 0,
                         spp: int = 0) -> None:
 
         if isinstance(sensor, int):
@@ -313,7 +313,7 @@ class ADIntegrator(mi.CppADIntegrator):
 
     def prepare(self,
                 sensor: mi.Sensor,
-                seed: int = 0,
+                seed: mi.UInt32 = 0,
                 spp: int = 0,
                 aovs: list = []):
         """
@@ -499,7 +499,7 @@ class RBIntegrator(ADIntegrator):
                        scene: mi.Scene,
                        params: Any,
                        sensor: Union[int, mi.Sensor] = 0,
-                       seed: int = 0,
+                       seed: mi.UInt32 = 0,
                        spp: int = 0) -> mi.TensorXf:
         """
         Evaluates the forward-mode derivative of the rendering step.
@@ -633,7 +633,7 @@ class RBIntegrator(ADIntegrator):
                         params: Any,
                         grad_in: mi.TensorXf,
                         sensor: Union[int, mi.Sensor] = 0,
-                        seed: int = 0,
+                        seed: mi.UInt32 = 0,
                         spp: int = 0) -> None:
         """
         Evaluates the reverse-mode derivative of the rendering step.
@@ -916,7 +916,7 @@ class PSIntegrator(ADIntegrator):
     def render_ad(self,
                   scene: mi.Scene,
                   sensor: Union[int, mi.Sensor],
-                  seed: int,
+                  seed: mi.UInt32,
                   spp: int,
                   mode: dr.ADMode) -> mi.TensorXf:
         """
@@ -1015,7 +1015,7 @@ class PSIntegrator(ADIntegrator):
                        scene: mi.Scene,
                        params: Any,
                        sensor: Union[int, mi.Sensor] = 0,
-                       seed: int = 0,
+                       seed: mi.UInt32 = 0,
                        spp: int = 0) -> mi.TensorXf:
         if isinstance(sensor, int):
             sensor = scene.sensors()[sensor]
@@ -1058,7 +1058,7 @@ class PSIntegrator(ADIntegrator):
                         params: Any,
                         grad_in: mi.TensorXf,
                         sensor: Union[int, mi.Sensor] = 0,
-                        seed: int = 0,
+                        seed: mi.UInt32 = 0,
                         spp: int = 0) -> None:
         if isinstance(sensor, int):
             sensor = scene.sensors()[sensor]

--- a/src/python/python/ad/projective.py
+++ b/src/python/python/ad/projective.py
@@ -240,7 +240,7 @@ class ProjectiveDetail():
     def init_indirect_silhouette(self,
                                  scene: mi.Scene,
                                  sensor: mi.Sensor,
-                                 seed: int):
+                                 seed: mi.UInt32):
         """
         Initialize the guiding structure for indirect discontinuous derivatives
         based on the guiding mode. The result is stored in this python class.

--- a/src/python/python/util.py
+++ b/src/python/python/util.py
@@ -379,7 +379,7 @@ def render(scene: mi.Scene,
            params: Any = None,
            sensor: Union[int, mi.Sensor] = 0,
            integrator: mi.Integrator = None,
-           seed: int = 0,
+           seed: mi.UInt32 = 0,
            seed_grad: int = 0,
            spp: int = 0,
            spp_grad: int = 0) -> mi.TensorXf:
@@ -433,14 +433,14 @@ def render(scene: mi.Scene,
         default, the integrator specified in the original scene description will
         be used.
 
-    Parameter ``seed`` (``int``)
+    Parameter ``seed`` (``mi.UInt32``)
         This parameter controls the initialization of the random number
         generator during the primal rendering step. It is crucial that you
         specify different seeds (e.g., an increasing sequence) if subsequent
         calls should produce statistically independent images (e.g. to
         de-correlate gradient-based optimization steps).
 
-    Parameter ``seed_grad`` (``int``)
+    Parameter ``seed_grad`` (``mi.UInt32``)
         This parameter is analogous to the ``seed`` parameter but targets the
         differential simulation phase. If not specified, the implementation will
         automatically compute a suitable value from the primal ``seed``.

--- a/src/render/python/sampler_v.cpp
+++ b/src/render/python/sampler_v.cpp
@@ -20,7 +20,7 @@ public:
         NB_OVERRIDE_PURE(fork);
     }
 
-    void seed(uint32_t seed, uint32_t wavefront_size = (uint32_t) -1) override {
+    void seed(UInt32 seed, uint32_t wavefront_size = (uint32_t) -1) override {
         NB_OVERRIDE(seed, seed, wavefront_size);
     }
 

--- a/src/render/sampler.cpp
+++ b/src/render/sampler.cpp
@@ -32,7 +32,7 @@ MI_VARIANT Sampler<Float, Spectrum>::Sampler(const Sampler &sampler)
 
 MI_VARIANT Sampler<Float, Spectrum>::~Sampler() { }
 
-MI_VARIANT void Sampler<Float, Spectrum>::seed(uint32_t /* seed */,
+MI_VARIANT void Sampler<Float, Spectrum>::seed(UInt32 /* seed */,
                                                uint32_t wavefront_size) {
     if constexpr (dr::is_array_v<Float>) {
         // Only overwrite when specified
@@ -91,12 +91,14 @@ Sampler<Float, Spectrum>::set_samples_per_wavefront(uint32_t samples_per_wavefro
 }
 
 MI_VARIANT typename Sampler<Float, Spectrum>::UInt32
-Sampler<Float, Spectrum>::compute_per_sequence_seed(uint32_t seed) const {
+Sampler<Float, Spectrum>::compute_per_sequence_seed(UInt32 seed) const {
     UInt32 indices      = dr::arange<UInt32>(m_wavefront_size),
            sequence_idx = m_samples_per_wavefront * (indices / m_samples_per_wavefront);
 
+    dr::make_opaque(seed);
+
     return sample_tea_32(dr::opaque<UInt32>(m_base_seed, 1),
-                         sequence_idx + dr::opaque<UInt32>(seed, 1)).first;
+                         sequence_idx + seed).first;
 }
 
 MI_VARIANT typename Sampler<Float, Spectrum>::UInt32
@@ -120,20 +122,20 @@ Sampler<Float, Spectrum>::current_sample_index() const {
 MI_VARIANT PCG32Sampler<Float, Spectrum>::PCG32Sampler(const Properties &props)
     : Base(props) { }
 
-MI_VARIANT void PCG32Sampler<Float, Spectrum>::seed(uint32_t seed,
+MI_VARIANT void PCG32Sampler<Float, Spectrum>::seed(UInt32 seed,
                                                     uint32_t wavefront_size) {
     Base::seed(seed, wavefront_size);
 
-    uint32_t seed_value = m_base_seed + seed;
+    UInt32 seed_value = m_base_seed + seed;
 
     if constexpr (dr::is_array_v<Float>) {
-        UInt32 idx = dr::arange<UInt32>(m_wavefront_size),
-               tmp = dr::opaque<UInt32>(seed_value);
+        UInt32 idx = dr::arange<UInt32>(m_wavefront_size);
+        dr::make_opaque(seed_value);
 
         /* Scramble seed and stream index using the Tiny Encryption Algorithm.
            Just providing a linearly increasing sequence of integers as streams
            does not produce a sufficiently statistically independent set of RNGs */
-        auto [v0, v1] = sample_tea_32(tmp, idx);
+        auto [v0, v1] = sample_tea_32(seed_value, idx);
 
         m_rng.seed(v0, v1);
     } else {

--- a/src/samplers/ldsampler.cpp
+++ b/src/samplers/ldsampler.cpp
@@ -107,7 +107,7 @@ public:
         return new LowDiscrepancySampler (*this);
     }
 
-    void seed(uint32_t seed, uint32_t wavefront_size) override {
+    void seed(UInt32 seed, uint32_t wavefront_size) override {
         Base::seed(seed, wavefront_size);
         m_scramble_seed = compute_per_sequence_seed(seed);
     }

--- a/src/samplers/multijitter.cpp
+++ b/src/samplers/multijitter.cpp
@@ -116,7 +116,7 @@ public:
         return new MultijitterSampler(*this);
     }
 
-    void seed(uint32_t seed, uint32_t wavefront_size) override {
+    void seed(UInt32 seed, uint32_t wavefront_size) override {
         Base::seed(seed, wavefront_size);
         m_permutation_seed = compute_per_sequence_seed(seed);
     }

--- a/src/samplers/orthogonal.cpp
+++ b/src/samplers/orthogonal.cpp
@@ -127,7 +127,7 @@ public:
         return new OrthogonalSampler(*this);
     }
 
-    void seed(uint32_t seed, uint32_t wavefront_size) override {
+    void seed(UInt32 seed, uint32_t wavefront_size) override {
         Base::seed(seed, wavefront_size);
         m_permutation_seed = compute_per_sequence_seed(seed);
     }

--- a/src/samplers/stratified.cpp
+++ b/src/samplers/stratified.cpp
@@ -108,7 +108,7 @@ public:
         return new StratifiedSampler(*this);
     }
 
-    void seed(uint32_t seed, uint32_t wavefront_size) override {
+    void seed(UInt32 seed, uint32_t wavefront_size) override {
         Base::seed(seed, wavefront_size);
         m_permutation_seed = compute_per_sequence_seed(seed);
     }

--- a/src/samplers/tests/test_independent.py
+++ b/src/samplers/tests/test_independent.py
@@ -2,7 +2,12 @@ import pytest
 import drjit as dr
 import mitsuba as mi
 
-from .utils import check_deep_copy_sampler_scalar ,check_deep_copy_sampler_wavefront
+from .utils import (
+    check_deep_copy_sampler_scalar,
+    check_deep_copy_sampler_wavefront,
+    check_sampler_kernel_hash_wavefront,
+)
+
 
 def test01_construct(variant_scalar_rgb):
     sampler = mi.load_dict({
@@ -52,5 +57,4 @@ def test05_jit_seed(variants_vec_rgb):
     sampler.seed(seed, 64)
     assert seed.state == state_before
 
-    sample = sampler.next_1d()
-
+    check_sampler_kernel_hash_wavefront(mi.UInt, sampler)

--- a/src/samplers/tests/test_independent.py
+++ b/src/samplers/tests/test_independent.py
@@ -42,3 +42,15 @@ def test04_copy_sampler_wavefront(variants_vec_backends_once):
     })
 
     check_deep_copy_sampler_wavefront(sampler)
+
+def test05_jit_seed(variants_vec_rgb):
+    sampler = mi.load_dict({
+        "type": "independent",
+    })
+    seed = mi.UInt(0)
+    state_before = seed.state
+    sampler.seed(seed, 64)
+    assert seed.state == state_before
+
+    sample = sampler.next_1d()
+

--- a/src/samplers/tests/test_ldsampler.py
+++ b/src/samplers/tests/test_ldsampler.py
@@ -2,8 +2,14 @@ import pytest
 import drjit as dr
 import mitsuba as mi
 
-from .utils import ( check_uniform_scalar_sampler, check_uniform_wavefront_sampler,
-                     check_deep_copy_sampler_scalar, check_deep_copy_sampler_wavefront )
+from .utils import (
+    check_uniform_scalar_sampler,
+    check_uniform_wavefront_sampler,
+    check_deep_copy_sampler_scalar,
+    check_deep_copy_sampler_wavefront,
+    check_sampler_kernel_hash_wavefront,
+)
+
 
 def test01_ldsampler_scalar(variant_scalar_rgb):
     sampler = mi.load_dict({
@@ -100,5 +106,4 @@ def test06_jit_seed(variants_vec_rgb):
     sampler.seed(seed, 64)
     assert seed.state == state_before
 
-    sample = sampler.next_1d()
-
+    check_sampler_kernel_hash_wavefront(mi.UInt, sampler)

--- a/src/samplers/tests/test_ldsampler.py
+++ b/src/samplers/tests/test_ldsampler.py
@@ -90,3 +90,15 @@ def test05_copy_sampler_wavefront(variants_vec_backends_once):
     sampler.seed(0, 1024)
 
     check_deep_copy_sampler_wavefront(sampler)
+    
+def test06_jit_seed(variants_vec_rgb):
+    sampler = mi.load_dict({
+        "type": "independent",
+    })
+    seed = mi.UInt(0)
+    state_before = seed.state
+    sampler.seed(seed, 64)
+    assert seed.state == state_before
+
+    sample = sampler.next_1d()
+

--- a/src/samplers/tests/test_multijitter.py
+++ b/src/samplers/tests/test_multijitter.py
@@ -38,3 +38,15 @@ def test04_copy_sampler_wavefront(variants_vec_backends_once):
     })
 
     check_deep_copy_sampler_wavefront(sampler)
+    
+def test05_jit_seed(variants_vec_rgb):
+    sampler = mi.load_dict({
+        "type": "independent",
+    })
+    seed = mi.UInt(0)
+    state_before = seed.state
+    sampler.seed(seed, 64)
+    assert seed.state == state_before
+
+    sample = sampler.next_1d()
+

--- a/src/samplers/tests/test_multijitter.py
+++ b/src/samplers/tests/test_multijitter.py
@@ -2,8 +2,14 @@ import pytest
 import drjit as dr
 import mitsuba as mi
 
-from .utils import ( check_uniform_scalar_sampler, check_uniform_wavefront_sampler,
-                     check_deep_copy_sampler_scalar, check_deep_copy_sampler_wavefront )
+from .utils import (
+    check_uniform_scalar_sampler,
+    check_uniform_wavefront_sampler,
+    check_deep_copy_sampler_scalar,
+    check_deep_copy_sampler_wavefront,
+    check_sampler_kernel_hash_wavefront,
+)
+
 
 def test01_multijitter_scalar(variant_scalar_rgb):
     sampler = mi.load_dict({
@@ -48,5 +54,4 @@ def test05_jit_seed(variants_vec_rgb):
     sampler.seed(seed, 64)
     assert seed.state == state_before
 
-    sample = sampler.next_1d()
-
+    check_sampler_kernel_hash_wavefront(mi.UInt, sampler)

--- a/src/samplers/tests/test_orthogonal.py
+++ b/src/samplers/tests/test_orthogonal.py
@@ -2,8 +2,14 @@ import pytest
 import drjit as dr
 import mitsuba as mi
 
-from .utils import ( check_uniform_scalar_sampler, check_uniform_wavefront_sampler,
-                     check_deep_copy_sampler_scalar, check_deep_copy_sampler_wavefront )
+from .utils import (
+    check_uniform_scalar_sampler,
+    check_uniform_wavefront_sampler,
+    check_deep_copy_sampler_scalar,
+    check_deep_copy_sampler_wavefront,
+    check_sampler_kernel_hash_wavefront,
+)
+
 
 def test01_orthogonal_scalar(variant_scalar_rgb):
     sampler = mi.load_dict({
@@ -48,5 +54,4 @@ def test05_jit_seed(variants_vec_rgb):
     sampler.seed(seed, 64)
     assert seed.state == state_before
 
-    sample = sampler.next_1d()
-
+    check_sampler_kernel_hash_wavefront(mi.UInt, sampler)

--- a/src/samplers/tests/test_orthogonal.py
+++ b/src/samplers/tests/test_orthogonal.py
@@ -38,3 +38,15 @@ def test04_copy_sampler_wavefront(variants_vec_backends_once):
     })
 
     check_deep_copy_sampler_wavefront(sampler, factor=37)
+    
+def test05_jit_seed(variants_vec_rgb):
+    sampler = mi.load_dict({
+        "type": "independent",
+    })
+    seed = mi.UInt(0)
+    state_before = seed.state
+    sampler.seed(seed, 64)
+    assert seed.state == state_before
+
+    sample = sampler.next_1d()
+

--- a/src/samplers/tests/test_stratified.py
+++ b/src/samplers/tests/test_stratified.py
@@ -39,3 +39,15 @@ def test04_copy_sampler_wavefront(variants_vec_backends_once):
     })
 
     check_deep_copy_sampler_wavefront(sampler)
+    
+def test05_jit_seed(variants_vec_rgb):
+    sampler = mi.load_dict({
+        "type": "independent",
+    })
+    seed = mi.UInt(0)
+    state_before = seed.state
+    sampler.seed(seed, 64)
+    assert seed.state == state_before
+
+    sample = sampler.next_1d()
+

--- a/src/samplers/tests/test_stratified.py
+++ b/src/samplers/tests/test_stratified.py
@@ -2,8 +2,14 @@ import pytest
 import drjit as dr
 import mitsuba as mi
 
-from .utils import ( check_uniform_scalar_sampler, check_uniform_wavefront_sampler,
-                     check_deep_copy_sampler_scalar, check_deep_copy_sampler_wavefront )
+from .utils import (
+    check_uniform_scalar_sampler,
+    check_uniform_wavefront_sampler,
+    check_deep_copy_sampler_scalar,
+    check_deep_copy_sampler_wavefront,
+    check_sampler_kernel_hash_wavefront,
+)
+
 
 def test01_stratified_scalar(variant_scalar_rgb):
     sampler = mi.load_dict({
@@ -49,5 +55,4 @@ def test05_jit_seed(variants_vec_rgb):
     sampler.seed(seed, 64)
     assert seed.state == state_before
 
-    sample = sampler.next_1d()
-
+    check_sampler_kernel_hash_wavefront(mi.UInt, sampler)


### PR DESCRIPTION
<!-- Please add the labels (e.g. bug fix, feature, ..) corresponding to this PR -->

## Description

This PR changes the signature of the `seed` function for samplers (and their implementations) to take a Dr.Jit `UInt32` instead of a `uint32_t` as the seed.
It also changes the signature `compute_per_sequence_seed` function to take the same type as the argument.
The change will eventually be necessary for function freezing, as it allows passing already opaque seeds to the render function and thereby prevents "re-recording" of the frozen function.

## Testing

<!-- Please describe the tests that you added to verify your changes. -->

## Checklist

<!-- Please make sure to complete this checklist before requesting a review. -->

- [ ] My code follows the [style guidelines](https://mitsuba.readthedocs.io/en/latest/src/developer_guide.html#coding-style) of this project
- [ ] My changes generate no new warnings
- [ ] My code also compiles for `cuda_*` and `llvm_*` variants. If you can't test this, please leave below
- [ ] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I cleaned the commit history and removed any "Merge" commits
- [ ] I give permission that the Mitsuba 3 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba/blob/master/LICENSE)