### PR TITLE
Changed integrator render functions to take UInt32 for seed

### DIFF
--- a/include/mitsuba/render/integrator.h
+++ b/include/mitsuba/render/integrator.h
@@ -76,7 +76,7 @@ public:
      */
     virtual TensorXf render(Scene *scene,
                             Sensor *sensor,
-                            uint32_t seed = 0,
+                            UInt32 seed = 0,
                             uint32_t spp = 0,
                             bool develop = true,
                             bool evaluate = true) = 0;
@@ -90,7 +90,7 @@ public:
      */
     TensorXf render(Scene *scene,
                     uint32_t sensor_index = 0,
-                    uint32_t seed = 0,
+                    UInt32 seed = 0,
                     uint32_t spp = 0,
                     bool develop = true,
                     bool evaluate = true);
@@ -167,7 +167,7 @@ public:
     virtual TensorXf render_forward(Scene* scene,
                                     void* params,
                                     Sensor *sensor,
-                                    uint32_t seed = 0,
+                                    UInt32 seed = 0,
                                     uint32_t spp = 0);
 
     /**
@@ -180,7 +180,7 @@ public:
     TensorXf render_forward(Scene* scene,
                             void* params,
                             uint32_t sensor_index = 0,
-                            uint32_t seed = 0,
+                            UInt32 seed = 0,
                             uint32_t spp = 0) {
 
         if (sensor_index >= scene->sensors().size())
@@ -257,7 +257,7 @@ public:
                                  void* params,
                                  const TensorXf& grad_in,
                                  Sensor* sensor,
-                                 uint32_t seed = 0,
+                                 UInt32 seed = 0,
                                  uint32_t spp = 0);
 
     /**
@@ -271,7 +271,7 @@ public:
                          void* params,
                          const TensorXf& grad_in,
                          uint32_t sensor_index = 0,
-                         uint32_t seed = 0,
+                         UInt32 seed = 0,
                          uint32_t spp = 0) {
 
         if (sensor_index >= scene->sensors().size())
@@ -417,7 +417,7 @@ public:
 
     TensorXf render(Scene *scene,
                     Sensor *sensor,
-                    uint32_t seed = 0,
+                    UInt32 seed = 0,
                     uint32_t spp = 0,
                     bool develop = true,
                     bool evaluate = true) override;
@@ -435,7 +435,7 @@ protected:
                               ImageBlock *block,
                               Float *aovs,
                               uint32_t sample_count,
-                              uint32_t seed,
+                              UInt32 seed,
                               uint32_t block_id,
                               uint32_t block_size) const;
 
@@ -542,7 +542,7 @@ public:
 
     TensorXf render(Scene *scene,
                     Sensor *sensor,
-                    uint32_t seed = 0,
+                    UInt32 seed = 0,
                     uint32_t spp = 0,
                     bool develop = true,
                     bool evaluate = true) override;

--- a/src/integrators/aov.cpp
+++ b/src/integrators/aov.cpp
@@ -355,7 +355,7 @@ public:
 
     TensorXf render(Scene *scene,
                     Sensor *sensor,
-                    uint32_t seed,
+                    UInt32 seed,
                     uint32_t spp,
                     bool develop,
                     bool evaluate) override {
@@ -386,7 +386,7 @@ public:
     TensorXf render_forward(Scene* scene,
                             void* params,
                             Sensor *sensor,
-                            uint32_t seed = 0,
+                            UInt32 seed = 0,
                             uint32_t spp = 0) override {
 
         // Perform forward mode propagation just for AOV image
@@ -418,7 +418,7 @@ public:
                          void* params,
                          const TensorXf& grad_in,
                          Sensor* sensor,
-                         uint32_t seed = 0,
+                         UInt32 seed = 0,
                          uint32_t spp = 0) override {
         size_t base_ch_count = sensor->film()->base_channels_count();
         auto [image_grads, aovs_grad] = split_channels(base_ch_count, grad_in);

--- a/src/render/integrator.cpp
+++ b/src/render/integrator.cpp
@@ -30,7 +30,7 @@ MI_VARIANT Integrator<Float, Spectrum>::Integrator(const Properties & props)
 MI_VARIANT typename Integrator<Float, Spectrum>::TensorXf
 Integrator<Float, Spectrum>::render(Scene *scene,
                                     uint32_t sensor_index,
-                                    uint32_t seed,
+                                    UInt32 seed,
                                     uint32_t spp,
                                     bool develop,
                                     bool evaluate) {
@@ -45,7 +45,7 @@ MI_VARIANT typename Integrator<Float, Spectrum>::TensorXf
 Integrator<Float, Spectrum>::render_forward(Scene* scene,
                                             void* /*params*/,
                                             Sensor *sensor,
-                                            uint32_t seed,
+                                            UInt32 seed,
                                             uint32_t spp) {
     auto forward_gradients = [&]() -> TensorXf {
         auto image = render(scene, sensor, seed, spp, true, false);
@@ -67,7 +67,7 @@ Integrator<Float, Spectrum>::render_backward(Scene* scene,
                                              void* /*params */,
                                              const TensorXf& grad_in,
                                              Sensor* sensor,
-                                             uint32_t seed,
+                                             UInt32 seed,
                                              uint32_t spp) {
     auto backward_gradients = [&]() -> void {
         auto image = render(scene, sensor, seed, spp, true, false);
@@ -120,7 +120,7 @@ MI_VARIANT SamplingIntegrator<Float, Spectrum>::~SamplingIntegrator() { }
 MI_VARIANT typename SamplingIntegrator<Float, Spectrum>::TensorXf
 SamplingIntegrator<Float, Spectrum>::render(Scene *scene,
                                             Sensor *sensor,
-                                            uint32_t seed,
+                                            UInt32 seed,
                                             uint32_t spp,
                                             bool develop,
                                             bool evaluate) {
@@ -372,7 +372,7 @@ MI_VARIANT void SamplingIntegrator<Float, Spectrum>::render_block(const Scene *s
                                                                    ImageBlock *block,
                                                                    Float *aovs,
                                                                    uint32_t sample_count,
-                                                                   uint32_t seed,
+                                                                   UInt32 seed,
                                                                    uint32_t block_id,
                                                                    uint32_t block_size) const {
 
@@ -544,7 +544,7 @@ MI_VARIANT AdjointIntegrator<Float, Spectrum>::~AdjointIntegrator() { }
 MI_VARIANT typename AdjointIntegrator<Float, Spectrum>::TensorXf
 AdjointIntegrator<Float, Spectrum>::render(Scene *scene,
                                            Sensor *sensor,
-                                           uint32_t seed,
+                                           UInt32 seed,
                                            uint32_t spp,
                                            bool develop,
                                            bool evaluate) {

--- a/src/render/python/integrator_v.cpp
+++ b/src/render/python/integrator_v.cpp
@@ -69,7 +69,7 @@ public:
 
     TensorXf render(Scene *scene,
                     Sensor *sensor,
-                    uint32_t seed,
+                    UInt32 seed,
                     uint32_t spp,
                     bool develop,
                     bool evaluate) override {
@@ -79,7 +79,7 @@ public:
     TensorXf render_forward(Scene* scene,
                             void* params,
                             Sensor *sensor,
-                            uint32_t seed = 0,
+                            UInt32 seed = 0,
                             uint32_t spp = 0) override {
         NB_OVERRIDE(render_forward, scene, params, sensor, seed, spp);
     }
@@ -88,7 +88,7 @@ public:
                          void* params,
                          const TensorXf& grad_in,
                          Sensor* sensor,
-                         uint32_t seed = 0,
+                         UInt32 seed = 0,
                          uint32_t spp = 0) override {
         NB_OVERRIDE(render_backward, scene, params, grad_in, sensor, seed, spp);
     }
@@ -135,7 +135,7 @@ public:
 
     TensorXf render(Scene *scene,
                     Sensor *sensor,
-                    uint32_t seed,
+                    UInt32 seed,
                     uint32_t spp,
                     bool develop,
                     bool evaluate) override {
@@ -194,7 +194,7 @@ public:
 
     TensorXf render(Scene *scene,
                     Sensor *sensor,
-                    uint32_t seed,
+                    UInt32 seed,
                     uint32_t spp,
                     bool develop,
                     bool evaluate) override {
@@ -204,7 +204,7 @@ public:
     TensorXf render_forward(Scene* scene,
                             void* params,
                             Sensor *sensor,
-                            uint32_t seed = 0,
+                            UInt32 seed = 0,
                             uint32_t spp = 0) override {
         nanobind::detail::ticket nb_ticket(nb_trampoline, "render_forward", false);
         if (nb_ticket.key.is_valid())
@@ -219,7 +219,7 @@ public:
                          void* params,
                          const TensorXf& grad_in,
                          Sensor* sensor,
-                         uint32_t seed = 0,
+                         UInt32 seed = 0,
                          uint32_t spp = 0) override {
         nanobind::detail::ticket nb_ticket(nb_trampoline, "render_backward", false);
         if (nb_ticket.key.is_valid())
@@ -281,7 +281,7 @@ MI_PY_EXPORT(Integrator) {
         .def(
             "render",
             [&](Integrator *integrator, Scene *scene, Sensor *sensor,
-                uint32_t seed, uint32_t spp, bool develop, bool evaluate) {
+                UInt32 seed, uint32_t spp, bool develop, bool evaluate) {
                 nb::gil_scoped_release release;
                 ScopedSignalHandler sh(integrator);
                 return integrator->render(scene, sensor, seed, spp, develop,
@@ -293,7 +293,7 @@ MI_PY_EXPORT(Integrator) {
         .def(
             "render",
             [&](Integrator *integrator, Scene *scene, uint32_t sensor,
-                uint32_t seed, uint32_t spp, bool develop, bool evaluate) {
+                UInt32 seed, uint32_t spp, bool develop, bool evaluate) {
                 nb::gil_scoped_release release;
                 ScopedSignalHandler sh(integrator);
                 return integrator->render(scene, sensor, seed, spp,
@@ -323,7 +323,7 @@ MI_PY_EXPORT(Integrator) {
         .def(
             "render_forward",
             [](SamplingIntegrator *integrator, Scene *scene, nb::object* params,
-                Sensor* sensor, uint32_t seed, uint32_t spp) {
+                Sensor* sensor, UInt32 seed, uint32_t spp) {
                 nb::gil_scoped_release release;
                 ScopedSignalHandler sh(integrator);
                 return integrator->render_forward(scene, params, sensor, seed, spp);
@@ -332,7 +332,7 @@ MI_PY_EXPORT(Integrator) {
         .def(
             "render_forward",
             [](SamplingIntegrator *integrator, Scene *scene, nb::object* params,
-                uint32_t sensor, uint32_t seed, uint32_t spp) {
+                uint32_t sensor, UInt32 seed, uint32_t spp) {
                 nb::gil_scoped_release release;
                 ScopedSignalHandler sh(integrator);
                 return integrator->render_forward(scene, params, sensor, seed, spp);
@@ -341,7 +341,7 @@ MI_PY_EXPORT(Integrator) {
         .def(
             "render_backward",
             [](SamplingIntegrator *integrator, Scene *scene, nb::object* params,
-                const TensorXf& grad_in, Sensor* sensor, uint32_t seed,
+                const TensorXf& grad_in, Sensor* sensor, UInt32 seed,
                 uint32_t spp) {
                 nb::gil_scoped_release release;
                 ScopedSignalHandler sh(integrator);
@@ -353,7 +353,7 @@ MI_PY_EXPORT(Integrator) {
         .def(
             "render_backward",
             [](SamplingIntegrator *integrator, Scene *scene, nb::object* params,
-                const TensorXf& grad_in, uint32_t sensor, uint32_t seed,
+                const TensorXf& grad_in, uint32_t sensor, UInt32 seed,
                 uint32_t spp) {
                 nb::gil_scoped_release release;
                 ScopedSignalHandler sh(integrator);
@@ -377,7 +377,7 @@ MI_PY_EXPORT(Integrator) {
         .def(
             "render_forward",
             [](AdjointIntegrator *integrator, Scene *scene, nb::object* params,
-                Sensor* sensor, uint32_t seed, uint32_t spp) {
+                Sensor* sensor, UInt32 seed, uint32_t spp) {
                 nb::gil_scoped_release release;
                 ScopedSignalHandler sh(integrator);
                 return integrator->render_forward(scene, params, sensor, seed, spp);
@@ -386,7 +386,7 @@ MI_PY_EXPORT(Integrator) {
         .def(
             "render_forward",
             [](AdjointIntegrator *integrator, Scene *scene, nb::object* params,
-                uint32_t sensor, uint32_t seed, uint32_t spp) {
+                uint32_t sensor, UInt32 seed, uint32_t spp) {
                 nb::gil_scoped_release release;
                 ScopedSignalHandler sh(integrator);
                 return integrator->render_forward(scene, params, sensor, seed, spp);
@@ -395,7 +395,7 @@ MI_PY_EXPORT(Integrator) {
         .def(
             "render_backward",
             [](AdjointIntegrator *integrator, Scene *scene, nb::object* params,
-                const TensorXf& grad_in, Sensor* sensor, uint32_t seed,
+                const TensorXf& grad_in, Sensor* sensor, UInt32 seed,
                 uint32_t spp) {
                 nb::gil_scoped_release release;
                 ScopedSignalHandler sh(integrator);
@@ -407,7 +407,7 @@ MI_PY_EXPORT(Integrator) {
         .def(
             "render_backward",
             [](AdjointIntegrator *integrator, Scene *scene, nb::object* params,
-                const TensorXf& grad_in, uint32_t sensor, uint32_t seed,
+                const TensorXf& grad_in, uint32_t sensor, UInt32 seed,
                 uint32_t spp) {
                 nb::gil_scoped_release release;
                 ScopedSignalHandler sh(integrator);


### PR DESCRIPTION
<!-- Please add the labels (e.g. bug fix, feature, ..) corresponding to this PR -->

## Description

The PR expands on [Change seed function to take drjit type for seed](https://github.com/mitsuba-renderer/mitsuba3/pull/1326#issue-2559768899), by changing the `render`, `render_forward` and `render_backward` signatures to take a `UInt32` for the `seed` argument as well.
This is necessary for function freezing, to allow changing the seed between calls to a frozen function without having to re-trace it.

## Testing

<!-- Please describe the tests that you added to verify your changes. -->

## Checklist

<!-- Please make sure to complete this checklist before requesting a review. -->

- [ ] My code follows the [style guidelines](https://mitsuba.readthedocs.io/en/latest/src/developer_guide.html#coding-style) of this project
- [ ] My changes generate no new warnings
- [ ] My code also compiles for `cuda_*` and `llvm_*` variants. If you can't test this, please leave below
- [ ] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I cleaned the commit history and removed any "Merge" commits
- [ ] I give permission that the Mitsuba 3 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba/blob/master/LICENSE)