### PR TITLE
Remove gc.collect() calls from RenderOp

### DIFF
--- a/src/python/python/ad/integrators/common.py
+++ b/src/python/python/ad/integrators/common.py
@@ -103,7 +103,6 @@ class ADIntegrator(mi.CppADIntegrator):
 
             # Explicitly delete any remaining unused variables
             del sampler, ray, weight, pos, L, valid
-            gc.collect()
 
             # Perform the weight division and return an image tensor
             film.put_block(block)
@@ -212,7 +211,6 @@ class ADIntegrator(mi.CppADIntegrator):
                 film.put_block(block)
 
                 del valid
-                gc.collect()
 
                 # This step launches a kernel
                 dr.schedule(block.tensor())
@@ -226,7 +224,6 @@ class ADIntegrator(mi.CppADIntegrator):
 
             # We don't need any of the outputs here
             del ray, weight, pos, block, sampler
-            gc.collect()
 
             # Run kernel representing side effects of the above
             dr.eval()
@@ -619,11 +616,6 @@ class RBIntegrator(ADIntegrator):
             del sampler, ray, weight, pos, L, valid, aovs, δL, δaovs, \
                 valid_2, params, state_out, state_out_2, block
 
-            # Probably a little overkill, but why not.. If there are any
-            # DrJit arrays to be collected by Python's cyclic GC, then
-            # freeing them may enable loop simplifications in dr.eval().
-            gc.collect()
-
             result_grad = film.develop()
 
         return result_grad
@@ -725,11 +717,6 @@ class RBIntegrator(ADIntegrator):
 
                 film.put_block(block)
 
-                # Probably a little overkill, but why not.. If there are any
-                # DrJit arrays to be collected by Python's cyclic GC, then
-                # freeing them may enable loop simplifications in dr.eval().
-                gc.collect()
-
                 image = film.develop()
 
                 dr.set_grad(image, grad_in)
@@ -790,7 +777,6 @@ class RBIntegrator(ADIntegrator):
             del L_2, valid_2, aovs_2, state_out, state_out_2, \
                 δL, δaovs, ray, weight, pos, sampler
 
-            gc.collect()
 
             # Run kernel representing side effects of the above
             dr.eval()

--- a/src/python/python/ad/projective.py
+++ b/src/python/python/ad/projective.py
@@ -269,12 +269,6 @@ class ProjectiveDetail():
         elif parent.guiding == 'octree':
             self.init_indirect_silhouette_octree(scene, sensor, seed)
 
-        # After cleaning up, only necessary guiding distribution storage should
-        # exist in the device memory. This usually occupies dozens of MBs for
-        # octree, and ~0.75GB for grid based guiding with default settings.
-        gc.collect()
-        gc.collect()
-        # TODO this should happen automatically
 
     @dr.syntax
     def init_indirect_silhouette_grid_unif(self, scene, sensor, seed):


### PR DESCRIPTION
I was benchmarking some very simple optimization I had and was surprised that it wasn't running as fast as expected. I am running on GPU and was hoping for near-realtime performance (even with Python re-tracing).

It turns out that the explicit `gc.collect()` calls in the RenderOp are actually quite expensive. When optimizing the color of a wall in the cornell box using PRB, the current master branch takes 27s for 1024 iterations on an RTX A5000. By removing the explicit gc.collect calls, I get down to 11s. The performance increases from 37 iterations per second to almost 90.

Given this result, I think we should consider getting rid of these gc.collect() calls in the innermost loop. As far as I know, these go back to pre-PRB, pre-Dr.Jit times when we often ran out of memory due to the AD graph.

Here is the reproducer I run:


```python

import drjit as dr
import mitsuba as mi
import tqdm

def run_optim():
    mi.set_variant('cuda_ad_rgb')
    scene = mi.cornell_box()
    scene['integrator'] = {'type': 'prb'}

    scene = mi.load_dict(scene)
    image_ref = mi.render(scene, spp=512)
    params = mi.traverse(scene)
    key = 'red.reflectance.value'
    print("Reference param ", params[key])
    params[key] = mi.Color3f(0.01, 0.2, 0.9)
    params.update()

    opt = mi.ad.Adam(lr=0.05)
    opt[key] = params[key]
    params.update(opt)
    for _ in tqdm.tqdm(range(1024)):
        image = mi.render(scene, params, spp=4)
        loss = dr.mean(dr.square(image - image_ref))
        dr.backward(loss)
        opt.step()
        opt[key] = dr.clip(opt[key], 0.0, 1.0)
        params.update(opt)
    print("Final param ", params[key])

run_optim()

```