### PR TITLE
Use variant-specific registry domains

### DIFF
--- a/include/mitsuba/core/class.h
+++ b/include/mitsuba/core/class.h
@@ -291,8 +291,10 @@ constexpr auto domain_name_for_class(const std::array<char, N> &class_name) {
     DRJIT_CALL_TEMPLATE_BEGIN(mitsuba::Name)
 
 #define MI_CALL_TEMPLATE_END(Name)                                                      \
+private:                                                                                \
     static constexpr std::array<char, sizeof(#Name) / sizeof(char)> MIClass_{#Name};    \
     static constexpr auto MIDomain_ = mitsuba::domain_name_for_class<Ts...>(MIClass_);  \
+public:                                                                                 \
     static constexpr const char *domain_() {                                            \
         return MIDomain_.data();                                                        \
     }                                                                                   \

--- a/include/mitsuba/core/class.h
+++ b/include/mitsuba/core/class.h
@@ -280,22 +280,18 @@ constexpr auto domain_name_for_class(const String &class_name) {
 /**
  * Adds the given class instance to a DrJit registry domain that is specific
  * to this backend and Mitsuba variant.
+ *
+ * Example usage:
+ *     MI_REGISTRY_PUT("BSDF", this);
  */
-#define MTS_REGISTRY_PUT(name, ptr)                                                       \
-    if constexpr (dr::is_jit_v<Float>) {                                                  \
-        static constexpr auto domain_name = domain_name_for_class<Float, Spectrum>(name); \
-        jit_registry_put(dr::backend_v<Float>, domain_name.data(), ptr);                  \
+#define MI_REGISTRY_PUT(name, ptr)                                                           \
     }
 
 
 #define MTS_CALL_TEMPLATE_BEGIN(Name)                                               \
     DRJIT_CALL_TEMPLATE_BEGIN(mitsuba::Name)
 
-#define MTS_CALL_TEMPLATE_END(Name)                                                 \
-    static constexpr auto __Domain = mitsuba::domain_name_for_class<Ts...>(#Name);  \
-    static constexpr const char *__domain() {                                       \
-        return __Domain.data();                                                     \
-    }                                                                               \
+#define MI_CALL_TEMPLATE_END(Name)                                                      \
     DRJIT_CALL_END(mitsuba::Name)
 
 

--- a/include/mitsuba/core/class.h
+++ b/include/mitsuba/core/class.h
@@ -136,6 +136,20 @@ private:
     static bool m_is_initialized;
 };
 
+
+/**
+ * Adds the given class instance to a DrJit registry domain that is specific
+ * to this backend and Mitsuba variant.
+ */
+template <typename Float, typename Spectrum>
+void variant_registry_put(const char *class_name, void *ptr) {
+    if constexpr (dr::is_jit_v<Float>) {
+        std::string variant = ::mitsuba::detail::get_variant<Float, Spectrum>();
+        std::string name = "mitsuba::" + variant + "__" + class_name;
+        jit_registry_put(dr::backend_v<Float>, name.c_str(), ptr);
+    }
+}
+
 /**
  * \brief Return the \ref Class object corresponding to a named class.
  *

--- a/include/mitsuba/render/bsdf.h
+++ b/include/mitsuba/render/bsdf.h
@@ -654,7 +654,7 @@ NAMESPACE_END(mitsuba)
 //! @{ \name Dr.Jit support for vectorized function calls
 // -----------------------------------------------------------------------
 
-MTS_CALL_TEMPLATE_BEGIN(BSDF)
+MI_CALL_TEMPLATE_BEGIN(BSDF)
     DRJIT_CALL_METHOD(sample)
     DRJIT_CALL_METHOD(eval)
     DRJIT_CALL_METHOD(eval_null_transmission)
@@ -670,7 +670,7 @@ MTS_CALL_TEMPLATE_BEGIN(BSDF)
     auto needs_differentials() const {
         return has_flag(flags(), mitsuba::BSDFFlags::NeedsDifferentials);
     }
-MTS_CALL_TEMPLATE_END(BSDF)
+MI_CALL_TEMPLATE_END(BSDF)
 
 //! @}
 // -----------------------------------------------------------------------

--- a/include/mitsuba/render/bsdf.h
+++ b/include/mitsuba/render/bsdf.h
@@ -654,7 +654,7 @@ NAMESPACE_END(mitsuba)
 //! @{ \name Dr.Jit support for vectorized function calls
 // -----------------------------------------------------------------------
 
-DRJIT_CALL_TEMPLATE_BEGIN(mitsuba::BSDF)
+MTS_CALL_TEMPLATE_BEGIN(BSDF)
     DRJIT_CALL_METHOD(sample)
     DRJIT_CALL_METHOD(eval)
     DRJIT_CALL_METHOD(eval_null_transmission)
@@ -670,7 +670,7 @@ DRJIT_CALL_TEMPLATE_BEGIN(mitsuba::BSDF)
     auto needs_differentials() const {
         return has_flag(flags(), mitsuba::BSDFFlags::NeedsDifferentials);
     }
-DRJIT_CALL_END(mitsuba::BSDF)
+MTS_CALL_TEMPLATE_END(BSDF)
 
 //! @}
 // -----------------------------------------------------------------------

--- a/include/mitsuba/render/emitter.h
+++ b/include/mitsuba/render/emitter.h
@@ -103,7 +103,7 @@ NAMESPACE_END(mitsuba)
 //! @{ \name Dr.Jit support for vectorized function calls
 // -----------------------------------------------------------------------
 
-DRJIT_CALL_TEMPLATE_BEGIN(mitsuba::Emitter)
+MTS_CALL_TEMPLATE_BEGIN(Emitter)
     DRJIT_CALL_METHOD(sample_ray)
     DRJIT_CALL_METHOD(sample_direction)
     DRJIT_CALL_METHOD(pdf_direction)
@@ -117,7 +117,7 @@ DRJIT_CALL_TEMPLATE_BEGIN(mitsuba::Emitter)
     DRJIT_CALL_GETTER(shape)
     DRJIT_CALL_GETTER(medium)
     DRJIT_CALL_GETTER(sampling_weight)
-DRJIT_CALL_END(mitsuba::Emitter)
+MTS_CALL_TEMPLATE_END(Emitter)
 
 //! @}
 // -----------------------------------------------------------------------

--- a/include/mitsuba/render/emitter.h
+++ b/include/mitsuba/render/emitter.h
@@ -103,7 +103,7 @@ NAMESPACE_END(mitsuba)
 //! @{ \name Dr.Jit support for vectorized function calls
 // -----------------------------------------------------------------------
 
-MTS_CALL_TEMPLATE_BEGIN(Emitter)
+MI_CALL_TEMPLATE_BEGIN(Emitter)
     DRJIT_CALL_METHOD(sample_ray)
     DRJIT_CALL_METHOD(sample_direction)
     DRJIT_CALL_METHOD(pdf_direction)
@@ -117,7 +117,7 @@ MTS_CALL_TEMPLATE_BEGIN(Emitter)
     DRJIT_CALL_GETTER(shape)
     DRJIT_CALL_GETTER(medium)
     DRJIT_CALL_GETTER(sampling_weight)
-MTS_CALL_TEMPLATE_END(Emitter)
+MI_CALL_TEMPLATE_END(Emitter)
 
 //! @}
 // -----------------------------------------------------------------------

--- a/include/mitsuba/render/medium.h
+++ b/include/mitsuba/render/medium.h
@@ -121,7 +121,7 @@ NAMESPACE_END(mitsuba)
 //! @{ \name Dr.Jit support for packets of Medium pointers
 // -----------------------------------------------------------------------
 
-DRJIT_CALL_TEMPLATE_BEGIN(mitsuba::Medium)
+MTS_CALL_TEMPLATE_BEGIN(Medium)
     DRJIT_CALL_GETTER(phase_function)
     DRJIT_CALL_GETTER(use_emitter_sampling)
     DRJIT_CALL_GETTER(is_homogeneous)
@@ -131,7 +131,7 @@ DRJIT_CALL_TEMPLATE_BEGIN(mitsuba::Medium)
     DRJIT_CALL_METHOD(sample_interaction)
     DRJIT_CALL_METHOD(transmittance_eval_pdf)
     DRJIT_CALL_METHOD(get_scattering_coefficients)
-DRJIT_CALL_END(mitsuba::Medium)
+MTS_CALL_TEMPLATE_END(Medium)
 
 //! @}
 // -----------------------------------------------------------------------

--- a/include/mitsuba/render/medium.h
+++ b/include/mitsuba/render/medium.h
@@ -121,7 +121,7 @@ NAMESPACE_END(mitsuba)
 //! @{ \name Dr.Jit support for packets of Medium pointers
 // -----------------------------------------------------------------------
 
-MTS_CALL_TEMPLATE_BEGIN(Medium)
+MI_CALL_TEMPLATE_BEGIN(Medium)
     DRJIT_CALL_GETTER(phase_function)
     DRJIT_CALL_GETTER(use_emitter_sampling)
     DRJIT_CALL_GETTER(is_homogeneous)
@@ -131,7 +131,7 @@ MTS_CALL_TEMPLATE_BEGIN(Medium)
     DRJIT_CALL_METHOD(sample_interaction)
     DRJIT_CALL_METHOD(transmittance_eval_pdf)
     DRJIT_CALL_METHOD(get_scattering_coefficients)
-MTS_CALL_TEMPLATE_END(Medium)
+MI_CALL_TEMPLATE_END(Medium)
 
 //! @}
 // -----------------------------------------------------------------------

--- a/include/mitsuba/render/phase.h
+++ b/include/mitsuba/render/phase.h
@@ -255,14 +255,14 @@ NAMESPACE_END(mitsuba)
 //! @{ \name Dr.Jit support for vectorized function calls
 // -----------------------------------------------------------------------
 
-DRJIT_CALL_TEMPLATE_BEGIN(mitsuba::PhaseFunction)
+MTS_CALL_TEMPLATE_BEGIN(PhaseFunction)
     DRJIT_CALL_METHOD(sample)
     DRJIT_CALL_METHOD(eval_pdf)
     DRJIT_CALL_METHOD(projected_area)
     DRJIT_CALL_METHOD(max_projected_area)
     DRJIT_CALL_GETTER(flags)
     DRJIT_CALL_GETTER(component_count)
-DRJIT_CALL_END(mitsuba::PhaseFunction)
+MTS_CALL_TEMPLATE_END(PhaseFunction)
 
 //! @}
 // -----------------------------------------------------------------------

--- a/include/mitsuba/render/phase.h
+++ b/include/mitsuba/render/phase.h
@@ -255,14 +255,14 @@ NAMESPACE_END(mitsuba)
 //! @{ \name Dr.Jit support for vectorized function calls
 // -----------------------------------------------------------------------
 
-MTS_CALL_TEMPLATE_BEGIN(PhaseFunction)
+MI_CALL_TEMPLATE_BEGIN(PhaseFunction)
     DRJIT_CALL_METHOD(sample)
     DRJIT_CALL_METHOD(eval_pdf)
     DRJIT_CALL_METHOD(projected_area)
     DRJIT_CALL_METHOD(max_projected_area)
     DRJIT_CALL_GETTER(flags)
     DRJIT_CALL_GETTER(component_count)
-MTS_CALL_TEMPLATE_END(PhaseFunction)
+MI_CALL_TEMPLATE_END(PhaseFunction)
 
 //! @}
 // -----------------------------------------------------------------------

--- a/include/mitsuba/render/sensor.h
+++ b/include/mitsuba/render/sensor.h
@@ -313,7 +313,7 @@ NAMESPACE_END(mitsuba)
 //! @{ \name Dr.Jit support for vectorized function calls
 // -----------------------------------------------------------------------
 
-MTS_CALL_TEMPLATE_BEGIN(Sensor)
+MI_CALL_TEMPLATE_BEGIN(Sensor)
     DRJIT_CALL_METHOD(sample_ray)
     DRJIT_CALL_METHOD(sample_ray_differential)
     DRJIT_CALL_METHOD(sample_direction)
@@ -326,4 +326,4 @@ MTS_CALL_TEMPLATE_BEGIN(Sensor)
     DRJIT_CALL_GETTER(flags)
     DRJIT_CALL_GETTER(shape)
     DRJIT_CALL_GETTER(medium)
-MTS_CALL_TEMPLATE_END(Sensor)
+MI_CALL_TEMPLATE_END(Sensor)

--- a/include/mitsuba/render/sensor.h
+++ b/include/mitsuba/render/sensor.h
@@ -313,7 +313,7 @@ NAMESPACE_END(mitsuba)
 //! @{ \name Dr.Jit support for vectorized function calls
 // -----------------------------------------------------------------------
 
-DRJIT_CALL_TEMPLATE_BEGIN(mitsuba::Sensor)
+MTS_CALL_TEMPLATE_BEGIN(Sensor)
     DRJIT_CALL_METHOD(sample_ray)
     DRJIT_CALL_METHOD(sample_ray_differential)
     DRJIT_CALL_METHOD(sample_direction)
@@ -326,4 +326,4 @@ DRJIT_CALL_TEMPLATE_BEGIN(mitsuba::Sensor)
     DRJIT_CALL_GETTER(flags)
     DRJIT_CALL_GETTER(shape)
     DRJIT_CALL_GETTER(medium)
-DRJIT_CALL_END(mitsuba::Sensor)
+MTS_CALL_TEMPLATE_END(Sensor)

--- a/include/mitsuba/render/shape.h
+++ b/include/mitsuba/render/shape.h
@@ -1079,7 +1079,7 @@ NAMESPACE_END(mitsuba)
 //! @{ \name Dr.Jit support for vectorized function calls
 // -----------------------------------------------------------------------
 
-MTS_CALL_TEMPLATE_BEGIN(Shape)
+MI_CALL_TEMPLATE_BEGIN(Shape)
     DRJIT_CALL_METHOD(compute_surface_interaction)
     DRJIT_CALL_METHOD(has_attribute)
     DRJIT_CALL_METHOD(eval_attribute)
@@ -1112,7 +1112,7 @@ MTS_CALL_TEMPLATE_BEGIN(Shape)
     auto is_mesh() const { return shape_type() == (uint32_t) mitsuba::ShapeType::Mesh; }
     auto is_medium_transition() const { return interior_medium() != nullptr ||
                                                exterior_medium() != nullptr; }
-MTS_CALL_TEMPLATE_END(Shape)
+MI_CALL_TEMPLATE_END(Shape)
 
 //! @}
 // -----------------------------------------------------------------------

--- a/include/mitsuba/render/shape.h
+++ b/include/mitsuba/render/shape.h
@@ -1079,7 +1079,7 @@ NAMESPACE_END(mitsuba)
 //! @{ \name Dr.Jit support for vectorized function calls
 // -----------------------------------------------------------------------
 
-DRJIT_CALL_TEMPLATE_BEGIN(mitsuba::Shape)
+MTS_CALL_TEMPLATE_BEGIN(Shape)
     DRJIT_CALL_METHOD(compute_surface_interaction)
     DRJIT_CALL_METHOD(has_attribute)
     DRJIT_CALL_METHOD(eval_attribute)
@@ -1112,7 +1112,7 @@ DRJIT_CALL_TEMPLATE_BEGIN(mitsuba::Shape)
     auto is_mesh() const { return shape_type() == (uint32_t) mitsuba::ShapeType::Mesh; }
     auto is_medium_transition() const { return interior_medium() != nullptr ||
                                                exterior_medium() != nullptr; }
-DRJIT_CALL_END(mitsuba::Shape)
+MTS_CALL_TEMPLATE_END(Shape)
 
 //! @}
 // -----------------------------------------------------------------------

--- a/resources/configure.py
+++ b/resources/configure.py
@@ -28,6 +28,7 @@ def write_core_config_cpp(f, enabled, default_variant):
     f.write('   helper various macros to instantiate multiple variants of Mitsuba. */\n\n')
 
     f.write('#pragma once\n\n')
+    f.write('#include <array>\n')
     f.write('#include <mitsuba/core/fwd.h>\n')
 
     enable_jit = False
@@ -89,6 +90,7 @@ def write_core_config_cpp(f, enabled, default_variant):
 
     f.write('NAMESPACE_BEGIN(mitsuba)\n')
     f.write('NAMESPACE_BEGIN(detail)\n')
+
     f.write('/// Convert a <Float, Spectrum> type pair into one of the strings in MI_VARIANT\n')
     f.write('template <typename Float_, typename Spectrum_> constexpr const char *get_variant() {\n')
     for index, (name, float_, spectrum) in enumerate(enabled):
@@ -98,6 +100,18 @@ def write_core_config_cpp(f, enabled, default_variant):
     f.write('    else\n')
     f.write('        return "";\n')
     f.write('}\n')
+
+    max_len = max(len(e[0]) for e in enabled)
+    f.write('/// Convert a <Float, Spectrum> type pair into a fixed-length string\n')
+    f.write('template <typename Float_, typename Spectrum_> constexpr std::array<char, %d> get_variant_padded() {\n' % (max_len+1))
+    for index, (name, float_, spectrum) in enumerate(enabled):
+        f.write('    %sif constexpr (std::is_same_v<Float_, %s> &&\n' % ('else ' if index > 0 else '', float_))
+        f.write('    %s              std::is_same_v<Spectrum_, %s>)\n' % ('     ' if index > 0 else '', spectrum))
+        f.write('        return std::array<char, %d>{"%s"};\n' % (max_len+1, name.ljust(max_len, '_')))
+    f.write('    else\n')
+    f.write('        return std::array<char, %d>{"%s"};\n' % (max_len+1, '_' * max_len))
+    f.write('}\n')
+
     f.write('NAMESPACE_END(detail)\n')
     f.write('NAMESPACE_END(mitsuba)\n')
 

--- a/src/core/tests/test_python.py
+++ b/src/core/tests/test_python.py
@@ -135,3 +135,23 @@ def test09_import_torch_order(order):
     })
 
     print(bsdf)
+
+
+def test10_variant_switching_vcall():
+    import mitsuba as mi
+
+    # Switch variants between two scenes and try to render the second scene.
+    # This will only work if the two scenes do not share the same JIT vectorized
+    # call registry
+    if ('llvm_ad_spectral' not in mi.variants() or
+        'llvm_ad_rgb' not in mi.variants()):
+        pytest.skip(f"Missing variants to properly run the test.")
+
+    mi.set_variant('llvm_ad_spectral')
+    scene1 = mi.load_dict(mi.cornell_box())
+
+    mi.set_variant('llvm_ad_rgb')
+    scene2 = mi.load_dict(mi.cornell_box())
+
+    mi.render(scene2, spp=1)
+

--- a/src/render/bsdf.cpp
+++ b/src/render/bsdf.cpp
@@ -8,7 +8,7 @@ NAMESPACE_BEGIN(mitsuba)
 
 MI_VARIANT BSDF<Float, Spectrum>::BSDF(const Properties &props)
     : m_flags(+BSDFFlags::Empty), m_id(props.id()) {
-    variant_registry_put<Float, Spectrum>("BSDF", this);
+    MTS_REGISTRY_PUT("BSDF", this);
 }
 
 MI_VARIANT BSDF<Float, Spectrum>::~BSDF() {

--- a/src/render/bsdf.cpp
+++ b/src/render/bsdf.cpp
@@ -8,7 +8,7 @@ NAMESPACE_BEGIN(mitsuba)
 
 MI_VARIANT BSDF<Float, Spectrum>::BSDF(const Properties &props)
     : m_flags(+BSDFFlags::Empty), m_id(props.id()) {
-    MTS_REGISTRY_PUT("BSDF", this);
+    MI_REGISTRY_PUT("BSDF", this);
 }
 
 MI_VARIANT BSDF<Float, Spectrum>::~BSDF() {

--- a/src/render/bsdf.cpp
+++ b/src/render/bsdf.cpp
@@ -8,8 +8,7 @@ NAMESPACE_BEGIN(mitsuba)
 
 MI_VARIANT BSDF<Float, Spectrum>::BSDF(const Properties &props)
     : m_flags(+BSDFFlags::Empty), m_id(props.id()) {
-    if constexpr (dr::is_jit_v<Float>)
-        jit_registry_put(dr::backend_v<Float>, "mitsuba::BSDF", this);
+    variant_registry_put<Float, Spectrum>("BSDF", this);
 }
 
 MI_VARIANT BSDF<Float, Spectrum>::~BSDF() {

--- a/src/render/emitter.cpp
+++ b/src/render/emitter.cpp
@@ -9,7 +9,7 @@ MI_VARIANT Emitter<Float, Spectrum>::Emitter(const Properties &props)
     : Base(props) {
         m_sampling_weight = props.get<ScalarFloat>("sampling_weight", 1.0f);
 
-        MTS_REGISTRY_PUT("Emitter", this);
+        MI_REGISTRY_PUT("Emitter", this);
     }
 
 MI_VARIANT Emitter<Float, Spectrum>::~Emitter() {

--- a/src/render/emitter.cpp
+++ b/src/render/emitter.cpp
@@ -9,11 +9,10 @@ MI_VARIANT Emitter<Float, Spectrum>::Emitter(const Properties &props)
     : Base(props) {
         m_sampling_weight = props.get<ScalarFloat>("sampling_weight", 1.0f);
 
-        if constexpr (dr::is_jit_v<Float>)
-            jit_registry_put(dr::backend_v<Float>, "mitsuba::Emitter", this);
+        variant_registry_put<Float, Spectrum>("Emitter", this);
     }
 
-MI_VARIANT Emitter<Float, Spectrum>::~Emitter() { 
+MI_VARIANT Emitter<Float, Spectrum>::~Emitter() {
     if constexpr (dr::is_jit_v<Float>)
         jit_registry_remove(this);
 }

--- a/src/render/emitter.cpp
+++ b/src/render/emitter.cpp
@@ -9,7 +9,7 @@ MI_VARIANT Emitter<Float, Spectrum>::Emitter(const Properties &props)
     : Base(props) {
         m_sampling_weight = props.get<ScalarFloat>("sampling_weight", 1.0f);
 
-        variant_registry_put<Float, Spectrum>("Emitter", this);
+        MTS_REGISTRY_PUT("Emitter", this);
     }
 
 MI_VARIANT Emitter<Float, Spectrum>::~Emitter() {

--- a/src/render/medium.cpp
+++ b/src/render/medium.cpp
@@ -11,7 +11,7 @@ MI_VARIANT Medium<Float, Spectrum>::Medium() :
     m_is_homogeneous(false),
     m_has_spectral_extinction(true) {
 
-    MTS_REGISTRY_PUT("Medium", this);
+    MI_REGISTRY_PUT("Medium", this);
 }
 
 MI_VARIANT Medium<Float, Spectrum>::Medium(const Properties &props) : m_id(props.id()) {
@@ -32,7 +32,7 @@ MI_VARIANT Medium<Float, Spectrum>::Medium(const Properties &props) : m_id(props
 
     m_sample_emitters = props.get<bool>("sample_emitters", true);
 
-    MTS_REGISTRY_PUT("Medium", this);
+    MI_REGISTRY_PUT("Medium", this);
 }
 
 MI_VARIANT Medium<Float, Spectrum>::~Medium() {

--- a/src/render/medium.cpp
+++ b/src/render/medium.cpp
@@ -11,7 +11,7 @@ MI_VARIANT Medium<Float, Spectrum>::Medium() :
     m_is_homogeneous(false),
     m_has_spectral_extinction(true) {
 
-    variant_registry_put<Float, Spectrum>("Medium", this);
+    MTS_REGISTRY_PUT("Medium", this);
 }
 
 MI_VARIANT Medium<Float, Spectrum>::Medium(const Properties &props) : m_id(props.id()) {
@@ -32,7 +32,7 @@ MI_VARIANT Medium<Float, Spectrum>::Medium(const Properties &props) : m_id(props
 
     m_sample_emitters = props.get<bool>("sample_emitters", true);
 
-    variant_registry_put<Float, Spectrum>("Medium", this);
+    MTS_REGISTRY_PUT("Medium", this);
 }
 
 MI_VARIANT Medium<Float, Spectrum>::~Medium() {

--- a/src/render/medium.cpp
+++ b/src/render/medium.cpp
@@ -7,12 +7,11 @@
 
 NAMESPACE_BEGIN(mitsuba)
 
-MI_VARIANT Medium<Float, Spectrum>::Medium() : 
-    m_is_homogeneous(false), 
+MI_VARIANT Medium<Float, Spectrum>::Medium() :
+    m_is_homogeneous(false),
     m_has_spectral_extinction(true) {
 
-    if constexpr (dr::is_jit_v<Float>)
-        jit_registry_put(dr::backend_v<Float>, "mitsuba::Medium", this);
+    variant_registry_put<Float, Spectrum>("Medium", this);
 }
 
 MI_VARIANT Medium<Float, Spectrum>::Medium(const Properties &props) : m_id(props.id()) {
@@ -33,8 +32,7 @@ MI_VARIANT Medium<Float, Spectrum>::Medium(const Properties &props) : m_id(props
 
     m_sample_emitters = props.get<bool>("sample_emitters", true);
 
-    if constexpr (dr::is_jit_v<Float>)
-        jit_registry_put(dr::backend_v<Float>, "mitsuba::Medium", this);
+    variant_registry_put<Float, Spectrum>("Medium", this);
 }
 
 MI_VARIANT Medium<Float, Spectrum>::~Medium() {

--- a/src/render/phase.cpp
+++ b/src/render/phase.cpp
@@ -7,7 +7,7 @@ NAMESPACE_BEGIN(mitsuba)
 MI_VARIANT
 PhaseFunction<Float, Spectrum>::PhaseFunction(const Properties &props)
     : m_flags(+PhaseFunctionFlags::Empty), m_id(props.id()) {
-    variant_registry_put<Float, Spectrum>("PhaseFunction", this);
+    MTS_REGISTRY_PUT("PhaseFunction", this);
 }
 
 MI_VARIANT PhaseFunction<Float, Spectrum>::~PhaseFunction() {

--- a/src/render/phase.cpp
+++ b/src/render/phase.cpp
@@ -7,8 +7,7 @@ NAMESPACE_BEGIN(mitsuba)
 MI_VARIANT
 PhaseFunction<Float, Spectrum>::PhaseFunction(const Properties &props)
     : m_flags(+PhaseFunctionFlags::Empty), m_id(props.id()) {
-    if constexpr (dr::is_jit_v<Float>)
-        jit_registry_put(dr::backend_v<Float>, "mitsuba::PhaseFunction", this);
+    variant_registry_put<Float, Spectrum>("PhaseFunction", this);
 }
 
 MI_VARIANT PhaseFunction<Float, Spectrum>::~PhaseFunction() {

--- a/src/render/phase.cpp
+++ b/src/render/phase.cpp
@@ -7,7 +7,7 @@ NAMESPACE_BEGIN(mitsuba)
 MI_VARIANT
 PhaseFunction<Float, Spectrum>::PhaseFunction(const Properties &props)
     : m_flags(+PhaseFunctionFlags::Empty), m_id(props.id()) {
-    MTS_REGISTRY_PUT("PhaseFunction", this);
+    MI_REGISTRY_PUT("PhaseFunction", this);
 }
 
 MI_VARIANT PhaseFunction<Float, Spectrum>::~PhaseFunction() {

--- a/src/render/sensor.cpp
+++ b/src/render/sensor.cpp
@@ -72,7 +72,7 @@ MI_VARIANT Sensor<Float, Spectrum>::Sensor(const Properties &props) : Base(props
         }
     }
 
-    variant_registry_put<Float, Spectrum>("Sensor", this);
+    MTS_REGISTRY_PUT("Sensor", this);
 }
 
 MI_VARIANT Sensor<Float, Spectrum>::~Sensor() {

--- a/src/render/sensor.cpp
+++ b/src/render/sensor.cpp
@@ -72,7 +72,7 @@ MI_VARIANT Sensor<Float, Spectrum>::Sensor(const Properties &props) : Base(props
         }
     }
 
-    MTS_REGISTRY_PUT("Sensor", this);
+    MI_REGISTRY_PUT("Sensor", this);
 }
 
 MI_VARIANT Sensor<Float, Spectrum>::~Sensor() {

--- a/src/render/sensor.cpp
+++ b/src/render/sensor.cpp
@@ -72,8 +72,7 @@ MI_VARIANT Sensor<Float, Spectrum>::Sensor(const Properties &props) : Base(props
         }
     }
 
-    if constexpr (dr::is_jit_v<Float>)
-        jit_registry_put(dr::backend_v<Float>, "mitsuba::Sensor", this);
+    variant_registry_put<Float, Spectrum>("Sensor", this);
 }
 
 MI_VARIANT Sensor<Float, Spectrum>::~Sensor() {

--- a/src/render/shape.cpp
+++ b/src/render/shape.cpp
@@ -71,8 +71,7 @@ MI_VARIANT Shape<Float, Spectrum>::Shape(const Properties &props) : m_id(props.i
 
     m_silhouette_sampling_weight = props.get<ScalarFloat>("silhouette_sampling_weight", 1.0f);
 
-    if constexpr (dr::is_jit_v<Float>)
-        jit_registry_put(dr::backend_v<Float>, "mitsuba::Shape", this);
+    variant_registry_put<Float, Spectrum>("Shape", this);
 }
 
 MI_VARIANT Shape<Float, Spectrum>::~Shape() {

--- a/src/render/shape.cpp
+++ b/src/render/shape.cpp
@@ -71,7 +71,7 @@ MI_VARIANT Shape<Float, Spectrum>::Shape(const Properties &props) : m_id(props.i
 
     m_silhouette_sampling_weight = props.get<ScalarFloat>("silhouette_sampling_weight", 1.0f);
 
-    variant_registry_put<Float, Spectrum>("Shape", this);
+    MTS_REGISTRY_PUT("Shape", this);
 }
 
 MI_VARIANT Shape<Float, Spectrum>::~Shape() {

--- a/src/render/shape.cpp
+++ b/src/render/shape.cpp
@@ -71,7 +71,7 @@ MI_VARIANT Shape<Float, Spectrum>::Shape(const Properties &props) : m_id(props.i
 
     m_silhouette_sampling_weight = props.get<ScalarFloat>("silhouette_sampling_weight", 1.0f);
 
-    MTS_REGISTRY_PUT("Shape", this);
+    MI_REGISTRY_PUT("Shape", this);
 }
 
 MI_VARIANT Shape<Float, Spectrum>::~Shape() {

--- a/src/render/shapegroup.cpp
+++ b/src/render/shapegroup.cpp
@@ -79,7 +79,7 @@ MI_VARIANT ShapeGroup<Float, Spectrum>::ShapeGroup(const Properties &props) {
     }
 #endif
 
-    variant_registry_put<Float, Spectrum>("ShapeGroup", this);
+    MTS_REGISTRY_PUT("ShapeGroup", this);
 }
 
 MI_VARIANT ShapeGroup<Float, Spectrum>::~ShapeGroup() {

--- a/src/render/shapegroup.cpp
+++ b/src/render/shapegroup.cpp
@@ -79,8 +79,7 @@ MI_VARIANT ShapeGroup<Float, Spectrum>::ShapeGroup(const Properties &props) {
     }
 #endif
 
-    if constexpr (dr::is_jit_v<Float>)
-        jit_registry_put(dr::backend_v<Float>, "mitsuba::ShapeGroup", this);
+    variant_registry_put<Float, Spectrum>("ShapeGroup", this);
 }
 
 MI_VARIANT ShapeGroup<Float, Spectrum>::~ShapeGroup() {

--- a/src/render/shapegroup.cpp
+++ b/src/render/shapegroup.cpp
@@ -79,7 +79,7 @@ MI_VARIANT ShapeGroup<Float, Spectrum>::ShapeGroup(const Properties &props) {
     }
 #endif
 
-    MTS_REGISTRY_PUT("ShapeGroup", this);
+    MI_REGISTRY_PUT("ShapeGroup", this);
 }
 
 MI_VARIANT ShapeGroup<Float, Spectrum>::~ShapeGroup() {

--- a/src/shapes/merge.cpp
+++ b/src/shapes/merge.cpp
@@ -52,7 +52,7 @@ public:
         Log(Info, "Collapsed %zu into %zu meshes. (took %s, %zu objects ignored)",
             visited, tbl.size(), util::time_string((float) timer.value()), ignored);
 
-        MTS_REGISTRY_PUT("Shape", this);
+        MI_REGISTRY_PUT("Shape", this);
     }
 
     std::vector<ref<Object>> expand() const override {

--- a/src/shapes/merge.cpp
+++ b/src/shapes/merge.cpp
@@ -52,8 +52,7 @@ public:
         Log(Info, "Collapsed %zu into %zu meshes. (took %s, %zu objects ignored)",
             visited, tbl.size(), util::time_string((float) timer.value()), ignored);
 
-        if constexpr (dr::is_jit_v<Float>)
-            jit_registry_put(dr::backend_v<Float>, "mitsuba::Shape", this);
+        variant_registry_put<Float, Spectrum>("Shape", this);
     }
 
     std::vector<ref<Object>> expand() const override {

--- a/src/shapes/merge.cpp
+++ b/src/shapes/merge.cpp
@@ -52,7 +52,7 @@ public:
         Log(Info, "Collapsed %zu into %zu meshes. (took %s, %zu objects ignored)",
             visited, tbl.size(), util::time_string((float) timer.value()), ignored);
 
-        variant_registry_put<Float, Spectrum>("Shape", this);
+        MTS_REGISTRY_PUT("Shape", this);
     }
 
     std::vector<ref<Object>> expand() const override {


### PR DESCRIPTION
## Description

Previously, we could easily segfault when performing a vcall if an object was previously created with another variant. For example, a `spectral_polarized` BSDF and an `rgb` BSDF.

Other than fixing the case below, I don't think this change could hurt since we never need or want instances from different variants to participate in the same vcalls (?).

## Testing

```py
import drjit as dr
import mitsuba as mi

def test01_test_variants_switching():
    mi.set_variant('cuda_ad_mono_polarized')
    # Unused, but registers objects into the registry
    scene1 = mi.load_dict(mi.cornell_box())

    mi.set_variant('cuda_ad_rgb')
    scene2 = mi.load_dict(mi.cornell_box())
   
    # Before this PR, this would segfault when e.g. collecting the results of the BSDF vcall,
    # because the `Spectrum` types of the BSDF instances were not compatible.
    image = mi.render(scene2)
    print(image)


if __name__ == "__main__":
    test01_test_variants_switching()
```


## Checklist

<!-- Please make sure to complete this checklist before requesting a review. -->

- [x] My code follows the [style guidelines](https://mitsuba.readthedocs.io/en/latest/src/developer_guide.html#coding-style) of this project
- [x] My changes generate no new warnings
- [x] My code also compiles for `cuda_*` and `llvm_*` variants. If you can't test this, please leave below
- [x] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 3 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba/blob/master/LICENSE)