### PR TITLE
Fix small compilation warnings (Clang 19)

### DIFF
--- a/include/mitsuba/core/ray.h
+++ b/include/mitsuba/core/ray.h
@@ -17,15 +17,16 @@ NAMESPACE_BEGIN(mitsuba)
 template <typename Point_, typename Spectrum_> struct Ray {
     static constexpr size_t Size = dr::size_v<Point_>;
 
-    using Point      = Point_;
+    using Point       = Point_;
     // TODO: need this because dr::value_t<MaskedArray<Point3f>> isn't a masked array
     using Float =
         std::conditional_t<dr::is_masked_array_v<Point>,
                            dr::detail::MaskedArray<dr::value_t<Point>>,
                            dr::value_t<Point>>;
-    using Vector     = mitsuba::Vector<Float, Size>;
-    using Spectrum   = Spectrum_;
-    using Wavelength = wavelength_t<Spectrum_>;
+    using ScalarFloat = dr::scalar_t<Float>;
+    using Vector      = mitsuba::Vector<Float, Size>;
+    using Spectrum    = Spectrum_;
+    using Wavelength  = wavelength_t<Spectrum_>;
 
     /// Ray origin
     Point o;
@@ -34,7 +35,7 @@ template <typename Point_, typename Spectrum_> struct Ray {
     /// Maximum position on the ray segment
     Float maxt = dr::Largest<Float>;
     /// Time value associated with this ray
-    Float time = 0.f;
+    Float time = (ScalarFloat) 0.f;
     /// Wavelength associated with the ray
     Wavelength wavelengths;
 
@@ -44,7 +45,7 @@ template <typename Point_, typename Spectrum_> struct Ray {
         : o(o), d(d), time(time), wavelengths(wavelengths) { }
 
     /// Construct a new ray (o, d) with time
-    Ray(const Point &o, const Vector &d, const Float &time=0.f)
+    Ray(const Point &o, const Vector &d, const Float &time = (ScalarFloat) 0.f)
         : o(o), d(d), time(time) { }
 
     /// Construct a new ray (o, d) with bounds
@@ -82,7 +83,7 @@ template <typename Point_, typename Spectrum_>
 struct RayDifferential : Ray<Point_, Spectrum_> {
     using Base = Ray<Point_, Spectrum_>;
 
-    MI_USING_TYPES(Float, Point, Vector, Wavelength)
+    MI_USING_TYPES(Float, ScalarFloat, Point, Vector, Wavelength)
     MI_USING_MEMBERS(o, d, maxt, time, wavelengths)
 
     Point o_x, o_y;
@@ -94,7 +95,7 @@ struct RayDifferential : Ray<Point_, Spectrum_> {
         : Base(ray), o_x(0), o_y(0), d_x(0), d_y(0), has_differentials(false) {}
 
     /// Construct a new ray (o, d) at time 'time'
-    RayDifferential(const Point &o_, const Vector &d_, Float time_ = 0.f,
+    RayDifferential(const Point &o_, const Vector &d_, Float time_ = (ScalarFloat) 0.f,
                     const Wavelength &wavelengths_ = Wavelength())
         : o_x(0), o_y(0), d_x(0), d_y(0), has_differentials(false) {
         o           = o_;

--- a/src/core/python/ray_v.cpp
+++ b/src/core/python/ray_v.cpp
@@ -5,21 +5,26 @@
 template<typename Ray>
 void bind_ray(nb::module_ &m, const char *name) {
     MI_PY_IMPORT_TYPES()
-    using Vector = typename Ray::Vector;
-    using Point  = typename Ray::Point;
+    // Re-import this specific `Ray`'s types in cased of mixed precision
+    // between Float and Spectrum.
+    using RayFloat       = typename Ray::Float;
+    using RayScalarFloat = typename Ray::ScalarFloat;
+    using RayWavelength  = typename Ray::Wavelength;
+    using Vector         = typename Ray::Vector;
+    using Point          = typename Ray::Point;
 
     MI_PY_CHECK_ALIAS(Ray, name) {
         auto ray = nb::class_<Ray>(m, name, D(Ray))
             .def(nb::init<>(), "Create an uninitialized ray")
             .def(nb::init<const Ray &>(), "Copy constructor", "other"_a)
-            .def(nb::init<Point, Vector, Float, const Wavelength &>(),
+            .def(nb::init<Point, Vector, RayFloat, const RayWavelength &>(),
                  D(Ray, Ray, 2),
-                 "o"_a, "d"_a, "time"_a=0.0, "wavelengths"_a=Wavelength())
-            .def(nb::init<Point, Vector, Float, Float, const Wavelength &>(),
+                 "o"_a, "d"_a, "time"_a=(RayScalarFloat) 0.0, "wavelengths"_a=RayWavelength())
+            .def(nb::init<Point, Vector, RayFloat, RayFloat, const RayWavelength &>(),
                  D(Ray, Ray, 3),
-                "o"_a, "d"_a, "maxt"_a, "time"_a, "wavelengths"_a)
-            .def(nb::init<const Ray &, Float>(),
-                D(Ray, Ray, 4), "other"_a, "maxt"_a)
+                 "o"_a, "d"_a, "maxt"_a, "time"_a, "wavelengths"_a)
+            .def(nb::init<const Ray &, RayFloat>(),
+                 D(Ray, Ray, 4), "other"_a, "maxt"_a)
             .def("__call__", &Ray::operator(), D(Ray, operator, call), "t"_a)
             .def_field(Ray, o,           D(Ray, o))
             .def_field(Ray, d,           D(Ray, d))
@@ -45,7 +50,7 @@ MI_PY_EXPORT(Ray) {
             .def(nb::init<const Ray3f &>(), "ray"_a)
             .def(nb::init<Point3f, Vector3f, Float, const Wavelength &>(),
                  "Initialize without differentials.",
-                 "o"_a, "d"_a, "time"_a=0.0, "wavelengths"_a=Wavelength())
+                 "o"_a, "d"_a, "time"_a=(ScalarFloat) 0.0, "wavelengths"_a=Wavelength())
             .def("scale_differential", &RayDifferential3f::scale_differential,
                  "amount"_a, D(RayDifferential, scale_differential))
             .def_field(RayDifferential3f, o_x, D(RayDifferential, o_x))


### PR DESCRIPTION
## Description

Fixes small precision-related compilation warnings that occurred with Clang 19.

## Checklist

<!-- Please make sure to complete this checklist before requesting a review. -->

- [x] My code follows the [style guidelines](https://mitsuba.readthedocs.io/en/latest/src/developer_guide.html#coding-style) of this project
- [x] My changes generate no new warnings
- [x] My code also compiles for `cuda_*` and `llvm_*` variants. If you can't test this, please leave below
- [ ] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 3 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba/blob/master/LICENSE)