### PR TITLE
`RadianceMeter::sample_ray_differential`  JIT zero initialize `RayDifferential`

### DIFF
--- a/src/sensors/radiancemeter.cpp
+++ b/src/sensors/radiancemeter.cpp
@@ -124,7 +124,7 @@ public:
                             const Point2f & /*aperture_sample*/,
                             Mask active) const override {
         MI_MASKED_FUNCTION(ProfilerPhase::EndpointSampleRay, active);
-        RayDifferential3f ray;
+        RayDifferential3f ray = dr::zeros<RayDifferential3f>();
         ray.time = time;
 
         // 1. Sample spectrum


### PR DESCRIPTION
Proposed fix for #1196. When used as an inner sensor to the batch sensor, we still need `ray.o_x` and `ray.o_y` to be valid JIT variables even if they're not used (`ray.has_differentials = false`).

This is because here `sample_ray_differential` is now a vectorized call which checks that the return type of variables for each callable are valid, which in particular includes all variables within the traversed `RayDifferential` Dr.Jit struct