### PR TITLE
Fix mi.sample_tea_float return type

### DIFF
--- a/include/mitsuba/core/random.h
+++ b/include/mitsuba/core/random.h
@@ -165,9 +165,9 @@ dr::float64_array_t<UInt32> sample_tea_float64(UInt32 v0, UInt32 v1, int rounds 
 
 
 /// Alias to \ref sample_tea_float32 or \ref sample_tea_float64 based given type size
-template <typename UInt>
-auto sample_tea_float(UInt v0, UInt v1, int rounds = 4) {
-    if constexpr(std::is_same_v<dr::scalar_t<UInt>, uint32_t>)
+template <typename Float, typename UInt32>
+auto sample_tea_float(UInt32 v0, UInt32 v1, int rounds = 4) {
+    if constexpr(std::is_same_v<dr::scalar_t<Float>, float>)
         return sample_tea_float32(v0, v1, rounds);
     else
         return sample_tea_float64(v0, v1, rounds);

--- a/src/core/python/random_v.cpp
+++ b/src/core/python/random_v.cpp
@@ -36,7 +36,7 @@ MI_PY_EXPORT(sample_tea) {
           "v0"_a, "v1"_a, "rounds"_a = 4, D(sample_tea_float64));
 
     m.attr("sample_tea_float") = m.attr(
-        sizeof(Float) != sizeof(Float64) ? "sample_tea_float32" : "sample_tea_float64");
+        sizeof(dr::scalar_t<Float>) != sizeof(dr::scalar_t<Float64>) ? "sample_tea_float32" : "sample_tea_float64");
 
     m.def("permute",
           permute<UInt32>,

--- a/src/core/tests/test_random.py
+++ b/src/core/tests/test_random.py
@@ -93,5 +93,6 @@ def test07_permute_kensler_uniform(variant_scalar_rgb):
         assert dr.allclose(1.0 / sample_count, mean)
 
 def test08_sample_tea_float(variants_all):
+    """Check that the return type of `mi.sample_tea_float` is correct, given the chosen variant."""
     f = mi.sample_tea_float(mi.UInt(0), mi.UInt(0))
     assert type(f) == mi.Float

--- a/src/core/tests/test_random.py
+++ b/src/core/tests/test_random.py
@@ -91,3 +91,7 @@ def test07_permute_kensler_uniform(variant_scalar_rgb):
 
         mean = np.mean(histogram)
         assert dr.allclose(1.0 / sample_count, mean)
+
+def test08_sample_tea_float(variants_all):
+    f = mi.sample_tea_float(mi.UInt(0), mi.UInt(0))
+    assert type(f) == mi.Float


### PR DESCRIPTION
<!-- Please add the labels (e.g. bug fix, feature, ..) corresponding to this PR -->

## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->
When calling `mi.sample_tea_float` the delegated function was chosen incorrectly, always selecting the `Float64` version.
On the C++ side the opposite happened, always selecting the `Float32` version.

The python fix is straight forward.
On the C++ side I added the result `Float` type as an additional template argument, because I did not see any other way to query the equivalent of `mi.Float` reliably. `MI_VARIANT_FLOAT` is not always to be defined.

## Testing

<!-- Please describe the tests that you added to verify your changes. -->
I have added `test08_sample_tea_float` to `test_random.py` to test the return type in the Python interface.

## Checklist

<!-- Please make sure to complete this checklist before requesting a review. -->

- [x] My code follows the [style guidelines](https://mitsuba.readthedocs.io/en/latest/src/developer_guide.html#coding-style) of this project
- [x] My changes generate no new warnings
- [x] My code also compiles for `cuda_*` and `llvm_*` variants. If you can't test this, please leave below
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 3 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba/blob/master/LICENSE)