### PR TITLE
setpath.ps1: Set `MITSUBA_DIR` to the directory of the Powershell script

### DIFF
--- a/resources/setpath.ps1
+++ b/resources/setpath.ps1
@@ -4,6 +4,6 @@
 # * named 'build'.
 # ***************************************************************
 
-$env:MITSUBA_DIR = Get-Location
+$env:MITSUBA_DIR = $PSScriptRoot
 $env:PATH = $env:MITSUBA_DIR + ";" + $env:PATH
 $env:PYTHONPATH = $env:MITSUBA_DIR + "\python" + ";" + $env:PYTHONPATH


### PR DESCRIPTION
<!-- Please add the labels (e.g. bug fix, feature, ..) corresponding to this PR -->

## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

The Powershell script `setpath.ps1` behaves differently from the other two scripts: it uses `Get-Location` to set `MITSUBA_DIR`, which sets it to the current _working directory_ and not the directory of the script: executing `setpath.ps1` from the repository root, therefore, does not set the proper PYTHONPATH.

Instead of `Get-Location`, this PR uses the variable `$PSScriptRoot` to get the proper script directory.

## Testing

<!-- Please describe the tests that you added to verify your changes. -->

Before the change.

```bash
PS path\to\mitsuba3> .\build\Release\setpath.ps1
PS path\to\mitsuba3> ${env:PYTHONPATH}
path\to\mitsuba3\python;
```
After the change.

```bash
PS path\to\mitsuba3> .\build\Release\setpath.ps1
PS path\to\mitsuba3> ${env:PYTHONPATH}
path\to\mitsuba3\build\Release\python;
```

## Checklist

<!-- Please make sure to complete this checklist before requesting a review. -->

- [X] My code follows the [style guidelines](https://mitsuba.readthedocs.io/en/latest/src/developer_guide.html#coding-style) of this project
- [X] My changes generate no new warnings
- [ ] My code also compiles for `cuda_*` and `llvm_*` variants. If you can't test this, please leave below
- [ ] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I cleaned the commit history and removed any "Merge" commits
- [X] I give permission that the Mitsuba 3 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba/blob/master/LICENSE)