### PR TITLE
Implement `SpotLight::eval_direction`

### DIFF
--- a/src/emitters/spot.cpp
+++ b/src/emitters/spot.cpp
@@ -197,7 +197,6 @@ public:
         active &= falloff > 0.f;  // Avoid invalid texture lookups
 
         SurfaceInteraction3f si      = dr::zeros<SurfaceInteraction3f>();
-        si.t                         = 0.f;
         si.time                      = it.time;
         si.wavelengths               = it.wavelengths;
         si.p                         = ds.p;
@@ -260,7 +259,6 @@ public:
         active &= falloff > 0.f;  // Avoid invalid texture lookups
 
         SurfaceInteraction3f si = dr::zeros<SurfaceInteraction3f>();
-        si.t                    = 0.f;
         si.time                 = it.time;
         si.wavelengths          = it.wavelengths;
         si.p                    = ds.p;

--- a/src/emitters/spot.cpp
+++ b/src/emitters/spot.cpp
@@ -249,6 +249,31 @@ public:
         return { wav, weight };
     }
 
+    Spectrum eval_direction(const Interaction3f &it,
+                            const DirectionSample3f &ds,
+                            Mask active) const override {
+        Float inv_dist = dr::rcp(ds.dist);
+        Vector3f local_d = m_to_world.value().inverse() * -ds.d;
+
+        // Evaluate emitted radiance & falloff profile
+        Float falloff = falloff_curve(local_d, active);
+        active &= falloff > 0.f;  // Avoid invalid texture lookups
+
+        SurfaceInteraction3f si = dr::zeros<SurfaceInteraction3f>();
+        si.t                    = 0.f;
+        si.time                 = it.time;
+        si.wavelengths          = it.wavelengths;
+        si.p                    = ds.p;
+
+        UnpolarizedSpectrum radiance = m_intensity->eval(si, active);
+        if (m_texture->is_spatially_varying()) {
+            si.uv = direction_to_uv(local_d);
+            radiance *= m_texture->eval(si, active);
+        }
+
+        return depolarizer<Spectrum>(radiance & active) * (falloff * dr::sqr(inv_dist));
+    }
+
     Spectrum eval(const SurfaceInteraction3f &, Mask) const override {
         return 0.f;
     }


### PR DESCRIPTION
## Description

Computing derivatives for scenes with spot lights results in an exception because the method `SpotLight::eval_direction` is not implemented. This PR adds the missing method.

The implementation reuses the relevant parts from `SpotLight::sample_direction`. ~~It is currently based on v3.5.2 because I could not get v3.6.0 to compile (even without any changes).~~ I've fixed the compilation and rebased the branch onto master.

## Testing

I've added tests to check that the spectrum output of `sample_direction` and `eval_direction` are equal.

## Checklist

- [x] My code follows the [style guidelines](https://mitsuba.readthedocs.io/en/latest/src/developer_guide.html#coding-style) of this project
- [x] My changes generate no new warnings
- [ ] My code also compiles for `cuda_*` and `llvm_*` variants. If you can't test this, please leave below
- [x] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 3 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba/blob/master/LICENSE)