### PR TITLE
[docs] Fix typo

### DIFF
--- a/docs/src/key_topics/scene_format.rst
+++ b/docs/src/key_topics/scene_format.rst
@@ -100,7 +100,7 @@ more complex example:
              (compact) binary representation -->
         <shape type="serialized">
             <string name="filename" value="lightsource.serialized"/>
-            <transform name="toWorld">
+            <transform name="to_world">
                 <translate x="5" y="-3" z="1"/>
             </transform>
 


### PR DESCRIPTION
## Description
Found a bit outdated scene example in the docs by accident.

## Checklist

- [ ] My code follows the [style guidelines](https://mitsuba.readthedocs.io/en/latest/src/developer_guide.html#coding-style) of this project
- [x] My changes generate no new warnings
- [ ] My code also compiles for `cuda_*` and `llvm_*` variants. If you can't test this, please leave below
- [ ] I have commented my code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 3 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba/blob/master/LICENSE)