### PR TITLE
Utilities for refactored Blender add-on

### DIFF
--- a/include/mitsuba/core/xml.h
+++ b/include/mitsuba/core/xml.h
@@ -3,6 +3,7 @@
 #include <mitsuba/mitsuba.h>
 #include <mitsuba/core/properties.h>
 #include <string>
+#include <map>
 
 /// Max level of nested <include> directives
 #define MI_XML_INCLUDE_MAX_RECURSION 15
@@ -94,9 +95,8 @@ extern MI_EXPORT_LIB std::vector<ref<Object>> expand_node(
 
 /// Read a Mitsuba XML file and return a list of pairs containing the
 /// name of the plugin and the corresponding populated Properties object
-extern MI_EXPORT_LIB std::vector<std::pair<std::string, Properties>> xml_to_properties(
-                                        const fs::path &path,
-                                        const std::string &variant);
+extern MI_EXPORT_LIB std::map<std::string, std::pair<std::string, Properties>>
+xml_to_properties(const fs::path &path, const std::string &variant);
 
 NAMESPACE_END(detail)
 

--- a/include/mitsuba/render/mesh.h
+++ b/include/mitsuba/render/mesh.h
@@ -428,6 +428,9 @@ protected:
      */
     void build_parameterization();
 
+    // Apply displacement map to vertex position (and recompute surface normals)
+    void apply_displacement_map();
+
     // Ensures that the sampling table are ready.
     DRJIT_INLINE void ensure_pmf_built() const {
         if (unlikely(m_area_pmf.empty()))
@@ -591,6 +594,9 @@ protected:
 
     /// Pointer to the scene that owns this mesh
     Scene<Float, Spectrum>* m_scene = nullptr;
+
+    /// Optional: displacement map to be applied during initialization
+    ref<Texture> m_displacement_map;
 };
 
 MI_EXTERN_CLASS(Mesh)

--- a/include/mitsuba/render/mesh.h
+++ b/include/mitsuba/render/mesh.h
@@ -16,7 +16,7 @@ NAMESPACE_BEGIN(mitsuba)
 template <typename Float, typename Spectrum>
 class MI_EXPORT_LIB Mesh : public Shape<Float, Spectrum> {
 public:
-    MI_IMPORT_TYPES()
+    MI_IMPORT_TYPES(BSDF, Texture)
     MI_IMPORT_BASE(Shape, m_to_world, mark_dirty, m_emitter, m_sensor, m_bsdf,
                    m_interior_medium, m_exterior_medium, m_is_instance,
                    m_discontinuity_types, m_shape_type, m_initialized)

--- a/src/core/python/CMakeLists.txt
+++ b/src/core/python/CMakeLists.txt
@@ -27,6 +27,7 @@ set(CORE_PY_SRC
   ${CMAKE_CURRENT_SOURCE_DIR}/appender.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/argparser.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/bitmap.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/blender.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/cast.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/filesystem.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/formatter.cpp

--- a/src/core/python/blender.cpp
+++ b/src/core/python/blender.cpp
@@ -1,0 +1,87 @@
+#include <nanobind/nanobind.h> // Needs to be first, to get `ref<T>` caster
+#include <mitsuba/python/python.h>
+#include <mitsuba/core/mstream.h>
+#include <mitsuba/core/bitmap.h>
+
+#include <drjit/python.h>
+#include <nanobind/ndarray.h>
+#include <nanobind/stl/string.h>
+#include <nanobind/stl/vector.h>
+#include <nanobind/stl/pair.h>
+
+/*
+ *  This file contains bindings for routines using in the Mitsuba-Blender add-on.
+ */
+
+// Blender struct to be used when object is passed using the `.as_pointer()` method.
+namespace blender {
+    struct ImBuf {
+        int x, y;
+        unsigned char planes;
+        int channels;
+        int flags;
+        char padding[24]; // Padding for other structs that are ignored here
+        float *data;
+        /// ...
+    };
+    struct RenderPass {
+        struct RenderPass *next, *prev;
+        int channels;
+        char name[64];
+        char chan_id[8];
+        ImBuf *ibuf;  // The only thing we are interested in
+        int rectx, recty;
+        // ...
+    };
+    struct PackedFile {
+        int size;
+        int seek;
+        const void *data;
+        void* padding;
+    };
+}
+
+using ContigCpuNdArray = nb::ndarray<nb::device::cpu, nb::c_contig>;
+
+MI_PY_EXPORT(blender) {
+    /// Routine to accelerates the writing of a numpy array image into a
+    /// RenderPass iBuf data buffer.
+    m.def("write_blender_framebuffer", [](ContigCpuNdArray data, const size_t ptr) {
+        blender::RenderPass *render_pass = reinterpret_cast<blender::RenderPass *>(ptr);
+
+          if (data.ndim() != 3)
+              throw nb::type_error("Invalid num of dimensions. Expected three!");
+
+          if (data.dtype() != nb::dtype<float>())
+              throw nb::type_error("Invalid array type. Expected float32!");
+
+          float* src = (float*) data.data();
+          float* dst = render_pass->ibuf->data;
+
+          const size_t width = data.shape(0);
+          const size_t height = data.shape(1);
+          const size_t src_channels = data.shape(2);
+          const size_t dst_channels = render_pass->channels;
+
+          for (size_t y = 0; y < height; ++y) {
+              size_t src_index = y * width * src_channels;
+              size_t dst_index = y * width * dst_channels;
+
+              for (size_t x = 0; x < width; ++x) {
+                  for (size_t c = 0; c < dst_channels; c++)
+                      dst[dst_index + c] = (c < src_channels ? src[src_index + c] : 1.f);
+
+                  src_index += src_channels;
+                  dst_index += dst_channels;
+              }
+        }
+    });
+
+    /// Routine to directly load a Bitmap image from a Blender packed file.
+    m.def("packed_file_to_bitmap", [](const size_t packed_file_ptr) {
+        blender::PackedFile *packed_file = reinterpret_cast<blender::PackedFile *>(packed_file_ptr);
+        ref<MemoryStream> stream = new MemoryStream((void *) packed_file->data, packed_file->size);
+        ref<Bitmap> bmp = new Bitmap(stream.get());
+        return bmp;
+    });
+}

--- a/src/core/python/properties_v.cpp
+++ b/src/core/python/properties_v.cpp
@@ -156,20 +156,20 @@ MI_PY_EXPORT(Properties) {
         // FIXME: Binding this enumeration leaks. Defining an internal enum to
         // an arbitrary class is fine, this seems to be specifically an issue
         // with defining an internal enum in Properties
-        //nb::enum_<Properties::Type>(p, "Type");
-            //.value("Bool",              Properties::Type::Bool,           D(Properties, Type, Bool))
-            //.value("Long",              Properties::Type::Long,           D(Properties, Type, Long))
-            //.value("Float",             Properties::Type::Float,          D(Properties, Type, Float))
-            //.value("Array3f",           Properties::Type::Array3f,        D(Properties, Type, Array3f))
-            //.value("Transform3f",       Properties::Type::Transform3f,    D(Properties, Type, Transform3f))
-            //.value("Transform4f",       Properties::Type::Transform4f,    D(Properties, Type, Transform4f))
-            //// .value("AnimatedTransform", Properties::Type::AnimatedTransform, D(Properties, Type, AnimatedTransform))
-            //.value("TensorHandle",      Properties::Type::Tensor,         D(Properties, Type, Tensor))
-            //.value("Color",             Properties::Type::Color,          D(Properties, Type, Color))
-            //.value("String",            Properties::Type::String,         D(Properties, Type, String))
-            //.value("NamedReference",    Properties::Type::NamedReference, D(Properties, Type, NamedReference))
-            //.value("Object",            Properties::Type::Object,         D(Properties, Type, Object))
-            //.value("Pointer",           Properties::Type::Pointer,        D(Properties, Type, Pointer))
-            //.export_values();
+        nb::enum_<Properties::Type>(p, "Type")
+            .value("Bool",              Properties::Type::Bool,           D(Properties, Type, Bool))
+            .value("Long",              Properties::Type::Long,           D(Properties, Type, Long))
+            .value("Float",             Properties::Type::Float,          D(Properties, Type, Float))
+            .value("Array3f",           Properties::Type::Array3f,        D(Properties, Type, Array3f))
+            .value("Transform3f",       Properties::Type::Transform3f,    D(Properties, Type, Transform3f))
+            .value("Transform4f",       Properties::Type::Transform4f,    D(Properties, Type, Transform4f))
+            // .value("AnimatedTransform", Properties::Type::AnimatedTransform, D(Properties, Type, AnimatedTransform))
+            .value("TensorHandle",      Properties::Type::Tensor,         D(Properties, Type, Tensor))
+            .value("Color",             Properties::Type::Color,          D(Properties, Type, Color))
+            .value("String",            Properties::Type::String,         D(Properties, Type, String))
+            .value("NamedReference",    Properties::Type::NamedReference, D(Properties, Type, NamedReference))
+            .value("Object",            Properties::Type::Object,         D(Properties, Type, Object))
+            .value("Pointer",           Properties::Type::Pointer,        D(Properties, Type, Pointer))
+            .export_values();
     }
 }

--- a/src/core/tests/test_xml.py
+++ b/src/core/tests/test_xml.py
@@ -327,7 +327,7 @@ def test26_xml_to_props_empty_scene(variant_scalar_rgb, tmp_path):
     props = mi.xml_to_props(filepath)
     assert len(props) == 1
 
-    class_name, properties = props[0]
+    class_name, properties = next(iter(props.values()))
     assert class_name == 'Scene'
     assert properties.plugin_name() == 'scene'
     assert len(properties.property_names()) == 0
@@ -350,13 +350,13 @@ def test27_xml_to_props_named_references(variant_scalar_rgb, tmp_path):
     assert len(props) == 2
 
     has_scene = False
-    for cls, prop in props:
+    for cls, prop in iter(props.values()):
         if cls == 'Scene':
             has_scene = True
             assert len(prop.named_references()) == 1
             _, ref_id = prop.named_references()[0]
             has_ref_id = False
-            for cls, prop in props:
+            for cls, prop in iter(props.values()):
                 if prop.id() == ref_id:
                     has_ref_id = True
                     assert prop.plugin_name() == 'point'
@@ -383,7 +383,7 @@ def test28_xml_to_props_property_args(variant_scalar_rgb, tmp_path):
     assert len(props) == 2
 
     has_sphere = False
-    for _, prop in props:
+    for _, prop in iter(props.values()):
         if prop.plugin_name() == 'sphere':
             has_sphere = True
             assert dr.allclose(prop['center'], [0, 0, -10])

--- a/src/python/main.cpp
+++ b/src/python/main.cpp
@@ -22,6 +22,7 @@ MI_PY_DECLARE(Struct);
 MI_PY_DECLARE(Appender);
 MI_PY_DECLARE(ArgParser);
 MI_PY_DECLARE(Bitmap);
+MI_PY_DECLARE(blender);
 MI_PY_DECLARE(Formatter);
 MI_PY_DECLARE(FileResolver);
 MI_PY_DECLARE(Logger);
@@ -52,6 +53,9 @@ MI_PY_DECLARE(DiscontinuityFlags);
 NB_MODULE(mitsuba_ext, m) {
     // Temporarily change the module name (for pydoc)
     m.attr("__name__") = "mitsuba";
+
+    nb::module_ blender = create_submodule(m, "blender");
+    blender.doc() = "Helper routines for the Mitsuba Blender add-on.";
 
     // Expose some constants in the main `mitsuba` module
     m.attr("__version__")      = MI_VERSION;
@@ -149,6 +153,7 @@ NB_MODULE(mitsuba_ext, m) {
     MI_PY_IMPORT(rfilter);
     MI_PY_IMPORT(Stream);
     MI_PY_IMPORT(Bitmap);
+    MI_PY_IMPORT_SUBMODULE(blender);
     MI_PY_IMPORT(Formatter);
     MI_PY_IMPORT(FileResolver);
     MI_PY_IMPORT(Logger);

--- a/src/render/film.cpp
+++ b/src/render/film.cpp
@@ -56,6 +56,7 @@ MI_VARIANT void Film<Float, Spectrum>::traverse(TraversalCallback *callback) {
     callback->put_parameter("size", m_size, +ParamFlags::NonDifferentiable);
     callback->put_parameter("crop_size", m_crop_size, +ParamFlags::NonDifferentiable);
     callback->put_parameter("crop_offset", m_crop_offset, +ParamFlags::NonDifferentiable);
+    callback->put_object("rfilter", m_filter, +ParamFlags::NonDifferentiable);
 }
 
 MI_VARIANT void Film<Float, Spectrum>::parameters_changed(const std::vector<std::string> &keys) {

--- a/src/render/mesh.cpp
+++ b/src/render/mesh.cpp
@@ -33,6 +33,9 @@ MI_VARIANT Mesh<Float, Spectrum>::Mesh(const Properties &props) : Base(props) {
     m_discontinuity_types = (uint32_t) DiscontinuityFlags::PerimeterType;
 
     m_shape_type = ShapeType::Mesh;
+
+    if (props.has_property("displacement"))
+        m_displacement_map = props.texture<Texture>("displacement");
 }
 
 MI_VARIANT
@@ -54,6 +57,8 @@ Mesh<Float, Spectrum>::Mesh(const std::string &name, ScalarSize vertex_count,
 
 MI_VARIANT
 void Mesh<Float, Spectrum>::initialize() {
+  apply_displacement_map();
+
 #if defined(MI_ENABLE_LLVM) && !defined(MI_ENABLE_EMBREE)
     m_vertex_positions_ptr = m_vertex_positions.data();
     m_faces_ptr = m_faces.data();
@@ -620,6 +625,28 @@ Mesh<Float, Spectrum>::build_indirect_silhouette_distribution() {
     dr::masked(weight, valid || boundary) = dr::detach(dr::norm(p1 - p0));
 
     m_sil_dedge_pmf = DiscreteDistribution<Float>(weight);
+}
+
+MI_VARIANT
+void Mesh<Float, Spectrum>::apply_displacement_map() {
+    if (!m_displacement_map)
+        return;
+
+    if (!has_vertex_texcoords())
+        Throw("Mesh::apply_displacement_map(): the mesh %s doesn't have vertex texture coordinates!", m_name);
+
+    if (!has_vertex_normals())
+        Throw("Mesh::apply_displacement_map(): displacement mapping is only supported on smooth objects!", m_name);
+
+    UInt32 idx = dr::arange<UInt32>(m_vertex_count);
+    SurfaceInteraction3f si = dr::zeros<SurfaceInteraction3f>();
+    si.uv = vertex_texcoord(idx);
+    Float disp = m_displacement_map->eval_1(si);
+
+    m_vertex_positions = dr::ravel(vertex_position(idx) + disp * vertex_normal(idx));
+
+    recompute_bbox();
+    recompute_vertex_normals();
 }
 
 MI_VARIANT

--- a/src/shapes/CMakeLists.txt
+++ b/src/shapes/CMakeLists.txt
@@ -4,7 +4,7 @@ add_plugin(obj          obj.cpp)
 add_plugin(ply          ply.cpp)
 add_plugin(blender      blender.cpp)
 add_plugin(serialized   serialized.cpp)
-add_plugin(meshholder   meshholder.cpp)
+add_plugin(buffermesh   buffermesh.cpp)
 
 add_plugin(cylinder     cylinder.cpp)
 add_plugin(disk         disk.cpp)

--- a/src/shapes/CMakeLists.txt
+++ b/src/shapes/CMakeLists.txt
@@ -4,6 +4,7 @@ add_plugin(obj          obj.cpp)
 add_plugin(ply          ply.cpp)
 add_plugin(blender      blender.cpp)
 add_plugin(serialized   serialized.cpp)
+add_plugin(meshholder   meshholder.cpp)
 
 add_plugin(cylinder     cylinder.cpp)
 add_plugin(disk         disk.cpp)

--- a/src/shapes/buffermesh.cpp
+++ b/src/shapes/buffermesh.cpp
@@ -7,9 +7,9 @@ NAMESPACE_BEGIN(mitsuba)
 
 /**!
 
-.. _shape-meshholder:
+.. _shape-buffermesh:
 
-Simple mesh holder (:monosp:`meshholder`)
+Simple buffer mesh (:monosp:`buffermesh`)
 -------------------------
 
 Simple mesh plugin that loads geometry directly from buffers. This is useful to
@@ -18,7 +18,7 @@ hold existing meshes in Python dictionaries.
  */
 
 template <typename Float, typename Spectrum>
-class MeshHolder final : public Mesh<Float, Spectrum> {
+class BufferMesh final : public Mesh<Float, Spectrum> {
 public:
     MI_IMPORT_BASE(Mesh, m_vertex_count, m_face_count, m_vertex_positions,
                    m_vertex_normals, m_vertex_texcoords, m_faces,
@@ -26,7 +26,7 @@ public:
     MI_IMPORT_TYPES()
     using typename Base::ScalarSize;
 
-    MeshHolder(const Properties &props) : Base(props) {
+    BufferMesh(const Properties &props) : Base(props) {
         auto vertex_positions = props.tensor<TensorXf>("vertex_positions");
         auto vertex_normals   = props.tensor<TensorXf>("vertex_normals");
         auto vertex_texcoords = props.tensor<TensorXf>("vertex_texcoords");
@@ -47,6 +47,6 @@ private:
     MI_DECLARE_CLASS()
 };
 
-MI_IMPLEMENT_CLASS_VARIANT(MeshHolder, Mesh)
-MI_EXPORT_PLUGIN(MeshHolder, "Mesh Holder")
+MI_IMPLEMENT_CLASS_VARIANT(BufferMesh, Mesh)
+MI_EXPORT_PLUGIN(BufferMesh, "Buffer Mesh")
 NAMESPACE_END(mitsuba)

--- a/src/shapes/meshholder.cpp
+++ b/src/shapes/meshholder.cpp
@@ -1,0 +1,52 @@
+#include <mitsuba/render/mesh.h>
+#include <mitsuba/core/properties.h>
+#include <mitsuba/core/util.h>
+#include <drjit/tensor.h>
+
+NAMESPACE_BEGIN(mitsuba)
+
+/**!
+
+.. _shape-meshholder:
+
+Simple mesh holder (:monosp:`meshholder`)
+-------------------------
+
+Simple mesh plugin that loads geometry directly from buffers. This is useful to
+hold existing meshes in Python dictionaries.
+
+ */
+
+template <typename Float, typename Spectrum>
+class MeshHolder final : public Mesh<Float, Spectrum> {
+public:
+    MI_IMPORT_BASE(Mesh, m_vertex_count, m_face_count, m_vertex_positions,
+                   m_vertex_normals, m_vertex_texcoords, m_faces,
+                   m_face_normals, recompute_vertex_normals, initialize)
+    MI_IMPORT_TYPES()
+    using typename Base::ScalarSize;
+
+    MeshHolder(const Properties &props) : Base(props) {
+        auto vertex_positions = props.tensor<TensorXf>("vertex_positions");
+        auto vertex_normals   = props.tensor<TensorXf>("vertex_normals");
+        auto vertex_texcoords = props.tensor<TensorXf>("vertex_texcoords");
+        auto faces            = props.tensor<TensorXf>("faces");
+
+        m_vertex_count = (ScalarSize) vertex_positions->shape(0) / 3;
+        m_face_count   = (ScalarSize) faces->shape(0) / 3;
+
+        m_vertex_positions = vertex_positions->array();
+        m_vertex_normals = vertex_normals->array();
+        m_vertex_texcoords = vertex_texcoords->array();
+        m_faces = faces->array();
+
+        initialize();
+    }
+
+private:
+    MI_DECLARE_CLASS()
+};
+
+MI_IMPLEMENT_CLASS_VARIANT(MeshHolder, Mesh)
+MI_EXPORT_PLUGIN(MeshHolder, "Mesh Holder")
+NAMESPACE_END(mitsuba)


### PR DESCRIPTION
This PR contributes necessary updates and utilities for the [major refactoring of the Mitsuba-Blender add-on](https://github.com/mitsuba-renderer/mitsuba-blender/compare/major_refactoring?expand=1).

Proposed changes:
- The `MeshHolder` shape plugin, a wrapper around `Mesh` to hold a mesh instance in a Python dictionary using tensors.
- Improvements to the `blender` shape plugin.
- Improvements to the `mi.xml_to_props` routine for importing Mitsuba scenes in Blender.
- Introduction of the `mitsuba.blender` submodule, that implements performance critial routines in C++, exposed in Python to be used by the add-on.
- The `Mesh` constructor now takes an optional `displacement_map` texture nested object that's used during construction to displace the vertex positions.