### PR TITLE
Shape: add, get and remove texture attributes

### DIFF
--- a/include/mitsuba/python/docstr.h
+++ b/include/mitsuba/python/docstr.h
@@ -4525,6 +4525,12 @@ static const char *__doc_mitsuba_Mesh_MeshAttribute_type = R"doc()doc";
 
 static const char *__doc_mitsuba_Mesh_add_attribute = R"doc(Add an attribute buffer with the given ``name`` and ``dim``)doc";
 
+static const char *__doc_mitsuba_Mesh_remove_attribute = R"doc(Remove an attribute with the given ``name``.
+
+Affects both mesh and texture attributes.
+
+Throws an exception if the attribute was not previously registered.)doc";
+
 static const char *__doc_mitsuba_Mesh_attribute_buffer = R"doc(Return the mesh attribute associated with ``name``)doc";
 
 static const char *__doc_mitsuba_Mesh_barycentric_coordinates = R"doc()doc";
@@ -7616,6 +7622,27 @@ static const char *__doc_mitsuba_Shape_embree_geometry = R"doc(Return the Embree
 static const char *__doc_mitsuba_Shape_emitter = R"doc(Return the area emitter associated with this shape (if any))doc";
 
 static const char *__doc_mitsuba_Shape_emitter_2 = R"doc(Return the area emitter associated with this shape (if any))doc";
+
+static const char *__doc_mitsuba_Shape_add_texture_attribute =
+R"doc(Add a texture attribute with the given ``name``.
+
+If an attribute with the same name already exists, it is replaced.
+
+Note that ``Mesh`` shapes can additionally handle per-vertex
+and per-face attributes via the ``Mesh::add_attribute method``.
+
+Parameter ``name``:
+    Name of the attribute
+Parameter ``texture``:
+    Texture to store. The dimensionality of the attribute
+    is simply the channel count of the texture.)doc";
+
+static const char *__doc_mitsuba_Shape_texture_attribute = R"doc(Return the texture attribute associated with \c name.)doc";
+
+static const char *__doc_mitsuba_Shape_remove_attribute =
+R"doc(Remove a texture texture with the given ``name``.
+
+Throws an exception if the attribute was not registered.)doc";
 
 static const char *__doc_mitsuba_Shape_eval_attribute =
 R"doc(Evaluate a specific shape attribute at the given surface interaction.
@@ -12513,4 +12540,3 @@ static const char *__doc_operator_lshift = R"doc(Turns a vector of elements into
 #if defined(__GNUG__)
 #pragma GCC diagnostic pop
 #endif
-

--- a/include/mitsuba/render/mesh.h
+++ b/include/mitsuba/render/mesh.h
@@ -87,16 +87,20 @@ public:
     const DynamicBuffer<UInt32>& faces_buffer() const { return m_faces; }
 
     /// Return the mesh attribute associated with \c name
-    FloatStorage& attribute_buffer(const std::string& name) {
-        auto attribute = m_mesh_attributes.find(name);
-        if (attribute == m_mesh_attributes.end())
-            Throw("attribute_buffer(): attribute %s doesn't exist.", name.c_str());
-        return attribute->second.buf;
-    }
+    FloatStorage& attribute_buffer(const std::string& name);
 
     /// Add an attribute buffer with the given \c name and \c dim
     void add_attribute(const std::string &name, size_t dim,
                        const std::vector<InputFloat> &buf);
+
+    /**
+     * Remove an attribute with the given \c name.
+     *
+     * Affects both mesh and texture attributes.
+     *
+     * Throws an exception if the attribute was not previously registered.
+     */
+    void remove_attribute(const std::string &name) override;
 
     /// Returns the vertex indices associated with triangle \c index
     template <typename Index>

--- a/include/mitsuba/render/shape.h
+++ b/include/mitsuba/render/shape.h
@@ -217,6 +217,18 @@ struct SilhouetteSample : public PositionSample<Float_, Spectrum_> {
  * This class provides core functionality for sampling positions on surfaces,
  * computing ray intersections, and bounding shapes within ray intersection
  * acceleration data structures.
+ *
+ * Two types of attributes can be associated with a shape:
+ * 1. Texture attributes (\c Shape::add_texture_attribute), which must be
+ *    a \c Texture instance but can have arbitrary resolution. The UV
+ *    parametrization of the shape is used to look up texture attribute values.
+ * 2. Mesh attributes (\c Mesh::add_attribute), which can only be added
+ *    to mesh-type Shapes. They must be either per-vertex or per-face attributes,
+ *    their name must start with "vertex_" (resp. "face_"), and their size
+ *    must match the number of vertices (resp. faces) of the mesh.
+ *
+ * Once registered, attributes are queried with the \c Shape::eval_attribute*
+ * methods.
  */
 template <typename Float, typename Spectrum>
 class MI_EXPORT_LIB Shape : public Object {
@@ -678,6 +690,35 @@ public:
      * The default implementation throws an exception.
      */
     virtual Float surface_area() const;
+
+    /**
+     * \brief Add a texture attribute with the given \c name.
+     *
+     * If an attribute with the same name already exists, it is replaced.
+     *
+     * Note that \c Mesh shapes can additionally handle per-vertex
+     * and per-face attributes via the \c Mesh::add_attribute method.
+     *
+     * \param name
+     *     Name of the attribute
+     * \param texture
+     *     Texture to store. The dimensionality of the attribute
+     *     is simply the channel count of the texture.
+     */
+    virtual void add_texture_attribute(const std::string &name, Texture *texture);
+
+    /// Return the texture attribute associated with \c name.
+    Texture *texture_attribute(const std::string &name);
+
+    /// Return the texture attribute associated with \c name.
+    const Texture *texture_attribute(const std::string &name) const;
+
+    /**
+     * \brief Remove a texture texture with the given \c name.
+     *
+     * Throws an exception if the attribute was not registered.
+     */
+    virtual void remove_attribute(const std::string &name);
 
     /**
      * \brief Returns whether this shape contains the specified attribute.

--- a/src/render/mesh.cpp
+++ b/src/render/mesh.cpp
@@ -1558,6 +1558,14 @@ Mesh<Float, Spectrum>::compute_surface_interaction(const Ray3f &ray,
 //! @{ \name Mesh attributes
 // =============================================================
 
+MI_VARIANT typename Mesh<Float, Spectrum>::FloatStorage &
+Mesh<Float, Spectrum>::attribute_buffer(const std::string &name) {
+    auto attribute = m_mesh_attributes.find(name);
+    if (attribute == m_mesh_attributes.end())
+        Throw("attribute_buffer(): attribute %s doesn't exist.", name.c_str());
+    return attribute->second.buf;
+}
+
 MI_VARIANT void Mesh<Float, Spectrum>::add_attribute(const std::string& name,
                                                      size_t dim,
                                                      const std::vector<InputFloat>& data) {
@@ -1568,7 +1576,7 @@ MI_VARIANT void Mesh<Float, Spectrum>::add_attribute(const std::string& name,
     bool is_vertex_attr = name.find("vertex_") == 0;
     bool is_face_attr   = name.find("face_") == 0;
     if (!is_vertex_attr && !is_face_attr)
-        Throw("add_attribute(): attribute name must start with either \"vertex_\" of \"face_\".");
+        Throw("add_attribute(): attribute name must start with either \"vertex_\" or \"face_\".");
 
     MeshAttributeType type = is_vertex_attr ? MeshAttributeType::Vertex : MeshAttributeType::Face;
     size_t count = is_vertex_attr ? m_vertex_count : m_face_count;
@@ -1586,6 +1594,16 @@ MI_VARIANT void Mesh<Float, Spectrum>::add_attribute(const std::string& name,
 
     FloatStorage buffer = dr::load<FloatStorage>(data.data(), count * dim);
     m_mesh_attributes.insert({ name, { dim, type, buffer } });
+}
+
+MI_VARIANT void
+Mesh<Float, Spectrum>::remove_attribute(const std::string &name) {
+    const auto& it = m_mesh_attributes.find(name);
+    if (it == m_mesh_attributes.end()) {
+        // Maybe it exists as a texture attribute, try that.
+        return Base::remove_attribute(name);
+    }
+    m_mesh_attributes.erase(it);
 }
 
 MI_VARIANT typename Mesh<Float, Spectrum>::Mask

--- a/src/render/python/shape_v.cpp
+++ b/src/render/python/shape_v.cpp
@@ -298,6 +298,10 @@ MI_PY_EXPORT(Shape) {
             &Shape::bbox, nb::const_), D(Shape, bbox, 2), "index"_a)
         .def("bbox", nb::overload_cast<ScalarUInt32, const ScalarBoundingBox3f &>(
             &Shape::bbox, nb::const_), D(Shape, bbox, 3), "index"_a, "clip"_a)
+        .def_method(Shape, add_texture_attribute, "name"_a, "texture"_a)
+        .def("texture_attribute", nb::overload_cast<const std::string &>(
+            &Shape::texture_attribute), D(Shape, texture_attribute), "name"_a)
+        .def_method(Shape, remove_attribute, "name"_a)
         .def_method(Shape, id)
         .def_method(Shape, is_mesh)
         .def_method(Shape, parameters_grad_enabled)
@@ -343,6 +347,8 @@ MI_PY_EXPORT(Shape) {
              D(Mesh, attribute_buffer))
         .def("add_attribute", &Mesh::add_attribute, "name"_a, "size"_a, "buffer"_a,
              D(Mesh, add_attribute))
+        .def("remove_attribute", &Mesh::remove_attribute, "name"_a,
+             D(Mesh, remove_attribute))
 
         .def("recompute_vertex_normals", &Mesh::recompute_vertex_normals)
         .def("recompute_bbox", &Mesh::recompute_bbox)

--- a/src/render/shape.cpp
+++ b/src/render/shape.cpp
@@ -53,7 +53,7 @@ MI_VARIANT Shape<Float, Spectrum>::Shape(const Properties &props) : m_id(props.i
                 m_exterior_medium = medium;
             }
         } else if (texture) {
-            m_texture_attributes.insert({ name, texture });
+            add_texture_attribute(name, texture);
         } else {
             continue;
         }
@@ -502,6 +502,37 @@ Shape<Float, Spectrum>::ray_intersect(const Ray3f &ray, uint32_t ray_flags, Mask
     MI_MASK_ARGUMENT(active);
     auto pi = ray_intersect_preliminary(ray, 0, active);
     return pi.compute_surface_interaction(ray, ray_flags, active);
+}
+
+MI_VARIANT void
+Shape<Float, Spectrum>::add_texture_attribute(const std::string& name, Texture *texture) {
+    // Replaces existing attribute with name `name`, if any.
+    m_texture_attributes.insert_or_assign(name, texture);
+}
+
+MI_VARIANT typename Shape<Float, Spectrum>::Texture *
+Shape<Float, Spectrum>::texture_attribute(const std::string &name) {
+    auto it = m_texture_attributes.find(name);
+    if (it == m_texture_attributes.end())
+        Throw("texture_attribute(): attribute %s doesn't exist.", name.c_str());
+    return it->second.get();
+}
+
+MI_VARIANT const typename Shape<Float, Spectrum>::Texture *
+Shape<Float, Spectrum>::texture_attribute(const std::string &name) const {
+    const auto it = m_texture_attributes.find(name);
+    if (it == m_texture_attributes.end())
+        Throw("texture_attribute(): attribute %s doesn't exist.", name.c_str());
+    return it->second.get();
+}
+
+
+MI_VARIANT void
+Shape<Float, Spectrum>::remove_attribute(const std::string& name) {
+    const auto& it = m_texture_attributes.find(name);
+    if (it == m_texture_attributes.end())
+        Throw("remove_attribute(): Attribute \"%s\" not found.", name);
+    m_texture_attributes.erase(it);
 }
 
 MI_VARIANT typename Shape<Float, Spectrum>::Mask

--- a/src/textures/tests/test_mesh_attribute.py
+++ b/src/textures/tests/test_mesh_attribute.py
@@ -114,8 +114,7 @@ def test03_invalid_attribute(variant_scalar_rgb):
         "name" : "vertex_colorr",
     })
 
-    si =  mesh.eval_parameterization([0, 0])
+    si = mesh.eval_parameterization([0, 0])
 
-    with pytest.raises(Exception) as e:
+    with pytest.raises(Exception, match="Invalid attribute requested"):
         texture.eval(si)
-    e.match("Invalid attribute requested")


### PR DESCRIPTION
## Description

Previously, per-shape texture attributes could only be added at construction time.
This PR expands the API so that both texture and mesh attributes can be added, queried, evaluated and removed.

In particular, this allows associating quantities with a shape independently of the vertex or shape count.

## Testing

Added a unit test.

## Checklist

<!-- Please make sure to complete this checklist before requesting a review. -->

- [x] My code follows the [style guidelines](https://mitsuba.readthedocs.io/en/latest/src/developer_guide.html#coding-style) of this project
- [x] My changes generate no new warnings
- [x] My code also compiles for `cuda_*` and `llvm_*` variants. If you can't test this, please leave below
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 3 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba/blob/master/LICENSE)