### PR TITLE
Fix GCC 13 build on aarch64

### DIFF
--- a/src/core/struct.cpp
+++ b/src/core/struct.cpp
@@ -4,12 +4,13 @@
 #include <mitsuba/core/stream.h>
 #include <mitsuba/core/hash.h>
 #include <mitsuba/core/jit.h>
+#include <drjit-core/half.h>
 #include <drjit/array.h>
 #include <drjit/color.h>
-#include <drjit-core/half.h>
-#include <unordered_map>
-#include <ostream>
+#include <cmath>
 #include <map>
+#include <ostream>
+#include <unordered_map>
 
 /// Set this to '1' to view generated conversion code
 #if !defined(MI_JIT_LOG_ASSEMBLY)


### PR DESCRIPTION
## Description

When `MI_STRUCTCONVERTER_USE_JIT == 0`, `std::rint` is used, which is from `<cmath>`.

Note: also requires a `nanothread` change that is  not included in this PR, the submodule pointers will have to bubble up from `drjit-core`: https://github.com/mitsuba-renderer/nanothread/pull/10


Note that there are many warnings of the style:
```cpp
In member function 'mitsuba::Point<Expr, (mitsuba::Transform<Point>::Size - 1)> mitsuba::Transform<Point>::transform_affine(const mitsuba::Point<T, (Size - 1)>&) const [with T = drjit::Packet<float, 16>; Expr = drjit::Packet<float, 16>; Point_ = mitsuba::Point<float, 4>]',                                                                                                                                                                                                                                           
    inlined from 'Result mitsuba::Transform<Point>::transform_affine(const mitsuba::Ray<mitsuba::Point<T, (Size - 1)>, Spectrum>&) const [with T = drjit::Packet<float, 16>; Spectrum = drjit::Matrix<mitsuba::Color<drjit::DiffArray<JitBackend::LLVM, float>, 1>, 4>; Expr = drjit::Packet<float, 16>; Result = mitsuba::Ray<mitsuba::Point<drjit::Packet<float, 16>, 3>, drjit::Matrix<mitsuba::Color<drjit::DiffArray<JitBackend::LLVM, float>, 1>, 4> >; Point_ = mitsuba::Point<float, 4>]' at /mitsuba3/include/mitsuba/core/transform.h:188:39,                                                                                                                                                                                                                 
    inlined from 'std::tuple<typename drjit::detail::mask<Value, int>::type, FloatP, mitsuba::Point<FloatP, 2>, typename drjit::detail::replace_scalar<FloatP, unsigned int, int>::type, typename drjit::detail::replace_scalar<FloatP, unsigned int, int>::type> mitsuba::SDFGrid<Float, Spectrum>::ray_intersect_preliminary_common_impl(const Ray3fP&, typename Base::ScalarIndex, drjit::mask_t<Value>) const [with FloatP = drjit::Packet<float, 16>; Ray3fP = mitsuba::Ray<mitsuba::Point<drjit::Packet<float, 16>, 3>, drjit::Matrix<mitsuba::Color<drjit::DiffArray<JitBackend::LLVM, float>, 1>, 4> >; Float = drjit::DiffArray<JitBackend::LLVM, float>; Spectrum = drjit::Matrix<mitsuba::Color<drjit::DiffArray<JitBackend::LLVM, float>, 1>, 4>]' at /mitsuba3/src/shapes/sdfgrid.cpp:671:44,                                                                                                                                                                                                                            
    inlined from 'std::tuple<FloatP, mitsuba::Point<FloatP, 2>, typename drjit::detail::replace_scalar<FloatP, unsigned int, int>::type, typename drjit::detail::replace_scalar<FloatP, unsigned int, int>::type> mitsuba::SDFGrid<Float, Spectrum>::ray_intersect_preliminary_impl(const Ray3fP&, typename Base::ScalarIndex, drjit::mask_t<Value>) const [with FloatP = drjit::Packet<float, 16>; Ray3fP = mitsuba::Ray<mitsuba::Point<drjit::Packet<float, 16>, 3>, drjit::Matrix<mitsuba::Color<drjit::DiffArray<JitBackend::LLVM, float>, 1>, 4> >; Float = drjit::DiffArray<JitBackend::LLVM, float>; Spectrum = drjit::Matrix<mitsuba::Color<drjit::DiffArray<JitBackend::LLVM, float>, 1>, 4>]' at /mitsuba3/src/shapes/sdfgrid.cpp:320:14:                     
/mitsuba3/include/mitsuba/core/transform.h:120:34: note: parameter passing for argument of type 'drjit::Matrix<float, 4>' when C++17 is enabled changed to match C++14 in GCC 10.1                                                          
  120 |         Matrix tr = dr::transpose(matrix);                                                                                                                                                                                                            
      |                     ~~~~~~~~~~~~~^~~~~~~~                                                                                                       
```

which we could disable with `-Wno-psabi` ([explanations](https://stackoverflow.com/questions/77729813/parameter-passing-for-argument-when-c17-is-enabled-changed-to-match-c14)), but I don't know if that would be too broad.


## Testing

Manually built on a Grace-Hopper node with GCC 13.

## Checklist

<!-- Please make sure to complete this checklist before requesting a review. -->

- [x] My code follows the [style guidelines](https://mitsuba.readthedocs.io/en/latest/src/developer_guide.html#coding-style) of this project
- [x] My changes generate no new warnings
- [x] My code also compiles for `cuda_*` and `llvm_*` variants. If you can't test this, please leave below
- [x] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 3 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba/blob/master/LICENSE)