### PR TITLE
[CI run] No longer require libc++ when using Clang

### DIFF
--- a/docs/src/developer_guide/compiling.rst
+++ b/docs/src/developer_guide/compiling.rst
@@ -98,7 +98,7 @@ TLDR: If you plan to use Mitsuba from Python, we recommend adding one of
 
     Note that compilation time and compilation memory usage is roughly
     proportional to the number of enabled variants, hence including many of them
-    (more than five) may not be advisable. Also note that the ``scalar_rgb`` 
+    (more than five) may not be advisable. Also note that the ``scalar_rgb``
     and *at least one AD variant* is mandatory.
 
 .. warning::
@@ -110,7 +110,7 @@ TLDR: If you plan to use Mitsuba from Python, we recommend adding one of
     be variant-agnostic and hence certain combinations of variants won't be allowed.
     For example, including just `scalar_rgb`, `scalar_spectral` and `llvm_ad_rgb`
     creates ambiguity as to which variant we should select to generate the Python stubs.
-    In short, if a disallowed combination of variants is selected, a compilation 
+    In short, if a disallowed combination of variants is selected, a compilation
     error will report what variant should be added to remove any ambiguity.
 
 Linux
@@ -131,8 +131,8 @@ To fetch all dependencies and Clang, enter the following commands on Ubuntu:
 
 .. code-block:: bash
 
-    # Install recent versions build tools, including Clang and libc++ (Clang's C++ library)
-    sudo apt install clang-17 libc++-17-dev libc++abi-17-dev cmake ninja-build
+    # Install recent versions build tools, including Clang
+    sudo apt install clang-17 cmake ninja-build
 
     # Install libraries for image I/O
     sudo apt install libpng-dev libjpeg-dev
@@ -167,7 +167,7 @@ inside the :monosp:`mitsuba3` root directory:
     # Create a directory where build products are stored
     mkdir build
     cd build
-    cmake -GNinja .. 
+    cmake -GNinja ..
     ninja
 
 
@@ -250,9 +250,9 @@ Now, compilation should be as simple as running the following from inside the
 
 .. code-block:: bash
 
-    mkdir build 
-    cd build 
-    cmake -GNinja .. 
+    mkdir build
+    cd build
+    cmake -GNinja ..
     ninja
 
 


### PR DESCRIPTION
## Description

```source ./.venv/bin/activate
pip install matplotlib==3.10.0

# Mitsuba built from `master` with Clang (--> libc++)
source ./build-Release/setpath.sh

python -c "import mitsuba as mi; from matplotlib import ft2font"
 [1]    40526 segmentation fault (core dumped)
```

When importing the module, two attributes that don't exist are looked up: `__path__` and `__cached__`. These [are optional](https://docs.python.org/3.12/reference/datamodel.html#module.__cached__), so it's fine that they don't exist.
But the way that `ft2font__getattr__` is implemented in the latest version leads to an exception being raised when they get looked up.
If we compile Mitsuba with GCC, libstdc++ is used, so the exception is correctly caught and handled and all is fine.
But with libc++, the exception thrown by ft2font is ABI-incompatible with the libc++ exception handlers, which results in a crash.

This is another instance of the classic `libc++` / `libstdc++` ABI incompatibility that we have run into multiple times before.
After some research, I wasn't able to find a way to fully isolate the exception handling routines of `libunwind` from exceptions thrown by other libraries built with `libstdc++`. After discussion with @wjakob, the simplest solution is then to stop requiring `libc++` to be used in conjunction with Clang (outside of macOS, where this is the default).

## Testing

CI run.

## Checklist

- [x] My code follows the [style guidelines](https://mitsuba.readthedocs.io/en/latest/src/developer_guide.html#coding-style) of this project
- [x] My changes generate no new warnings
- [x] My code also compiles for `cuda_*` and `llvm_*` variants. If you can't test this, please leave below
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 3 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba/blob/master/LICENSE)