### PR TITLE
Raw constant texture plugin

### DIFF
--- a/docs/generate_plugin_doc.py
+++ b/docs/generate_plugin_doc.py
@@ -78,6 +78,7 @@ SPECTRUM_ORDERING = [
     'srgb',
     'd65',
     'blackbody'
+    'rawconstant'
 ]
 
 SAMPLER_ORDERING = [

--- a/docs/generated/extracted_rst_api.rst
+++ b/docs/generated/extracted_rst_api.rst
@@ -35,7 +35,7 @@
         Parameter ``sensor`` (:py:obj:`mitsuba.Sensor`):
             *no description available*
 
-        Parameter ``seed`` (int):
+        Parameter ``seed`` (drjit.llvm.ad.UInt):
             *no description available*
 
         Parameter ``spp`` (int):
@@ -55,7 +55,7 @@
         Parameter ``sensor`` (:py:obj:`mitsuba.Sensor`):
             *no description available*
 
-        Parameter ``seed`` (int):
+        Parameter ``seed`` (drjit.llvm.ad.UInt):
             *no description available*
 
         Parameter ``spp`` (int):
@@ -2736,7 +2736,7 @@
 
 .. py:data:: mitsuba.DEBUG
     :type: bool
-    :value: False
+    :value: True
 
 .. py:class:: mitsuba.DefaultFormatter
 
@@ -5166,7 +5166,7 @@
 
         Overloaded function.
 
-        1. ``render(self, scene: :py:obj:`mitsuba.Scene`, sensor: :py:obj:`mitsuba.Sensor`, seed: int = 0, spp: int = 0, develop: bool = True, evaluate: bool = True) -> drjit.llvm.ad.TensorXf``
+        1. ``render(self, scene: :py:obj:`mitsuba.Scene`, sensor: :py:obj:`mitsuba.Sensor`, seed: drjit.llvm.ad.UInt = 0, spp: int = 0, develop: bool = True, evaluate: bool = True) -> drjit.llvm.ad.TensorXf``
 
         Render the scene
 
@@ -5174,7 +5174,7 @@
         other parameters are optional and control different aspects of the
         rendering process. In particular:
 
-        Parameter ``seed`` (int):
+        Parameter ``seed`` (drjit.llvm.ad.UInt):
             This parameter controls the initialization of the random number
             generator. It is crucial that you specify different seeds (e.g.,
             an increasing sequence) if subsequent ``render``() calls should
@@ -5200,7 +5200,7 @@
             (``develop=true``) or modified film (``develop=false``) represent
             the rendering task as an unevaluated computation graph.
 
-        2. ``render(self, scene: :py:obj:`mitsuba.Scene`, sensor: int = 0, seed: int = 0, spp: int = 0, develop: bool = True, evaluate: bool = True) -> drjit.llvm.ad.TensorXf``
+        2. ``render(self, scene: :py:obj:`mitsuba.Scene`, sensor: int = 0, seed: drjit.llvm.ad.UInt = 0, spp: int = 0, develop: bool = True, evaluate: bool = True) -> drjit.llvm.ad.TensorXf``
 
         Render the scene
 
@@ -5744,7 +5744,7 @@
 
 .. py:data:: mitsuba.MI_VERSION
     :type: str
-    :value: 3.6.2
+    :value: 3.6.4
 
 .. py:data:: mitsuba.MI_VERSION_MAJOR
     :type: int
@@ -5756,7 +5756,7 @@
 
 .. py:data:: mitsuba.MI_VERSION_PATCH
     :type: int
-    :value: 2
+    :value: 4
 
 .. py:data:: mitsuba.MI_YEAR
     :type: str
@@ -7394,7 +7394,7 @@
         Parameter ``other`` (:py:obj:`mitsuba.Mesh`):
             *no description available*
 
-        Returns → ref<mitsuba::Mesh<drjit::DiffArray<(JitBackend)2, float>, mitsuba::Color<drjit::DiffArray<(JitBackend)2, float>, 3ul>>>:
+        Returns → ref<mitsuba::Mesh<drjit::DiffArray<(JitBackend)2, float>, mitsuba::Color<drjit::DiffArray<(JitBackend)2, float>, 3ul> > >:
             *no description available*
 
     .. py:method:: mitsuba.Mesh.opposite_dedge(self, index, active=True)
@@ -7431,6 +7431,20 @@
             *no description available*
 
     .. py:method:: mitsuba.Mesh.recompute_vertex_normals()
+
+        Returns → None:
+            *no description available*
+
+    .. py:method:: mitsuba.Mesh.remove_attribute(self, name)
+
+        Remove an attribute with the given ``name``.
+
+        Affects both mesh and texture attributes.
+
+        Throws an exception if the attribute was not previously registered.
+
+        Parameter ``name`` (str):
+            *no description available*
 
         Returns → None:
             *no description available*
@@ -8026,7 +8040,7 @@
     filter that spans multiple pixels, the denoiser might identify some
     local variance as a feature of the scene and will not denoise it.
 
-    .. py:method:: __init__(self, input_size, albedo=False, normals=False, temporal=False)
+    .. py:method:: __init__(self, input_size, albedo=False, normals=False, temporal=False, denoise_alpha=False)
 
         Constructs an OptiX denoiser
         
@@ -8035,34 +8049,35 @@
         
         Parameter ``albedo`` (bool):
             Whether or not albedo information will also be given to the
-            denoiser.
+            denoiser. This parameter is optional, by default it is false.
         
         Parameter ``normals`` (bool):
             Whether or not shading normals information will also be given to
-            the Denoiser.
+            the denoiser. This parameter is optional, by default it is false.
+        
+        Parameter ``temporal`` (bool):
+            Whether or not temporal information will also be given to the
+            denoiser. This parameter is optional, by default it is false.
+        
+        Parameter ``denoise_alpha`` (bool):
+            Whether or not the alpha channel (if specified in the noisy input)
+            should be denoised too. This parameter is optional, by default it
+            is false.
         
         Returns:
             A callable object which will apply the OptiX denoiser.
 
-        Parameter ``temporal`` (bool):
-            *no description available*
-
         
-    .. py:method:: mitsuba.OptixDenoiser.__call__(self, noisy, denoise_alpha=True, albedo, normals, to_sensor=None, flow, previous_denoised)
+    .. py:method:: mitsuba.OptixDenoiser.__call__(self, noisy, albedo, normals, to_sensor=None, flow, previous_denoised)
 
         Overloaded function.
 
-        1. ``__call__(self, noisy: drjit.llvm.ad.TensorXf, denoise_alpha: bool = True, albedo: drjit.llvm.ad.TensorXf, normals: drjit.llvm.ad.TensorXf, to_sensor: object | None = None, flow: drjit.llvm.ad.TensorXf, previous_denoised: drjit.llvm.ad.TensorXf) -> drjit.llvm.ad.TensorXf``
+        1. ``__call__(self, noisy: drjit.llvm.ad.TensorXf, albedo: drjit.llvm.ad.TensorXf, normals: drjit.llvm.ad.TensorXf, to_sensor: object | None = None, flow: drjit.llvm.ad.TensorXf, previous_denoised: drjit.llvm.ad.TensorXf) -> drjit.llvm.ad.TensorXf``
 
         Apply denoiser on inputs which are TensorXf objects.
 
         Parameter ``noisy`` (drjit.llvm.ad.TensorXf):
             The noisy input. (tensor shape: (width, height, 3 | 4))
-
-        Parameter ``denoise_alpha`` (bool):
-            Whether or not the alpha channel (if specified in the noisy input)
-            should be denoised too. This parameter is optional, by default it
-            is true.
 
         Parameter ``albedo`` (drjit.llvm.ad.TensorXf):
             Albedo information of the noisy rendering. This parameter is
@@ -8101,7 +8116,7 @@
         Returns → drjit.llvm.ad.TensorXf:
             The denoised input.
 
-        2. ``__call__(self, noisy: :py:obj:`mitsuba.Bitmap`, denoise_alpha: bool = True, albedo_ch: str = '', normals_ch: str = '', to_sensor: object | None = None, flow_ch: str = '', previous_denoised_ch: str = '', noisy_ch: str = '<root>') -> :py:obj:`mitsuba.Bitmap```
+        2. ``__call__(self, noisy: :py:obj:`mitsuba.Bitmap`, albedo_ch: str = '', normals_ch: str = '', to_sensor: object | None = None, flow_ch: str = '', previous_denoised_ch: str = '', noisy_ch: str = '<root>') -> :py:obj:`mitsuba.Bitmap```
 
         Apply denoiser on inputs which are Bitmap objects.
 
@@ -8109,11 +8124,6 @@
             The noisy input. When passing additional information like albedo
             or normals to the denoiser, this Bitmap object must be a
             MultiChannel bitmap.
-
-        Parameter ``denoise_alpha`` (bool):
-            Whether or not the alpha channel (if specified in the noisy input)
-            should be denoised too. This parameter is optional, by default it
-            is true.
 
         Parameter ``albedo_ch``:
             The name of the channel in the ``noisy`` parameter which contains
@@ -9988,7 +9998,7 @@
         Parameter ``sensor`` (:py:obj:`mitsuba.Sensor`):
             *no description available*
 
-        Parameter ``seed`` (int):
+        Parameter ``seed`` (drjit.llvm.ad.UInt):
             *no description available*
 
         Parameter ``spp`` (int):
@@ -10008,7 +10018,7 @@
         Parameter ``sensor`` (:py:obj:`mitsuba.Sensor`):
             *no description available*
 
-        Parameter ``seed`` (int):
+        Parameter ``seed`` (drjit.llvm.ad.UInt):
             *no description available*
 
         Parameter ``spp`` (int):
@@ -12713,6 +12723,25 @@
 
     Forward declaration for `SilhouetteSample`
 
+    .. py:method:: mitsuba.Shape.add_texture_attribute(self, name, texture)
+
+        Add a texture attribute with the given ``name``.
+
+        If an attribute with the same name already exists, it is replaced.
+
+        Note that ``Mesh`` shapes can additionally handle per-vertex and per-
+        face attributes via the ``Mesh::add_attribute`` method.
+
+        Parameter ``name`` (str):
+            Name of the attribute
+
+        Parameter ``texture`` (:py:obj:`mitsuba.Texture`):
+            Texture to store. The dimensionality of the attribute is simply
+            the channel count of the texture.
+
+        Returns → None:
+            *no description available*
+
     .. py:method:: mitsuba.Shape.bbox()
 
         Overloaded function.
@@ -13186,6 +13215,18 @@
         Returns → drjit.llvm.ad.Bool:
             *no description available*
 
+    .. py:method:: mitsuba.Shape.remove_attribute(self, name)
+
+        Remove a texture texture with the given ``name``.
+
+        Throws an exception if the attribute was not registered.
+
+        Parameter ``name`` (str):
+            *no description available*
+
+        Returns → None:
+            *no description available*
+
     .. py:method:: mitsuba.Shape.sample_direction(self, it, sample, active=True)
 
         Sample a direction towards this shape with respect to solid angles
@@ -13294,6 +13335,16 @@
         Returns → :py:obj:`mitsuba.Sensor`:
             *no description available*
 
+    .. py:method:: mitsuba.Shape.set_bsdf(self, bsdf)
+
+        Set the shape's BSDF
+
+        Parameter ``bsdf`` (:py:obj:`mitsuba.BSDF`):
+            *no description available*
+
+        Returns → None:
+            *no description available*
+
     .. py:method:: mitsuba.Shape.shape_type()
 
         Returns the shape type ShapeType of this shape
@@ -13325,6 +13376,16 @@
         The default implementation throws an exception.
 
         Returns → drjit.llvm.ad.Float:
+            *no description available*
+
+    .. py:method:: mitsuba.Shape.texture_attribute(self, name)
+
+        Return the texture attribute associated with ``name``.
+
+        Parameter ``name`` (str):
+            *no description available*
+
+        Returns → :py:obj:`mitsuba.Texture`:
             *no description available*
 
 .. py:class:: mitsuba.ShapePtr
@@ -16821,7 +16882,7 @@
         Creates a transformation that converts from 'frame' to the standard
         basis
 
-        Parameter ``frame`` (mitsuba::Frame<drjit::DiffArray<(JitBackend)2, double>>):
+        Parameter ``frame`` (mitsuba::Frame<drjit::DiffArray<(JitBackend)2, double> >):
             *no description available*
 
         Returns → :py:obj:`mitsuba.Transform4d`:
@@ -16934,7 +16995,7 @@
         Creates a transformation that converts from the standard basis to
         'frame'
 
-        Parameter ``frame`` (mitsuba::Frame<drjit::DiffArray<(JitBackend)2, double>>):
+        Parameter ``frame`` (mitsuba::Frame<drjit::DiffArray<(JitBackend)2, double> >):
             *no description available*
 
         Returns → :py:obj:`mitsuba.Transform4d`:
@@ -18060,7 +18121,7 @@
 
         Overloaded function.
 
-        1. ``render(self, scene: :py:obj:`mitsuba.Scene`, sensor: :py:obj:`mitsuba.Sensor`, seed: int = 0, spp: int = 0, develop: bool = True, evaluate: bool = True) -> drjit.llvm.ad.TensorXf``
+        1. ``render(self, scene: :py:obj:`mitsuba.Scene`, sensor: :py:obj:`mitsuba.Sensor`, seed: drjit.llvm.ad.UInt = 0, spp: int = 0, develop: bool = True, evaluate: bool = True) -> drjit.llvm.ad.TensorXf``
 
         Render the scene
 
@@ -18068,7 +18129,7 @@
         other parameters are optional and control different aspects of the
         rendering process. In particular:
 
-        Parameter ``seed`` (int):
+        Parameter ``seed`` (drjit.llvm.ad.UInt):
             This parameter controls the initialization of the random number
             generator. It is crucial that you specify different seeds (e.g.,
             an increasing sequence) if subsequent ``render``() calls should
@@ -18094,7 +18155,7 @@
             (``develop=true``) or modified film (``develop=false``) represent
             the rendering task as an unevaluated computation graph.
 
-        2. ``render(self, scene: :py:obj:`mitsuba.Scene`, sensor: int = 0, seed: int = 0, spp: int = 0, develop: bool = True, evaluate: bool = True) -> drjit.llvm.ad.TensorXf``
+        2. ``render(self, scene: :py:obj:`mitsuba.Scene`, sensor: int = 0, seed: drjit.llvm.ad.UInt = 0, spp: int = 0, develop: bool = True, evaluate: bool = True) -> drjit.llvm.ad.TensorXf``
 
         Render the scene
 
@@ -18122,7 +18183,7 @@
         Parameter ``sensor`` (:py:obj:`mitsuba.Sensor`):
             *no description available*
 
-        Parameter ``seed`` (int):
+        Parameter ``seed`` (drjit.llvm.ad.UInt):
             *no description available*
 
         Parameter ``spp`` (int):
@@ -18145,7 +18206,7 @@
         Parameter ``sensor`` (:py:obj:`mitsuba.Sensor`):
             *no description available*
 
-        Parameter ``seed`` (int):
+        Parameter ``seed`` (drjit.llvm.ad.UInt):
             *no description available*
 
         Parameter ``spp`` (int):
@@ -18390,7 +18451,7 @@
         Parameter ``sensor`` (:py:obj:`mitsuba.Sensor`):
             *no description available*
 
-        Parameter ``seed`` (int):
+        Parameter ``seed`` (drjit.llvm.ad.UInt):
             *no description available*
 
         Parameter ``spp`` (int):
@@ -18413,7 +18474,7 @@
         Parameter ``sensor`` (:py:obj:`mitsuba.Sensor`):
             *no description available*
 
-        Parameter ``seed`` (int):
+        Parameter ``seed`` (drjit.llvm.ad.UInt):
             *no description available*
 
         Parameter ``spp`` (int):

--- a/docs/generated/mitsuba_api.rst
+++ b/docs/generated/mitsuba_api.rst
@@ -2,44 +2,44 @@ Core
 ----
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 20545
-  :end-line: 20641
+  :start-line: 20606
+  :end-line: 20702
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 20792
-  :end-line: 20796
+  :start-line: 20853
+  :end-line: 20857
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 21493
-  :end-line: 21497
+  :start-line: 21554
+  :end-line: 21558
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 21463
-  :end-line: 21475
+  :start-line: 21524
+  :end-line: 21536
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 11994
-  :end-line: 12080
+  :start-line: 12004
+  :end-line: 12090
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 21506
-  :end-line: 21510
+  :start-line: 21567
+  :end-line: 21571
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 20782
-  :end-line: 20791
+  :start-line: 20843
+  :end-line: 20852
 
 ------------
 
@@ -80,20 +80,20 @@ Core
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 14058
-  :end-line: 14540
+  :start-line: 14119
+  :end-line: 14601
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 14541
-  :end-line: 14572
+  :start-line: 14602
+  :end-line: 14633
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 17533
-  :end-line: 17564
+  :start-line: 17594
+  :end-line: 17625
 
 ------------
 
@@ -122,206 +122,206 @@ Core
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 8337
-  :end-line: 8359
+  :start-line: 8347
+  :end-line: 8369
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 8647
-  :end-line: 8689
+  :start-line: 8657
+  :end-line: 8699
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 12081
-  :end-line: 12091
+  :start-line: 12091
+  :end-line: 12101
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 13999
-  :end-line: 14057
+  :start-line: 14060
+  :end-line: 14118
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 14573
-  :end-line: 14827
+  :start-line: 14634
+  :end-line: 14888
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 14828
-  :end-line: 14924
+  :start-line: 14889
+  :end-line: 14985
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 16274
-  :end-line: 16476
+  :start-line: 16335
+  :end-line: 16537
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 16477
-  :end-line: 16484
+  :start-line: 16538
+  :end-line: 16545
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 16485
-  :end-line: 16512
+  :start-line: 16546
+  :end-line: 16573
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 19083
-  :end-line: 19096
+  :start-line: 19144
+  :end-line: 19157
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 19097
-  :end-line: 19109
+  :start-line: 19158
+  :end-line: 19170
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 19110
-  :end-line: 19116
+  :start-line: 19171
+  :end-line: 19177
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 19117
-  :end-line: 19131
+  :start-line: 19178
+  :end-line: 19192
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 19132
-  :end-line: 19141
+  :start-line: 19193
+  :end-line: 19202
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 19142
-  :end-line: 19153
+  :start-line: 19203
+  :end-line: 19214
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 19154
-  :end-line: 19163
+  :start-line: 19215
+  :end-line: 19224
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 19164
-  :end-line: 19174
+  :start-line: 19225
+  :end-line: 19235
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 19175
-  :end-line: 19280
+  :start-line: 19236
+  :end-line: 19341
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 19281
-  :end-line: 19284
+  :start-line: 19342
+  :end-line: 19345
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 19285
-  :end-line: 19295
+  :start-line: 19346
+  :end-line: 19356
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 19296
-  :end-line: 19310
+  :start-line: 19357
+  :end-line: 19371
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 19411
-  :end-line: 19421
+  :start-line: 19472
+  :end-line: 19482
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 20424
-  :end-line: 20434
+  :start-line: 20485
+  :end-line: 20495
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 20435
-  :end-line: 20445
+  :start-line: 20496
+  :end-line: 20506
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 20446
-  :end-line: 20456
+  :start-line: 20507
+  :end-line: 20517
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 20457
-  :end-line: 20467
+  :start-line: 20518
+  :end-line: 20528
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 20468
-  :end-line: 20478
+  :start-line: 20529
+  :end-line: 20539
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 20479
-  :end-line: 20489
+  :start-line: 20540
+  :end-line: 20550
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 20490
-  :end-line: 20500
+  :start-line: 20551
+  :end-line: 20561
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 20501
-  :end-line: 20511
+  :start-line: 20562
+  :end-line: 20572
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 20512
-  :end-line: 20522
+  :start-line: 20573
+  :end-line: 20583
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 20523
-  :end-line: 20533
+  :start-line: 20584
+  :end-line: 20594
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 20534
-  :end-line: 20544
+  :start-line: 20595
+  :end-line: 20605
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 17194
-  :end-line: 17238
+  :start-line: 17255
+  :end-line: 17299
 
 ------------
 
@@ -329,32 +329,32 @@ Parsing
 -------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 19449
-  :end-line: 19461
+  :start-line: 19510
+  :end-line: 19522
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 19462
-  :end-line: 19487
+  :start-line: 19523
+  :end-line: 19548
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 19488
-  :end-line: 19500
+  :start-line: 19549
+  :end-line: 19561
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 22536
-  :end-line: 22546
+  :start-line: 22597
+  :end-line: 22607
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 22547
-  :end-line: 22556
+  :start-line: 22608
+  :end-line: 22617
 
 ------------
 
@@ -362,14 +362,14 @@ Object
 ------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 7882
-  :end-line: 8011
+  :start-line: 7896
+  :end-line: 8025
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 8012
-  :end-line: 8013
+  :start-line: 8026
+  :end-line: 8027
 
 ------------
 
@@ -383,8 +383,8 @@ Properties
 ----------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 8934
-  :end-line: 9122
+  :start-line: 8944
+  :end-line: 9132
 
 ------------
 
@@ -404,8 +404,8 @@ Bitmap
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 9611
-  :end-line: 9725
+  :start-line: 9621
+  :end-line: 9735
 
 ------------
 
@@ -413,290 +413,290 @@ Warp
 ----
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 21511
-  :end-line: 21523
+  :start-line: 21572
+  :end-line: 21584
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 21524
-  :end-line: 21545
+  :start-line: 21585
+  :end-line: 21606
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 21546
-  :end-line: 21555
+  :start-line: 21607
+  :end-line: 21616
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 21556
-  :end-line: 21576
+  :start-line: 21617
+  :end-line: 21637
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 21577
-  :end-line: 21596
+  :start-line: 21638
+  :end-line: 21657
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 21597
-  :end-line: 21610
+  :start-line: 21658
+  :end-line: 21671
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 21611
-  :end-line: 21620
+  :start-line: 21672
+  :end-line: 21681
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 21621
-  :end-line: 21636
+  :start-line: 21682
+  :end-line: 21697
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 21637
-  :end-line: 21649
+  :start-line: 21698
+  :end-line: 21710
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 21650
-  :end-line: 21662
+  :start-line: 21711
+  :end-line: 21723
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 21663
-  :end-line: 21696
-
-------------
-
-.. include:: generated/extracted_rst_api.rst
-  :start-line: 21697
-  :end-line: 21716
-
-------------
-
-.. include:: generated/extracted_rst_api.rst
-  :start-line: 21717
-  :end-line: 21727
-
-------------
-
-.. include:: generated/extracted_rst_api.rst
-  :start-line: 21728
-  :end-line: 21737
-
-------------
-
-.. include:: generated/extracted_rst_api.rst
-  :start-line: 21738
+  :start-line: 21724
   :end-line: 21757
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
   :start-line: 21758
-  :end-line: 21776
+  :end-line: 21777
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 21777
-  :end-line: 21787
+  :start-line: 21778
+  :end-line: 21788
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 21788
-  :end-line: 21795
+  :start-line: 21789
+  :end-line: 21798
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 21796
-  :end-line: 21805
+  :start-line: 21799
+  :end-line: 21818
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 21806
-  :end-line: 21815
+  :start-line: 21819
+  :end-line: 21837
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 21816
-  :end-line: 21832
+  :start-line: 21838
+  :end-line: 21848
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 21833
-  :end-line: 21845
+  :start-line: 21849
+  :end-line: 21856
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 21846
-  :end-line: 21855
+  :start-line: 21857
+  :end-line: 21866
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 21856
-  :end-line: 21865
+  :start-line: 21867
+  :end-line: 21876
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 21866
-  :end-line: 21875
+  :start-line: 21877
+  :end-line: 21893
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 21876
-  :end-line: 21885
-
-------------
-
-.. include:: generated/extracted_rst_api.rst
-  :start-line: 21886
-  :end-line: 21896
-
-------------
-
-.. include:: generated/extracted_rst_api.rst
-  :start-line: 21897
+  :start-line: 21894
   :end-line: 21906
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
   :start-line: 21907
-  :end-line: 21917
+  :end-line: 21916
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 21918
-  :end-line: 21927
+  :start-line: 21917
+  :end-line: 21926
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 21928
-  :end-line: 21945
+  :start-line: 21927
+  :end-line: 21936
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 21946
-  :end-line: 21961
+  :start-line: 21937
+  :end-line: 21946
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 21962
-  :end-line: 21972
+  :start-line: 21947
+  :end-line: 21957
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 21973
-  :end-line: 21983
+  :start-line: 21958
+  :end-line: 21967
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 21984
-  :end-line: 21993
+  :start-line: 21968
+  :end-line: 21978
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 21994
-  :end-line: 22007
+  :start-line: 21979
+  :end-line: 21988
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 22008
-  :end-line: 22020
+  :start-line: 21989
+  :end-line: 22006
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 22021
+  :start-line: 22007
+  :end-line: 22022
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 22023
   :end-line: 22033
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
   :start-line: 22034
-  :end-line: 22043
+  :end-line: 22044
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 22044
-  :end-line: 22053
+  :start-line: 22045
+  :end-line: 22054
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 22054
-  :end-line: 22066
+  :start-line: 22055
+  :end-line: 22068
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 22067
-  :end-line: 22076
+  :start-line: 22069
+  :end-line: 22081
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 22077
-  :end-line: 22086
+  :start-line: 22082
+  :end-line: 22094
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 22087
-  :end-line: 22096
+  :start-line: 22095
+  :end-line: 22104
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 22097
-  :end-line: 22106
+  :start-line: 22105
+  :end-line: 22114
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 22107
-  :end-line: 22122
+  :start-line: 22115
+  :end-line: 22127
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 22123
-  :end-line: 22132
+  :start-line: 22128
+  :end-line: 22137
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 22133
-  :end-line: 22145
+  :start-line: 22138
+  :end-line: 22147
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 22148
+  :end-line: 22157
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 22158
+  :end-line: 22167
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 22168
+  :end-line: 22183
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 22184
+  :end-line: 22193
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 22194
+  :end-line: 22206
 
 ------------
 
@@ -728,8 +728,8 @@ Distributions
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 7673
-  :end-line: 7851
+  :start-line: 7687
+  :end-line: 7865
 
 ------------
 
@@ -809,254 +809,254 @@ Math
 ----
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 19538
-  :end-line: 19541
+  :start-line: 19599
+  :end-line: 19602
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 19542
-  :end-line: 19545
+  :start-line: 19603
+  :end-line: 19606
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 19546
-  :end-line: 19549
+  :start-line: 19607
+  :end-line: 19610
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 19550
-  :end-line: 19583
+  :start-line: 19611
+  :end-line: 19644
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 19584
-  :end-line: 19625
+  :start-line: 19645
+  :end-line: 19686
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 19626
-  :end-line: 19635
+  :start-line: 19687
+  :end-line: 19696
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 19636
-  :end-line: 19648
-
-------------
-
-.. include:: generated/extracted_rst_api.rst
-  :start-line: 19649
-  :end-line: 19662
-
-------------
-
-.. include:: generated/extracted_rst_api.rst
-  :start-line: 19663
-  :end-line: 19675
-
-------------
-
-.. include:: generated/extracted_rst_api.rst
-  :start-line: 19676
-  :end-line: 19685
-
-------------
-
-.. include:: generated/extracted_rst_api.rst
-  :start-line: 19686
-  :end-line: 19693
-
-------------
-
-.. include:: generated/extracted_rst_api.rst
-  :start-line: 19694
-  :end-line: 19701
-
-------------
-
-.. include:: generated/extracted_rst_api.rst
-  :start-line: 19702
+  :start-line: 19697
   :end-line: 19709
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
   :start-line: 19710
-  :end-line: 19717
+  :end-line: 19723
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 19718
-  :end-line: 19727
+  :start-line: 19724
+  :end-line: 19736
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 19728
-  :end-line: 19743
+  :start-line: 19737
+  :end-line: 19746
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 19744
-  :end-line: 19753
+  :start-line: 19747
+  :end-line: 19754
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 19754
-  :end-line: 19767
+  :start-line: 19755
+  :end-line: 19762
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 20932
-  :end-line: 21016
+  :start-line: 19763
+  :end-line: 19770
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 21017
-  :end-line: 21067
+  :start-line: 19771
+  :end-line: 19778
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 21068
-  :end-line: 21091
+  :start-line: 19779
+  :end-line: 19788
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 21092
-  :end-line: 21115
+  :start-line: 19789
+  :end-line: 19804
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 21116
-  :end-line: 21139
+  :start-line: 19805
+  :end-line: 19814
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 21140
-  :end-line: 21220
+  :start-line: 19815
+  :end-line: 19828
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 21221
-  :end-line: 21286
+  :start-line: 20993
+  :end-line: 21077
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 21287
-  :end-line: 21346
+  :start-line: 21078
+  :end-line: 21128
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 21347
-  :end-line: 21417
+  :start-line: 21129
+  :end-line: 21152
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 20267
-  :end-line: 20279
+  :start-line: 21153
+  :end-line: 21176
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 20280
-  :end-line: 20297
+  :start-line: 21177
+  :end-line: 21200
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 20298
-  :end-line: 20315
+  :start-line: 21201
+  :end-line: 21281
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 20316
-  :end-line: 20337
+  :start-line: 21282
+  :end-line: 21347
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 20338
-  :end-line: 20361
+  :start-line: 21348
+  :end-line: 21407
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 9125
-  :end-line: 9214
+  :start-line: 21408
+  :end-line: 21478
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 20362
-  :end-line: 20374
+  :start-line: 20328
+  :end-line: 20340
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 19020
-  :end-line: 19029
+  :start-line: 20341
+  :end-line: 20358
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 20375
-  :end-line: 20392
+  :start-line: 20359
+  :end-line: 20376
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 20393
-  :end-line: 20423
+  :start-line: 20377
+  :end-line: 20398
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 19311
-  :end-line: 19338
+  :start-line: 20399
+  :end-line: 20422
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 19339
-  :end-line: 19359
+  :start-line: 9135
+  :end-line: 9224
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 19360
-  :end-line: 19373
+  :start-line: 20423
+  :end-line: 20435
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 19374
-  :end-line: 19410
+  :start-line: 19081
+  :end-line: 19090
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 20241
-  :end-line: 20266
+  :start-line: 20436
+  :end-line: 20453
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 20454
+  :end-line: 20484
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 19372
+  :end-line: 19399
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 19400
+  :end-line: 19420
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 19421
+  :end-line: 19434
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 19435
+  :end-line: 19471
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 20302
+  :end-line: 20327
 
 ------------
 
@@ -1064,56 +1064,56 @@ Random
 ------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 20658
-  :end-line: 20679
+  :start-line: 20719
+  :end-line: 20740
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 20680
-  :end-line: 20701
+  :start-line: 20741
+  :end-line: 20762
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 20702
-  :end-line: 20727
+  :start-line: 20763
+  :end-line: 20788
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 20728
-  :end-line: 20750
+  :start-line: 20789
+  :end-line: 20811
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 20751
-  :end-line: 20773
+  :start-line: 20812
+  :end-line: 20834
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 8160
-  :end-line: 8336
+  :start-line: 8170
+  :end-line: 8346
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 20176
-  :end-line: 20204
+  :start-line: 20237
+  :end-line: 20265
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 20205
-  :end-line: 20240
+  :start-line: 20266
+  :end-line: 20301
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 20857
-  :end-line: 20869
+  :start-line: 20918
+  :end-line: 20930
 
 ------------
 
@@ -1142,49 +1142,19 @@ Types
 -----
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 10064
-  :end-line: 10334
+  :start-line: 10074
+  :end-line: 10344
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 10335
-  :end-line: 10625
+  :start-line: 10345
+  :end-line: 10635
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 10626
-  :end-line: 10701
-
-------------
-
-.. include:: generated/extracted_rst_api.rst
-  :start-line: 10702
-  :end-line: 10703
-
-------------
-
-.. include:: generated/extracted_rst_api.rst
-  :start-line: 10704
-  :end-line: 10705
-
-------------
-
-.. include:: generated/extracted_rst_api.rst
-  :start-line: 10706
-  :end-line: 10707
-
-------------
-
-.. include:: generated/extracted_rst_api.rst
-  :start-line: 10708
-  :end-line: 10709
-
-------------
-
-.. include:: generated/extracted_rst_api.rst
-  :start-line: 10710
+  :start-line: 10636
   :end-line: 10711
 
 ------------
@@ -1329,54 +1299,54 @@ Types
 
 .. include:: generated/extracted_rst_api.rst
   :start-line: 10758
-  :end-line: 10877
+  :end-line: 10759
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 10878
-  :end-line: 10997
+  :start-line: 10760
+  :end-line: 10761
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 10998
-  :end-line: 11202
+  :start-line: 10762
+  :end-line: 10763
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 11203
-  :end-line: 11407
+  :start-line: 10764
+  :end-line: 10765
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 11408
-  :end-line: 11409
+  :start-line: 10766
+  :end-line: 10767
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 11410
-  :end-line: 11411
+  :start-line: 10768
+  :end-line: 10887
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 11412
-  :end-line: 11413
+  :start-line: 10888
+  :end-line: 11007
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 11414
-  :end-line: 11415
+  :start-line: 11008
+  :end-line: 11212
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 11416
+  :start-line: 11213
   :end-line: 11417
 
 ------------
@@ -1472,20 +1442,50 @@ Types
 ------------
 
 .. include:: generated/extracted_rst_api.rst
+  :start-line: 11448
+  :end-line: 11449
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 11450
+  :end-line: 11451
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 11452
+  :end-line: 11453
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 11454
+  :end-line: 11455
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 11456
+  :end-line: 11457
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
   :start-line: 1839
   :end-line: 1840
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 17239
-  :end-line: 17240
+  :start-line: 17300
+  :end-line: 17301
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 17241
-  :end-line: 17242
+  :start-line: 17302
+  :end-line: 17303
 
 ------------
 
@@ -1526,188 +1526,158 @@ Types
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 15193
-  :end-line: 15194
+  :start-line: 15254
+  :end-line: 15255
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 15195
-  :end-line: 15196
+  :start-line: 15256
+  :end-line: 15257
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 15197
-  :end-line: 15198
+  :start-line: 15258
+  :end-line: 15259
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 15199
-  :end-line: 15200
+  :start-line: 15260
+  :end-line: 15261
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 15201
-  :end-line: 15202
+  :start-line: 15262
+  :end-line: 15263
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 15203
-  :end-line: 15204
+  :start-line: 15264
+  :end-line: 15265
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 17243
-  :end-line: 17244
+  :start-line: 17304
+  :end-line: 17305
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 17245
-  :end-line: 17246
+  :start-line: 17306
+  :end-line: 17307
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 17247
-  :end-line: 17248
+  :start-line: 17308
+  :end-line: 17309
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 17249
-  :end-line: 17250
+  :start-line: 17310
+  :end-line: 17311
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 17251
-  :end-line: 17252
+  :start-line: 17312
+  :end-line: 17313
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 17253
-  :end-line: 17254
+  :start-line: 17314
+  :end-line: 17315
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 17255
-  :end-line: 17256
+  :start-line: 17316
+  :end-line: 17317
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 17257
-  :end-line: 17258
+  :start-line: 17318
+  :end-line: 17319
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 17259
-  :end-line: 17260
+  :start-line: 17320
+  :end-line: 17321
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 17261
-  :end-line: 17262
+  :start-line: 17322
+  :end-line: 17323
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 17263
-  :end-line: 17264
+  :start-line: 17324
+  :end-line: 17325
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 17265
-  :end-line: 17266
+  :start-line: 17326
+  :end-line: 17327
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 17267
-  :end-line: 17268
+  :start-line: 17328
+  :end-line: 17329
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 17269
-  :end-line: 17270
+  :start-line: 17330
+  :end-line: 17331
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 17271
-  :end-line: 17272
+  :start-line: 17332
+  :end-line: 17333
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 17273
-  :end-line: 17274
+  :start-line: 17334
+  :end-line: 17335
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 17275
-  :end-line: 17276
+  :start-line: 17336
+  :end-line: 17337
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 17277
-  :end-line: 17278
+  :start-line: 17338
+  :end-line: 17339
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 17279
-  :end-line: 17280
+  :start-line: 17340
+  :end-line: 17341
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 17281
-  :end-line: 17282
-
-------------
-
-.. include:: generated/extracted_rst_api.rst
-  :start-line: 8690
-  :end-line: 8691
-
-------------
-
-.. include:: generated/extracted_rst_api.rst
-  :start-line: 8692
-  :end-line: 8693
-
-------------
-
-.. include:: generated/extracted_rst_api.rst
-  :start-line: 8694
-  :end-line: 8695
-
-------------
-
-.. include:: generated/extracted_rst_api.rst
-  :start-line: 8696
-  :end-line: 8697
-
-------------
-
-.. include:: generated/extracted_rst_api.rst
-  :start-line: 8698
-  :end-line: 8699
+  :start-line: 17342
+  :end-line: 17343
 
 ------------
 
@@ -1802,14 +1772,44 @@ Types
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 7878
-  :end-line: 7879
+  :start-line: 8730
+  :end-line: 8731
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 7880
-  :end-line: 7881
+  :start-line: 8732
+  :end-line: 8733
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 8734
+  :end-line: 8735
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 8736
+  :end-line: 8737
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 8738
+  :end-line: 8739
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 7892
+  :end-line: 7893
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 7894
+  :end-line: 7895
 
 ------------
 
@@ -1832,26 +1832,26 @@ Types
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 9123
-  :end-line: 9124
+  :start-line: 9133
+  :end-line: 9134
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 15434
-  :end-line: 15713
+  :start-line: 15495
+  :end-line: 15774
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 15714
-  :end-line: 15993
+  :start-line: 15775
+  :end-line: 16054
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 15994
-  :end-line: 16273
+  :start-line: 16055
+  :end-line: 16334
 
 ------------
 
@@ -1874,26 +1874,26 @@ Types
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 16513
-  :end-line: 16636
+  :start-line: 16574
+  :end-line: 16697
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 16637
-  :end-line: 16760
+  :start-line: 16698
+  :end-line: 16821
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 16761
-  :end-line: 16969
+  :start-line: 16822
+  :end-line: 17030
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 16970
-  :end-line: 17178
+  :start-line: 17031
+  :end-line: 17239
 
 ------------
 
@@ -1940,32 +1940,32 @@ Types
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 9215
-  :end-line: 9285
+  :start-line: 9225
+  :end-line: 9295
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 9286
-  :end-line: 9356
+  :start-line: 9296
+  :end-line: 9366
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 9357
-  :end-line: 9427
+  :start-line: 9367
+  :end-line: 9437
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 9428
-  :end-line: 9492
+  :start-line: 9438
+  :end-line: 9502
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 9493
-  :end-line: 9547
+  :start-line: 9503
+  :end-line: 9557
 
 ------------
 
@@ -2051,26 +2051,26 @@ Constants
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 19422
-  :end-line: 19425
+  :start-line: 19483
+  :end-line: 19486
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 19426
-  :end-line: 19429
+  :start-line: 19487
+  :end-line: 19490
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 19430
-  :end-line: 19433
+  :start-line: 19491
+  :end-line: 19494
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 19434
-  :end-line: 19437
+  :start-line: 19495
+  :end-line: 19498
 
 ------------
 
@@ -2084,8 +2084,8 @@ Denoiser
 --------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 8014
-  :end-line: 8159
+  :start-line: 8028
+  :end-line: 8169
 
 ------------
 
@@ -2123,20 +2123,20 @@ BSDF
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 17179
-  :end-line: 17193
+  :start-line: 17240
+  :end-line: 17254
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 7673
-  :end-line: 7851
-
-------------
-
-.. include:: generated/extracted_rst_api.rst
-  :start-line: 7852
+  :start-line: 7687
   :end-line: 7865
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 7866
+  :end-line: 7879
 
 ------------
 
@@ -2162,32 +2162,32 @@ Integrator
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 7866
-  :end-line: 7877
+  :start-line: 7880
+  :end-line: 7891
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 9952
-  :end-line: 10063
+  :start-line: 9962
+  :end-line: 10073
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 18031
-  :end-line: 18319
+  :start-line: 18092
+  :end-line: 18380
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 18320
-  :end-line: 18572
+  :start-line: 18381
+  :end-line: 18633
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 18573
-  :end-line: 18724
+  :start-line: 18634
+  :end-line: 18785
 
 ------------
 
@@ -2225,26 +2225,26 @@ Sensor
 ------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 12092
-  :end-line: 12427
+  :start-line: 12102
+  :end-line: 12437
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 12428
-  :end-line: 12708
+  :start-line: 12438
+  :end-line: 12718
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 8896
-  :end-line: 8933
+  :start-line: 8906
+  :end-line: 8943
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 20150
-  :end-line: 20162
+  :start-line: 20211
+  :end-line: 20223
 
 ------------
 
@@ -2270,20 +2270,20 @@ Medium
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 8487
-  :end-line: 8516
+  :start-line: 8497
+  :end-line: 8526
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 8517
-  :end-line: 8543
+  :start-line: 8527
+  :end-line: 8553
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 8544
-  :end-line: 8646
+  :start-line: 8554
+  :end-line: 8656
 
 ------------
 
@@ -2291,32 +2291,32 @@ Shape
 -----
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 12709
-  :end-line: 13328
+  :start-line: 12719
+  :end-line: 13389
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 13329
-  :end-line: 13854
+  :start-line: 13390
+  :end-line: 13915
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 13855
-  :end-line: 13896
+  :start-line: 13916
+  :end-line: 13957
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
   :start-line: 7233
-  :end-line: 7518
+  :end-line: 7532
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 7519
-  :end-line: 7672
+  :start-line: 7533
+  :end-line: 7686
 
 ------------
 
@@ -2324,8 +2324,8 @@ Texture
 -------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 15205
-  :end-line: 15433
+  :start-line: 15266
+  :end-line: 15494
 
 ------------
 
@@ -2333,14 +2333,14 @@ Volume
 ------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 17283
-  :end-line: 17425
+  :start-line: 17344
+  :end-line: 17486
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 17426
-  :end-line: 17532
+  :start-line: 17487
+  :end-line: 17593
 
 ------------
 
@@ -2348,26 +2348,26 @@ PhaseFunction
 -------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 8360
-  :end-line: 8486
+  :start-line: 8370
+  :end-line: 8496
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 8487
-  :end-line: 8516
+  :start-line: 8497
+  :end-line: 8526
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 8517
-  :end-line: 8543
+  :start-line: 8527
+  :end-line: 8553
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 8544
-  :end-line: 8646
+  :start-line: 8554
+  :end-line: 8656
 
 ------------
 
@@ -2408,8 +2408,8 @@ Filter
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 9548
-  :end-line: 9610
+  :start-line: 9558
+  :end-line: 9620
 
 ------------
 
@@ -2417,8 +2417,8 @@ Sampler
 -------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 9778
-  :end-line: 9951
+  :start-line: 9788
+  :end-line: 9961
 
 ------------
 
@@ -2426,14 +2426,14 @@ Scene
 -----
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 11448
-  :end-line: 11993
+  :start-line: 11458
+  :end-line: 12003
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 19030
-  :end-line: 19033
+  :start-line: 19091
+  :end-line: 19094
 
 ------------
 
@@ -2441,8 +2441,8 @@ Record
 ------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 8730
-  :end-line: 8800
+  :start-line: 8740
+  :end-line: 8810
 
 ------------
 
@@ -2459,14 +2459,14 @@ Record
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 14925
-  :end-line: 15192
+  :start-line: 14986
+  :end-line: 15253
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 8801
-  :end-line: 8895
+  :start-line: 8811
+  :end-line: 8905
 
 ------------
 
@@ -2474,98 +2474,98 @@ Spectrum
 --------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 20870
-  :end-line: 20893
+  :start-line: 20931
+  :end-line: 20954
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 20894
-  :end-line: 20910
+  :start-line: 20955
+  :end-line: 20971
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 20911
-  :end-line: 20931
+  :start-line: 20972
+  :end-line: 20992
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 21418
-  :end-line: 21428
+  :start-line: 21479
+  :end-line: 21489
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 21429
-  :end-line: 21441
+  :start-line: 21490
+  :end-line: 21502
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 21442
-  :end-line: 21449
+  :start-line: 21503
+  :end-line: 21510
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 21450
-  :end-line: 21462
+  :start-line: 21511
+  :end-line: 21523
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 18986
-  :end-line: 18996
+  :start-line: 19047
+  :end-line: 19057
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 18997
-  :end-line: 19007
+  :start-line: 19058
+  :end-line: 19068
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 19008
-  :end-line: 19019
+  :start-line: 19069
+  :end-line: 19080
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 22557
-  :end-line: 22570
+  :start-line: 22618
+  :end-line: 22631
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 20163
-  :end-line: 20175
+  :start-line: 20224
+  :end-line: 20236
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 19524
-  :end-line: 19537
+  :start-line: 19585
+  :end-line: 19598
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 19063
-  :end-line: 19082
+  :start-line: 19124
+  :end-line: 19143
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 19438
-  :end-line: 19448
+  :start-line: 19499
+  :end-line: 19509
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 20642
-  :end-line: 20657
+  :start-line: 20703
+  :end-line: 20718
 
 ------------
 
@@ -2573,116 +2573,116 @@ Polarization
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 19814
-  :end-line: 19823
+  :start-line: 19875
+  :end-line: 19884
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 19824
-  :end-line: 19833
+  :start-line: 19885
+  :end-line: 19894
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 19834
-  :end-line: 19848
+  :start-line: 19895
+  :end-line: 19909
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 19849
-  :end-line: 19857
+  :start-line: 19910
+  :end-line: 19918
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 19858
-  :end-line: 19871
+  :start-line: 19919
+  :end-line: 19932
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 19872
-  :end-line: 19890
+  :start-line: 19933
+  :end-line: 19951
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 19891
-  :end-line: 19899
+  :start-line: 19952
+  :end-line: 19960
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 19900
-  :end-line: 19939
+  :start-line: 19961
+  :end-line: 20000
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 19940
-  :end-line: 19968
+  :start-line: 20001
+  :end-line: 20029
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 19969
-  :end-line: 19998
+  :start-line: 20030
+  :end-line: 20059
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 19999
-  :end-line: 20028
+  :start-line: 20060
+  :end-line: 20089
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 20029
-  :end-line: 20042
+  :start-line: 20090
+  :end-line: 20103
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 20043
-  :end-line: 20061
+  :start-line: 20104
+  :end-line: 20122
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 20062
-  :end-line: 20078
+  :start-line: 20123
+  :end-line: 20139
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 20079
-  :end-line: 20095
+  :start-line: 20140
+  :end-line: 20156
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 20096
-  :end-line: 20115
+  :start-line: 20157
+  :end-line: 20176
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 20116
-  :end-line: 20126
+  :start-line: 20177
+  :end-line: 20187
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 19034
-  :end-line: 19041
+  :start-line: 19095
+  :end-line: 19102
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 21476
-  :end-line: 21483
+  :start-line: 21537
+  :end-line: 21544
 
 ------------
 
@@ -2690,14 +2690,14 @@ Util
 ----
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 21484
-  :end-line: 21488
+  :start-line: 21545
+  :end-line: 21549
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 21489
-  :end-line: 21492
+  :start-line: 21550
+  :end-line: 21553
 
 ------------
 
@@ -2705,56 +2705,56 @@ Chi2
 ----
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 18821
-  :end-line: 18834
+  :start-line: 18882
+  :end-line: 18895
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 18835
-  :end-line: 18938
+  :start-line: 18896
+  :end-line: 18999
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 18939
-  :end-line: 18949
+  :start-line: 19000
+  :end-line: 19010
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 18950
-  :end-line: 18953
+  :start-line: 19011
+  :end-line: 19014
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 18954
-  :end-line: 18958
+  :start-line: 19015
+  :end-line: 19019
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 18959
-  :end-line: 18972
+  :start-line: 19020
+  :end-line: 19033
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 18973
-  :end-line: 18976
+  :start-line: 19034
+  :end-line: 19037
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 18977
-  :end-line: 18981
+  :start-line: 19038
+  :end-line: 19042
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 18982
-  :end-line: 18985
+  :start-line: 19043
+  :end-line: 19046
 
 ------------
 
@@ -2762,56 +2762,56 @@ Autodiff
 --------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 17565
-  :end-line: 17625
-
-------------
-
-.. include:: generated/extracted_rst_api.rst
   :start-line: 17626
-  :end-line: 17632
+  :end-line: 17686
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 17633
-  :end-line: 17671
+  :start-line: 17687
+  :end-line: 17693
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 17672
-  :end-line: 17736
+  :start-line: 17694
+  :end-line: 17732
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 17737
+  :start-line: 17733
   :end-line: 17797
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
   :start-line: 17798
-  :end-line: 17828
+  :end-line: 17858
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 17829
-  :end-line: 17971
+  :start-line: 17859
+  :end-line: 17889
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 17972
-  :end-line: 18021
+  :start-line: 17890
+  :end-line: 18032
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 18022
-  :end-line: 18030
+  :start-line: 18033
+  :end-line: 18082
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 18083
+  :end-line: 18091
 
 ------------
 
@@ -2867,134 +2867,134 @@ Other
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 9726
-  :end-line: 9777
+  :start-line: 9736
+  :end-line: 9787
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 13897
-  :end-line: 13998
+  :start-line: 13958
+  :end-line: 14059
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 18725
-  :end-line: 18729
+  :start-line: 18786
+  :end-line: 18790
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 18730
-  :end-line: 18815
+  :start-line: 18791
+  :end-line: 18876
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 18816
-  :end-line: 18820
+  :start-line: 18877
+  :end-line: 18881
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 19042
-  :end-line: 19049
+  :start-line: 19103
+  :end-line: 19110
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 19050
-  :end-line: 19054
+  :start-line: 19111
+  :end-line: 19115
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 19055
-  :end-line: 19062
+  :start-line: 19116
+  :end-line: 19123
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 19501
-  :end-line: 19507
+  :start-line: 19562
+  :end-line: 19568
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 19508
-  :end-line: 19523
+  :start-line: 19569
+  :end-line: 19584
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 19768
-  :end-line: 19771
+  :start-line: 19829
+  :end-line: 19832
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 19772
-  :end-line: 19778
+  :start-line: 19833
+  :end-line: 19839
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 19779
-  :end-line: 19791
+  :start-line: 19840
+  :end-line: 19852
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 19792
-  :end-line: 19805
+  :start-line: 19853
+  :end-line: 19866
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 19806
-  :end-line: 19813
+  :start-line: 19867
+  :end-line: 19874
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 20127
-  :end-line: 20149
+  :start-line: 20188
+  :end-line: 20210
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 20774
-  :end-line: 20781
+  :start-line: 20835
+  :end-line: 20842
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 20797
-  :end-line: 20813
+  :start-line: 20858
+  :end-line: 20874
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 20814
-  :end-line: 20829
+  :start-line: 20875
+  :end-line: 20890
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 20830
-  :end-line: 20856
+  :start-line: 20891
+  :end-line: 20917
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 21498
-  :end-line: 21505
+  :start-line: 21559
+  :end-line: 21566
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 22146
-  :end-line: 22535
+  :start-line: 22207
+  :end-line: 22596
 
 ------------
 

--- a/include/mitsuba/python/docstr.h
+++ b/include/mitsuba/python/docstr.h
@@ -101,13 +101,95 @@ static const char *__doc_OptixBuildInputCustomPrimitiveArray_sbtIndexOffsetStrid
 
 static const char *__doc_OptixBuildInputCustomPrimitiveArray_strideInBytes = R"doc()doc";
 
+static const char *__doc_OptixBuildInputDisplacementMicromap = R"doc()doc";
+
+static const char *__doc_OptixBuildInputDisplacementMicromap_displacementMicromapArray = R"doc()doc";
+
+static const char *__doc_OptixBuildInputDisplacementMicromap_displacementMicromapIndexBuffer = R"doc()doc";
+
+static const char *__doc_OptixBuildInputDisplacementMicromap_displacementMicromapIndexOffset = R"doc()doc";
+
+static const char *__doc_OptixBuildInputDisplacementMicromap_displacementMicromapIndexSizeInBytes = R"doc()doc";
+
+static const char *__doc_OptixBuildInputDisplacementMicromap_displacementMicromapIndexStrideInBytes = R"doc()doc";
+
+static const char *__doc_OptixBuildInputDisplacementMicromap_displacementMicromapUsageCounts = R"doc()doc";
+
+static const char *__doc_OptixBuildInputDisplacementMicromap_indexingMode = R"doc()doc";
+
+static const char *__doc_OptixBuildInputDisplacementMicromap_numDisplacementMicromapUsageCounts = R"doc()doc";
+
+static const char *__doc_OptixBuildInputDisplacementMicromap_triangleFlagsBuffer = R"doc()doc";
+
+static const char *__doc_OptixBuildInputDisplacementMicromap_triangleFlagsStrideInBytes = R"doc()doc";
+
+static const char *__doc_OptixBuildInputDisplacementMicromap_vertexBiasAndScaleBuffer = R"doc()doc";
+
+static const char *__doc_OptixBuildInputDisplacementMicromap_vertexBiasAndScaleFormat = R"doc()doc";
+
+static const char *__doc_OptixBuildInputDisplacementMicromap_vertexBiasAndScaleStrideInBytes = R"doc()doc";
+
+static const char *__doc_OptixBuildInputDisplacementMicromap_vertexDirectionFormat = R"doc()doc";
+
+static const char *__doc_OptixBuildInputDisplacementMicromap_vertexDirectionStrideInBytes = R"doc()doc";
+
+static const char *__doc_OptixBuildInputDisplacementMicromap_vertexDirectionsBuffer = R"doc()doc";
+
 static const char *__doc_OptixBuildInputInstanceArray = R"doc()doc";
+
+static const char *__doc_OptixBuildInputInstanceArray_instanceStride = R"doc()doc";
 
 static const char *__doc_OptixBuildInputInstanceArray_instances = R"doc()doc";
 
 static const char *__doc_OptixBuildInputInstanceArray_numInstances = R"doc()doc";
 
+static const char *__doc_OptixBuildInputOpacityMicromap = R"doc()doc";
+
+static const char *__doc_OptixBuildInputOpacityMicromap_indexBuffer = R"doc()doc";
+
+static const char *__doc_OptixBuildInputOpacityMicromap_indexOffset = R"doc()doc";
+
+static const char *__doc_OptixBuildInputOpacityMicromap_indexSizeInBytes = R"doc()doc";
+
+static const char *__doc_OptixBuildInputOpacityMicromap_indexStrideInBytes = R"doc()doc";
+
+static const char *__doc_OptixBuildInputOpacityMicromap_indexingMode = R"doc()doc";
+
+static const char *__doc_OptixBuildInputOpacityMicromap_micromapUsageCounts = R"doc()doc";
+
+static const char *__doc_OptixBuildInputOpacityMicromap_numMicromapUsageCounts = R"doc()doc";
+
+static const char *__doc_OptixBuildInputOpacityMicromap_opacityMicromapArray = R"doc()doc";
+
+static const char *__doc_OptixBuildInputSphereArray = R"doc()doc";
+
+static const char *__doc_OptixBuildInputSphereArray_flags = R"doc()doc";
+
+static const char *__doc_OptixBuildInputSphereArray_numSbtRecords = R"doc()doc";
+
+static const char *__doc_OptixBuildInputSphereArray_numVertices = R"doc()doc";
+
+static const char *__doc_OptixBuildInputSphereArray_primitiveIndexOffset = R"doc()doc";
+
+static const char *__doc_OptixBuildInputSphereArray_radiusBuffers = R"doc()doc";
+
+static const char *__doc_OptixBuildInputSphereArray_radiusStrideInBytes = R"doc()doc";
+
+static const char *__doc_OptixBuildInputSphereArray_sbtIndexOffsetBuffer = R"doc()doc";
+
+static const char *__doc_OptixBuildInputSphereArray_sbtIndexOffsetSizeInBytes = R"doc()doc";
+
+static const char *__doc_OptixBuildInputSphereArray_sbtIndexOffsetStrideInBytes = R"doc()doc";
+
+static const char *__doc_OptixBuildInputSphereArray_singleRadius = R"doc()doc";
+
+static const char *__doc_OptixBuildInputSphereArray_vertexBuffers = R"doc()doc";
+
+static const char *__doc_OptixBuildInputSphereArray_vertexStrideInBytes = R"doc()doc";
+
 static const char *__doc_OptixBuildInputTriangleArray = R"doc()doc";
+
+static const char *__doc_OptixBuildInputTriangleArray_displacementMicromap = R"doc()doc";
 
 static const char *__doc_OptixBuildInputTriangleArray_flags = R"doc()doc";
 
@@ -122,6 +204,8 @@ static const char *__doc_OptixBuildInputTriangleArray_numIndexTriplets = R"doc()
 static const char *__doc_OptixBuildInputTriangleArray_numSbtRecords = R"doc()doc";
 
 static const char *__doc_OptixBuildInputTriangleArray_numVertices = R"doc()doc";
+
+static const char *__doc_OptixBuildInputTriangleArray_opacityMicromap = R"doc()doc";
 
 static const char *__doc_OptixBuildInputTriangleArray_preTransform = R"doc()doc";
 
@@ -153,13 +237,39 @@ static const char *__doc_OptixBuiltinISOptions_curveEndcapFlags = R"doc()doc";
 
 static const char *__doc_OptixBuiltinISOptions_usesMotionBlur = R"doc()doc";
 
+static const char *__doc_OptixDenoiserAOVType = R"doc()doc";
+
+static const char *__doc_OptixDenoiserAOVType_OPTIX_DENOISER_AOV_TYPE_BEAUTY = R"doc()doc";
+
+static const char *__doc_OptixDenoiserAOVType_OPTIX_DENOISER_AOV_TYPE_DIFFUSE = R"doc()doc";
+
+static const char *__doc_OptixDenoiserAOVType_OPTIX_DENOISER_AOV_TYPE_NONE = R"doc()doc";
+
+static const char *__doc_OptixDenoiserAOVType_OPTIX_DENOISER_AOV_TYPE_REFLECTION = R"doc()doc";
+
+static const char *__doc_OptixDenoiserAOVType_OPTIX_DENOISER_AOV_TYPE_REFRACTION = R"doc()doc";
+
+static const char *__doc_OptixDenoiserAOVType_OPTIX_DENOISER_AOV_TYPE_SPECULAR = R"doc()doc";
+
+static const char *__doc_OptixDenoiserAlphaMode = R"doc()doc";
+
+static const char *__doc_OptixDenoiserAlphaMode_OPTIX_DENOISER_ALPHA_MODE_COPY = R"doc()doc";
+
+static const char *__doc_OptixDenoiserAlphaMode_OPTIX_DENOISER_ALPHA_MODE_DENOISE = R"doc()doc";
+
 static const char *__doc_OptixDenoiserGuideLayer = R"doc()doc";
 
 static const char *__doc_OptixDenoiserGuideLayer_albedo = R"doc()doc";
 
 static const char *__doc_OptixDenoiserGuideLayer_flow = R"doc()doc";
 
+static const char *__doc_OptixDenoiserGuideLayer_flowTrustworthiness = R"doc()doc";
+
 static const char *__doc_OptixDenoiserGuideLayer_normal = R"doc()doc";
+
+static const char *__doc_OptixDenoiserGuideLayer_outputInternalGuideLayer = R"doc()doc";
+
+static const char *__doc_OptixDenoiserGuideLayer_previousOutputInternalGuideLayer = R"doc()doc";
 
 static const char *__doc_OptixDenoiserLayer = R"doc()doc";
 
@@ -169,6 +279,8 @@ static const char *__doc_OptixDenoiserLayer_output = R"doc()doc";
 
 static const char *__doc_OptixDenoiserLayer_previousOutput = R"doc()doc";
 
+static const char *__doc_OptixDenoiserLayer_type = R"doc()doc";
+
 static const char *__doc_OptixDenoiserModelKind = R"doc()doc";
 
 static const char *__doc_OptixDenoiserModelKind_OPTIX_DENOISER_MODEL_KIND_HDR = R"doc()doc";
@@ -176,6 +288,8 @@ static const char *__doc_OptixDenoiserModelKind_OPTIX_DENOISER_MODEL_KIND_HDR = 
 static const char *__doc_OptixDenoiserModelKind_OPTIX_DENOISER_MODEL_KIND_TEMPORAL = R"doc()doc";
 
 static const char *__doc_OptixDenoiserOptions = R"doc()doc";
+
+static const char *__doc_OptixDenoiserOptions_denoiseAlpha = R"doc()doc";
 
 static const char *__doc_OptixDenoiserOptions_guideAlbedo = R"doc()doc";
 
@@ -185,13 +299,19 @@ static const char *__doc_OptixDenoiserParams = R"doc()doc";
 
 static const char *__doc_OptixDenoiserParams_blendFactor = R"doc()doc";
 
-static const char *__doc_OptixDenoiserParams_denoiseAlpha = R"doc()doc";
-
 static const char *__doc_OptixDenoiserParams_hdrAverageColor = R"doc()doc";
 
 static const char *__doc_OptixDenoiserParams_hdrIntensity = R"doc()doc";
 
+static const char *__doc_OptixDenoiserParams_temporalModeUsePreviousLayers = R"doc()doc";
+
 static const char *__doc_OptixDenoiserSizes = R"doc()doc";
+
+static const char *__doc_OptixDenoiserSizes_computeAverageColorSizeInBytes = R"doc()doc";
+
+static const char *__doc_OptixDenoiserSizes_computeIntensitySizeInBytes = R"doc()doc";
+
+static const char *__doc_OptixDenoiserSizes_internalGuideLayerPixelSizeInBytes = R"doc()doc";
 
 static const char *__doc_OptixDenoiserSizes_overlapWindowSizeInPixels = R"doc()doc";
 
@@ -200,6 +320,14 @@ static const char *__doc_OptixDenoiserSizes_stateSizeInBytes = R"doc()doc";
 static const char *__doc_OptixDenoiserSizes_withOverlapScratchSizeInBytes = R"doc()doc";
 
 static const char *__doc_OptixDenoiserSizes_withoutOverlapScratchSizeInBytes = R"doc()doc";
+
+static const char *__doc_OptixDisplacementMicromapUsageCount = R"doc()doc";
+
+static const char *__doc_OptixDisplacementMicromapUsageCount_count = R"doc()doc";
+
+static const char *__doc_OptixDisplacementMicromapUsageCount_format = R"doc()doc";
+
+static const char *__doc_OptixDisplacementMicromapUsageCount_subdivisionLevel = R"doc()doc";
 
 static const char *__doc_OptixHitGroupData = R"doc(Stores information about a Shape on the Optix side)doc";
 
@@ -263,6 +391,14 @@ static const char *__doc_OptixMotionOptions_timeBegin = R"doc()doc";
 
 static const char *__doc_OptixMotionOptions_timeEnd = R"doc()doc";
 
+static const char *__doc_OptixOpacityMicromapUsageCount = R"doc()doc";
+
+static const char *__doc_OptixOpacityMicromapUsageCount_count = R"doc()doc";
+
+static const char *__doc_OptixOpacityMicromapUsageCount_format = R"doc()doc";
+
+static const char *__doc_OptixOpacityMicromapUsageCount_subdivisionLevel = R"doc()doc";
+
 static const char *__doc_OptixPayloadType = R"doc()doc";
 
 static const char *__doc_OptixPayloadType_numPayloadValues = R"doc()doc";
@@ -270,6 +406,8 @@ static const char *__doc_OptixPayloadType_numPayloadValues = R"doc()doc";
 static const char *__doc_OptixPayloadType_payloadSemantics = R"doc()doc";
 
 static const char *__doc_OptixPipelineCompileOptions = R"doc()doc";
+
+static const char *__doc_OptixPipelineCompileOptions_allowOpacityMicromaps = R"doc()doc";
 
 static const char *__doc_OptixPipelineCompileOptions_exceptionFlags = R"doc()doc";
 
@@ -302,6 +440,16 @@ static const char *__doc_OptixPixelFormat_OPTIX_PIXEL_FORMAT_HALF4 = R"doc()doc"
 static const char *__doc_OptixPixelFormat_OPTIX_PIXEL_FORMAT_UCHAR3 = R"doc()doc";
 
 static const char *__doc_OptixPixelFormat_OPTIX_PIXEL_FORMAT_UCHAR4 = R"doc()doc";
+
+static const char *__doc_OptixProgramGroupCallables = R"doc()doc";
+
+static const char *__doc_OptixProgramGroupCallables_entryFunctionNameCC = R"doc()doc";
+
+static const char *__doc_OptixProgramGroupCallables_entryFunctionNameDC = R"doc()doc";
+
+static const char *__doc_OptixProgramGroupCallables_moduleCC = R"doc()doc";
+
+static const char *__doc_OptixProgramGroupCallables_moduleDC = R"doc()doc";
 
 static const char *__doc_OptixProgramGroupDesc = R"doc()doc";
 
@@ -391,7 +539,7 @@ static const char *__doc_mitsuba_AdjointIntegrator_6 = R"doc()doc";
 
 static const char *__doc_mitsuba_AdjointIntegrator_AdjointIntegrator = R"doc(Create an integrator)doc";
 
-static const char *__doc_mitsuba_AdjointIntegrator_class = R"doc(//! @})doc";
+static const char *__doc_mitsuba_AdjointIntegrator_class = R"doc()doc";
 
 static const char *__doc_mitsuba_AdjointIntegrator_m_max_depth =
 R"doc(Longest visualized path depth (\c -1 = infinite). A value of ``1``
@@ -732,13 +880,13 @@ static const char *__doc_mitsuba_BSDFSample3_BSDFSample3_4 = R"doc(//! @})doc";
 
 static const char *__doc_mitsuba_BSDFSample3_eta = R"doc(Relative index of refraction in the sampled direction)doc";
 
-static const char *__doc_mitsuba_BSDFSample3_fields = R"doc(//! @})doc";
+static const char *__doc_mitsuba_BSDFSample3_fields = R"doc()doc";
 
-static const char *__doc_mitsuba_BSDFSample3_fields_2 = R"doc(//! @})doc";
+static const char *__doc_mitsuba_BSDFSample3_fields_2 = R"doc()doc";
 
-static const char *__doc_mitsuba_BSDFSample3_labels = R"doc(//! @})doc";
+static const char *__doc_mitsuba_BSDFSample3_labels = R"doc()doc";
 
-static const char *__doc_mitsuba_BSDFSample3_name = R"doc(//! @})doc";
+static const char *__doc_mitsuba_BSDFSample3_name = R"doc()doc";
 
 static const char *__doc_mitsuba_BSDFSample3_operator_assign = R"doc(//! @})doc";
 
@@ -754,7 +902,7 @@ static const char *__doc_mitsuba_BSDFSample3_wo = R"doc(Normalized outgoing dire
 
 static const char *__doc_mitsuba_BSDF_BSDF = R"doc(//! @})doc";
 
-static const char *__doc_mitsuba_BSDF_class = R"doc(//! @})doc";
+static const char *__doc_mitsuba_BSDF_class = R"doc()doc";
 
 static const char *__doc_mitsuba_BSDF_component_count = R"doc(Number of components this BSDF is comprised of.)doc";
 
@@ -2061,13 +2209,13 @@ choosing one of several objects (shapes, emitters, ..) on which the
 position lies. In that case, the ``object`` attribute stores a pointer
 to this object.)doc";
 
-static const char *__doc_mitsuba_DirectionSample_fields = R"doc(//! @})doc";
+static const char *__doc_mitsuba_DirectionSample_fields = R"doc()doc";
 
-static const char *__doc_mitsuba_DirectionSample_fields_2 = R"doc(//! @})doc";
+static const char *__doc_mitsuba_DirectionSample_fields_2 = R"doc()doc";
 
-static const char *__doc_mitsuba_DirectionSample_labels = R"doc(//! @})doc";
+static const char *__doc_mitsuba_DirectionSample_labels = R"doc()doc";
 
-static const char *__doc_mitsuba_DirectionSample_name = R"doc(//! @})doc";
+static const char *__doc_mitsuba_DirectionSample_name = R"doc()doc";
 
 static const char *__doc_mitsuba_DirectionSample_operator_array = R"doc(Convenience operator for masking)doc";
 
@@ -2335,7 +2483,7 @@ static const char *__doc_mitsuba_DummyStream_can_read = R"doc()doc";
 
 static const char *__doc_mitsuba_DummyStream_can_write = R"doc()doc";
 
-static const char *__doc_mitsuba_DummyStream_class = R"doc(//! @})doc";
+static const char *__doc_mitsuba_DummyStream_class = R"doc()doc";
 
 static const char *__doc_mitsuba_DummyStream_close =
 R"doc(Closes the stream. No further read or write operations are permitted.
@@ -2816,7 +2964,7 @@ static const char *__doc_mitsuba_FileStream_can_read = R"doc(True except if the 
 
 static const char *__doc_mitsuba_FileStream_can_write = R"doc(Whether the field was open in write-mode (and was not closed))doc";
 
-static const char *__doc_mitsuba_FileStream_class = R"doc(//! @})doc";
+static const char *__doc_mitsuba_FileStream_class = R"doc()doc";
 
 static const char *__doc_mitsuba_FileStream_close =
 R"doc(Closes the stream and the underlying file. No further read or write
@@ -3817,17 +3965,17 @@ static const char *__doc_mitsuba_Interaction_Interaction_3 = R"doc(//! @})doc";
 
 static const char *__doc_mitsuba_Interaction_Interaction_4 = R"doc(//! @})doc";
 
-static const char *__doc_mitsuba_Interaction_fields = R"doc(//! @})doc";
+static const char *__doc_mitsuba_Interaction_fields = R"doc()doc";
 
-static const char *__doc_mitsuba_Interaction_fields_2 = R"doc(//! @})doc";
+static const char *__doc_mitsuba_Interaction_fields_2 = R"doc()doc";
 
 static const char *__doc_mitsuba_Interaction_is_valid = R"doc(Is the current interaction valid?)doc";
 
-static const char *__doc_mitsuba_Interaction_labels = R"doc(//! @})doc";
+static const char *__doc_mitsuba_Interaction_labels = R"doc()doc";
 
 static const char *__doc_mitsuba_Interaction_n = R"doc(Geometric normal (only valid for ``SurfaceInteraction``))doc";
 
-static const char *__doc_mitsuba_Interaction_name = R"doc(//! @})doc";
+static const char *__doc_mitsuba_Interaction_name = R"doc()doc";
 
 static const char *__doc_mitsuba_Interaction_offset_p =
 R"doc(Compute an offset position, used when spawning a ray from this
@@ -4229,17 +4377,17 @@ static const char *__doc_mitsuba_MediumInteraction_MediumInteraction_3 = R"doc(/
 
 static const char *__doc_mitsuba_MediumInteraction_combined_extinction = R"doc()doc";
 
-static const char *__doc_mitsuba_MediumInteraction_fields = R"doc(//! @})doc";
+static const char *__doc_mitsuba_MediumInteraction_fields = R"doc()doc";
 
-static const char *__doc_mitsuba_MediumInteraction_fields_2 = R"doc(//! @})doc";
+static const char *__doc_mitsuba_MediumInteraction_fields_2 = R"doc()doc";
 
-static const char *__doc_mitsuba_MediumInteraction_labels = R"doc(//! @})doc";
+static const char *__doc_mitsuba_MediumInteraction_labels = R"doc()doc";
 
 static const char *__doc_mitsuba_MediumInteraction_medium = R"doc(Pointer to the associated medium)doc";
 
 static const char *__doc_mitsuba_MediumInteraction_mint = R"doc(mint used when sampling the given distance ``t``)doc";
 
-static const char *__doc_mitsuba_MediumInteraction_name = R"doc(//! @})doc";
+static const char *__doc_mitsuba_MediumInteraction_name = R"doc()doc";
 
 static const char *__doc_mitsuba_MediumInteraction_operator_assign = R"doc(//! @})doc";
 
@@ -4421,7 +4569,7 @@ static const char *__doc_mitsuba_MemoryStream_can_write = R"doc(Always returns t
 
 static const char *__doc_mitsuba_MemoryStream_capacity = R"doc(Return the current capacity of the underlying memory buffer)doc";
 
-static const char *__doc_mitsuba_MemoryStream_class = R"doc(//! @})doc";
+static const char *__doc_mitsuba_MemoryStream_class = R"doc()doc";
 
 static const char *__doc_mitsuba_MemoryStream_close =
 R"doc(Closes the stream. No further read or write operations are permitted.
@@ -4524,12 +4672,6 @@ static const char *__doc_mitsuba_Mesh_MeshAttribute_size = R"doc()doc";
 static const char *__doc_mitsuba_Mesh_MeshAttribute_type = R"doc()doc";
 
 static const char *__doc_mitsuba_Mesh_add_attribute = R"doc(Add an attribute buffer with the given ``name`` and ``dim``)doc";
-
-static const char *__doc_mitsuba_Mesh_remove_attribute = R"doc(Remove an attribute with the given ``name``.
-
-Affects both mesh and texture attributes.
-
-Throws an exception if the attribute was not previously registered.)doc";
 
 static const char *__doc_mitsuba_Mesh_attribute_buffer = R"doc(Return the mesh attribute associated with ``name``)doc";
 
@@ -4748,11 +4890,20 @@ static const char *__doc_mitsuba_Mesh_recompute_bbox = R"doc(Recompute the bound
 
 static const char *__doc_mitsuba_Mesh_recompute_vertex_normals = R"doc(Compute smooth vertex normals and replace the current normal values)doc";
 
+static const char *__doc_mitsuba_Mesh_remove_attribute =
+R"doc(Remove an attribute with the given ``name``.
+
+Affects both mesh and texture attributes.
+
+Throws an exception if the attribute was not previously registered.)doc";
+
 static const char *__doc_mitsuba_Mesh_sample_position = R"doc()doc";
 
 static const char *__doc_mitsuba_Mesh_sample_precomputed_silhouette = R"doc()doc";
 
 static const char *__doc_mitsuba_Mesh_sample_silhouette = R"doc()doc";
+
+static const char *__doc_mitsuba_Mesh_set_bsdf = R"doc(Set the shape's BSDF)doc";
 
 static const char *__doc_mitsuba_Mesh_set_scene = R"doc()doc";
 
@@ -5153,11 +5304,20 @@ Parameter ``input_size``:
 
 Parameter ``albedo``:
     Whether or not albedo information will also be given to the
-    denoiser.
+    denoiser. This parameter is optional, by default it is false.
 
 Parameter ``normals``:
     Whether or not shading normals information will also be given to
-    the Denoiser.
+    the denoiser. This parameter is optional, by default it is false.
+
+Parameter ``temporal``:
+    Whether or not temporal information will also be given to the
+    denoiser. This parameter is optional, by default it is false.
+
+Parameter ``denoise_alpha``:
+    Whether or not the alpha channel (if specified in the noisy input)
+    should be denoised too. This parameter is optional, by default it
+    is false.
 
 Returns:
     A callable object which will apply the OptiX denoiser.)doc";
@@ -5191,11 +5351,6 @@ R"doc(Apply denoiser on inputs which are TensorXf objects.
 
 Parameter ``noisy``:
     The noisy input. (tensor shape: (width, height, 3 | 4))
-
-Parameter ``denoise_alpha``:
-    Whether or not the alpha channel (if specified in the noisy input)
-    should be denoised too. This parameter is optional, by default it
-    is true.
 
 Parameter ``albedo``:
     Albedo information of the noisy rendering. This parameter is
@@ -5241,11 +5396,6 @@ Parameter ``noisy``:
     The noisy input. When passing additional information like albedo
     or normals to the denoiser, this Bitmap object must be a
     MultiChannel bitmap.
-
-Parameter ``denoise_alpha``:
-    Whether or not the alpha channel (if specified in the noisy input)
-    should be denoised too. This parameter is optional, by default it
-    is true.
 
 Parameter ``albedo_ch``:
     The name of the channel in the ``noisy`` parameter which contains
@@ -5424,7 +5574,7 @@ static const char *__doc_mitsuba_PhaseFunctionFlags_Microflake = R"doc()doc";
 
 static const char *__doc_mitsuba_PhaseFunction_PhaseFunction = R"doc(//! @})doc";
 
-static const char *__doc_mitsuba_PhaseFunction_class = R"doc(//! @})doc";
+static const char *__doc_mitsuba_PhaseFunction_class = R"doc()doc";
 
 static const char *__doc_mitsuba_PhaseFunction_component_count = R"doc(Number of components this phase function is comprised of.)doc";
 
@@ -5596,15 +5746,15 @@ static const char *__doc_mitsuba_PositionSample_delta =
 R"doc(Set if the sample was drawn from a degenerate (Dirac delta)
 distribution)doc";
 
-static const char *__doc_mitsuba_PositionSample_fields = R"doc(//! @})doc";
+static const char *__doc_mitsuba_PositionSample_fields = R"doc()doc";
 
-static const char *__doc_mitsuba_PositionSample_fields_2 = R"doc(//! @})doc";
+static const char *__doc_mitsuba_PositionSample_fields_2 = R"doc()doc";
 
-static const char *__doc_mitsuba_PositionSample_labels = R"doc(//! @})doc";
+static const char *__doc_mitsuba_PositionSample_labels = R"doc()doc";
 
 static const char *__doc_mitsuba_PositionSample_n = R"doc(Sampled surface normal (if applicable))doc";
 
-static const char *__doc_mitsuba_PositionSample_name = R"doc(//! @})doc";
+static const char *__doc_mitsuba_PositionSample_name = R"doc()doc";
 
 static const char *__doc_mitsuba_PositionSample_operator_assign = R"doc(//! @})doc";
 
@@ -5667,17 +5817,17 @@ Parameter ``ray_flags``:
 Returns:
     A data structure containing the detailed information)doc";
 
-static const char *__doc_mitsuba_PreliminaryIntersection_fields = R"doc(//! @})doc";
+static const char *__doc_mitsuba_PreliminaryIntersection_fields = R"doc()doc";
 
-static const char *__doc_mitsuba_PreliminaryIntersection_fields_2 = R"doc(//! @})doc";
+static const char *__doc_mitsuba_PreliminaryIntersection_fields_2 = R"doc()doc";
 
 static const char *__doc_mitsuba_PreliminaryIntersection_instance = R"doc(Stores a pointer to the parent instance (if applicable))doc";
 
 static const char *__doc_mitsuba_PreliminaryIntersection_is_valid = R"doc(Is the current interaction valid?)doc";
 
-static const char *__doc_mitsuba_PreliminaryIntersection_labels = R"doc(//! @})doc";
+static const char *__doc_mitsuba_PreliminaryIntersection_labels = R"doc()doc";
 
-static const char *__doc_mitsuba_PreliminaryIntersection_name = R"doc(//! @})doc";
+static const char *__doc_mitsuba_PreliminaryIntersection_name = R"doc()doc";
 
 static const char *__doc_mitsuba_PreliminaryIntersection_operator_assign = R"doc(//! @})doc";
 
@@ -6609,7 +6759,7 @@ static const char *__doc_mitsuba_SamplingIntegrator_6 = R"doc()doc";
 
 static const char *__doc_mitsuba_SamplingIntegrator_SamplingIntegrator = R"doc(//! @})doc";
 
-static const char *__doc_mitsuba_SamplingIntegrator_class = R"doc(//! @})doc";
+static const char *__doc_mitsuba_SamplingIntegrator_class = R"doc()doc";
 
 static const char *__doc_mitsuba_SamplingIntegrator_m_block_size = R"doc(Size of (square) image blocks to render in parallel (in scalar mode))doc";
 
@@ -7524,6 +7674,21 @@ static const char *__doc_mitsuba_Shape_Shape = R"doc(//! @})doc";
 
 static const char *__doc_mitsuba_Shape_Shape_2 = R"doc()doc";
 
+static const char *__doc_mitsuba_Shape_add_texture_attribute =
+R"doc(Add a texture attribute with the given ``name``.
+
+If an attribute with the same name already exists, it is replaced.
+
+Note that ``Mesh`` shapes can additionally handle per-vertex and per-
+face attributes via the ``Mesh::add_attribute`` method.
+
+Parameter ``name``:
+    Name of the attribute
+
+Parameter ``texture``:
+    Texture to store. The dimensionality of the attribute is simply
+    the channel count of the texture.)doc";
+
 static const char *__doc_mitsuba_Shape_bbox =
 R"doc(Return an axis aligned box that bounds all shape primitives (including
 any transformations that may have been applied to them))doc";
@@ -7547,7 +7712,7 @@ static const char *__doc_mitsuba_Shape_bsdf = R"doc(Return the shape's BSDF)doc"
 
 static const char *__doc_mitsuba_Shape_bsdf_2 = R"doc(Return the shape's BSDF)doc";
 
-static const char *__doc_mitsuba_Shape_class = R"doc(//! @})doc";
+static const char *__doc_mitsuba_Shape_class = R"doc()doc";
 
 static const char *__doc_mitsuba_Shape_compute_surface_interaction =
 R"doc(Compute and return detailed information related to a surface
@@ -7622,27 +7787,6 @@ static const char *__doc_mitsuba_Shape_embree_geometry = R"doc(Return the Embree
 static const char *__doc_mitsuba_Shape_emitter = R"doc(Return the area emitter associated with this shape (if any))doc";
 
 static const char *__doc_mitsuba_Shape_emitter_2 = R"doc(Return the area emitter associated with this shape (if any))doc";
-
-static const char *__doc_mitsuba_Shape_add_texture_attribute =
-R"doc(Add a texture attribute with the given ``name``.
-
-If an attribute with the same name already exists, it is replaced.
-
-Note that ``Mesh`` shapes can additionally handle per-vertex
-and per-face attributes via the ``Mesh::add_attribute method``.
-
-Parameter ``name``:
-    Name of the attribute
-Parameter ``texture``:
-    Texture to store. The dimensionality of the attribute
-    is simply the channel count of the texture.)doc";
-
-static const char *__doc_mitsuba_Shape_texture_attribute = R"doc(Return the texture attribute associated with \c name.)doc";
-
-static const char *__doc_mitsuba_Shape_remove_attribute =
-R"doc(Remove a texture texture with the given ``name``.
-
-Throws an exception if the attribute was not registered.)doc";
 
 static const char *__doc_mitsuba_Shape_eval_attribute =
 R"doc(Evaluate a specific shape attribute at the given surface interaction.
@@ -7859,8 +8003,6 @@ static const char *__doc_mitsuba_Shape_parameters_grad_enabled =
 R"doc(Return whether any shape's parameters that introduce visibility
 discontinuities require gradients (default return false))doc";
 
-static const char *__doc_mitsuba_Shape_set_bsdf = R"doc(Set the shape's BSDF)doc";
-
 static const char *__doc_mitsuba_Shape_pdf_direction =
 R"doc(Query the probability density of sample_direction()
 
@@ -8029,6 +8171,11 @@ static const char *__doc_mitsuba_Shape_ray_test_packet_3 = R"doc()doc";
 
 static const char *__doc_mitsuba_Shape_ray_test_scalar = R"doc()doc";
 
+static const char *__doc_mitsuba_Shape_remove_attribute =
+R"doc(Remove a texture texture with the given ``name``.
+
+Throws an exception if the attribute was not registered.)doc";
+
 static const char *__doc_mitsuba_Shape_sample_direction =
 R"doc(Sample a direction towards this shape with respect to solid angles
 measured at a reference position within the scene
@@ -8118,6 +8265,8 @@ static const char *__doc_mitsuba_Shape_sensor = R"doc(Return the area sensor ass
 
 static const char *__doc_mitsuba_Shape_sensor_2 = R"doc(Return the area sensor associated with this shape (if any))doc";
 
+static const char *__doc_mitsuba_Shape_set_bsdf = R"doc(Set the shape's BSDF)doc";
+
 static const char *__doc_mitsuba_Shape_set_id = R"doc(Set a string identifier)doc";
 
 static const char *__doc_mitsuba_Shape_shape_type = R"doc(Returns the shape type ShapeType of this shape)doc";
@@ -8133,6 +8282,10 @@ The function assumes that the object is not undergoing some kind of
 time-dependent scaling.
 
 The default implementation throws an exception.)doc";
+
+static const char *__doc_mitsuba_Shape_texture_attribute = R"doc(Return the texture attribute associated with ``name``.)doc";
+
+static const char *__doc_mitsuba_Shape_texture_attribute_2 = R"doc(Return the texture attribute associated with ``name``.)doc";
 
 static const char *__doc_mitsuba_Shape_traverse = R"doc()doc";
 
@@ -8152,9 +8305,9 @@ static const char *__doc_mitsuba_SilhouetteSample_d = R"doc(Direction of the bou
 
 static const char *__doc_mitsuba_SilhouetteSample_discontinuity_type = R"doc(Type of discontinuity (DiscontinuityFlags))doc";
 
-static const char *__doc_mitsuba_SilhouetteSample_fields = R"doc(//! @})doc";
+static const char *__doc_mitsuba_SilhouetteSample_fields = R"doc()doc";
 
-static const char *__doc_mitsuba_SilhouetteSample_fields_2 = R"doc(//! @})doc";
+static const char *__doc_mitsuba_SilhouetteSample_fields_2 = R"doc()doc";
 
 static const char *__doc_mitsuba_SilhouetteSample_flags =
 R"doc(The set of ``DiscontinuityFlags`` that were used to generate this
@@ -8168,9 +8321,9 @@ curvature for interior silhouettes.)doc";
 
 static const char *__doc_mitsuba_SilhouetteSample_is_valid = R"doc(Is the current boundary segment valid=)doc";
 
-static const char *__doc_mitsuba_SilhouetteSample_labels = R"doc(//! @})doc";
+static const char *__doc_mitsuba_SilhouetteSample_labels = R"doc()doc";
 
-static const char *__doc_mitsuba_SilhouetteSample_name = R"doc(//! @})doc";
+static const char *__doc_mitsuba_SilhouetteSample_name = R"doc()doc";
 
 static const char *__doc_mitsuba_SilhouetteSample_offset =
 R"doc(Offset along the boundary segment direction (`d`) to avoid self-
@@ -8351,7 +8504,7 @@ static const char *__doc_mitsuba_Stream_can_read = R"doc(Can we read from the st
 
 static const char *__doc_mitsuba_Stream_can_write = R"doc(Can we write to the stream?)doc";
 
-static const char *__doc_mitsuba_Stream_class = R"doc(@})doc";
+static const char *__doc_mitsuba_Stream_class = R"doc()doc";
 
 static const char *__doc_mitsuba_Stream_close =
 R"doc(Closes the stream.
@@ -8814,9 +8967,9 @@ static const char *__doc_mitsuba_SurfaceInteraction_emitter =
 R"doc(Return the emitter associated with the intersection (if any) \note
 Defined in scene.h)doc";
 
-static const char *__doc_mitsuba_SurfaceInteraction_fields = R"doc(//! @})doc";
+static const char *__doc_mitsuba_SurfaceInteraction_fields = R"doc()doc";
 
-static const char *__doc_mitsuba_SurfaceInteraction_fields_2 = R"doc(//! @})doc";
+static const char *__doc_mitsuba_SurfaceInteraction_fields_2 = R"doc()doc";
 
 static const char *__doc_mitsuba_SurfaceInteraction_finalize_surface_interaction =
 R"doc(Fills uninitialized fields after a call to
@@ -8844,9 +8997,9 @@ static const char *__doc_mitsuba_SurfaceInteraction_is_medium_transition = R"doc
 
 static const char *__doc_mitsuba_SurfaceInteraction_is_sensor = R"doc(Is the intersected shape also a sensor?)doc";
 
-static const char *__doc_mitsuba_SurfaceInteraction_labels = R"doc(//! @})doc";
+static const char *__doc_mitsuba_SurfaceInteraction_labels = R"doc()doc";
 
-static const char *__doc_mitsuba_SurfaceInteraction_name = R"doc(//! @})doc";
+static const char *__doc_mitsuba_SurfaceInteraction_name = R"doc()doc";
 
 static const char *__doc_mitsuba_SurfaceInteraction_operator_array = R"doc(Convenience operator for masking)doc";
 
@@ -9760,9 +9913,9 @@ static const char *__doc_mitsuba_Transform_Transform_6 = R"doc(//! @})doc";
 
 static const char *__doc_mitsuba_Transform_extract = R"doc(Extract a lower-dimensional submatrix)doc";
 
-static const char *__doc_mitsuba_Transform_fields = R"doc(//! @})doc";
+static const char *__doc_mitsuba_Transform_fields = R"doc()doc";
 
-static const char *__doc_mitsuba_Transform_fields_2 = R"doc(//! @})doc";
+static const char *__doc_mitsuba_Transform_fields_2 = R"doc()doc";
 
 static const char *__doc_mitsuba_Transform_from_frame =
 R"doc(Creates a transformation that converts from 'frame' to the standard
@@ -9779,7 +9932,7 @@ arithmetic))doc";
 
 static const char *__doc_mitsuba_Transform_inverse_transpose = R"doc()doc";
 
-static const char *__doc_mitsuba_Transform_labels = R"doc(//! @})doc";
+static const char *__doc_mitsuba_Transform_labels = R"doc()doc";
 
 static const char *__doc_mitsuba_Transform_look_at =
 R"doc(Create a look-at camera transformation
@@ -9795,7 +9948,7 @@ Parameter ``up``:
 
 static const char *__doc_mitsuba_Transform_matrix = R"doc(//! @{ \name Fields)doc";
 
-static const char *__doc_mitsuba_Transform_name = R"doc(//! @})doc";
+static const char *__doc_mitsuba_Transform_name = R"doc()doc";
 
 static const char *__doc_mitsuba_Transform_operator_assign = R"doc()doc";
 
@@ -10111,7 +10264,7 @@ static const char *__doc_mitsuba_ZStream_child_stream = R"doc(Returns the child 
 
 static const char *__doc_mitsuba_ZStream_child_stream_2 = R"doc(Returns the child stream of this compression stream)doc";
 
-static const char *__doc_mitsuba_ZStream_class = R"doc(//! @})doc";
+static const char *__doc_mitsuba_ZStream_class = R"doc()doc";
 
 static const char *__doc_mitsuba_ZStream_close =
 R"doc(Closes the stream, but not the underlying child stream. No further
@@ -12542,3 +12695,4 @@ static const char *__doc_operator_lshift = R"doc(Turns a vector of elements into
 #if defined(__GNUG__)
 #pragma GCC diagnostic pop
 #endif
+

--- a/src/spectra/CMakeLists.txt
+++ b/src/spectra/CMakeLists.txt
@@ -1,10 +1,11 @@
 set(MI_PLUGIN_PREFIX "spectra")
 
 add_plugin(blackbody blackbody.cpp)
-add_plugin(uniform uniform.cpp)
-add_plugin(regular regular.cpp)
-add_plugin(irregular irregular.cpp)
 add_plugin(d65 d65.cpp)
+add_plugin(irregular irregular.cpp)
+add_plugin(regular regular.cpp)
+add_plugin(rawconstant rawconstant.cpp)
 add_plugin(srgb srgb.cpp)
+add_plugin(uniform uniform.cpp)
 
 set(MI_PLUGIN_TARGETS "${MI_PLUGIN_TARGETS}" PARENT_SCOPE)

--- a/src/spectra/rawconstant.cpp
+++ b/src/spectra/rawconstant.cpp
@@ -1,0 +1,195 @@
+#include <mitsuba/core/properties.h>
+#include <mitsuba/render/texture.h>
+
+NAMESPACE_BEGIN(mitsuba)
+
+/**!
+
+.. _spectrum-rawconstant:
+
+Raw constant-valued texture (:monosp:`rawconstant`)
+---------------------------------------------------
+
+.. pluginparameters::
+
+ * - value
+   - :paramtype:`float` or :paramtype:`vector`
+   - The constant value(s) to be returned. Can be a single float or a 3D vector.
+   - |exposed|, |differentiable|
+
+A constant-valued texture that returns the same value regardless of color mode,
+UV coordinates or wavelength. No color conversion or range validation takes place.
+The value can be 1D or 3D. For 1D inputs, the same value is replicated across components
+when a 3D value is queried.
+
+If color-handling is desired, see the :ref:`spectrum-srgb <spectrum-srgb>` plugin instead.
+
+.. tabs::
+    .. code-tab:: xml
+        :name: rawconstant-1d
+
+        <texture type="rawconstant">
+            <float name="value" value="0.5"/>
+        </texture>
+
+    .. code-tab:: xml
+        :name: rawconstant-3d
+
+        <texture type="rawconstant">
+            <vector name="value" value="0.5, 1.0, 0.3"/>
+        </texture>
+
+    .. code-tab:: python
+
+        'type': 'rawconstant',
+        'value': 0.5  # or [0.5, -2.0, 0.3]
+
+ */
+
+// Actualy ipmlementation, templated over the channel count.
+template <typename Float, typename Spectrum, size_t Channels>
+class RawConstantTextureImpl final : public Texture<Float, Spectrum> {
+public:
+    MI_IMPORT_TYPES(Texture)
+    static_assert(Channels == 1 || Channels == 3, "Channels must be 1 or 3.");
+    using Value = std::conditional_t<Channels == 1, Float, Vector3f>;
+
+    RawConstantTextureImpl(const Properties &props, const Value &value)
+        : Texture(props), m_value(value) {}
+
+    UnpolarizedSpectrum eval(const SurfaceInteraction3f &/*si*/, Mask active) const override {
+        MI_MASKED_FUNCTION(ProfilerPhase::TextureEvaluate, active);
+
+        if constexpr (dr::size_v<UnpolarizedSpectrum> == Channels || Channels == 1) {
+            // The number of values we have either matches the number of entries
+            // in an UnpolarizedSpectrum, or we can broadcast to it.
+            return m_value;
+        } else {
+            // All other cases: throw to avoid unintuitive behavior.
+            Throw("RawConstantTexture: eval() is not defined for %d channels "
+                  "in variant where UnpolarizedSpectrum has %d entries.",
+                  Channels, dr::size_v<UnpolarizedSpectrum>);
+        }
+    }
+
+    Float eval_1(const SurfaceInteraction3f &/*si*/, Mask active) const override {
+        MI_MASKED_FUNCTION(ProfilerPhase::TextureEvaluate, active);
+        if constexpr (Channels == 1) {
+            return m_value;
+        } else {
+            Throw("RawConstantTexture: eval_1() is not defined for 3D-valued textures.");
+        }
+    }
+
+    Color3f eval_3(const SurfaceInteraction3f &/*si*/, Mask active) const override {
+        MI_MASKED_FUNCTION(ProfilerPhase::TextureEvaluate, active);
+        // If we have a single value, just broadcast it across all channels.
+        return Color3f(m_value);
+    }
+
+    std::pair<Wavelength, UnpolarizedSpectrum>
+    sample_spectrum(const SurfaceInteraction3f &si, const Wavelength &sample,
+                    Mask active) const override {
+        MI_MASKED_FUNCTION(ProfilerPhase::TextureSample, active);
+        Wavelength wavelengths = dr::empty<Wavelength>();
+        if constexpr (is_spectral_v<Spectrum>) {
+            // Even though the value is constant, we may still want a valid
+            // wavelength to be sampled.
+            wavelengths = MI_CIE_MIN + (MI_CIE_MAX - MI_CIE_MIN) * sample;
+        }
+        return { wavelengths, eval(si, active) };
+    }
+
+    Float mean() const override {
+        return dr::mean(m_value);
+    }
+
+    ScalarFloat max() const override {
+        return dr::max_nested(m_value);
+    }
+
+    void traverse(TraversalCallback *callback) override {
+        callback->put_parameter("value", m_value, +ParamFlags::Differentiable);
+    }
+
+    void parameters_changed(const std::vector<std::string> &/*keys*/ = {}) override {
+        dr::make_opaque(m_value);
+    }
+
+    std::string to_string() const override {
+        std::ostringstream oss;
+        oss << "RawConstantTexture[" << std::endl
+            << "  value = " << m_value << std::endl
+            << "]";
+        return oss.str();
+    }
+
+    MI_DECLARE_CLASS()
+protected:
+    Value m_value;
+};
+
+// Note: this gets expanded to a `RawConstantTextureImpl` specialized to the channel count.
+template <typename Float, typename Spectrum>
+class RawConstantTexture final : public Texture<Float, Spectrum> {
+public:
+    MI_IMPORT_TYPES(Texture)
+
+    RawConstantTexture(const Properties &props) : Texture(props), m_props(props) {
+        if (!props.has_property("value"))
+            Throw("RawConstantTexture: missing required parameter \"value\""
+                  " (1D `float` or 3D `vector` expected).");
+        props.mark_queried("value");
+    }
+
+    std::vector<ref<Object>> expand() const override {
+        switch (m_props.type("value")) {
+            case Properties::Type::Array3f: {
+                Vector3f value = m_props.get<ScalarVector3f>("value");
+                return { ref<Object>(
+                    new RawConstantTextureImpl<Float, Spectrum, 3>(m_props, value)) };
+            }
+            case Properties::Type::Float: {
+                ScalarFloat value = m_props.get<ScalarFloat>("value");
+                return { ref<Object>(
+                    new RawConstantTextureImpl<Float, Spectrum, 1>(m_props, value)) };
+            }
+
+            default:
+                Throw("RawConstantTexture: parameter \"value\" has incorrect "
+                      "type,"
+                      " expected `float` or 3D `vector`.");
+        }
+    }
+
+    MI_DECLARE_CLASS()
+protected:
+    Properties m_props;
+};
+
+MI_IMPLEMENT_CLASS_VARIANT(RawConstantTexture, Texture)
+MI_EXPORT_PLUGIN(RawConstantTexture, "Raw constant value texture")
+
+NAMESPACE_BEGIN(detail)
+template <size_t Channels>
+constexpr const char * plugin_class_name() {
+    if constexpr (Channels == 1) {
+        return "RawConstantTexture1f";
+    } else {
+        static_assert(Channels == 3, "Invalid number of channels");
+        return "RawConstantTexture3f";
+    }
+}
+NAMESPACE_END(detail)
+
+template <typename Float, typename Spectrum, size_t Channels>
+Class *RawConstantTextureImpl<Float, Spectrum, Channels>::m_class
+    = new Class(detail::plugin_class_name<Channels>(), "MonteCarloIntegrator",
+                ::mitsuba::detail::get_variant<Float, Spectrum>(), nullptr, nullptr);
+
+template <typename Float, typename Spectrum, size_t Channels>
+const Class *RawConstantTextureImpl<Float, Spectrum, Channels>::class_() const {
+    return m_class;
+}
+
+NAMESPACE_END(mitsuba)

--- a/src/spectra/tests/test_rawconstant.py
+++ b/src/spectra/tests/test_rawconstant.py
@@ -1,0 +1,84 @@
+import pytest
+import drjit as dr
+import mitsuba as mi
+
+
+def make_texture(value, xml: bool = False):
+    if xml:
+        if isinstance(value, float):
+            value_string = f'<float name="value" value="{value}"/>'
+        else:
+            assert len(value) == 3
+            value_string = f'<vector name="value" value="{value[0]}, {value[1]}, {value[2]}"/>'
+        return mi.load_string(f'<texture type="rawconstant" version="3.0.0">{value_string}</texture>')
+    else:
+        return mi.load_dict({
+            "type" : "rawconstant",
+            "value": value
+        })
+
+@pytest.mark.parametrize("use_xml", [True, False])
+def test01_construct(variants_all, use_xml):
+    si = dr.zeros(mi.SurfaceInteraction3f)
+
+    # 1D raw constant texture
+    tex1 = make_texture(-2.5, xml=use_xml)
+    assert dr.allclose(tex1.eval_1(si), -2.5)
+    assert dr.allclose(tex1.eval_3(si), [-2.5, -2.5, -2.5])
+
+    # 3D raw constant texture
+    tex3 = make_texture([-0.5, 2.0, -1.3], xml=use_xml)
+    with pytest.raises(RuntimeError, match=r"eval_1\(\) is not defined for 3D-valued textures"):
+        tex3.eval_1(si)
+    assert dr.allclose(tex3.eval_3(si), [-0.5, 2.0, -1.3])
+
+
+def test02_eval(variants_all):
+    si = dr.zeros(mi.SurfaceInteraction3f)
+
+    for v in ([-0.5, 2.0, -1.3], -0.5):
+        channels = 1 if isinstance(v, float) else len(v)
+        tex = make_texture(v)
+
+        # Either returns the original 3 values, or broadcasts the single value to 3D
+        assert dr.allclose(tex.eval_3(si), v)
+        if channels == 1:
+            assert dr.allclose(tex.eval_1(si), v)
+        else:
+            with pytest.raises(RuntimeError, match=r"eval_1\(\) is not defined for 3D-valued textures"):
+                tex.eval_1(si)
+
+        # eval() is more tricky as it depends on the variant
+        if channels == 1:
+            assert dr.allclose(tex.eval(si), mi.UnpolarizedSpectrum(v))
+        else:
+            if mi.is_rgb or dr.size_v(mi.UnpolarizedSpectrum) == channels:
+                # In RGB mode, should return full vector
+                assert dr.allclose(tex.eval(si), v)
+            else:
+                with pytest.raises(RuntimeError, match=r"RawConstantTexture: eval\(\) is not defined for 3 channels.*"):
+                    tex.eval(si)
+
+
+def test03_sample_spectrum(variants_all):
+    si = dr.zeros(mi.SurfaceInteraction3f)
+
+    for v in ([-0.5, 4.0, -3.3], -0.5):
+        channels = 1 if isinstance(v, float) else len(v)
+        tex = make_texture(v)
+
+        if channels == 1 or dr.size_v(mi.UnpolarizedSpectrum) == channels:
+            wav, spec = tex.sample_spectrum(si, sample=si.wavelengths)
+            assert dr.allclose(spec, tex.eval(si))
+        else:
+            with pytest.raises(RuntimeError, match=r"RawConstantTexture: eval\(\) is not defined for 3 channels.*"):
+                tex.eval(si)
+
+
+def test04_mean_max(variants_all):
+    for v in ([-0.5, 4.0, -3.3], -0.5):
+        vmax = 4.0 if isinstance(v, list) else v
+        tex = make_texture(v)
+
+        assert dr.allclose(tex.mean(), dr.mean(v))
+        assert dr.allclose(tex.max(), vmax)


### PR DESCRIPTION
## Description

Adds `rawconstant`, a simple texture plugin that stores raw 1D/3D values without any color space conversion or spectral upsampling.
As far as I could tell, all of the existing plugins perform either some kind of color handling. `bitmap` allows raw values, but it has a lot of extra complexity and requires at least `2x2` values.

## Testing

Added unit tests.

## Checklist

<!-- Please make sure to complete this checklist before requesting a review. -->

- [x] My code follows the [style guidelines](https://mitsuba.readthedocs.io/en/latest/src/developer_guide.html#coding-style) of this project
- [x] My changes generate no new warnings
- [x] My code also compiles for `cuda_*` and `llvm_*` variants. If you can't test this, please leave below
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 3 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba/blob/master/LICENSE)