### PR TITLE
set_variant(): try next requested variant if one fails to import

### DIFF
--- a/src/python/alias.cpp
+++ b/src/python/alias.cpp
@@ -262,20 +262,22 @@ NB_MODULE(mitsuba_alias, m) {
     mi_dict = m.attr("__dict__").ptr();
     nb::object mi_ext = import_with_deepbind_if_necessary("mitsuba.mitsuba_ext");
     nb::dict mitsuba_ext_dict = mi_ext.attr("__dict__");
-    for (const auto &k : mitsuba_ext_dict.keys())
+    for (const auto &k : mitsuba_ext_dict.keys()) {
         if (!nb::bool_(k.attr("startswith")("__")) &&
             !nb::bool_(k.attr("endswith")("__"))) {
             Safe_PyDict_SetItem(mi_dict, k.ptr(), mitsuba_ext_dict[k].ptr());
         }
+    }
 
     // Import contents of `mitsuba.python` into top-level `mitsuba` module
     nb::object mi_python = nb::module_::import_("mitsuba.python");
     nb::dict mitsuba_python_dict = mi_python.attr("__dict__");
-    for (const auto &k : mitsuba_python_dict.keys())
+    for (const auto &k : mitsuba_python_dict.keys()) {
         if (!nb::bool_(k.attr("startswith")("__")) &&
             !nb::bool_(k.attr("endswith")("__"))) {
             Safe_PyDict_SetItem(mi_dict, k.ptr(), mitsuba_python_dict[k].ptr());
         }
+    }
 
     /// Cleanup static variables, this is called when the interpreter is exiting
     auto atexit = nb::module_::import_("atexit");

--- a/src/python/alias.cpp
+++ b/src/python/alias.cpp
@@ -99,7 +99,7 @@ static void set_variant(nb::args args) {
     for (const auto &arg : args) {
         if (PyDict_Contains(variant_modules, arg.ptr()) == 1) {
             // Variant is at least compiled, we can attempt to use it.
-            valid_variants.append(nb::borrow(arg));
+            valid_variants.append(arg);
         }
     }
 
@@ -135,11 +135,12 @@ static void set_variant(nb::args args) {
             // CUDA driver is installed, but there is no GPU available.
             // We only allow such failures as long as we have more variants to try.
             if (!is_last && e.matches(PyExc_ImportError)) {
-                // nb::str var_str = requested_variant;
-                // jit_log(LogLevel::Debug,
-                //         "The requested variant \"{}\" could not be loaded, "
-                //         "attempting the next one. The exception was: {}",
-                //         var_str.c_str(), e.what());
+                const auto mi = nb::module_::import_("mitsuba");
+                mi.attr("Log")(
+                    mi.attr("LogLevel").attr("Debug"),
+                    nb::str("The requested variant \"{}\" could not be loaded, "
+                            "attempting the next one. The exception was:\n{}\n")
+                        .format(requested_variant, e.what()));
                 continue;
             } else {
                 throw e;

--- a/src/python/main_v.cpp
+++ b/src/python/main_v.cpp
@@ -120,6 +120,16 @@ using Caster = nb::object(*)(mitsuba::Object *);
 Caster cast_object = nullptr;
 
 NB_MODULE(MI_VARIANT_NAME, m) {
+    /* scoped */ {
+        // Before loading everything in and creating a lot of references to
+        // various objects, we ensure that this backend can be initialized
+        // without issues by creating a simple variable.
+        // If initialization fails, an exception will be raised, which the user
+        // can catch and handle if desired.
+        // Leaving initialization to fail later would lead to reference leaks.
+        MI_VARIANT_FLOAT(0);
+    }
+
     m.attr("__name__") = "mitsuba";
 
     // Create sub-modules


### PR DESCRIPTION
## Description

If the user specifies several variants in order, e.g.:

```py
mi.set_variant("cuda_ad_rgb", "llvm_ad_rgb")
```

and they are all compiled (available) but some fail to import, then keep trying with the next requested variant instead of throwing an exception.

This could happen e.g. when requested a CUDA variant with the NVIDIA driver installed / CUDA available but no GPU available, or when LLVM is not installed.

## Testing

On a machine with the NVIDIA driver installed,

```bash
CUDA_VISIBLE_DEVICES= python -c 'import mitsuba as mi; mi.set_variant("cuda_ad_rgb", "llvm_ad_rgb"); print(mi.variant())'
```

Old behavior: raises `ImportError` and exits.
New behavior: fails to load `cuda_ad_rgb`, but correctly goes to the second choice `llvm_ad_rgb`.

The old behavior can still be obtained by requesting a single variant at a time (no fallback): `mi.set_variant("cuda_ad_rgb")`

## Checklist

<!-- Please make sure to complete this checklist before requesting a review. -->

- [x] My code follows the [style guidelines](https://mitsuba.readthedocs.io/en/latest/src/developer_guide.html#coding-style) of this project
- [x] My changes generate no new warnings
- [x] My code also compiles for `cuda_*` and `llvm_*` variants. If you can't test this, please leave below
- [x] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 3 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba/blob/master/LICENSE)