### PR TITLE
Fix #1331 Incorrect normal maps rendered using AOV integrator with `normalmap` BSDF

### DIFF
--- a/include/mitsuba/render/bsdf.h
+++ b/include/mitsuba/render/bsdf.h
@@ -589,6 +589,21 @@ public:
     virtual Spectrum eval_diffuse_reflectance(const SurfaceInteraction3f &si,
                                               Mask active = true) const;
 
+    /**
+     * \brief Returns the shading frame accounting for any pertubations that may 
+     * performed by the BSDF during evaluation.
+     *
+     * \param si
+     *     Surface interaction associated with the query
+     *
+     * \return
+     *     The perturbed shading frame. By default simply returns the surface
+     *     interaction shading frame.
+     */
+    virtual Frame3f sh_frame(const SurfaceInteraction3f &si, Mask /*active*/) const {
+        return si.sh_frame;
+    }
+
     /// Return a human-readable representation of the BSDF
     std::string to_string() const override = 0;
 
@@ -666,6 +681,7 @@ MI_CALL_TEMPLATE_BEGIN(BSDF)
     DRJIT_CALL_METHOD(eval_attribute)
     DRJIT_CALL_METHOD(eval_attribute_1)
     DRJIT_CALL_METHOD(eval_attribute_3)
+    DRJIT_CALL_METHOD(sh_frame)
     DRJIT_CALL_GETTER(flags)
     auto needs_differentials() const {
         return has_flag(flags(), mitsuba::BSDFFlags::NeedsDifferentials);

--- a/src/bsdfs/bumpmap.cpp
+++ b/src/bsdfs/bumpmap.cpp
@@ -220,6 +220,10 @@ public:
         return result;
     }
 
+    Frame3f sh_frame(const SurfaceInteraction3f &si, Mask active) const override {
+        return frame(si, active);
+    }
+
     Spectrum eval_diffuse_reflectance(const SurfaceInteraction3f &si,
                                       Mask active) const override {
         return m_nested_bsdf->eval_diffuse_reflectance(si, active);

--- a/src/bsdfs/normalmap.cpp
+++ b/src/bsdfs/normalmap.cpp
@@ -208,6 +208,10 @@ public:
         return { frame_wrt_si, frame_wrt_world };
     }
 
+    Frame3f sh_frame(const SurfaceInteraction3f &si, Mask active) const override {
+        return frame(si, active).second;
+    }
+
     Spectrum eval_diffuse_reflectance(const SurfaceInteraction3f &si,
                                       Mask active) const override {
         return m_nested_bsdf->eval_diffuse_reflectance(si, active);

--- a/src/integrators/aov.cpp
+++ b/src/integrators/aov.cpp
@@ -281,10 +281,18 @@ public:
                     *aovs++ = si.n.z();
                     break;
 
-                case Type::ShadingNormal:
-                    *aovs++ = si.sh_frame.n.x();
-                    *aovs++ = si.sh_frame.n.y();
-                    *aovs++ = si.sh_frame.n.z();
+                case Type::ShadingNormal: {
+                        Frame3f sh_frame = dr::zeros<Frame3f>();
+                        if (dr::any_or<true>(si.is_valid()))
+                        {
+                            Mask valid = active && si.is_valid();
+                            BSDFPtr m_bsdf = si.bsdf(ray);
+                            sh_frame = m_bsdf->sh_frame(si, valid);
+                        }
+                        *aovs++ = sh_frame.n.x();
+                        *aovs++ = sh_frame.n.y();
+                        *aovs++ = sh_frame.n.z();
+                    }
                     break;
 
                 case Type::dPdU:


### PR DESCRIPTION
When requesting the shading frame in the AOV integrator, we need to consider the perturbations that may be performed by a `normalmap` BSDF

Also added a corresponding test in `test_aov.py`