### PR TITLE
Improve `Bitmap` support in Jupyter notebooks

### DIFF
--- a/include/mitsuba/core/platform.h
+++ b/include/mitsuba/core/platform.h
@@ -20,11 +20,13 @@
 #  define MI_IMPORT   __declspec(dllimport)
 #  define MI_NOINLINE __declspec(noinline)
 #  define MI_INLINE   __forceinline
+#  define MI_RESTRICT  __restrict
 #else
 #  define MI_EXPORT    __attribute__ ((visibility("default")))
 #  define MI_IMPORT
 #  define MI_NOINLINE  __attribute__ ((noinline))
 #  define MI_INLINE    __attribute__((always_inline)) inline
+#  define MI_RESTRICT  __restrict__
 #endif
 
 #define MI_MODULE_LIB    1

--- a/src/core/python/bitmap.cpp
+++ b/src/core/python/bitmap.cpp
@@ -100,7 +100,7 @@ void from_cpu_dlpack(Bitmap *b, ContigCpuNdArray data,
         memcpy(b->data(), data.data(), b->buffer_size());
 }
 
-char *base64_encode(char * __restrict__ p, const uint8_t * __restrict__ src, size_t size) {
+char *base64_encode(char * MI_RESTRICT p, const uint8_t * MI_RESTRICT src, size_t size) {
     const char *map = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
     const size_t triplets = size / 3, remain = size - triplets * 3;
 


### PR DESCRIPTION
The `Bitmap._repr_html()` enables viewing Mitsuba `Bitmap` objects in Jupyter notebooks. This commit makes the following changes:

- Use JPG (compression level 99%) instead of PNG images, which is faster to de/encode.

- Base-64 encode locally instead of copying back and forth several times.

- Don't force the image size to 300 px, just give the image and let the Jupyter notebook figure out how to display it.
