### PR TITLE
Fix `path` with `max_depth==1` for scalar variants

### DIFF
--- a/src/integrators/path.cpp
+++ b/src/integrators/path.cpp
@@ -197,6 +197,7 @@ public:
 
             if (dr::none_or<false>(active_next)) {
                 ls.active = active_next;
+                ls.valid_ray |= (si.emitter(scene) != nullptr) && !m_hide_emitters;
                 return; // early exit for scalar mode
             }
 

--- a/src/integrators/tests/test_integrators.py
+++ b/src/integrators/tests/test_integrators.py
@@ -23,3 +23,20 @@ def test01_trampoline_id(variants_vec_backends_once_rgb):
 
     params = mi.traverse(scene)
     assert 'my_integrator.depth' in params
+
+
+def test02_path_directly_visible(variants_all_rgb):
+    scene_description = mi.cornell_box()
+    # Look only at light
+    scene_description['sensor']['film']['crop_offset_x'] = 124
+    scene_description['sensor']['film']['crop_offset_y'] = 36
+    scene_description['sensor']['film']['crop_width'] = 1
+    scene_description['sensor']['film']['crop_height'] = 1
+    scene = mi.load_dict(scene_description)
+
+    integrator = mi.load_dict({
+        'type': 'path',
+        'max_depth': 1,
+    })
+    img = mi.render(scene, integrator=integrator)
+    assert dr.allclose(img.array, [18.387, 13.9873, 6.75357])


### PR DESCRIPTION
## Description
Small fix in scalar variants for the `path` integrator: directly visible emitters would not be rendered despite `hide_emitters` being turned off. 

Fixes #1537

## Testing

One small regression test for the new behavior.