### PR TITLE
Fix inconsitent UV mapping in sphere plugin

### DIFF
--- a/include/mitsuba/core/vector.h
+++ b/include/mitsuba/core/vector.h
@@ -143,11 +143,11 @@ template <typename Vector3f> std::pair<Vector3f, Vector3f> coordinate_system(con
  * \param v
  *      Vector to convert
  * \return
- *      The azimuthal and polar angles respectively.
+ *      The polar and azimuthal angles respectively.
  */
 template <typename Value>
 MI_INLINE Point<Value, 2> dir_to_sph(const Vector<Value, 3> &v) {
-    return { dr::atan2(v.y(), v.x()), dr::unit_angle_z(v) };
+    return { dr::unit_angle_z(v), dr::atan2(v.y(), v.x()) };
 }
 
 /**

--- a/src/emitters/sunsky.cpp
+++ b/src/emitters/sunsky.cpp
@@ -171,6 +171,8 @@ public:
         Vector3f local_sun_dir = m_to_world.value().inverse().transform_affine(m_sun_dir);
 
         m_sun_angles = dir_to_sph(local_sun_dir);
+        m_sun_angles = { m_sun_angles.y(), m_sun_angles.x() }; // flip convention
+
         m_local_sun_frame = Frame3f(local_sun_dir);
 
         Float sun_eta = 0.5f * dr::Pi<Float> - m_sun_angles.y();
@@ -275,7 +277,10 @@ public:
         } else {
             local_sun_dir = m_to_world.value().inverse().transform_affine(m_sun_dir);
         }
+
         m_sun_angles = dir_to_sph(local_sun_dir);
+        m_sun_angles = { m_sun_angles.y(), m_sun_angles.x() }; // flip convention
+
         m_local_sun_frame = Frame3f(local_sun_dir);
 
         Float eta = 0.5f * dr::Pi<Float> - m_sun_angles.y();
@@ -815,7 +820,9 @@ private:
         Float sin_theta = Frame3f::sin_theta(local_dir);
         active &= (Frame3f::cos_theta(local_dir) >= 0.f) && (sin_theta != 0.f);
         sin_theta = dr::maximum(sin_theta, dr::Epsilon<Float>);
-        Float sky_pdf = tgmm_pdf(dir_to_sph(local_dir), active) / sin_theta;
+        Point2f angles = dir_to_sph(local_dir);
+        angles = { angles.y(), angles.x() }; // flip convention
+        Float sky_pdf = tgmm_pdf(angles, active) / sin_theta;
 
         Float cosine_cutoff = dr::cos(m_sun_half_aperture);
         Float sun_pdf = warp::square_to_uniform_cone_pdf(

--- a/src/shapes/sphere.cpp
+++ b/src/shapes/sphere.cpp
@@ -212,7 +212,7 @@ public:
         Point3f local = warp::square_to_uniform_sphere(sample);
 
         PositionSample3f ps = dr::zeros<PositionSample3f>();
-        ps.p = dr::fmadd(local, m_radius.value(), m_center.value());
+        ps.p = m_to_world.value().transform_affine(local);
         ps.n = local;
 
         if (m_flip_normals)
@@ -221,7 +221,12 @@ public:
         ps.time = time;
         ps.delta = m_radius.value() == 0.f;
         ps.pdf = m_inv_surface_area;
-        ps.uv = sample;
+
+        Point2f angles = dir_to_sph(Vector3f(local));
+        Float theta = angles.x();
+        Float phi = angles.y();
+        dr::masked(phi, phi < 0.f) += 2.f * dr::Pi<Float>;
+        ps.uv = Point2f(phi * dr::InvTwoPi<Float>, theta * dr::InvPi<Float>);
 
         return ps;
     }
@@ -326,8 +331,11 @@ public:
     SurfaceInteraction3f eval_parameterization(const Point2f &uv,
                                                uint32_t ray_flags,
                                                Mask active) const override {
-        Point3f local = warp::square_to_uniform_sphere(uv);
-        Point3f p = dr::fmadd(local, m_radius.value(), m_center.value());
+        Float phi = uv.x() * dr::TwoPi<Float>;
+        Float theta = uv.y() * dr::Pi<Float>;
+
+        Point3f local = sph_to_dir(theta, phi);
+        Point3f p = m_to_world.value().transform_affine(local);
 
         Ray3f ray(p + local, -local, 0, Wavelength(0));
 
@@ -382,8 +390,14 @@ public:
 
         Point3f sample = dr::zeros<Point3f>(dr::width(ss));
         sample.x() = warp::tangent_direction_to_interval(ss.n, ss.d);
-        sample.y() = ss.uv.x();
-        sample.z() = ss.uv.y();
+
+        Float theta = ss.uv.y() * dr::Pi<Float>;
+        Float phi = ss.uv.x() * dr::TwoPi<Float>;
+        Vector3f local = sph_to_dir(theta, phi);
+
+        Point2f sample_square = warp::uniform_sphere_to_square(local);
+        sample.y() = sample_square.x();
+        sample.z() = sample_square.y();
 
         return sample;
     }
@@ -395,7 +409,10 @@ public:
         if constexpr (!dr::is_diff_v<Float>) {
             return si.p;
         } else {
-            Point3f local  = warp::square_to_uniform_sphere(dr::detach(si.uv));
+            Float phi = si.uv.x() * dr::TwoPi<Float>;
+            Float theta = si.uv.y() * dr::Pi<Float>;
+            Point3f local = dr::detach(sph_to_dir(theta, phi));
+
             Point3f p_diff = m_to_world.value().transform_affine(local);
 
             return dr::replace_grad(si.p, p_diff);
@@ -431,7 +448,13 @@ public:
         ss.p = dr::fmadd(OXd, radius, center);
         ss.d = dr::normalize(ss.p - viewpoint);
         ss.n = dr::normalize(ss.p - center);
-        ss.uv = warp::uniform_sphere_to_square(Vector3f(ss.n));
+
+        Point3f local = m_to_object.value().transform_affine(ss.p);
+        Point2f angles = dir_to_sph(Vector3f(local));
+        Float theta = angles.x();
+        Float phi = angles.y();
+        dr::masked(phi, phi < 0.f) += 2.f * dr::Pi<Float>;
+        ss.uv = Point2f(phi * dr::InvTwoPi<Float>, theta * dr::InvPi<Float>);
 
         Vector3f frame_t = dr::normalize(viewpoint - ss.p);
         ss.silhouette_d = dr::cross(ss.n, frame_t);
@@ -673,17 +696,18 @@ public:
         si.t = dr::select(active, si.t, dr::Infinity<Float>);
 
         if (likely(need_uv)) {
-            Float rd_2  = dr::square(local.x()) + dr::square(local.y()),
-                  theta = unit_angle_z(local),
-                  phi   = dr::atan2(local.y(), local.x());
+            Point2f angles = dir_to_sph(Vector3f(local));
+            Float theta = angles.x();
+            Float phi = angles.y();
 
             dr::masked(phi, phi < 0.f) += 2.f * dr::Pi<Float>;
-
             si.uv = Point2f(phi * dr::InvTwoPi<Float>, theta * dr::InvPi<Float>);
+
             if (likely(need_dp_duv)) {
                 si.dp_du = Vector3f(-local.y(), local.x(), 0.f);
 
-                Float rd      = dr::sqrt(rd_2),
+                Float rd_2    = dr::square(local.x()) + dr::square(local.y()),
+                      rd      = dr::sqrt(rd_2),
                       inv_rd  = dr::rcp(rd),
                       cos_phi = local.x() * inv_rd,
                       sin_phi = local.y() * inv_rd;


### PR DESCRIPTION
## Description

The different `Shape` methods `compute_surface_interaction`, `sample_position`, `eval_parameterization`, ... define a UV mapping. Some of these were inconsistent. This PR is pass over all the methods to define UV parameterizations as remapped spherical coordinates.

Fixes #1539 

## Testing

The `test_sphere.py` now contains a test to check for consistency between the methods.