### PR TITLE
fix specular/eta texture reference

### DIFF
--- a/src/bsdfs/principled.cpp
+++ b/src/bsdfs/principled.cpp
@@ -277,9 +277,9 @@ public:
         callback->put_parameter("diffuse_reflectance_sampling_rate", m_diff_refl_srate, +ParamFlags::NonDifferentiable);
 
         if (m_eta_specular) //Only one of them traversed! (based on xml file)
-            callback->put_parameter("eta",      m_eta,      ParamFlags::Differentiable | ParamFlags::Discontinuous);
+            callback->put_parameter("eta",      m_eta.get(),      ParamFlags::Differentiable | ParamFlags::Discontinuous);
         else
-            callback->put_parameter("specular", m_specular, ParamFlags::Differentiable | ParamFlags::Discontinuous);
+            callback->put_parameter("specular", m_specular.get(), ParamFlags::Differentiable | ParamFlags::Discontinuous);
 
         callback->put_object("roughness",       m_roughness.get(),   ParamFlags::Differentiable | ParamFlags::Discontinuous);
         callback->put_object("base_color",      m_base_color.get(),  +ParamFlags::Differentiable);


### PR DESCRIPTION
<!-- Please add the labels (e.g. bug fix, feature, ..) corresponding to this PR -->

## Description

Recently, loading a textured specular or eta map in a principled BSDF e.g. with

```python
import mitsuba as mi

mi.set_variant("cuda_ad_rgb")

mi.load_dict({
    'type':'principled',
    'specular':{
        'type':'bitmap',
        'filename':'dummy_specular.exr'
    }
})
```

results in the following:
 `RuntimeError: ​[properties.cpp:86] The property "specular" has the wrong type (expected <d> or <l>, is <N8nanobind3refIN7mitsuba6ObjectEEE>)`
 
 This only affects specular/eta maps. This PR seems to fix the issue but I'm curious to why this only appeared now, is it due to some recent change in nanobind and the handling of references?

## Checklist

<!-- Please make sure to complete this checklist before requesting a review. -->

- [x] My code follows the [style guidelines](https://mitsuba.readthedocs.io/en/latest/src/developer_guide.html#coding-style) of this project
- [x] My changes generate no new warnings
- [x] My code also compiles for `cuda_*` and `llvm_*` variants. If you can't test this, please leave below
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 3 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba/blob/master/LICENSE)