### PR TITLE
Re-enable Python bindings for Properties::Type (fixes the Blender plugin)

### DIFF
--- a/src/core/python/properties_v.cpp
+++ b/src/core/python/properties_v.cpp
@@ -153,23 +153,24 @@ MI_PY_EXPORT(Properties) {
             .def(nb::self != nb::self, D(Properties, operator_ne))
             .def_repr(PropertiesV);
 
-        // FIXME: Binding this enumeration leaks. Defining an internal enum to
-        // an arbitrary class is fine, this seems to be specifically an issue
-        // with defining an internal enum in Properties
-        //nb::enum_<Properties::Type>(p, "Type");
-            //.value("Bool",              Properties::Type::Bool,           D(Properties, Type, Bool))
-            //.value("Long",              Properties::Type::Long,           D(Properties, Type, Long))
-            //.value("Float",             Properties::Type::Float,          D(Properties, Type, Float))
-            //.value("Array3f",           Properties::Type::Array3f,        D(Properties, Type, Array3f))
-            //.value("Transform3f",       Properties::Type::Transform3f,    D(Properties, Type, Transform3f))
-            //.value("Transform4f",       Properties::Type::Transform4f,    D(Properties, Type, Transform4f))
-            //// .value("AnimatedTransform", Properties::Type::AnimatedTransform, D(Properties, Type, AnimatedTransform))
-            //.value("TensorHandle",      Properties::Type::Tensor,         D(Properties, Type, Tensor))
-            //.value("Color",             Properties::Type::Color,          D(Properties, Type, Color))
-            //.value("String",            Properties::Type::String,         D(Properties, Type, String))
-            //.value("NamedReference",    Properties::Type::NamedReference, D(Properties, Type, NamedReference))
-            //.value("Object",            Properties::Type::Object,         D(Properties, Type, Object))
-            //.value("Pointer",           Properties::Type::Pointer,        D(Properties, Type, Pointer))
-            //.export_values();
+        if (auto h = nb::type<Properties::Type>(); h)
+            p.attr("Type") = h;
+        else {
+            nb::enum_<Properties::Type>(p, "Type")
+                .value("Bool",              Properties::Type::Bool,              D(Properties, Type, Bool))
+                .value("Long",              Properties::Type::Long,              D(Properties, Type, Long))
+                .value("Float",             Properties::Type::Float,             D(Properties, Type, Float))
+                .value("Array3f",           Properties::Type::Array3f,           D(Properties, Type, Array3f))
+                .value("Transform3f",       Properties::Type::Transform3f,       D(Properties, Type, Transform3f))
+                .value("Transform4f",       Properties::Type::Transform4f,       D(Properties, Type, Transform4f))
+                .value("AnimatedTransform", Properties::Type::AnimatedTransform, D(Properties, Type, AnimatedTransform))
+                .value("TensorHandle",      Properties::Type::Tensor,            D(Properties, Type, Tensor))
+                .value("Color",             Properties::Type::Color,             D(Properties, Type, Color))
+                .value("String",            Properties::Type::String,            D(Properties, Type, String))
+                .value("NamedReference",    Properties::Type::NamedReference,    D(Properties, Type, NamedReference))
+                .value("Object",            Properties::Type::Object,            D(Properties, Type, Object))
+                .value("Pointer",           Properties::Type::Pointer,           D(Properties, Type, Pointer))
+                .export_values();
+        }
     }
 }

--- a/src/core/tests/test_properties.py
+++ b/src/core/tests/test_properties.py
@@ -40,6 +40,14 @@ def test02_type_is_preserved(variant_scalar_rgb):
     assert type(p['prop_5']) is Array3f64
     assert type(p['prop_6']) is mi.ScalarColor3d
 
+    assert p.type('prop_1') == mi.Properties.Type.Long
+    assert p.type('prop_2') == mi.Properties.Type.String
+    assert p.type('prop_3') == mi.Properties.Type.Bool
+    assert p.type('prop_4') == mi.Properties.Type.Float
+    assert p.type('prop_5') == mi.Properties.Type.Array3f
+    assert p.type('prop_6') == mi.Properties.Type.Color
+    assert p.type('prop_7') == mi.Properties.Type.Object
+
     assert p['prop_1'] == 1
     assert p['prop_2'] == '1'
     assert p['prop_3'] == False


### PR DESCRIPTION
This PR re-enables the Python bindings for Properties::Type. The motivation for this is that the Blender importer queries the types of properties (e.g., https://github.com/mitsuba-renderer/mitsuba-blender/blob/5a12adda2d0da3ccf3c125a54e36f7cf57988957/mitsuba-blender/io/importer/emitters.py#L52), which currently is broken.

One minor complication is that the enum is nested in Properties, which itself is variant dependent. However, the enum isn't. I therefore added some logic to detect if the type was already bound, similar to the `MI_PY_CHECK_ALIAS` macro. I am not sure if this is the best option, but it seems to work.

I also modified the unit tests to exercise the functionality