### PR TITLE
Fix parameter updates on `area` with `rectangle`

### DIFF
--- a/src/render/shape.cpp
+++ b/src/render/shape.cpp
@@ -668,11 +668,13 @@ MI_VARIANT void Shape<Float, Spectrum>::initialize() {
     }
 
     // Explicitly register this shape as the parent of the provided sub-objects
-    if (m_emitter)
-        m_emitter->set_shape(this);
+    if (!m_initialized) {
+        if (m_emitter)
+            m_emitter->set_shape(this);
 
-    if (m_sensor)
-        m_sensor->set_shape(this);
+        if (m_sensor)
+            m_sensor->set_shape(this);
+    }
 
     m_initialized = true;
 }

--- a/src/shapes/tests/test_rectangle.py
+++ b/src/shapes/tests/test_rectangle.py
@@ -447,3 +447,22 @@ def test18_inv_transpose(variants_all_ad_rgb):
                      [0, 0, 0, -1],
                      [0, 0, 0, 0]])
     )
+
+def test19_area_emitter_update(variants_vec_rgb):
+    emitter = mi.load_dict({
+        'type': 'rectangle',
+        'emitter': {
+            'type': 'area',
+        },
+        'to_world': mi.ScalarTransform4f()
+    })
+
+    params = mi.traverse(emitter)
+    params['to_world'] = mi.Transform4f().scale(mi.Vector3f(2, 2, 1))
+    params.update()
+
+    assert dr.allclose(params['to_world'].matrix, [[2, 0, 0, 0],
+                                                   [0, 2, 0, 0],
+                                                   [0, 0, 1, 0],
+                                                   [0, 0, 0, 1]])
+    assert emitter.surface_area() == 16


### PR DESCRIPTION
## Description

The shape assigned to area emitters tries to assign itself as the parent of its respective emitter. This should only be done once, when the the `Shape` is instantiated. Currently, for the `rectangle` it also happened on parameter updates, leading to a confusing error message. This PR fixes that issue.

Fixes #1574

## Testing

New regression test for this use case.