### PR TITLE
Clarify the documentation of the `uniform` spectrum plugin

### DIFF
--- a/src/spectra/uniform.cpp
+++ b/src/spectra/uniform.cpp
@@ -15,18 +15,20 @@ Uniform spectrum (:monosp:`uniform`)
 
  * - wavelength_min
    - |float|
-   - Minimum wavelength of the spectral range in nanometers.
+   - Lower bound of the wavelength sampling range in nanometers. Default: 360 nm
 
  * - wavelength_max
    - |float|
-   - Maximum wavelength of the spectral range in nanometers.
+   - Upper bound of the wavelength sampling range in nanometers. Default: 830 nm
 
  * - value
    - |float|
    - Value of the spectral function across the specified spectral range.
    - |exposed|, |differentiable|
 
-This spectrum returns a constant reflectance or emission value between 360 and 830nm.
+This spectrum returns a constant reflectance or emission value over the spectral
+dimension. It implements a uniform sampling method on a finite spectral range
+controlled by the ``wavelength_min`` and ``wavelength_max`` parameters.
 
 .. tabs::
     .. code-tab:: xml


### PR DESCRIPTION
## Description

This is a suggested update for the documentation of the `uniform` plugin. I find the current state a bit confusing, as it does not state clearly that the spectral range only applies to sampling.

## Checklist

**I compiled the documentation and it renders correctly.**

- [x] My code follows the [style guidelines](https://mitsuba.readthedocs.io/en/latest/src/developer_guide.html#coding-style) of this project
- [x] My changes generate no new warnings
- [x] My code also compiles for `cuda_*` and `llvm_*` variants. If you can't test this, please leave below
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 3 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba/blob/master/LICENSE)