### PR TITLE
Reduce synchronizations when setting up scene in OptiX 

### DIFF
--- a/src/render/mesh.cpp
+++ b/src/render/mesh.cpp
@@ -1865,6 +1865,7 @@ MI_VARIANT void Mesh<Float, Spectrum>::optix_prepare_geometry() { }
 
 MI_VARIANT void Mesh<Float, Spectrum>::optix_build_input(OptixBuildInput &build_input) const {
     m_vertex_buffer_ptr = (void*) m_vertex_positions.data(); // triggers dr::eval()
+
     build_input.type                           = OPTIX_BUILD_INPUT_TYPE_TRIANGLES;
     build_input.triangleArray.vertexFormat     = OPTIX_VERTEX_FORMAT_FLOAT3;
     build_input.triangleArray.indexFormat      = OPTIX_INDICES_FORMAT_UNSIGNED_INT3;

--- a/src/render/scene_optix.inl
+++ b/src/render/scene_optix.inl
@@ -450,7 +450,6 @@ MI_VARIANT void Scene<Float, Spectrum>::accel_init_gpu(const Properties &props) 
 
 MI_VARIANT void Scene<Float, Spectrum>::accel_parameters_changed_gpu() {
     if constexpr (dr::is_cuda_v<Float>) {
-        dr::sync_thread();
         MiOptixSceneState &s = *(MiOptixSceneState *) m_accel;
 
         if (!m_shapes.empty()) {

--- a/src/shapes/bsplinecurve.cpp
+++ b/src/shapes/bsplinecurve.cpp
@@ -1014,7 +1014,6 @@ public:
 
 #if defined(MI_ENABLE_EMBREE)
     RTCGeometry embree_geometry(RTCDevice device) override {
-        dr::eval(m_control_points); // Make sure the buffer is evaluated
         RTCGeometry geom = rtcNewGeometry(device, RTC_GEOMETRY_TYPE_ROUND_BSPLINE_CURVE);
         rtcSetSharedGeometryBuffer(geom, RTC_BUFFER_TYPE_VERTEX, 0, RTC_FORMAT_FLOAT4,
                                    m_control_points.data(), 0, 4 * sizeof(InputFloat),
@@ -1031,10 +1030,8 @@ public:
     void optix_prepare_geometry() override { }
 
     void optix_build_input(OptixBuildInput &build_input) const override {
-        dr::eval(m_control_points); // Make sure the buffer is evaluated
         m_vertex_buffer_ptr = (CUdeviceptr*) m_control_points.data();
         m_radius_buffer_ptr = (CUdeviceptr*) (m_control_points.data() + 3);
-        m_index_buffer_ptr  = (CUdeviceptr*) m_indices.data();
 
         build_input.type                            = OPTIX_BUILD_INPUT_TYPE_CURVES;
         build_input.curveArray.curveType            = OPTIX_PRIMITIVE_TYPE_ROUND_CUBIC_BSPLINE;
@@ -1047,7 +1044,7 @@ public:
         build_input.curveArray.widthBuffers         = (CUdeviceptr*) &m_radius_buffer_ptr;
         build_input.curveArray.widthStrideInBytes   = sizeof( InputFloat ) * 4;
 
-        build_input.curveArray.indexBuffer          = (CUdeviceptr) m_index_buffer_ptr;
+        build_input.curveArray.indexBuffer          = (CUdeviceptr) m_indices.data();
         build_input.curveArray.indexStrideInBytes   = sizeof( ScalarIndex );
 
         build_input.curveArray.normalBuffers        = 0;
@@ -1301,7 +1298,6 @@ private:
     // For OptiX build input
     mutable CUdeviceptr* m_vertex_buffer_ptr = nullptr;
     mutable CUdeviceptr* m_radius_buffer_ptr = nullptr;
-    mutable CUdeviceptr* m_index_buffer_ptr = nullptr;
 #endif
 };
 

--- a/src/shapes/cylinder.cpp
+++ b/src/shapes/cylinder.cpp
@@ -779,7 +779,8 @@ public:
                                        (float) 1.f,
                                        (float) 1.f };
 
-            jit_memcpy(JitBackend::CUDA, m_optix_data_ptr, &data, sizeof(OptixCylinderData));
+            jit_memcpy_async(JitBackend::CUDA, m_optix_data_ptr, &data,
+                             sizeof(OptixCylinderData));
         }
     }
 #endif

--- a/src/shapes/disk.cpp
+++ b/src/shapes/disk.cpp
@@ -544,7 +544,8 @@ public:
 
             OptixDiskData data = { bbox(), m_to_object.scalar() };
 
-            jit_memcpy(JitBackend::CUDA, m_optix_data_ptr, &data, sizeof(OptixDiskData));
+            jit_memcpy_async(JitBackend::CUDA, m_optix_data_ptr, &data,
+                             sizeof(OptixDiskData));
         }
     }
 #endif

--- a/src/shapes/linearcurve.cpp
+++ b/src/shapes/linearcurve.cpp
@@ -388,7 +388,6 @@ public:
 
 #if defined(MI_ENABLE_EMBREE)
     RTCGeometry embree_geometry(RTCDevice device) override {
-        dr::eval(m_control_points); // Make sure the buffer is evaluated
         RTCGeometry geom = rtcNewGeometry(device, RTC_GEOMETRY_TYPE_ROUND_LINEAR_CURVE);
 
         rtcSetSharedGeometryBuffer(geom, RTC_BUFFER_TYPE_VERTEX, 0, RTC_FORMAT_FLOAT4,
@@ -407,13 +406,11 @@ public:
     void optix_prepare_geometry() override { }
 
     void optix_build_input(OptixBuildInput &build_input) const override {
-        dr::eval(m_control_points); // Make sure the buffer is evaluated
         m_vertex_buffer_ptr = (CUdeviceptr*) m_control_points.data();
         m_radius_buffer_ptr = (CUdeviceptr*) (m_control_points.data() + 3);
-        m_index_buffer_ptr  = (CUdeviceptr*) m_indices.data();
 
-        build_input.type = OPTIX_BUILD_INPUT_TYPE_CURVES;
-        build_input.curveArray.curveType = OPTIX_PRIMITIVE_TYPE_ROUND_LINEAR;
+        build_input.type                            = OPTIX_BUILD_INPUT_TYPE_CURVES;
+        build_input.curveArray.curveType            = OPTIX_PRIMITIVE_TYPE_ROUND_LINEAR;
         build_input.curveArray.numPrimitives        = (unsigned int) dr::width(m_indices);
 
         build_input.curveArray.vertexBuffers        = (CUdeviceptr*) &m_vertex_buffer_ptr;
@@ -423,7 +420,7 @@ public:
         build_input.curveArray.widthBuffers         = (CUdeviceptr*) &m_radius_buffer_ptr;
         build_input.curveArray.widthStrideInBytes   = sizeof( InputFloat ) * 4;
 
-        build_input.curveArray.indexBuffer          = (CUdeviceptr) m_index_buffer_ptr;
+        build_input.curveArray.indexBuffer          = (CUdeviceptr) m_indices.data();
         build_input.curveArray.indexStrideInBytes   = sizeof( ScalarIndex );
 
         build_input.curveArray.normalBuffers        = 0;
@@ -515,7 +512,6 @@ private:
     // For OptiX build input
     mutable void* m_vertex_buffer_ptr = nullptr;
     mutable void* m_radius_buffer_ptr = nullptr;
-    mutable void* m_index_buffer_ptr = nullptr;
 #endif
 };
 

--- a/src/shapes/sdfgrid.cpp
+++ b/src/shapes/sdfgrid.cpp
@@ -573,7 +573,6 @@ public:
                                        static_cast<uint32_t>(shape[1]),
                                        static_cast<uint32_t>(shape[0]) };
 
-            dr::eval(m_grid_texture.value()); // Make sure the SDF data is evaluated
             OptixSDFGridData data = { (uint32_t *) m_voxel_indices_ptr,
                                       resolution[0],
                                       resolution[1],
@@ -583,13 +582,13 @@ public:
                                       m_voxel_size.scalar()[2],
                                       m_grid_texture.tensor().array().data(),
                                       m_to_object.scalar() };
-            jit_memcpy(JitBackend::CUDA, m_optix_data_ptr, &data,
-                       sizeof(OptixSDFGridData));
+            jit_memcpy_async(JitBackend::CUDA, m_optix_data_ptr, &data,
+                             sizeof(OptixSDFGridData));
         }
     }
 
     void optix_build_input(OptixBuildInput &build_input) const override {
-        build_input.type = OPTIX_BUILD_INPUT_TYPE_CUSTOM_PRIMITIVES;
+        build_input.type                               = OPTIX_BUILD_INPUT_TYPE_CUSTOM_PRIMITIVES;
         build_input.customPrimitiveArray.aabbBuffers   = &m_bboxes_ptr;
         build_input.customPrimitiveArray.numPrimitives = m_filled_voxel_count;
         build_input.customPrimitiveArray.strideInBytes = 6 * sizeof(float);

--- a/src/shapes/sphere.cpp
+++ b/src/shapes/sphere.cpp
@@ -775,8 +775,8 @@ public:
                                      (Vector<float, 3>) m_center.scalar(),
                                      (float) m_radius.scalar() };
 
-            jit_memcpy(JitBackend::CUDA, m_optix_data_ptr, &data,
-                       sizeof(OptixSphereData));
+            jit_memcpy_async(JitBackend::CUDA, m_optix_data_ptr, &data,
+                             sizeof(OptixSphereData));
         }
     }
 #endif


### PR DESCRIPTION
## Description

This PR removes some unnecessary synchronizations that were being explicitly triggered during the OptiX scene setup.
In addition, it also removes some superfluous calls to `dr::eval()`.

Notes:
Most shapes explicitly synchronize on a call to `parameters_changed()`. This is theoretically only necessary on LLVM backends, as the scalar values are used in the ray intersection routines (by synchronizing, we wait for any running kernels to terminate before updating the scalar parameters). However, in practice, the shape parameters are stores as `field` objects and an update of the JIT value will trigger a synchronization to keep the scalar value up-to-date too.  In another PR, I will try to alleviate this problem.

## Testing

No new tests.