### PR TITLE
Support spectral variants in `*_projective` integrators

### DIFF
--- a/include/mitsuba/render/shape.h
+++ b/include/mitsuba/render/shape.h
@@ -209,10 +209,10 @@ struct SilhouetteSample : public PositionSample<Float_, Spectrum_> {
      * an intersection point at its origin due to numerical instabilities in
      * the intersection routines.
      */
-    Ray3f spawn_ray() const {
+    Ray3f spawn_ray(Wavelength wavelengths = dr::zeros<Wavelength>()) const {
         Vector3f o_offset = (1 + dr::max(dr::abs(p))) *
                             (d * offset + n * math::ShapeEpsilon<Float>);
-        return Ray3f(p + o_offset, d);
+        return Ray3f(p + o_offset, d, 0.f, wavelengths);
     }
 
     //! @}

--- a/src/core/python/ray_v.cpp
+++ b/src/core/python/ray_v.cpp
@@ -19,7 +19,7 @@ void bind_ray(nb::module_ &m, const char *name) {
             .def(nb::init<const Ray &>(), "Copy constructor", "other"_a)
             .def(nb::init<Point, Vector, RayFloat, const RayWavelength &>(),
                  D(Ray, Ray, 2),
-                 "o"_a, "d"_a, "time"_a=(RayScalarFloat) 0.0, "wavelengths"_a=RayWavelength())
+                 "o"_a, "d"_a, "time"_a=(RayScalarFloat) 0.0, "wavelengths"_a=dr::zeros<RayWavelength>())
             .def(nb::init<Point, Vector, RayFloat, RayFloat, const RayWavelength &>(),
                  D(Ray, Ray, 3),
                  "o"_a, "d"_a, "maxt"_a, "time"_a, "wavelengths"_a)

--- a/src/python/python/ad/guiding.py
+++ b/src/python/python/ad/guiding.py
@@ -421,7 +421,7 @@ class OcSpaceDistr(BaseGuidingDistr):
         query_point.y = dr.lerp(aabb_min_rep.y, aabb_max_rep.y, sampler_extra.next_1d())
         query_point.z = dr.lerp(aabb_min_rep.z, aabb_max_rep.z, sampler_extra.next_1d())
 
-        value, _ = self.eval_indirect_integrand_handle(query_point, sampler_extra)
+        value, _, _ = self.eval_indirect_integrand_handle(query_point, sampler_extra)
 
         mass = dr.zeros(mi.Float, leaf_count)
         scatter_idx = dr.arange(mi.UInt32, leaf_count)

--- a/src/python/python/ad/integrators/direct_projective.py
+++ b/src/python/python/ad/integrators/direct_projective.py
@@ -265,8 +265,7 @@ class DirectProjectiveIntegrator(PSIntegrator):
 
             # ----------- Estimate the radiance of the background -----------
 
-            ray_bg = ss.spawn_ray()
-            ray_bg.wavelengths = wavelengths
+            ray_bg = ss.spawn_ray(wavelengths)
             si_bg = scene.ray_intersect(ray_bg, active=active)
             radiance_bg = si_bg.emitter(scene).eval(si_bg, active)
 
@@ -286,8 +285,7 @@ class DirectProjectiveIntegrator(PSIntegrator):
         elif curr_depth == 0:
 
             # ----------- Estimate the radiance of the background -----------
-            ray_bg = ss.spawn_ray()
-            ray_bg.wavelengths = wavelengths
+            ray_bg = ss.spawn_ray(wavelengths)
             radiance_bg, _, _, _ = self.sample(
                 dr.ADMode.Primal, scene, sampler, ray_bg, curr_depth, None, None, active, False, None)
 
@@ -353,8 +351,7 @@ class DirectProjectiveIntegrator(PSIntegrator):
         # Trace a ray to the camera ray intersection
         ss_importance = mi.SilhouetteSample3f(ss)
         ss_importance.d = -ss_importance.d
-        ray_boundary = ss_importance.spawn_ray()
-        ray_boundary.wavelengths = wavelengths
+        ray_boundary = ss_importance.spawn_ray(wavelengths)
         if preprocess:
             si_boundary = scene.ray_intersect(ray_boundary, active=active)
         else:

--- a/src/python/python/ad/integrators/direct_projective.py
+++ b/src/python/python/ad/integrators/direct_projective.py
@@ -260,12 +260,13 @@ class DirectProjectiveIntegrator(PSIntegrator):
         return L, active, [], guide_seed if project else None
 
 
-    def sample_radiance_difference(self, scene, ss, curr_depth, sampler, active):
+    def sample_radiance_difference(self, scene, ss, curr_depth, sampler, wavelengths, active):
         if curr_depth == 1:
 
             # ----------- Estimate the radiance of the background -----------
 
             ray_bg = ss.spawn_ray()
+            ray_bg.wavelengths = wavelengths
             si_bg = scene.ray_intersect(ray_bg, active=active)
             radiance_bg = si_bg.emitter(scene).eval(si_bg, active)
 
@@ -286,6 +287,7 @@ class DirectProjectiveIntegrator(PSIntegrator):
 
             # ----------- Estimate the radiance of the background -----------
             ray_bg = ss.spawn_ray()
+            ray_bg.wavelengths = wavelengths
             radiance_bg, _, _, _ = self.sample(
                 dr.ADMode.Primal, scene, sampler, ray_bg, curr_depth, None, None, active, False, None)
 
@@ -300,6 +302,7 @@ class DirectProjectiveIntegrator(PSIntegrator):
             # Create a dummy ray that we never perform ray-intersection with to
             # compute other fields in ``si``
             dummy_ray = mi.Ray3f(ss.p - ss.d, ss.d)
+            dummy_ray.wavelengths = wavelengths
 
             # The ray origin is wrong, but this is fine if we only need the primal
             # radiance
@@ -344,13 +347,14 @@ class DirectProjectiveIntegrator(PSIntegrator):
         return radiance_diff, active_diff
 
 
-    def sample_importance(self, scene, sensor, ss, max_depth, sampler, preprocess, active):
+    def sample_importance(self, scene, sensor, ss, max_depth, sampler, wavelengths, preprocess, active):
         del max_depth  # Unused
 
         # Trace a ray to the camera ray intersection
         ss_importance = mi.SilhouetteSample3f(ss)
         ss_importance.d = -ss_importance.d
         ray_boundary = ss_importance.spawn_ray()
+        ray_boundary.wavelengths = wavelengths
         if preprocess:
             si_boundary = scene.ray_intersect(ray_boundary, active=active)
         else:

--- a/src/python/python/ad/integrators/prb_projective.py
+++ b/src/python/python/ad/integrators/prb_projective.py
@@ -382,7 +382,7 @@ class PathProjectiveIntegrator(PSIntegrator):
         )
 
 
-    def sample_radiance_difference(self, scene, ss, curr_depth, sampler, active):
+    def sample_radiance_difference(self, scene, ss, curr_depth, sampler, wavelengths, active):
         """
         See ``PSIntegrator.sample_radiance_difference()`` for a description of
         this interface and the role of the various parameters and return values.
@@ -391,6 +391,7 @@ class PathProjectiveIntegrator(PSIntegrator):
         # ----------- Estimate the radiance of the background -----------
 
         ray_bg = ss.spawn_ray()
+        ray_bg.wavelengths = wavelengths
         radiance_bg, _, _, _ = self.sample(
             dr.ADMode.Primal, scene, sampler, ray_bg, curr_depth, None, None, active, False, None)
 
@@ -406,6 +407,7 @@ class PathProjectiveIntegrator(PSIntegrator):
         # Create a dummy ray that we never perform ray-intersection with to
         # compute other fields in ``si``
         dummy_ray = mi.Ray3f(ss.p - ss.d, ss.d)
+        ray_bg.wavelengths = wavelengths
 
         # The ray origin is wrong, but this is fine if we only need the primal
         # radiance
@@ -440,7 +442,8 @@ class PathProjectiveIntegrator(PSIntegrator):
 
 
     @dr.syntax
-    def sample_importance(self, scene, sensor, ss, max_depth, sampler, preprocess, active):
+    def sample_importance(self, scene, sensor, ss, max_depth, sampler,
+                          wavelengths, preprocess, active):
         """
         See ``PSIntegrator.sample_importance()`` for a description of this
         interface and the role of the various parameters and return values.
@@ -450,6 +453,7 @@ class PathProjectiveIntegrator(PSIntegrator):
         ss_importance = mi.SilhouetteSample3f(ss)
         ss_importance.d = -ss_importance.d
         ray_boundary = ss_importance.spawn_ray()
+        ray_boundary.wavelengths = wavelengths
         if dr.hint(preprocess, mode='scalar'):
             si_boundary = scene.ray_intersect(ray_boundary, active=active)
         else:

--- a/src/python/python/ad/integrators/prb_projective.py
+++ b/src/python/python/ad/integrators/prb_projective.py
@@ -390,8 +390,7 @@ class PathProjectiveIntegrator(PSIntegrator):
 
         # ----------- Estimate the radiance of the background -----------
 
-        ray_bg = ss.spawn_ray()
-        ray_bg.wavelengths = wavelengths
+        ray_bg = ss.spawn_ray(wavelengths)
         radiance_bg, _, _, _ = self.sample(
             dr.ADMode.Primal, scene, sampler, ray_bg, curr_depth, None, None, active, False, None)
 
@@ -452,8 +451,7 @@ class PathProjectiveIntegrator(PSIntegrator):
         # Trace a ray to the sensor end of the boundary segment
         ss_importance = mi.SilhouetteSample3f(ss)
         ss_importance.d = -ss_importance.d
-        ray_boundary = ss_importance.spawn_ray()
-        ray_boundary.wavelengths = wavelengths
+        ray_boundary = ss_importance.spawn_ray(wavelengths)
         if dr.hint(preprocess, mode='scalar'):
             si_boundary = scene.ray_intersect(ray_boundary, active=active)
         else:

--- a/src/python/python/ad/integrators/prb_projective.py
+++ b/src/python/python/ad/integrators/prb_projective.py
@@ -390,10 +390,7 @@ class PathProjectiveIntegrator(PSIntegrator):
 
         # ----------- Estimate the radiance of the background -----------
 
-        ray_bg = mi.Ray3f(
-            ss.p + (1 + dr.max(dr.abs(ss.p))) * (ss.d * ss.offset + ss.n * mi.math.ShapeEpsilon),
-            ss.d
-        )
+        ray_bg = ss.spawn_ray()
         radiance_bg, _, _, _ = self.sample(
             dr.ADMode.Primal, scene, sampler, ray_bg, curr_depth, None, None, active, False, None)
 
@@ -450,10 +447,9 @@ class PathProjectiveIntegrator(PSIntegrator):
         """
 
         # Trace a ray to the sensor end of the boundary segment
-        ray_boundary = mi.Ray3f(
-            ss.p + (1 + dr.max(dr.abs(ss.p))) * (-ss.d * ss.offset + ss.n * mi.math.ShapeEpsilon),
-            -ss.d
-        )
+        ss_importance = mi.SilhouetteSample3f(ss)
+        ss_importance.d = -ss_importance.d
+        ray_boundary = ss_importance.spawn_ray()
         if dr.hint(preprocess, mode='scalar'):
             si_boundary = scene.ray_intersect(ray_boundary, active=active)
         else:

--- a/src/render/python/shape_v.cpp
+++ b/src/render/python/shape_v.cpp
@@ -36,7 +36,8 @@ MI_PY_EXPORT(SilhouetteSample) {
         .def_rw("offset",             &SilhouetteSample3f::offset,             D(SilhouetteSample, offset))
         // Methods
         .def("is_valid",  &SilhouetteSample3f::is_valid,  D(SilhouetteSample, is_valid))
-        .def("spawn_ray", &SilhouetteSample3f::spawn_ray, D(SilhouetteSample, spawn_ray))
+        .def("spawn_ray", &SilhouetteSample3f::spawn_ray,
+             "wavelengths"_a = dr::zeros<Wavelength>(), D(SilhouetteSample, spawn_ray))
         .def_repr(SilhouetteSample3f);
 
     MI_PY_DRJIT_STRUCT(ss, SilhouetteSample3f, p, discontinuity_type, n, uv,


### PR DESCRIPTION
## Description

The `projective` integrators never had support for `*_spectral` variants. This PR adds the necessary logic to handle those variants. In short, it required an extra step to sample a set of wavelengths per boundary path and some interface changes to pass these around.

The current implementation uses the sensor's SRF to sample the wavelengths, this was an arbitrary choice.

Fixes #1567 

## Testing

No new tests. We should eventually change the testing infrastructure for AD integrators to support more variants.