### PR TITLE
Frozen functions auto opaque

### DIFF
--- a/src/render/tests/test_freeze.py
+++ b/src/render/tests/test_freeze.py
@@ -915,7 +915,8 @@ def test10_shape_sample_position(variants_vec_rgb, shape, auto_opaque):
         assert dr.all(res.delta == ref.delta)
 
 
-@pytest.mark.parametrize("optimizer", ["sgd", "adam"])
+# TODO: add rmsprop
+@pytest.mark.parametrize("optimizer", ["sgd", "rmsprop", "adam"])
 @pytest.mark.parametrize("auto_opaque", [False, True])
 def test11_optimizer(variants_vec_rgb, optimizer, auto_opaque):
     """
@@ -959,6 +960,8 @@ def test11_optimizer(variants_vec_rgb, optimizer, auto_opaque):
 
         if optimizer == "adam":
             opt = mi.ad.Adam(lr=0.05)
+        elif optimizer == "rmsprop":
+            opt = dr.opt.RMSProp(lr = 0.001)
         elif optimizer == "sgd":
             opt = mi.ad.SGD(lr=0.005, momentum=0.1)
         opt[k] = mi.Color3f(0.01, 0.2, 0.9)
@@ -973,10 +976,10 @@ def test11_optimizer(variants_vec_rgb, optimizer, auto_opaque):
     image_frozen, param_frozen = run(n, frozen)
 
     if auto_opaque:
-        if optimizer == "sgd":
-            assert frozen.n_recordings == 2
-        else:
+        if optimizer == "adam":
             assert frozen.n_recordings == 3
+        else:
+            assert frozen.n_recordings == 2
     else:
         assert frozen.n_recordings == 2
 


### PR DESCRIPTION
<!-- Please add the labels (e.g. bug fix, feature, ..) corresponding to this PR -->

## Description

This PR adds tests for the auto-opaque feature ([drjit#361](https://github.com/mitsuba-renderer/drjit/pull/361)), and bumps the subrepo for drjit to the `frozen-functions-auto-opaque` branch.

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

## Testing

For the tests introduced in #1477, this PR adds an `auto_opaque` flag to toggle the feature.

<!-- Please describe the tests that you added to verify your changes. -->

## Checklist

<!-- Please make sure to complete this checklist before requesting a review. -->

- [x] My code follows the [style guidelines](https://mitsuba.readthedocs.io/en/latest/src/developer_guide.html#coding-style) of this project
- [ ] My changes generate no new warnings
- [ ] My code also compiles for `cuda_*` and `llvm_*` variants. If you can't test this, please leave below
- [ ] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 3 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba/blob/master/LICENSE)