### PR TITLE
[Typos] Serialized file should be “*.serialized”

### DIFF
--- a/src/shapes/serialized.cpp
+++ b/src/shapes/serialized.cpp
@@ -20,7 +20,7 @@ Serialized mesh loader (:monosp:`serialized`)
 
  * - filename
    - |string|
-   - Filename of the OBJ file that should be loaded
+   - Filename of the serialized file that should be loaded
 
  * - shape_index
    - |int|


### PR DESCRIPTION
- This will also fix the doc
![Serialized](https://github.com/user-attachments/assets/bf7a71d7-5621-47fa-bfe9-a4e31722e89e)
