### PR TITLE
Prevent NEE on constant emitter

### DIFF
--- a/src/render/scene.cpp
+++ b/src/render/scene.cpp
@@ -99,11 +99,14 @@ MI_VARIANT
 void Scene<Float, Spectrum>::update_emitter_sampling_distribution() {
     // Check if we need to use non-uniform emitter sampling.
     bool non_uniform_sampling = false;
-    for (auto &e : m_emitters) {
-        if (e->sampling_weight() != ScalarFloat(1.0)) {
-            non_uniform_sampling = true;
-            break;
+
+    if (m_emitters.size() > 1) {
+      for (auto &e : m_emitters) {
+          if (e->sampling_weight() != ScalarFloat(1.0)) {
+              non_uniform_sampling = true;
+              break;
         }
+      }
     }
     size_t n_emitters = m_emitters.size();
     if (non_uniform_sampling) {


### PR DESCRIPTION
This PR disable next event estimation for the constant emitter as it will always perform worst than BSDF sampling.

The following images show the difference of before and after, when rendering a simple diffuse plane with 1 SPP.

Before:
![image](https://github.com/user-attachments/assets/ae88114e-0f47-4977-9a4f-774b8eab648a)

After:
![image](https://github.com/user-attachments/assets/747134eb-0bb1-4d93-96c8-d0eaba722529)
