### PR TITLE
MeshPtr: bind default constructor

### DIFF
--- a/src/render/python/shape_v.cpp
+++ b/src/render/python/shape_v.cpp
@@ -288,8 +288,11 @@ template <typename Ptr, typename Cls> void bind_mesh_generic(Cls &cls) {
     if constexpr (dr::is_array_v<Ptr> && dr::is_jit_v<Ptr>) {
         // Custom constructor to automatically zero-out non-Mesh pointer entries.
         // using ShapePtr = dr::replace_scalar_t<Ptr, Shape *>;
-        cls
-            .def("__init__", [](Ptr *dst, const ShapePtr &ptr) {
+        cls.def("__init__", [](Ptr *dst) {
+               // Zero-sized pointer array.
+               new (dst) Ptr();
+           })
+           .def("__init__", [](Ptr *dst, const ShapePtr &ptr) {
                 ShapePtr filtered = dr::select(ptr->is_mesh(), ptr, dr::zeros<ShapePtr>());
                 Ptr mesh = dr::reinterpret_array<Ptr>(filtered);
                 // Placement new.

--- a/src/render/tests/test_mesh.py
+++ b/src/render/tests/test_mesh.py
@@ -1312,6 +1312,17 @@ def test34_mesh_ptr(variants_vec_rgb):
     is_nnz = dr.reinterpret_array(mi.UInt32, meshes) != 0
     assert dr.all(is_nnz == (True, False, True))
 
+    # It should be possible to construct an empty MeshPtr.
+    assert dr.width(mi.ShapePtr()) == 0
+    assert dr.width(mi.MeshPtr()) == 0
+    assert dr.width(dr.zeros(mi.MeshPtr, 0)) == 0
+    assert dr.width(dr.empty(mi.MeshPtr, 0)) == 0
+
+    # It should be possible to reshape down to zero elements.
+    a = dr.zeros(mi.MeshPtr, 4)
+    b = dr.reshape(mi.MeshPtr, a, 0, shrink=True)
+    assert dr.width(b) == 0
+
 
 @fresolver_append_path
 def test35_mesh_vcalls(variants_vec_rgb):


### PR DESCRIPTION
<!-- Please add the labels (e.g. bug fix, feature, ..) corresponding to this PR -->

## Description

Adds the missing binding for `MeshPtr`'s default constructor, which creates a size-0 `MeshPtr` array.

## Testing

Updated unit test.

## Checklist

<!-- Please make sure to complete this checklist before requesting a review. -->

- [x] My code follows the [style guidelines](https://mitsuba.readthedocs.io/en/latest/src/developer_guide.html#coding-style) of this project
- [x] My changes generate no new warnings
- [x] My code also compiles for `cuda_*` and `llvm_*` variants. If you can't test this, please leave below
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 3 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba/blob/master/LICENSE)