### PR TITLE
Fix volume integrators

### DIFF
--- a/src/python/python/ad/integrators/prbvolpath.py
+++ b/src/python/python/ad/integrators/prbvolpath.py
@@ -177,7 +177,7 @@ class PRBVolpathIntegrator(RBIntegrator):
 
                 # Handle null and real scatter events
                 if dr.hint(self.handle_null_scattering, mode='scalar'):
-                    scatter_prob = index_spectrum(mei.sigma_t, channel) / index_spectrum(mei.combined_extinction, channel)
+                    scatter_prob = dr.mean(mei.sigma_t / mei.combined_extinction)
                     act_null_scatter = (sampler.next_1d(active_medium) >= scatter_prob) & active_medium
                     act_medium_scatter = ~act_null_scatter & active_medium
                     weight[act_null_scatter] *= mei.sigma_n / dr.detach(1 - scatter_prob)


### PR DESCRIPTION
## Description

This PR fixes an issue where heterogeneous media would be incorrectly rendered when it had a specially-varying `sigma_a` coefficient. 

The issue lied in the weighting of the light paths: the null-scattering probability was incorrectly calculated. It was solely based on the wavelength/channel that is used to construct the path, rather than probability of all wavelengths having a null-scattering event (see section 3.1 of [reference](https://cgg.mff.cuni.cz/~wilkie/Website/EGSR_14_files/WNDWH14HWSS.pdf)).

Fixes #1387 

## Testing

This PR includes a new test scene with a 0-valued albedo volume (only absorption) which would fail prior to the changes in this PR.

:warning:  Merge mitsuba-data submodule first