### PR TITLE
Rectangle: fix `flip_normals` behavior

### DIFF
--- a/include/mitsuba/python/docstr.h
+++ b/include/mitsuba/python/docstr.h
@@ -8050,6 +8050,9 @@ the scene by this shape
 Includes instanced geometry. The default implementation simply returns
 the same value as primitive_count().)doc";
 
+static const char *__doc_mitsuba_Shape_has_flipped_normals =
+R"doc(Does this shape have flipped normals?)doc";
+
 static const char *__doc_mitsuba_Shape_embree_geometry = R"doc(Return the Embree version of this shape)doc";
 
 static const char *__doc_mitsuba_Shape_emitter = R"doc(Return the area emitter associated with this shape (if any))doc";
@@ -13162,4 +13165,3 @@ static const char *__doc_operator_lshift = R"doc(Turns a vector of elements into
 #if defined(__GNUG__)
 #pragma GCC diagnostic pop
 #endif
-

--- a/include/mitsuba/render/mesh.h
+++ b/include/mitsuba/render/mesh.h
@@ -184,6 +184,9 @@ public:
     /// Does this mesh use face normals?
     bool has_face_normals() const { return m_face_normals; }
 
+    /// Does this shape have flipped normals?
+    bool has_flipped_normals() const override { return m_flip_normals; }
+
     /// @}
     // =========================================================================
 

--- a/include/mitsuba/render/shape.h
+++ b/include/mitsuba/render/shape.h
@@ -918,6 +918,9 @@ public:
      */
     virtual ScalarSize effective_primitive_count() const;
 
+    /// Does this shape have flipped normals?
+    virtual bool has_flipped_normals() const;
+
 
 #if defined(MI_ENABLE_EMBREE)
     /// Return the Embree version of this shape
@@ -1196,11 +1199,12 @@ MI_CALL_TEMPLATE_BEGIN(Shape)
     DRJIT_CALL_GETTER(exterior_medium)
     DRJIT_CALL_GETTER(silhouette_discontinuity_types)
     DRJIT_CALL_GETTER(silhouette_sampling_weight)
+    DRJIT_CALL_GETTER(has_flipped_normals)
     DRJIT_CALL_GETTER(shape_type)
     auto is_emitter() const { return emitter() != nullptr; }
     auto is_sensor() const { return sensor() != nullptr; }
     auto is_mesh() const { return (shape_type() & +mitsuba::ShapeType::Mesh) != 0; }
-    auto is_ellipsoids() const { 
+    auto is_ellipsoids() const {
         auto st = shape_type();
         st &= ~mitsuba::ShapeType::Mesh;
         return ((st & (uint32_t) mitsuba::ShapeType::Ellipsoids) |

--- a/src/python/python/tonemap.py
+++ b/src/python/python/tonemap.py
@@ -6,21 +6,19 @@ if __name__ == '__main__':
     mi.set_variant('scalar_rgb')
 
     mi.set_log_level(mi.LogLevel.Info)
-    te = mi.ThreadEnvironment()
 
     def tonemap(fname, scale):
-        with mi.ScopedSetThreadEnvironment(te):
-            try:
-                img_in = mi.Bitmap(fname)
-                if scale != 1:
-                    img_in = mi.Bitmap(mi.TensorXf(img_in) * scale)
-                img_out = img_in.convert(mi.Bitmap.PixelFormat.RGB, mi.Struct.Type.UInt8, True)
-                fname_out = fname.replace('.exr', '.png')
-                img_out.write(fname_out)
-                mi.Log(mi.LogLevel.Info, 'Wrote "%s".' % fname_out)
-            except Exception as e:
-                sys.stderr.write('Could not tonemap image "%s": %s!\n' %
-                    (fname, str(e)))
+        try:
+            img_in = mi.Bitmap(fname)
+            if scale != 1:
+                img_in = mi.Bitmap(mi.TensorXf(img_in) * scale)
+            img_out = img_in.convert(mi.Bitmap.PixelFormat.RGB, mi.Struct.Type.UInt8, True)
+            fname_out = fname.replace('.exr', '.png')
+            img_out.write(fname_out)
+            mi.Log(mi.LogLevel.Info, 'Wrote "%s".' % fname_out)
+        except Exception as e:
+            sys.stderr.write('Could not tonemap image "%s": %s!\n' %
+                (fname, str(e)))
 
     class MyParser(argparse.ArgumentParser):
         def error(self, message):

--- a/src/render/mesh.cpp
+++ b/src/render/mesh.cpp
@@ -637,6 +637,7 @@ Mesh<Float, Spectrum>::merge(const Mesh *other) const {
         other->has_vertex_normals() != has_vertex_normals() ||
         other->has_vertex_texcoords() != has_vertex_texcoords() ||
         other->has_face_normals() != has_face_normals() ||
+        other->has_flipped_normals() != has_flipped_normals() ||
         other->has_mesh_attributes() || has_mesh_attributes())
         Throw("Mesh::merge(): the two meshes are incompatible (%s and %s)!",
               to_string(), other->to_string());
@@ -653,6 +654,7 @@ Mesh<Float, Spectrum>::merge(const Mesh *other) const {
     if (m_emitter)
         props.set_object("emitter", (Object *) m_emitter.get());
     props.set_bool("face_normals", m_face_normals);
+    props.set_bool("flip_normals", m_flip_normals);
 
     ref<Mesh> result = new Mesh(
         m_name + " + " + other->m_name, m_vertex_count + other->vertex_count(),

--- a/src/render/python/shape_v.cpp
+++ b/src/render/python/shape_v.cpp
@@ -234,7 +234,12 @@ template <typename Ptr, typename Cls> void bind_shape_generic(Cls &cls) {
             [](Ptr shape) {
                 return shape->surface_area();
             },
-            D(Shape, surface_area));
+            D(Shape, surface_area))
+       .def("has_flipped_normals",
+            [](Ptr shape) {
+                return shape->has_flipped_normals();
+            },
+            D(Shape, has_flipped_normals));
 }
 
 template <typename Ptr, typename Cls> void bind_mesh_generic(Cls &cls) {
@@ -305,7 +310,10 @@ template <typename Ptr, typename Cls> void bind_mesh_generic(Cls &cls) {
             })
             .def("__init__", [](Ptr *dst, const Mesh *ptr) {
                 new (dst) Ptr(ptr);
-            });
+            })
+            .def("has_flipped_normals", [](Ptr shape) {
+                return shape->has_flipped_normals();
+            }, D(Shape, has_flipped_normals));
     }
 }
 

--- a/src/render/shape.cpp
+++ b/src/render/shape.cpp
@@ -626,6 +626,10 @@ Shape<Float, Spectrum>::effective_primitive_count() const {
     return primitive_count();
 }
 
+MI_VARIANT bool Shape<Float, Spectrum>::has_flipped_normals() const {
+    return false;
+}
+
 MI_VARIANT void Shape<Float, Spectrum>::traverse(TraversalCallback *callback) {
     callback->put_object("bsdf", m_bsdf.get(), +ParamFlags::Differentiable);
     if (m_emitter)

--- a/src/render/tests/test_mesh.py
+++ b/src/render/tests/test_mesh.py
@@ -18,6 +18,7 @@ def mixed_shapes_scene():
         "shape3": {
             "type" : "ply",
             "filename" : "resources/data/tests/ply/rectangle_uv.ply",
+            "flip_normals": True,
         },
     }, parallel=False)
 
@@ -1348,6 +1349,7 @@ def test35_mesh_vcalls(variants_vec_rgb):
     assert dr.all(meshes.has_vertex_texcoords() == active)
     assert not dr.any(meshes.has_mesh_attributes())
     assert not dr.any(meshes.has_face_normals())
+    assert dr.all(meshes.has_flipped_normals() == [False, False, True])
 
     idx = mi.UInt32([0, 99, 1])
     face_idx = meshes.face_indices(idx, active=active)

--- a/src/shapes/cylinder.cpp
+++ b/src/shapes/cylinder.cpp
@@ -266,6 +266,11 @@ public:
         return dr::TwoPi<ScalarFloat> * m_radius.value() * m_length.value();
     }
 
+    /// Does this cylinder have flipped normals?
+    bool has_flipped_normals() const override {
+        return m_flip_normals;
+    }
+
     PositionSample3f sample_position(Float time, const Point2f &sample,
                                      Mask active) const override {
         MI_MASK_ARGUMENT(active);

--- a/src/shapes/rectangle.cpp
+++ b/src/shapes/rectangle.cpp
@@ -85,7 +85,7 @@ template <typename Float, typename Spectrum>
 class Rectangle final : public Mesh<Float, Spectrum> {
 public:
     MI_IMPORT_BASE(Mesh, m_to_world, m_to_object, m_is_instance,
-                   m_discontinuity_types, m_shape_type, initialize,
+                   m_discontinuity_types, m_shape_type, m_flip_normals, initialize,
                    m_vertex_count, m_face_count, m_faces, m_vertex_positions,
                    m_vertex_normals, m_vertex_texcoords, get_children_string)
     using typename Base::FloatStorage;
@@ -105,11 +105,6 @@ public:
     };
 
     Rectangle(const Properties &props) : Base(props) {
-        if (props.get<bool>("flip_normals", false))
-            m_to_world =
-                m_to_world.scalar() *
-                ScalarTransform4f::scale(ScalarVector3f(1.f, 1.f, -1.f));
-
         m_vertex_count = 4;
         m_face_count = 2;
         m_shape_type = ShapeType::Rectangle;
@@ -197,6 +192,9 @@ public:
         ps.uv   = sample;
         ps.time = time;
         ps.delta = false;
+
+        if (m_flip_normals)
+            ps.n = -ps.n;
 
         return ps;
     }

--- a/src/shapes/sphere.cpp
+++ b/src/shapes/sphere.cpp
@@ -214,6 +214,11 @@ public:
         return 4.f * dr::Pi<ScalarFloat> * dr::square(m_radius.value());
     }
 
+    /// Does this sphere have flipped normals?
+    bool has_flipped_normals() const override {
+        return m_flip_normals;
+    }
+
     // =============================================================
     //! @{ \name Sampling routines
     // =============================================================


### PR DESCRIPTION
<!-- Please add the labels (e.g. bug fix, feature, ..) corresponding to this PR -->

## Description

Before, the normal flip from `flip_normals` was both baked in at construction, and re-applied on-the-fly in the inherited Mesh methods.
The issue was visible e.g. when attaching an area emitter to a `rectangle` shape. Depending on `flip_normals`, the emitter should shine either towards the camera or towards the background.
But this was not the case:

|                 | Not flipped | Flipped |
|-----------------|-------------|---------|
| OBJ shape       |      ![rect_ref_normal](https://github.com/user-attachments/assets/9c57cd63-96b1-44af-bfaa-fd2bb0d48585)       |      ![rect_ref_flipped](https://github.com/user-attachments/assets/9d9066a9-24a5-446d-8d71-f0324310c532)   |
| Rectangle shape |     ![rect_test_normal](https://github.com/user-attachments/assets/b08d6144-79c2-49ad-b73f-51118b307cf0)        |     ![rect_test_flipped](https://github.com/user-attachments/assets/4fca120e-5bbe-43d6-9696-d1b55f5527f7)    |

With this PR, the normal flip is left to the parent Mesh, which leads to a consistent behavior.

|                 | Not flipped | Flipped |
|-----------------|-------------|---------|
| OBJ shape       |       ![rect_ref_normal](https://github.com/user-attachments/assets/c4dfe2da-69c9-401d-b0e3-65a28c6afe6d)      |      ![rect_ref_flipped](https://github.com/user-attachments/assets/84eb0452-7f8b-44fd-990b-9f8daf26a551)   |
| Rectangle shape |     ![rect_test_normal](https://github.com/user-attachments/assets/90dc704f-0f9e-461d-b874-b56999e0b686)        |      ![rect_test_flipped](https://github.com/user-attachments/assets/f3a0e20e-b6b3-4633-9710-d13c15a09f2e)   |


I've also included other small changes:
- Add a `has_flipped_normals()` getter
- `Mesh::merge()` now respects `m_flip_normals` (it was ignored and reset to `false` previously, as far as I could tell?)
- Remove usage of `ThreadEnvironment` in `tonemap.py`


## Testing

Added a unit test.

## Checklist

<!-- Please make sure to complete this checklist before requesting a review. -->

- [x] My code follows the [style guidelines](https://mitsuba.readthedocs.io/en/latest/src/developer_guide.html#coding-style) of this project
- [x] My changes generate no new warnings
- [x] My code also compiles for `cuda_*` and `llvm_*` variants. If you can't test this, please leave below
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 3 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba/blob/master/LICENSE)