### PR TITLE
Make ``Transform3f/4f`` methods callable even when static

### DIFF
--- a/docs/porting_3_6.rst
+++ b/docs/porting_3_6.rst
@@ -137,45 +137,6 @@ longer needed.
   expensive, branch-specific computations when the condition for evaluating a 
   particular branch is relatively rare.
 
-
-Removal of static ``mi.Transform*`` functions
----------------------------------------------
-
-In prior releases of Mitsuba 3, the collection of ``mi.Transform*`` types could be
-instatiated via an initial static function call and then subsequent chained
-instance calls, such as
-
-.. code-block:: python
-
-  x = mi.Transform4f.translate([1,2,3]).scale(3.0).rotate([1, 0, 0], 0.5)
-
-However, a common pitfall was that subsequently calling
-
-.. code-block:: python
-
-  y = x.scale(3.0)
-
-would in fact call the static function implementation and hence the value of
-``y.matrix`` would unexpectedly be
-
-.. code-block:: python
-
-  [[[3, 0, 0, 0],
-  [0, 3, 0, 0],
-  [0, 0, 3, 0],
-  [0, 0, 0, 1]]]
-
-rather than applied to the existing transform ``x``.
-
-From Mitsuba 3.6.0 onwards, all ``mi.Transform*`` static function have been 
-removed and instead a user can default construct the identity transform before
-chaining any subsequent transforms
-
-.. code-block:: python
-
-  # mi.Transform4f() is the identity transform
-  x = mi.Transform4f().translate([1,2,3]).scale(3.0).rotate([1, 0, 0], 0.5)
-
 ..
 
   Bitmap textures: Half-precision storage by default where possible

--- a/src/core/python/transform_v.cpp
+++ b/src/core/python/transform_v.cpp
@@ -86,6 +86,9 @@ void bind_transform3(nb::module_ &m, const char *name) {
     if constexpr (dr::is_dynamic_v<Float>)
         trans3.def(nb::init<const ScalarTransform3f &>(), "Broadcast constructor");
 
+    // Patch methods to be callable as Transform3f().f() and Transform3f.f()
+    nb::module_::import_("mitsuba.detail").attr("patch_transform")(trans3);
+
     MI_PY_DRJIT_STRUCT(trans3, Transform3f, matrix, inverse_transpose)
 }
 
@@ -189,6 +192,9 @@ void bind_transform4(nb::module_ &m, const char *name) {
 
     if constexpr (dr::is_dynamic_v<Float>)
         trans4.def(nb::init<const ScalarTransform4f &>(), "Broadcast constructor");
+
+    // Patch methods to be callable as Transform4f().f() and Transform4f.f()
+    nb::module_::import_("mitsuba.detail").attr("patch_transform")(trans4);
 
     MI_PY_DRJIT_STRUCT(trans4, Transform4f, matrix, inverse_transpose)
 }

--- a/src/core/tests/test_transform.py
+++ b/src/core/tests/test_transform.py
@@ -175,41 +175,17 @@ def test08_transform_chain(variants_all_rgb):
     assert T.to_frame(mi.Frame3f([1, 0, 0])).scale(4.0) == T.to_frame(mi.Frame3f([1, 0, 0])) @ T.scale(4.0)
 
 
-# def test08_atransform_construct(variant_scalar_rgb):
-#     t = mi.Transform4f.rotate([1, 0, 0], 30)
-#     a = AnimatedTransform(t)
+def test06_dual_callable(variant_scalar_rgb):
+    """Test dual callable functionality - calling Transform methods as class methods"""
+    # Dual callable is automatically enabled when Transform classes are created
 
-#     t0 = a.eval(0)
-#     assert t0 == t
-#     assert not t0.has_scale()
-#     # Animation is constant over time
-#     for v in [10, 200, 1e5]:
-#         assert np.all(t0 == a.eval(v))
+    # Test that class methods create identity transform first
+    T = mi.Transform4f
+    assert dr.allclose(T.translate([1, 2, 3]).matrix, T().translate([1, 2, 3]).matrix)
+    assert dr.allclose(T.scale([2, 2, 2]).matrix, T().scale([2, 2, 2]).matrix)
+    assert dr.allclose(T.rotate([0, 1, 0], 45).matrix, T().rotate([0, 1, 0], 45).matrix)
 
-
-# def test10_atransform_interpolate_rotation(variant_scalar_rgb):
-#     a = AnimatedTransform()
-#     axis = np.array([1.0, 2.0, 3.0])
-#     axis /= la.norm(axis)
-
-#     trafo0 = mi.Transform4f.rotate(axis, 0)
-#     trafo1 = mi.Transform4f.rotate(axis, 30)
-#     trafo_mid = mi.Transform4f.rotate(axis, 15)
-#     a.append(2, trafo0)
-#     a.append(3, trafo1)
-
-#     assert dr.allclose(a.eval(-10).matrix, trafo0.matrix)
-#     assert dr.allclose(a.eval(2.5).matrix, trafo_mid.matrix)
-#     assert dr.allclose(a.eval( 10).matrix, trafo1.matrix)
-
-
-# def test11_atransform_interpolate_scale(variant_scalar_rgb):
-#     a = AnimatedTransform()
-#     trafo0 = mi.Transform4f.scale([1,2,3])
-#     trafo1 = mi.Transform4f.scale([4,5,6])
-#     trafo_mid = mi.Transform4f.scale([2.5, 3.5, 4.5])
-#     a.append(2, trafo0)
-#     a.append(3, trafo1)
-#     assert dr.allclose(a.eval(-10).matrix, trafo0.matrix)
-#     assert dr.allclose(a.eval(2.5).matrix, trafo_mid.matrix)
-#     assert dr.allclose(a.eval( 10).matrix, trafo1.matrix)
+    # Test chaining works correctly
+    t1 = T.translate([1, 0, 0]).rotate([0, 1, 0], 45).scale([2, 2, 2])
+    t2 = T().translate([1, 0, 0]).rotate([0, 1, 0], 45).scale([2, 2, 2])
+    assert dr.allclose(t1.matrix, t2.matrix)

--- a/src/python/__init__.py
+++ b/src/python/__init__.py
@@ -30,6 +30,9 @@ if _dr.__version__ != DRJIT_VERSION_REQUIREMENT:
                       % (DRJIT_VERSION_REQUIREMENT))
 del DRJIT_VERSION_REQUIREMENT
 
+# Import detail module before native extensions
+from . import detail
+
 with _dr.detail.scoped_rtld_deepbind():
     # Replaces 'mitsuba' in sys.modules with itself (mitsuba_alias)
     from . import mitsuba_alias

--- a/src/python/alias.cpp
+++ b/src/python/alias.cpp
@@ -217,17 +217,16 @@ NB_MODULE(mitsuba_alias, m) {
     curr_variant = nb::none();
     variant_change_callbacks = nb::set();
 
-    if (!variant_modules) {
+    if (!variant_modules)
         variant_modules = PyDict_New();
-    }
 
     // Need to populate `__path__` we do it by using the `__file__` attribute
     // of a Python file which is located in the same directory as this module
-    nb::module_ os = nb::module_::import_("os");
+    nb::module_ path = nb::module_::import_("os").attr("path");
     nb::module_ cfg = nb::module_::import_("mitsuba.config");
-    nb::object cfg_path = os.attr("path").attr("realpath")(cfg.attr("__file__"));
-    nb::object mi_dir = os.attr("path").attr("dirname")(cfg_path);
-    nb::object mi_py_dir = os.attr("path").attr("join")(mi_dir, "python");
+    nb::object cfg_path = path.attr("realpath")(cfg.attr("__file__"));
+    nb::object mi_dir = path.attr("dirname")(cfg_path);
+    nb::object mi_py_dir = path.attr("join")(mi_dir, "python");
     nb::list paths{};
     paths.append(nb::str(mi_dir));
     paths.append(nb::str(mi_py_dir));
@@ -252,11 +251,12 @@ NB_MODULE(mitsuba_alias, m) {
     /// Only used for variant-specific attributes e.g. mi.scalar_rgb.T
     m.def("__getattr__", [](nb::handle key) { return get_attr(key); });
 
-    // `mitsuba.detail` submodule
-    nb::module_ mi_detail = m.def_submodule("detail");
+    // Create the detail submodule
+    nb::module_ mi_detail = nb::module_::import_("mitsuba.detail");
     mi_detail.def("add_variant_callback", add_variant_callback);
     mi_detail.def("remove_variant_callback", remove_variant_callback);
     mi_detail.def("clear_variant_callbacks", clear_variant_callbacks);
+    m.attr("detail") = mi_detail;
 
     /// Fill `__dict__` with all objects in `mitsuba_ext` and `mitsuba.python`
     mi_dict = m.attr("__dict__").ptr();

--- a/src/python/detail.py
+++ b/src/python/detail.py
@@ -1,0 +1,33 @@
+"""Mitsuba detail module - internal implementation details."""
+
+class TransformWrapper:
+    '''
+    Helper functor that wraps Transform3f/Transform4f methods so that the following two
+    calling conventions are equivalent:
+
+     - Transform4f().translate().scale()...
+     - Transform4f.translate().scale()...
+    '''
+    def __init__(self, method_name, original_method):
+        self.method_name = method_name
+        self.original_method = original_method
+
+    def __get__(self, obj, objtype=None):
+        if obj is None:
+            def wrapper(*args, **kwargs):
+                instance = objtype()
+                return self.original_method.__get__(instance, objtype)(*args, **kwargs)
+            wrapper.__name__ = self.method_name
+            return wrapper
+        else:
+            return self.original_method.__get__(obj, objtype)
+
+
+def patch_transform(transform_cls):
+    methods = ['translate', 'scale', 'rotate', 'perspective',
+               'orthographic', 'look_at', 'from_frame', 'to_frame']
+
+    for method_name in methods:
+        if hasattr(transform_cls, method_name):
+            original = getattr(transform_cls, method_name)
+            setattr(transform_cls, method_name, TransformWrapper(method_name, original))

--- a/src/python/mitsuba_stubs/__init__.py
+++ b/src/python/mitsuba_stubs/__init__.py
@@ -60,6 +60,8 @@ sys.modules[__name__ +'.quad']       = mi.quad
 sys.modules[__name__ +'.mueller']    = mi.mueller
 sys.modules[__name__ +'.misc']       = mi.misc
 sys.modules[__name__ +'.python']     = mi.python
-sys.modules[__name__ +'.detail']     = mi.detail
+# detail module might not be available during stub generation
+if hasattr(mi, 'detail'):
+    sys.modules[__name__ +'.detail']     = mi.detail
 sys.modules[__name__ +'.filesystem'] = mi.filesystem
 


### PR DESCRIPTION
When Mitsuba switched to the nanobind-based bindings, code of the form

```
Transform4f.scale().rotate()...
```

had to be rewritten as

```
Transform4f().scale().rotate()...
```

Following this commit, both conventions will legal and produce the same result.