### PR TITLE
Frozen Functions followup

### DIFF
--- a/include/mitsuba/core/bitmap.h
+++ b/include/mitsuba/core/bitmap.h
@@ -653,7 +653,7 @@ public:
      bool m_owns_data;
      Properties m_metadata;
 
-    MI_TRAVERSE_CB(Object, m_size);
+    MI_TRAVERSE_CB(Object, m_size)
 };
 
 

--- a/include/mitsuba/core/bsphere.h
+++ b/include/mitsuba/core/bsphere.h
@@ -75,7 +75,7 @@ template <typename Point_> struct BoundingSphere: drjit::TraversableBase {
         );
     }
 
-    MI_TRAVERSE_CB(drjit::TraversableBase, center, radius);
+    MI_TRAVERSE_CB(drjit::TraversableBase, center, radius)
 };
 
 /// Print a string representation of the bounding sphere

--- a/include/mitsuba/core/distr_1d.h
+++ b/include/mitsuba/core/distr_1d.h
@@ -274,7 +274,7 @@ private:
     Vector2u m_valid;
 
     MI_TRAVERSE_CB(drjit::TraversableBase, m_pmf, m_cdf, m_sum, m_normalization,
-                   m_valid);
+                   m_valid)
 };
 
 /**
@@ -610,7 +610,7 @@ private:
 
     MI_TRAVERSE_CB(drjit::TraversableBase, m_pdf, m_cdf, m_integral,
                    m_normalization, m_interval_size, m_inv_interval_size,
-                   m_valid);
+                   m_valid)
 };
 
 /**
@@ -985,7 +985,7 @@ private:
     ScalarFloat m_max = 0.f;
 
     MI_TRAVERSE_CB(drjit::TraversableBase, m_nodes, m_pdf, m_cdf, m_integral,
-                   m_normalization, m_valid);
+                   m_normalization, m_valid)
 };
 
 template <typename Value>

--- a/include/mitsuba/core/fwd.h
+++ b/include/mitsuba/core/fwd.h
@@ -379,7 +379,7 @@ extern "C" {
  * inherits. The other arguments should list all members of that class, which
  * are supposed to be read only traversable.
  */
-#define MI_TRAVERSE_CB_RO(Base, ...)                                       \
+#define MI_TRAVERSE_CB_RO(Base, ...)                                           \
         void traverse_1_cb_ro(void *payload,                                   \
                               drjit::detail::traverse_callback_ro fn)          \
             const override {                                                   \

--- a/include/mitsuba/core/fwd.h
+++ b/include/mitsuba/core/fwd.h
@@ -379,7 +379,7 @@ extern "C" {
  * inherits. The other arguments should list all members of that class, which
  * are supposed to be read only traversable.
  */
-#define MI_TRAVERSE_CB_RO(Base, ...)                                           \
+#define MI_TRAVERSE_CB_RO(Base, ...)                                       \
         void traverse_1_cb_ro(void *payload,                                   \
                               drjit::detail::traverse_callback_ro fn)          \
             const override {                                                   \
@@ -387,9 +387,10 @@ extern "C" {
                           drjit::TraversableBase,                              \
                           std::remove_pointer_t<decltype(this)>>::value);      \
             /*                                                                 \
-             * Only traverse the objects for frozen functions, since           \
+             * Only traverse the scene for frozen functions, since             \
              * accidentally traversing the scene in loops or vcalls can cause  \
-             * issues.                                                         \
+             * errors with variable size mismatches, and backpropagation of    \
+             * gradients.                                                      \
              */                                                                \
             if (!jit_flag(JitFlag::EnableObjectTraversal))                     \
                 return;                                                        \
@@ -413,9 +414,10 @@ extern "C" {
                           drjit::TraversableBase,                              \
                           std::remove_pointer_t<decltype(this)>>::value);      \
             /*                                                                 \
-             * Only traverse the objects for frozen functions, since           \
+             * Only traverse the scene for frozen functions, since             \
              * accidentally traversing the scene in loops or vcalls can cause  \
-             * issues.                                                         \
+             * errors with variable size mismatches, and backpropagation of    \
+             * gradients.                                                      \
              */                                                                \
             if (!jit_flag(JitFlag::EnableObjectTraversal))                     \
                 return;                                                        \
@@ -479,9 +481,10 @@ public:                                                                        \
             void *payload, drjit::detail::traverse_callback_ro fn) const {     \
                                                                                \
             /*                                                                 \
-             * Only traverse the objects for frozen functions, since           \
+             * Only traverse the scene for frozen functions, since             \
              * accidentally traversing the scene in loops or vcalls can cause  \
-             * issues.                                                         \
+             * errors with variable size mismatches, and backpropagation of    \
+             * gradients.                                                      \
              */                                                                \
             if (!jit_flag(JitFlag::EnableObjectTraversal))                     \
                 return;                                                        \
@@ -500,8 +503,9 @@ public:                                                                        \
                                                                                \
             /*                                                                 \
              * Only traverse the scene for frozen functions, since             \
-             * accidentally traversing the objects in loops or vcalls can      \
-             * cause issues.                                                   \
+             * accidentally traversing the scene in loops or vcalls can cause  \
+             * errors with variable size mismatches, and backpropagation of    \
+             * gradients.                                                      \
              */                                                                \
             if (!jit_flag(JitFlag::EnableObjectTraversal))                     \
                 return;                                                        \

--- a/include/mitsuba/render/bsdf.h
+++ b/include/mitsuba/render/bsdf.h
@@ -613,7 +613,7 @@ protected:
     /// Flags for each component of this BSDF.
     std::vector<uint32_t> m_components;
 
-    MI_TRAVERSE_CB(Object);
+    MI_TRAVERSE_CB(Object)
 };
 
 // -----------------------------------------------------------------------

--- a/include/mitsuba/render/emitter.h
+++ b/include/mitsuba/render/emitter.h
@@ -93,7 +93,7 @@ protected:
     /// True if the emitters's parameters have changed
     bool m_dirty = false;
 
-    MI_TRAVERSE_CB(Base);
+    MI_TRAVERSE_CB(Base)
 };
 
 MI_EXTERN_CLASS(Emitter)

--- a/include/mitsuba/render/sensor.h
+++ b/include/mitsuba/render/sensor.h
@@ -160,7 +160,7 @@ protected:
     ref<const Texture> m_srf;
     bool m_alpha;
 
-    MI_TRAVERSE_CB(Base, m_film, m_sampler, m_srf);
+    MI_TRAVERSE_CB(Base, m_film, m_sampler, m_srf)
 };
 
 //! @}
@@ -215,7 +215,7 @@ protected:
     ScalarFloat m_far_clip;
     Float m_focus_distance;
 
-    MI_TRAVERSE_CB(Base, m_focus_distance);
+    MI_TRAVERSE_CB(Base, m_focus_distance)
 };
 
 // ========================================================================

--- a/include/mitsuba/render/texture.h
+++ b/include/mitsuba/render/texture.h
@@ -225,7 +225,7 @@ public:
 protected:
     Texture(const Properties &);
 
-    MI_TRAVERSE_CB(Object);
+    MI_TRAVERSE_CB(Object)
 };
 
 MI_EXTERN_CLASS(Texture)

--- a/include/mitsuba/render/volume.h
+++ b/include/mitsuba/render/volume.h
@@ -117,7 +117,7 @@ protected:
     /// Number of channels stored in the volume
     uint32_t m_channel_count;
 
-    MI_TRAVERSE_CB(Object);
+    MI_TRAVERSE_CB(Object)
 };
 
 MI_EXTERN_CLASS(Volume)

--- a/src/bsdfs/bumpmap.cpp
+++ b/src/bsdfs/bumpmap.cpp
@@ -245,7 +245,7 @@ protected:
     ref<Texture> m_nested_texture;
     ref<Base> m_nested_bsdf;
 
-    MI_TRAVERSE_CB(Base, m_nested_texture, m_nested_bsdf);
+    MI_TRAVERSE_CB(Base, m_nested_texture, m_nested_bsdf)
 };
 
 MI_EXPORT_PLUGIN(BumpMap)

--- a/src/bsdfs/circular.cpp
+++ b/src/bsdfs/circular.cpp
@@ -167,7 +167,7 @@ private:
     ref<Texture> m_transmittance;
     bool m_left_handed;
 
-    MI_TRAVERSE_CB(Base, m_transmittance);
+    MI_TRAVERSE_CB(Base, m_transmittance)
 };
 
 MI_EXPORT_PLUGIN(CircularPolarizer)

--- a/src/bsdfs/conductor.cpp
+++ b/src/bsdfs/conductor.cpp
@@ -331,7 +331,7 @@ private:
     ref<Texture> m_specular_reflectance;
     ref<Texture> m_eta, m_k;
 
-    MI_TRAVERSE_CB(Base, m_specular_reflectance, m_eta, m_k);
+    MI_TRAVERSE_CB(Base, m_specular_reflectance, m_eta, m_k)
 };
 
 MI_EXPORT_PLUGIN(SmoothConductor)

--- a/src/bsdfs/dielectric.cpp
+++ b/src/bsdfs/dielectric.cpp
@@ -397,7 +397,7 @@ private:
     ref<Texture> m_specular_reflectance;
     ref<Texture> m_specular_transmittance;
 
-    MI_TRAVERSE_CB(Base, m_eta, m_specular_reflectance,m_specular_transmittance);
+    MI_TRAVERSE_CB(Base, m_eta, m_specular_reflectance,m_specular_transmittance)
 };
 
 MI_EXPORT_PLUGIN(SmoothDielectric)

--- a/src/bsdfs/diffuse.cpp
+++ b/src/bsdfs/diffuse.cpp
@@ -195,7 +195,7 @@ public:
 private:
     ref<Texture> m_reflectance;
 
-    MI_TRAVERSE_CB(Base, m_reflectance);
+    MI_TRAVERSE_CB(Base, m_reflectance)
 };
 
 MI_EXPORT_PLUGIN(SmoothDiffuse)

--- a/src/bsdfs/mask.cpp
+++ b/src/bsdfs/mask.cpp
@@ -247,7 +247,7 @@ private:
     ref<Texture> m_opacity;
     ref<Base> m_nested_bsdf;
 
-    MI_TRAVERSE_CB(Base, m_opacity, m_nested_bsdf);
+    MI_TRAVERSE_CB(Base, m_opacity, m_nested_bsdf)
 };
 
 MI_EXPORT_PLUGIN(MaskBSDF)

--- a/src/bsdfs/measured.cpp
+++ b/src/bsdfs/measured.cpp
@@ -496,7 +496,7 @@ private:
     bool m_jacobian;
     int m_reduction;
 
-    MI_TRAVERSE_CB(Base, m_ndf, m_sigma, m_vndf, m_luminance, m_spectra);
+    MI_TRAVERSE_CB(Base, m_ndf, m_sigma, m_vndf, m_luminance, m_spectra)
 };
 
 MI_EXPORT_PLUGIN(Measured)

--- a/src/bsdfs/measured_polarized.cpp
+++ b/src/bsdfs/measured_polarized.cpp
@@ -399,7 +399,7 @@ private:
     ScalarFloat m_alpha_sample;
     Interpolator  m_interpolator;
 
-    MI_TRAVERSE_CB(Base, m_interpolator);
+    MI_TRAVERSE_CB(Base, m_interpolator)
 };
 
 MI_EXPORT_PLUGIN(MeasuredPolarized)

--- a/src/bsdfs/normalmap.cpp
+++ b/src/bsdfs/normalmap.cpp
@@ -233,7 +233,7 @@ protected:
     ref<Base> m_nested_bsdf;
     ref<Texture> m_normalmap;
 
-    MI_TRAVERSE_CB(Base, m_nested_bsdf, m_normalmap);
+    MI_TRAVERSE_CB(Base, m_nested_bsdf, m_normalmap)
 };
 
 MI_EXPORT_PLUGIN(NormalMap);

--- a/src/bsdfs/plastic.cpp
+++ b/src/bsdfs/plastic.cpp
@@ -392,7 +392,7 @@ private:
     bool m_nonlinear;
 
     MI_TRAVERSE_CB(Base, m_diffuse_reflectance, m_specular_reflectance,
-                   m_specular_sampling_weight);
+                   m_specular_sampling_weight)
 };
 
 MI_EXPORT_PLUGIN(SmoothPlastic)

--- a/src/bsdfs/polarizer.cpp
+++ b/src/bsdfs/polarizer.cpp
@@ -219,7 +219,7 @@ private:
     ref<Texture> m_theta;
     ref<Texture> m_transmittance;
 
-    MI_TRAVERSE_CB(Base, m_theta, m_transmittance);
+    MI_TRAVERSE_CB(Base, m_theta, m_transmittance)
 };
 
 MI_EXPORT_PLUGIN(LinearPolarizer)

--- a/src/bsdfs/pplastic.cpp
+++ b/src/bsdfs/pplastic.cpp
@@ -473,7 +473,7 @@ private:
     Float m_specular_sampling_weight;
 
     MI_TRAVERSE_CB(Base, m_diffuse_reflectance, m_specular_reflectance,
-                   m_alpha_u, m_alpha_v, m_eta, m_specular_sampling_weight);
+                   m_alpha_u, m_alpha_v, m_eta, m_specular_sampling_weight)
 };
 
 MI_EXPORT_PLUGIN(PolarizedPlastic)

--- a/src/bsdfs/principled.cpp
+++ b/src/bsdfs/principled.cpp
@@ -898,7 +898,7 @@ private:
     MI_TRAVERSE_CB(Base, m_base_color, m_roughness, m_anisotropic, m_sheen,
                    m_sheen_tint, m_spec_trans, m_flatness, m_spec_tint,
                    m_clearcoat, m_clearcoat_gloss, m_metallic, m_eta,
-                   m_specular);
+                   m_specular)
 };
 
 MI_EXPORT_PLUGIN(Principled)

--- a/src/bsdfs/principledthin.cpp
+++ b/src/bsdfs/principledthin.cpp
@@ -756,7 +756,7 @@ private:
 
     MI_TRAVERSE_CB(Base, m_base_color, m_roughness, m_anisotropic, m_sheen,
                    m_sheen_tint, m_spec_trans, m_flatness, m_spec_tint,
-                   m_diff_trans, m_eta_thin);
+                   m_diff_trans, m_eta_thin)
 };
 
 MI_EXPORT_PLUGIN(PrincipledThin)

--- a/src/bsdfs/retarder.cpp
+++ b/src/bsdfs/retarder.cpp
@@ -207,7 +207,7 @@ private:
     ref<Texture> m_delta;
     ref<Texture> m_transmittance;
 
-    MI_TRAVERSE_CB(Base, m_theta, m_delta, m_transmittance);
+    MI_TRAVERSE_CB(Base, m_theta, m_delta, m_transmittance)
 };
 
 MI_EXPORT_PLUGIN(LinearRetarder)

--- a/src/bsdfs/roughconductor.cpp
+++ b/src/bsdfs/roughconductor.cpp
@@ -548,7 +548,7 @@ private:
     ref<Texture> m_specular_reflectance;
 
     MI_TRAVERSE_CB(Base, m_alpha_u, m_alpha_v, m_eta, m_k,
-                   m_specular_reflectance);
+                   m_specular_reflectance)
 };
 
 MI_EXPORT_PLUGIN(RoughConductor)

--- a/src/bsdfs/roughdielectric.cpp
+++ b/src/bsdfs/roughdielectric.cpp
@@ -641,7 +641,7 @@ private:
     bool m_sample_visible;
 
     MI_TRAVERSE_CB(Base, m_specular_reflectance, m_specular_transmittance,
-                   m_alpha_u, m_alpha_v, m_eta, m_inv_eta);
+                   m_alpha_u, m_alpha_v, m_eta, m_inv_eta)
 };
 
 MI_EXPORT_PLUGIN(RoughDielectric)

--- a/src/bsdfs/roughplastic.cpp
+++ b/src/bsdfs/roughplastic.cpp
@@ -540,7 +540,7 @@ private:
 
     MI_TRAVERSE_CB(Base, m_diffuse_reflectance, m_specular_reflectance, m_eta,
                    m_inv_eta_2, m_alpha, m_specular_sampling_weight,
-                   m_external_transmittance, m_internal_reflectance);
+                   m_external_transmittance, m_internal_reflectance)
 };
 
 MI_EXPORT_PLUGIN(RoughPlastic)

--- a/src/bsdfs/thindielectric.cpp
+++ b/src/bsdfs/thindielectric.cpp
@@ -235,7 +235,7 @@ private:
     ref<Texture> m_specular_reflectance;
 
     MI_TRAVERSE_CB(Base, m_eta, m_specular_reflectance,
-                   m_specular_transmittance);
+                   m_specular_transmittance)
 };
 
 MI_EXPORT_PLUGIN(ThinDielectric)

--- a/src/bsdfs/twosided.cpp
+++ b/src/bsdfs/twosided.cpp
@@ -377,7 +377,7 @@ public:
 protected:
     ref<Base> m_brdf[2];
 
-    MI_TRAVERSE_CB(Base, m_brdf[0], m_brdf[1]);
+    MI_TRAVERSE_CB(Base, m_brdf[0], m_brdf[1])
 };
 
 MI_EXPORT_PLUGIN(TwoSidedBRDF)

--- a/src/emitters/area.cpp
+++ b/src/emitters/area.cpp
@@ -271,7 +271,7 @@ public:
 private:
     ref<Texture> m_radiance;
 
-    MI_TRAVERSE_CB(Base, m_radiance);
+    MI_TRAVERSE_CB(Base, m_radiance)
 };
 
 MI_EXPORT_PLUGIN(AreaLight)

--- a/src/emitters/directional.cpp
+++ b/src/emitters/directional.cpp
@@ -232,7 +232,7 @@ protected:
     ref<Texture> m_irradiance;
     ScalarBoundingSphere3f m_bsphere;
 
-    MI_TRAVERSE_CB(Base, m_irradiance);
+    MI_TRAVERSE_CB(Base, m_irradiance)
 };
 
 MI_EXPORT_PLUGIN(DirectionalEmitter)

--- a/src/emitters/point.cpp
+++ b/src/emitters/point.cpp
@@ -207,7 +207,7 @@ private:
     ref<Texture> m_intensity;
     field<Point3f> m_position;
 
-    MI_TRAVERSE_CB(Base, m_intensity, m_position);
+    MI_TRAVERSE_CB(Base, m_intensity, m_position)
 };
 
 

--- a/src/films/hdrfilm.cpp
+++ b/src/films/hdrfilm.cpp
@@ -614,7 +614,7 @@ protected:
     mutable std::mutex m_mutex;
     std::vector<std::string> m_channels;
 
-    MI_TRAVERSE_CB(Base, m_storage);
+    MI_TRAVERSE_CB(Base, m_storage)
 };
 
 MI_EXPORT_PLUGIN(HDRFilm)

--- a/src/integrators/aov.cpp
+++ b/src/integrators/aov.cpp
@@ -572,7 +572,7 @@ private:
     std::vector<std::string> m_aov_names;
     std::vector<ref<Base>> m_integrators;
 
-    MI_TRAVERSE_CB(Base, m_integrators);
+    MI_TRAVERSE_CB(Base, m_integrators)
 };
 
 MI_EXPORT_PLUGIN(AOVIntegrator)

--- a/src/integrators/moment.cpp
+++ b/src/integrators/moment.cpp
@@ -142,7 +142,7 @@ private:
     std::vector<std::string> m_aov_names;
     std::vector<std::pair<ref<Base>, size_t>> m_integrators;
 
-    MI_TRAVERSE_CB(Base, m_integrators);
+    MI_TRAVERSE_CB(Base, m_integrators)
 };
 
 MI_EXPORT_PLUGIN(MomentIntegrator)

--- a/src/integrators/stokes.cpp
+++ b/src/integrators/stokes.cpp
@@ -145,7 +145,7 @@ public:
 private:
     ref<Base> m_integrator;
 
-    MI_TRAVERSE_CB(Base, m_integrator);
+    MI_TRAVERSE_CB(Base, m_integrator)
 };
 
 MI_EXPORT_PLUGIN(StokesIntegrator)

--- a/src/media/heterogeneous.cpp
+++ b/src/media/heterogeneous.cpp
@@ -216,7 +216,7 @@ private:
     ScalarFloat m_scale;
     Float m_max_density;
 
-    MI_TRAVERSE_CB(Base, m_sigmat, m_albedo, m_max_density);
+    MI_TRAVERSE_CB(Base, m_sigmat, m_albedo, m_max_density)
 };
 
 MI_EXPORT_PLUGIN(HeterogeneousMedium)

--- a/src/media/homogeneous.cpp
+++ b/src/media/homogeneous.cpp
@@ -195,7 +195,7 @@ private:
     ref<Volume> m_sigmat, m_albedo;
     ScalarFloat m_scale;
 
-    MI_TRAVERSE_CB(Base, m_sigmat, m_albedo, m_scale);
+    MI_TRAVERSE_CB(Base, m_sigmat, m_albedo, m_scale)
 };
 
 MI_EXPORT_PLUGIN(HomogeneousMedium)

--- a/src/render/scene.cpp
+++ b/src/render/scene.cpp
@@ -639,9 +639,10 @@ void Scene<Float, Spectrum>::traverse_1_cb_ro(
     void *payload, drjit::detail::traverse_callback_ro fn) const {
 
     // Only traverse the scene for frozen functions, since accidentally
-    // traversing the scene in loops or vcalls can cause issues.
+    // traversing the scene in loops or vcalls can cause errors with variable
+    // size mismatches, and backpropagation of gradients.
     if (!jit_flag(JitFlag::EnableObjectTraversal))
-        return;
+    return;
 
     if constexpr (!std::is_same_v<Object, drjit::TraversableBase>)
         Object::traverse_1_cb_ro(payload, fn);
@@ -660,7 +661,8 @@ void Scene<Float, Spectrum>::traverse_1_cb_rw(
     void *payload, drjit::detail::traverse_callback_rw fn) {
 
     // Only traverse the scene for frozen functions, since accidentally
-    // traversing the scene in loops or vcalls can cause issues.
+    // traversing the scene in loops or vcalls can cause errors with variable
+    // size mismatches, and backpropagation of gradients.
     if (!jit_flag(JitFlag::EnableObjectTraversal))
         return;
 

--- a/src/render/scene_embree.inl
+++ b/src/render/scene_embree.inl
@@ -179,7 +179,6 @@ MI_VARIANT void Scene<Float, Spectrum>::accel_parameters_changed_cpu() {
         if (m_accel_handle.index())
             jit_var_set_callback(m_accel_handle.index(), nullptr, nullptr);
         m_accel_handle = UInt64::map_(s.accel, 1, false);
-        // m_accel_handle = dr::opaque<UInt64>(s.accel);
         jit_var_set_callback(
             m_accel_handle.index(),
             [](uint32_t /* index */, int free, void *payload) {

--- a/src/sensors/perspective.cpp
+++ b/src/sensors/perspective.cpp
@@ -415,7 +415,7 @@ private:
 
     MI_TRAVERSE_CB(Base, m_camera_to_sample, m_sample_to_camera, m_image_rect,
                    m_normalization, m_x_fov, m_dx, m_dy,
-                   m_principal_point_offset);
+                   m_principal_point_offset)
 };
 
 MI_EXPORT_PLUGIN(PerspectiveCamera)

--- a/src/shapes/cube.cpp
+++ b/src/shapes/cube.cpp
@@ -164,7 +164,7 @@ public:
 
     MI_DECLARE_CLASS(Cube)
 
-    MI_TRAVERSE_CB(Base);
+    MI_TRAVERSE_CB(Base)
 };
 
 MI_EXPORT_PLUGIN(Cube)

--- a/src/shapes/cylinder.cpp
+++ b/src/shapes/cylinder.cpp
@@ -818,7 +818,7 @@ private:
     bool m_flip_normals;
     static constexpr float silhouette_offset = 1e-3f;
 
-    MI_TRAVERSE_CB(Base, m_radius, m_length, m_inv_surface_area);
+    MI_TRAVERSE_CB(Base, m_radius, m_length, m_inv_surface_area)
 };
 
 MI_EXPORT_PLUGIN(Cylinder)

--- a/src/shapes/obj.cpp
+++ b/src/shapes/obj.cpp
@@ -410,7 +410,7 @@ public:
 
     MI_DECLARE_CLASS(OBJMesh)
 
-    MI_TRAVERSE_CB(Base);
+    MI_TRAVERSE_CB(Base)
 };
 
 MI_EXPORT_PLUGIN(OBJMesh)

--- a/src/shapes/rectangle.cpp
+++ b/src/shapes/rectangle.cpp
@@ -620,7 +620,7 @@ private:
     Frame3f m_frame;
     Float m_inv_surface_area;
 
-    MI_TRAVERSE_CB(Base, m_frame, m_inv_surface_area);
+    MI_TRAVERSE_CB(Base, m_frame, m_inv_surface_area)
 };
 
 MI_EXPORT_PLUGIN(Rectangle)

--- a/src/spectra/d65.cpp
+++ b/src/spectra/d65.cpp
@@ -315,7 +315,7 @@ private:
 
     bool m_has_value = false;
 
-    MI_TRAVERSE_CB(Base, m_value, m_nested_texture, m_d65);
+    MI_TRAVERSE_CB(Base, m_value, m_nested_texture, m_d65)
 };
 
 MI_EXPORT_PLUGIN(D65Spectrum)

--- a/src/spectra/irregular.cpp
+++ b/src/spectra/irregular.cpp
@@ -176,7 +176,7 @@ public:
 private:
     IrregularContinuousDistribution<Wavelength> m_distr;
 
-    MI_TRAVERSE_CB(Texture, m_distr);
+    MI_TRAVERSE_CB(Texture, m_distr)
 };
 
 MI_EXPORT_PLUGIN(IrregularSpectrum)

--- a/src/spectra/regular.cpp
+++ b/src/spectra/regular.cpp
@@ -170,7 +170,7 @@ public:
 private:
     ContinuousDistribution<Wavelength> m_distr;
 
-    MI_TRAVERSE_CB(Texture, m_distr);
+    MI_TRAVERSE_CB(Texture, m_distr)
 };
 
 MI_EXPORT_PLUGIN(RegularSpectrum)

--- a/src/spectra/srgb.cpp
+++ b/src/spectra/srgb.cpp
@@ -146,7 +146,7 @@ protected:
 
     Color<Float, ChannelCount> m_value;
 
-    MI_TRAVERSE_CB(Texture, m_value);
+    MI_TRAVERSE_CB(Texture, m_value)
 };
 
 MI_EXPORT_PLUGIN(SRGBReflectanceSpectrum)

--- a/src/spectra/uniform.cpp
+++ b/src/spectra/uniform.cpp
@@ -124,7 +124,7 @@ private:
     Float m_value;
     ScalarVector2f m_range;
 
-    MI_TRAVERSE_CB(Texture, m_value);
+    MI_TRAVERSE_CB(Texture, m_value)
 };
 
 MI_EXPORT_PLUGIN(UniformSpectrum)

--- a/src/textures/bitmap.cpp
+++ b/src/textures/bitmap.cpp
@@ -355,7 +355,7 @@ private:
     mutable ref<Bitmap> m_bitmap;
     TensorXf m_tensor;
 
-    MI_TRAVERSE_CB(Texture, m_bitmap, m_tensor);
+    MI_TRAVERSE_CB(Texture, m_bitmap, m_tensor)
 };
 
 template <typename Float, typename Spectrum, typename StoredType>
@@ -919,7 +919,7 @@ protected:
     mutable std::mutex m_mutex;
     std::unique_ptr<DiscreteDistribution2D<Float>> m_distr2d;
 
-    MI_TRAVERSE_CB(Texture, m_mean, m_texture, m_distr2d);
+    MI_TRAVERSE_CB(Texture, m_mean, m_texture, m_distr2d)
 };
 
 MI_EXPORT_PLUGIN(BitmapTexture)

--- a/src/textures/volume.cpp
+++ b/src/textures/volume.cpp
@@ -92,7 +92,7 @@ public:
 protected:
     ref<Volume> m_volume;
 
-    MI_TRAVERSE_CB(Texture, m_volume);
+    MI_TRAVERSE_CB(Texture, m_volume)
 };
 
 MI_EXPORT_PLUGIN(VolumeAdapter)

--- a/src/volumes/const.cpp
+++ b/src/volumes/const.cpp
@@ -96,7 +96,7 @@ public:
 protected:
     ref<Texture> m_value;
 
-    MI_TRAVERSE_CB(Base, m_value);
+    MI_TRAVERSE_CB(Base, m_value)
 };
 
 MI_EXPORT_PLUGIN(ConstVolume)

--- a/src/volumes/grid.cpp
+++ b/src/volumes/grid.cpp
@@ -626,7 +626,7 @@ protected:
     ScalarFloat m_max;
     std::vector<ScalarFloat> m_max_per_channel;
 
-    MI_TRAVERSE_CB(Base, m_texture);
+    MI_TRAVERSE_CB(Base, m_texture)
 };
 
 MI_EXPORT_PLUGIN(GridVolume)


### PR DESCRIPTION
<!-- Please add the labels (e.g. bug fix, feature, ..) corresponding to this PR -->

## Description

This PR fixes some mistakes in the frozen functions PR.
- Removes unnecessary semicolons
- Improves comments related to frozen function only traversal

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->


## Checklist

<!-- Please make sure to complete this checklist before requesting a review. -->

- [x] My code follows the [style guidelines](https://mitsuba.readthedocs.io/en/latest/src/developer_guide.html#coding-style) of this project
- [x] My changes generate no new warnings
- [x] My code also compiles for `cuda_*` and `llvm_*` variants. If you can't test this, please leave below
- [ ] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I cleaned the commit history and removed any "Merge" commits
- [ ] I give permission that the Mitsuba 3 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba/blob/master/LICENSE)