### PR TITLE
Fix use of DRJIT_CALL_END macro in mesh.h

### DIFF
--- a/include/mitsuba/render/mesh.h
+++ b/include/mitsuba/render/mesh.h
@@ -634,7 +634,7 @@ DRJIT_CALL_TEMPLATE_INHERITED_BEGIN(mitsuba::Mesh, mitsuba::Shape)
     DRJIT_CALL_GETTER(has_vertex_texcoords)
     DRJIT_CALL_GETTER(has_mesh_attributes)
     DRJIT_CALL_GETTER(has_face_normals)
-DRJIT_CALL_END()
+DRJIT_CALL_INHERITED_END()
 
 //! @}
 // -----------------------------------------------------------------------


### PR DESCRIPTION
Minor: fix use of call end macro in mesh.h to use the correct "inherited" version