### PR TITLE
Attempt removing GC calls from the test suite

### DIFF
--- a/src/conftest.py
+++ b/src/conftest.py
@@ -49,9 +49,6 @@ def clean_up():
     periodically frees the malloc cache to prevent the testcases from hogging
     all system memory.
     '''
-    gc.collect()
-    gc.collect()
-
     dr.kernel_history_clear()
     dr.flush_malloc_cache()
     dr.flush_kernel_cache()


### PR DESCRIPTION
I've noticed when running small self-contained tests that a significant portion of the runtime is spent in the cleanup callback after each executed test run. (A set of 20 tests went from ~6s to .04s after removing the GC calls). Let's see what happens at a larger scale when removing this..