### PR TITLE
``conftest.py`` refactored: metric collection, filtering/sorting, lower test memory usage

### DIFF
--- a/ext/CMakeLists.txt
+++ b/ext/CMakeLists.txt
@@ -266,7 +266,7 @@ if (CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64")
 set(PNG_ARM_NEON "on" CACHE STRING " " FORCE)
 endif()
 add_subdirectory(libpng)
-set_property(TARGET png png_genfiles PROPERTY FOLDER "dependencies")
+set_property(TARGET png PROPERTY FOLDER "dependencies")
 set_property(TARGET png PROPERTY OUTPUT_NAME "png-mitsuba")
 
 set(PNG_INCLUDE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/libpng;${CMAKE_CURRENT_BINARY_DIR}/libpng" PARENT_SCOPE)

--- a/include/mitsuba/render/sunsky.h
+++ b/include/mitsuba/render/sunsky.h
@@ -28,30 +28,30 @@ static constexpr Float WAVELENGTHS[WAVELENGTH_COUNT] = {
 };
 
 /// Number of control points for interpolation in the skylight model
-static const constexpr size_t SKY_CTRL_PTS = 6;
+static const constexpr uint32_t SKY_CTRL_PTS = 6;
 /// Number of parameters for the skylight model equation
-static const constexpr size_t SKY_PARAMS = 9;
+static const constexpr uint32_t SKY_PARAMS = 9;
 
 /// Number of control points for interpolation in the sun model
-static const constexpr size_t SUN_CTRL_PTS = 4;
+static const constexpr uint32_t SUN_CTRL_PTS = 4;
 /// Number of segments for the piecewise polynomial in the sun model
-static const constexpr size_t SUN_SEGMENTS = 45;
+static const constexpr uint32_t SUN_SEGMENTS = 45;
 /// Number of coefficients for the sun's limb darkening
-static const constexpr size_t SUN_LD_PARAMS = 6;
+static const constexpr uint32_t SUN_LD_PARAMS = 6;
 
 /// Number of elevation control points for the tgmm sampling tables
-static const constexpr size_t ELEVATION_CTRL_PTS = 30;
+static const constexpr uint32_t ELEVATION_CTRL_PTS = 30;
 /// Number of gaussian components in the tgmm
-static const constexpr size_t TGMM_COMPONENTS = 5;
+static const constexpr uint32_t TGMM_COMPONENTS = 5;
 /// Number of parameters for each gaussian component
-static const constexpr size_t TGMM_GAUSSIAN_PARAMS = 5;
+static const constexpr uint32_t TGMM_GAUSSIAN_PARAMS = 5;
 
 /// Sun half aperture angle in radians
 #define SUN_HALF_APERTURE (dr::deg_to_rad(0.5358/2.0))
 /// Mean radius of the Earth
 static const constexpr double EARTH_MEAN_RADIUS = 6371.01;   // In km
 /// Astronomical unit
-static const constexpr size_t ASTRONOMICAL_UNIT = 149597890; // In km
+static const constexpr double ASTRONOMICAL_UNIT = 149597890; // In km
 
 /// Conversion constant to convert spectral solar luminosity to RGB
 static const constexpr float SPEC_TO_RGB_SUN_CONV = 467.069280386f;
@@ -215,7 +215,7 @@ DynamicBuffer<Float> sky_radiance_params(
     const uint32_t t_block_size = dataset_size / TURBITDITY_LVLS,
                    a_block_size = t_block_size / ALBEDO_LVLS,
                    result_size  = a_block_size / SKY_CTRL_PTS,
-                   nb_params    = result_size / albedo.size();
+                   nb_params    = result_size / (uint32_t) albedo.size();
                                              // albedo.size() <==> NB_CHANNELS
 
     // Interpolate on elevation

--- a/resources/setpath.sh
+++ b/resources/setpath.sh
@@ -42,27 +42,30 @@ if [ "$BASH_VERSION" ]; then
     }
     complete -F _mitsuba -o default mitsuba
 elif [ "$ZSH_VERSION" ]; then
-    _mitsuba() {
-        _arguments \
-            '-a[Add an entry to the search path]' \
-            '-h[Help]' \
-            '-m[Select the variant/mode (e.g. "llvm_rgb")]' \
-            '-o[Specify the output filename]' \
-            '-s[Sensor/camera index to use for rendering]' \
-            '-t[Override the number of threads]' \
-            '-u[Update the scene description to the latest version]' \
-            '-v[Be more verbose. Can be specified multiple times]' \
-            '-D[Define a constant that can be referenced in the scene]' \
-            '*: :->file'
+    # Check if shell is interactive and compdef is available
+    if [[ -o interactive ]] && (( $+functions[compdef] )); then
+        _mitsuba() {
+            _arguments \
+                '-a[Add an entry to the search path]' \
+                '-h[Help]' \
+                '-m[Select the variant/mode (e.g. "llvm_rgb")]' \
+                '-o[Specify the output filename]' \
+                '-s[Sensor/camera index to use for rendering]' \
+                '-t[Override the number of threads]' \
+                '-u[Update the scene description to the latest version]' \
+                '-v[Be more verbose. Can be specified multiple times]' \
+                '-D[Define a constant that can be referenced in the scene]' \
+                '*: :->file'
 
-        if [[ $state == '-' ]]; then
-            :
-        elif [[ $words[CURRENT-1] == '-m' ]]; then
-            compadd "$@" ${=MI_VARIANTS}
-        else
-            _files
-        fi
+            if [[ $state == '-' ]]; then
+                :
+            elif [[ $words[CURRENT-1] == '-m' ]]; then
+                compadd "$@" ${=MI_VARIANTS}
+            else
+                _files
+            fi
 
-    }
-    compdef _mitsuba mitsuba
+        }
+        compdef _mitsuba mitsuba
+    fi
 fi

--- a/src/bsdfs/tests/test_dielectric.py
+++ b/src/bsdfs/tests/test_dielectric.py
@@ -174,5 +174,5 @@ def test06_attached_sampling(variants_all_ad_rgb):
     assert dr.grad_enabled(weight)
     
     dr.forward(angle)
-    assert dr.allclose(dr.grad(weight), 0.008912204764783382)
+    assert dr.allclose(mi.unpolarized_spectrum(dr.grad(weight)), 0.008912204764783382)
     

--- a/src/bsdfs/tests/test_hair.py
+++ b/src/bsdfs/tests/test_hair.py
@@ -123,7 +123,7 @@ def test04_sample_numeric(variants_vec_backends_once_rgb):
 
 @pytest.mark.slow
 def test05_sample_consistency(variants_vec_backends_once_rgb):
-    total = int(1e8)
+    total = int(1e7)
     sampler = mi.load_dict({'type': 'independent', 'sample_count': total})
     sampler.seed(seed = 4, wavefront_size = total)
 

--- a/src/bsdfs/tests/test_rough_dielectric.py
+++ b/src/bsdfs/tests/test_rough_dielectric.py
@@ -244,5 +244,5 @@ def test13_attached_sampling(variants_all_ad_rgb):
     assert dr.grad_enabled(weight)
 
     dr.forward(angle)
-    assert dr.allclose(dr.grad(weight), 0.02079637348651886)
+    assert dr.allclose(mi.unpolarized_spectrum(dr.grad(weight)), 0.02079637348651886)
     

--- a/src/conftest.py
+++ b/src/conftest.py
@@ -1,146 +1,338 @@
-# This file rewrites exceptions caught by PyTest and makes traces involving
-# pybind11 classes more readable. It e.g. replaces "<built-in method allclose
-# of PyCapsule object at 0x7ffa78041090>" by "allclose" which is arguably just
-# as informative and much more compact.
+"""
+PyTest configuration for Mitsuba 3.
 
+This module configures the test environment for Mitsuba, providing:
+- Variant-specific fixtures for running tests with different rendering backends
+- Test metrics collection (memory, time, kernel launches)
+- Test cleanup between runs to prevent resource leaks
+- Random number generator fixtures with fixed seeds for reproducibility
+"""
+
+import time
 import pytest
-import re
-import gc
 import drjit as dr
 import mitsuba as mi
 
-re1 = re.compile(r'<built-in method (\w*) of PyCapsule object at 0x[0-9a-f]*>')
-re2 = re.compile(r'<bound method PyCapsule.(\w*)[^>]*>')
-
-
-def patch_line(s):
-    s = re1.sub(r'\1', s)
-    s = re2.sub(r'\1', s)
-    return s
-
-
-def patch_tb(tb):  # tb: ReprTraceback
-    for entry in tb.reprentries:
-        entry.lines = [patch_line(l) for l in entry.lines]
-
+# ===== RNG Seedinng Fixture =====
 
 
 @pytest.fixture
 def np_rng():
     import numpy as np
+
     return np.random.default_rng(seed=12345)
 
 
-@pytest.hookimpl(hookwrapper=True)
-def pytest_runtest_makereport(item, call):
-    outcome = yield
-    rep = outcome.get_result()
-    if rep.outcome == 'failed':
-        if hasattr(rep.longrepr, 'chain'):
-            for entry in rep.longrepr.chain:
-                patch_tb(entry[0])
-    return rep
+# ===== Variant Fixture Generation =====
 
 
-def clean_up():
-    '''
-    Ensure no leftover instances from other tests are still in registry, wait
-    for all running kernels to finish and reset the JitFlag to default. Also
-    periodically frees the malloc cache to prevent the testcases from hogging
-    all system memory.
-    '''
+def _variant_fixture_impl(request, variant):
+    """
+    Set variant and clean up after test. Ensures no leftover instances
+    from other tests are still in registry, waits for all running kernels
+    to finish and resets the JitFlag to default. Also frees the malloc cache to
+    prevent tests from hogging all system memory.
+    """
+    mi.set_variant(variant)
+    yield variant
+
+    # Clean up after test
+    dr.sync_thread()
+    dr.flush_kernel_cache()
     dr.kernel_history_clear()
     dr.flush_malloc_cache()
-    dr.flush_kernel_cache()
-
-    if hasattr(dr, 'sync_thread'):
-        dr.sync_thread()
-        dr.detail.clear_registry()
-        dr.set_flag(dr.JitFlag.Default, True)
+    dr.detail.malloc_clear_statistics()
+    dr.detail.clear_registry()
+    dr.set_flag(dr.JitFlag.Default, True)
 
 
 def generate_fixture(variant):
     @pytest.fixture()
-    def fixture():
-        try:
-            clean_up()
-            mi.set_variant(variant)
-        except Exception:
-            pytest.skip('Mitsuba variant "%s" is not enabled!' % variant)
-    globals()['variant_' + variant] = fixture
+    def fixture(request):
+        yield from _variant_fixture_impl(request, variant)
 
-
-# Compute set of valid variants
-suffix_variants = [a + b for a in ["_mono", "_mono_polarized", "_rgb", "_spectral", "_spectral_polarized"] for b in ["", "_double"]]
-scalar_variants = ["scalar" + s for s in suffix_variants]
-other_variants  = [a + b + c for a in ["llvm", "cuda"] for b in ["", "_ad"] for c in suffix_variants]
-
-for variant in scalar_variants + other_variants:
-    generate_fixture(variant)
-del generate_fixture
+    globals()["variant_" + variant] = fixture
 
 
 def generate_fixture_group(name, variants):
     @pytest.fixture(params=variants)
     def fixture(request):
-        variant = request.param
-        try:
-            clean_up()
-            mi.set_variant(variant)
-        except Exception:
-            pytest.skip('Mitsuba variant "%s" is not enabled!' % variant)
-        return variant
-    globals()['variants_' + name] = fixture
+        yield from _variant_fixture_impl(request, request.param)
 
-variants = mi.variants()
+    globals()["variants_" + name] = fixture
 
-any_scalar = next((x for x in variants if x.startswith('scalar')), 'scalar_rgb')
-any_llvm   = next((x for x in variants if x.startswith('llvm')),   'llvm_rgb')
-any_cuda   = next((x for x in variants if x.startswith('cuda')),   'cuda_rgb')
-any_llvm_rgb = 'llvm_rgb' if 'llvm_rgb' in variants else 'llvm_ad_rgb'
-any_cuda_rgb = 'cuda_rgb' if 'cuda_rgb' in variants else 'cuda_ad_rgb'
-any_llvm_spectral = 'llvm_spectral' if 'llvm_spectral' in variants else 'llvm_ad_spectral'
-any_cuda_spectral = 'cuda_spectral' if 'cuda_spectral' in variants else 'cuda_ad_spectral'
 
+class VariantFilter(list):
+    """Helper class for filtering Mitsuba variants with a chainable interface."""
+
+    def all(self, *patterns):
+        """Return a new filter with variants containing all specified patterns."""
+        return VariantFilter([v for v in self if all(p in v for p in patterns)])
+
+    def exclude(self, *patterns):
+        """Return a new filter excluding variants containing any of the patterns."""
+        return VariantFilter([v for v in self if not any(p in v for p in patterns)])
+
+    def one(self):
+        """Return a list with the first variant, or empty list if none."""
+        return self[:1]
+
+
+# Get all compiled variants and filter by backend availability
+available = []
+for variant in mi.variants():
+    if variant.startswith("cuda") and not dr.has_backend(dr.JitBackend.CUDA):
+        continue
+    if variant.startswith("llvm") and not dr.has_backend(dr.JitBackend.LLVM):
+        continue
+    available.append(variant)
+
+# Create the variant filter helper
+v = VariantFilter(available)
+
+# Generate all possible variant names for fixture creation
+suffixes = ["_mono", "_mono_polarized", "_rgb", "_spectral", "_spectral_polarized"]
+suffix_variants = [a + b for a in suffixes for b in ["", "_double"]]
+all_possible_variants = ["scalar" + s for s in suffix_variants] + [
+    a + b + c for a in ["llvm", "cuda"] for b in ["", "_ad"] for c in suffix_variants]
+
+# Create single variant fixtures for all possible variants
+for variant in all_possible_variants:
+    generate_fixture(variant)
+
+# Create variant groups using the filter helper
 variant_groups = {
-    'any_scalar' : [any_scalar],
-    'any_llvm' : [any_llvm],
-    'any_cuda' : [any_cuda],
-    'all' : variants,
-    'all_scalar' : [x for x in variants if x.startswith('scalar')],
-    'all_rgb' : [x for x in variants if x.endswith('rgb')],
-    'all_spectral' : [x for x in variants if x.endswith('spectral')],
-    'all_backends_once' : [any_scalar, any_llvm, any_cuda],
-    'vec_backends_once' : [any_llvm, any_cuda],
-    'vec_backends_once_rgb' : [any_llvm_rgb, any_cuda_rgb],
-    'vec_backends_once_spectral' : [any_llvm_spectral, any_cuda_spectral],
-    'vec_rgb' : [x for x in variants if x.endswith('rgb') and not x.startswith('scalar')],
-    'vec_spectral' : [x for x in variants if x.endswith('spectral') and not x.startswith('scalar')],
-    'all_ad_rgb' : [x for x in variants if x.endswith('ad_rgb')],
-    'all_ad_spectral' : [x for x in variants if x.endswith('ad_spectral')],
+    "any_scalar": v.all("scalar").one(),
+    "any_llvm": v.all("llvm").one(),
+    "any_cuda": v.all("cuda").one(),
+    "all": v,
+    "all_scalar": v.all("scalar"),
+    "all_rgb": v.all("rgb"),
+    "all_spectral": v.all("spectral"),
+    "all_backends_once": v.all("scalar").one()
+    + v.all("llvm").one()
+    + v.all("cuda").one(),
+    "vec_backends_once": v.all("llvm").one() + v.all("cuda").one(),
+    "vec_backends_once_rgb": v.all("llvm", "rgb").one() + v.all("cuda", "rgb").one(),
+    "vec_backends_once_spectral": v.all("llvm", "spectral").one()
+    + v.all("cuda", "spectral").one(),
+    "vec_rgb": v.all("rgb").exclude("scalar"),
+    "vec_spectral": v.all("spectral").exclude("scalar"),
+    "all_ad_rgb": v.all("ad", "rgb"),
+    "all_ad_spectral": v.all("ad", "spectral"),
 }
 
-del variants
+# Create parameterized group fixtures (only for non-empty groups)
+for name, variant_list in variant_groups.items():
+    generate_fixture_group(name, variant_list)
 
-for name, variants in variant_groups.items():
-    generate_fixture_group(name, variants)
-del generate_fixture_group
+
+class TestMetricsPlugin:
+    """
+    Pytest plugin that collects and reports performance metrics for tests.
+
+    Supports tracking:
+    - memory: Peak memory usage with breakdown by allocation type
+    - time: Test execution duration
+    - launches: Number of kernel launches
+
+    Usage: pytest --collect-metrics=memory,time,launches
+    """
+
+    def __init__(self, metrics_to_collect):
+        self.data = {}  # {test_name: {metric: value}}
+        self.enabled = set(metrics_to_collect)
+        self.start_times = {}  # For timing tests
+        self.start_launch_stats = {}  # For kernel launch tracking
+
+    @pytest.hookimpl
+    def pytest_runtest_setup(self, item):
+        """Called before each test setup"""
+        test_name = item.nodeid
+        if "time" in self.enabled:
+            self.start_times[test_name] = time.perf_counter()
+        if "launches" in self.enabled:
+            self.start_launch_stats[test_name] = dr.detail.launch_stats()
+        if "memory" in self.enabled:
+            dr.detail.malloc_clear_statistics()
+
+    @pytest.hookimpl
+    def pytest_runtest_teardown(self, item):
+        """Called after each test teardown"""
+        test_name = item.nodeid
+        metrics = {}
+
+        # Collect memory usage with breakdown
+        if "memory" in self.enabled:
+            memory_stats = {}
+            total = 0
+            for alloc_type in [
+                dr.detail.AllocType.Host,
+                dr.detail.AllocType.HostAsync,
+                dr.detail.AllocType.HostPinned,
+                dr.detail.AllocType.Device,
+            ]:
+                usage = dr.detail.malloc_watermark(alloc_type)
+                if usage > 0:
+                    memory_stats[alloc_type.name] = usage
+                    total += usage
+
+            if total > 0:
+                metrics["memory"] = {"total": total, "breakdown": memory_stats}
+
+        # Collect execution time
+        if "time" in self.enabled:
+            if test_name in self.start_times:
+                metrics["time"] = time.perf_counter() - self.start_times.pop(test_name)
+
+        # Collect kernel launches (relative count)
+        if "launches" in self.enabled:
+            if test_name in self.start_launch_stats:
+                launches, soft_misses, hard_misses = dr.detail.launch_stats()
+                start_launches, start_soft, start_hard = self.start_launch_stats.pop(
+                    test_name
+                )
+                metrics["launches"] = {
+                    "total": launches - start_launches,
+                    "soft_misses": soft_misses - start_soft,
+                    "hard_misses": hard_misses - start_hard,
+                }
+
+        if metrics:
+            self.data[test_name] = metrics
+
+    @pytest.hookimpl
+    def pytest_sessionfinish(self, session, exitstatus):
+        """Called after the entire test session"""
+        if not self.data:
+            return
+
+        print("\n=== Test Metrics Report ===")
+
+        # Report top 100 for each enabled metric
+        for metric in sorted(self.enabled):
+            # Get tests that have this metric
+            tests_with_metric = []
+            for name, data in self.data.items():
+                if metric in data:
+                    tests_with_metric.append((name, data[metric]))
+
+            if not tests_with_metric:
+                continue
+
+            # Sort by metric value (descending) and take top 100
+            key_func = (
+                lambda x: x[1]["total"] if metric in ("memory", "launches") else x[1]
+            )
+            tests_with_metric.sort(key=key_func, reverse=True)
+            top_tests = tests_with_metric[:100]
+
+            print(f"\nTop tests by {metric}:")
+            for test_name, value in top_tests:
+                print(f"  {test_name}")
+                if metric == "memory":
+                    print(f"    Total: {mi.misc.mem_string(value['total'])}")
+                    for alloc_type, usage in value["breakdown"].items():
+                        if usage > 0:
+                            print(
+                                f"    - {alloc_type.lower()}: {mi.misc.mem_string(usage)}"
+                            )
+                elif metric == "time":
+                    print(f"    {value:.1f} seconds")
+                elif metric == "launches":
+                    total = value["total"]
+                    soft = value["soft_misses"]
+                    hard = value["hard_misses"]
+                    print(f"    {total:,} kernel launches")
+                    if soft > 0 or hard > 0:
+                        print(f"    - cache misses: {soft:,} soft, {hard:,} hard")
+
+
+def pytest_addoption(parser, pluginmanager):
+    parser.addoption(
+        "--generate_ref",
+        action="store_true",
+        help="Generate reference images for regression tests",
+    )
+    parser.addoption(
+        "--collect-metrics",
+        help="Comma-separated metrics to collect: memory,time,launches",
+    )
 
 
 def pytest_configure(config):
-    markexpr = config.getoption("markexpr", 'False')
-    if not 'not slow' in markexpr:
-        print("""\033[93mRunning the full test suite. To skip slow tests, please run 'pytest -m "not slow"' \033[0m""")
+    markexpr = config.getoption("markexpr", "False")
+    if not "not slow" in markexpr:
+        print(
+            """\033[93mRunning the full test suite. To skip slow tests, please run 'pytest -m "not slow"' \033[0m"""
+        )
 
     config.addinivalue_line(
         "markers", "slow: marks tests as slow (deselect with -m 'not slow')"
     )
 
-# Add support for generating reference images for RenderRegressionTest
+    # Conditionally register the test metrics plugin
+    metrics_arg = config.getoption("--collect-metrics", "")
+    if metrics_arg:
+        requested_metrics = set(m.strip() for m in metrics_arg.split(","))
+        valid_metrics = {"memory", "time", "launches"}
+        invalid_metrics = requested_metrics - valid_metrics
 
-def pytest_addoption(parser, pluginmanager):
-    parser.addoption("--generate_ref", action="store_true")
+        if invalid_metrics:
+            raise pytest.UsageError(
+                f"Invalid metrics specified: {', '.join(sorted(invalid_metrics))}. "
+                f"Valid metrics are: {', '.join(sorted(valid_metrics))}"
+            )
 
-@pytest.fixture(scope='session')
+        # Register the plugin
+        metrics_plugin = TestMetricsPlugin(requested_metrics)
+        config.pluginmanager.register(metrics_plugin, "test_metrics")
+
+
+@pytest.fixture(scope="session")
 def regression_test_options(request):
-    return { 'generate_ref':  request.config.option.generate_ref }
+    return {"generate_ref": request.config.option.generate_ref}
+
+
+def pytest_collection_modifyitems(config, items):
+    """
+    Modify test collection to:
+    1. Filter out tests for non-existent variants
+    2. Sort tests by variant to minimize variant switching
+    """
+    import re
+
+    pattern = re.compile(r"\[((cuda|llvm|scalar)_[^,-\]]*)")
+
+    variant_items = []
+    for item in items:
+        # Skip tests with empty variant groups
+        if 'NOTSET' in item.name:
+            continue
+
+        # Try to extract variant from test name
+        match = pattern.search(item.name)
+        if match:
+            variant = match.group(1)
+        else:
+            # Try to extract from fixture names
+            variant = "z"
+            for fixname in item.fixturenames:
+                if fixname.startswith("variant_"):
+                    variant = fixname[8:]
+                    break
+
+        # Skip unavailable variants
+        if variant != "z" and variant not in v:
+            continue
+
+        variant_items.append((variant, item.location, item))
+
+    variant_items.sort()
+
+    if len(items) != len(variant_items):
+        print(
+            f"\033[93m-- Filtered tests with unavailable variants ({len(items)} →  {len(variant_items)})\033[0m"
+        )
+
+    items[:] = [item[2] for item in variant_items]

--- a/src/conftest.py
+++ b/src/conftest.py
@@ -261,11 +261,11 @@ def pytest_addoption(parser, pluginmanager):
 
 
 def pytest_configure(config):
-    markexpr = config.getoption("markexpr", "False")
-    if not "not slow" in markexpr:
-        print(
-            """\033[93mRunning the full test suite. To skip slow tests, please run 'pytest -m "not slow"' \033[0m"""
-        )
+    import sys
+    # Show warning only if pytest was run without any arguments (full test suite)
+    # sys.argv will be just the pytest executable when no args provided
+    if len(sys.argv) <= 1:
+        print("""\033[93mRunning the full test suite. To skip slow tests, please run 'pytest -m "not slow"' \033[0m""")
 
     config.addinivalue_line(
         "markers", "slow: marks tests as slow (deselect with -m 'not slow')"

--- a/src/core/python/spectrum_v.cpp
+++ b/src/core/python/spectrum_v.cpp
@@ -33,11 +33,11 @@ MI_PY_EXPORT(Spectrum) {
 
     .def("sample_rgb_spectrum", &sample_rgb_spectrum<Float>, "sample"_a,
         D(sample_rgb_spectrum))
-    .def("sample_rgb_spectrum", &sample_rgb_spectrum<Spectrum>, "sample"_a,
+    .def("sample_rgb_spectrum", &sample_rgb_spectrum<UnpolarizedSpectrum>, "sample"_a,
         D(sample_rgb_spectrum))
     .def("pdf_rgb_spectrum", &pdf_rgb_spectrum<Float>, "wavelengths"_a,
         D(pdf_rgb_spectrum))
-    .def("pdf_rgb_spectrum", &pdf_rgb_spectrum<Spectrum>, "wavelengths"_a,
+    .def("pdf_rgb_spectrum", &pdf_rgb_spectrum<UnpolarizedSpectrum>, "wavelengths"_a,
         D(pdf_rgb_spectrum));
 
     m.def("xyz_to_srgb", &xyz_to_srgb<Float>,

--- a/src/emitters/sunsky.cpp
+++ b/src/emitters/sunsky.cpp
@@ -1025,7 +1025,7 @@ private:
         m_turbidity = turb;
         dr::make_opaque(m_turbidity);
 
-        m_sun_half_aperture = dr::deg_to_rad(0.5f * (float) props.get<ScalarFloat>("sun_aperture", 0.5358));
+        m_sun_half_aperture = dr::deg_to_rad(.5f * props.get<float>("sun_aperture", 0.5358f));
         if (m_sun_half_aperture <= 0.f || 0.5f * dr::Pi<Float> <= m_sun_half_aperture)
             Log(Error, "Invalid sun aperture angle: %f, must be in ]0, 90[ degrees!", dr::rad_to_deg(2 * m_sun_half_aperture));
 

--- a/src/emitters/tests/test_area.py
+++ b/src/emitters/tests/test_area.py
@@ -86,7 +86,7 @@ def test03_sample_ray(variants_vec_spectral, spectrum_key):
     # Sample a position on the shape
     ps = shape.sample_position(time, pos_sample)
 
-    assert dr.allclose(res, spec * shape.surface_area() * dr.pi)
+    assert dr.allclose(mi.unpolarized_spectrum(res), spec * shape.surface_area() * dr.pi)
     assert dr.allclose(ray.time, time)
     assert dr.allclose(ray.wavelengths, wav)
     assert dr.allclose(ray.o, ps.p, atol=1e-3)

--- a/src/emitters/tests/test_constant.py
+++ b/src/emitters/tests/test_constant.py
@@ -57,7 +57,7 @@ def test02_sample_ray(variants_vec_spectral, spectrum_key):
     it = dr.zeros(mi.SurfaceInteraction3f, 3)
     wav, spec = spectrum.sample_spectrum(it, mi.sample_shifted(wavelength_sample))
 
-    assert dr.allclose(res, spec * 4 * dr.pi * dr.pi)
+    assert dr.allclose(mi.unpolarized_spectrum(res), spec * 4 * dr.pi * dr.pi)
     assert dr.allclose(ray.time, time)
     assert dr.allclose(ray.wavelengths, wav)
     assert dr.allclose(ray.o, mi.warp.square_to_uniform_sphere(pos_sample))

--- a/src/emitters/tests/test_directionalarea.py
+++ b/src/emitters/tests/test_directionalarea.py
@@ -86,7 +86,7 @@ def test03_sample_ray(variants_vec_spectral, spectrum_key):
     # Sample a position on the shape
     ps = shape.sample_position(time, pos_sample)
 
-    assert dr.allclose(res, spec * shape.surface_area())
+    assert dr.allclose(mi.unpolarized_spectrum(res), spec * shape.surface_area())
     assert dr.allclose(ray.time, time)
     assert dr.allclose(ray.wavelengths, wav)
     assert dr.allclose(ray.o, ps.p, atol=1e-3)

--- a/src/emitters/tests/test_point.py
+++ b/src/emitters/tests/test_point.py
@@ -49,7 +49,7 @@ def test01_point_sample_ray(variants_vec_spectral, spectrum_key):
     it = dr.zeros(mi.SurfaceInteraction3f, 3)
     wav, spec = spectrum.sample_spectrum(it, mi.sample_shifted(wavelength_sample))
 
-    assert dr.allclose(res, spec * 4 * dr.pi)
+    assert dr.allclose(mi.unpolarized_spectrum(res), spec * 4 * dr.pi)
     assert dr.allclose(ray.time, time)
     assert dr.allclose(ray.wavelengths, wav)
     assert dr.allclose(ray.d, mi.warp.square_to_uniform_sphere(dir_sample))

--- a/src/emitters/tests/test_spot.py
+++ b/src/emitters/tests/test_spot.py
@@ -14,10 +14,9 @@ spectrum_dicts = {
 }
 
 lookat_transforms = [
-    mi.scalar_rgb.ScalarTransform4f().look_at([0, 1, 0], [0, 0, 0], [1, 0, 0]),
-    mi.scalar_rgb.ScalarTransform4f().look_at([0, 0, 1], [0, 0, 0], [0, -1, 0])
+    [[0, 1, 0, 0], [0, 0, -1, 1], [-1, 0, 0, 0], [0, 0, 0, 1]], # look_at([0, 1, 0], [0, 0, 0], [1, 0, 0])
+    [[1, 0, 0, 0], [0, -1, 0, 0], [0, 0, -1, 1], [0, 0, 0, 1]], # look_at([0, 0, 1], [0, 0, 0], [0, -1, 0])
 ]
-
 
 def create_emitter_and_spectrum(lookat, cutoff_angle, s_key='d65'):
     spectrum = mi.load_dict(spectrum_dicts[s_key])
@@ -43,6 +42,7 @@ def create_emitter_and_spectrum(lookat, cutoff_angle, s_key='d65'):
 def test_sample_direction(variant_scalar_spectral, spectrum_key, it_pos, wavelength_sample, cutoff_angle, lookat):
     """ Check the correctness of the sample_direction() method """
 
+    lookat = mi.ScalarTransform4f(lookat)
     cutoff_angle_rad = cutoff_angle / 180 * dr.pi
     beam_width_rad = cutoff_angle_rad * 0.75
     inv_transition_width = 1 / (cutoff_angle_rad - beam_width_rad)
@@ -96,6 +96,7 @@ def test_sample_direction(variant_scalar_spectral, spectrum_key, it_pos, wavelen
 def test_sample_ray(variants_vec_spectral, spectrum_key, wavelength_sample, pos_sample, cutoff_angle, lookat):
     # Check the correctness of the sample_ray() method
 
+    lookat = mi.ScalarTransform4f(lookat)
     cutoff_angle_rad = cutoff_angle / 180 * dr.pi
     cos_cutoff_angle_rad = dr.cos(cutoff_angle_rad)
     beam_width_rad = cutoff_angle_rad * 0.75
@@ -143,6 +144,7 @@ def test_sample_ray(variants_vec_spectral, spectrum_key, wavelength_sample, pos_
 def test_eval_direction(variant_scalar_spectral, spectrum_key, it_pos, wavelength_sample, cutoff_angle, lookat):
     """ Check the correctness of the sample_direction() method """
 
+    lookat = mi.ScalarTransform4f(lookat)
     cutoff_angle_rad = cutoff_angle / 180 * dr.pi
     beam_width_rad = cutoff_angle_rad * 0.75
     inv_transition_width = 1 / (cutoff_angle_rad - beam_width_rad)
@@ -170,6 +172,7 @@ def test_eval_direction(variant_scalar_spectral, spectrum_key, it_pos, wavelengt
 def test_eval(variants_vec_spectral, spectrum_key, lookat, cutoff_angle):
     # Check the correctness of the eval() method
 
+    lookat = mi.ScalarTransform4f(lookat)
     emitter, spectrum = create_emitter_and_spectrum(
         lookat, cutoff_angle, spectrum_key)
 

--- a/src/emitters/tests/test_spot.py
+++ b/src/emitters/tests/test_spot.py
@@ -129,7 +129,7 @@ def test_sample_ray(variants_vec_spectral, spectrum_key, wavelength_sample, pos_
     spec = dr.select(angle <= cutoff_angle_rad, spec, 0)
 
     assert dr.allclose(
-        res, spec / mi.warp.square_to_uniform_cone_pdf(trafo.inverse() @ ray.d, cos_cutoff_angle_rad))
+        mi.unpolarized_spectrum(res), spec / mi.warp.square_to_uniform_cone_pdf(trafo.inverse() @ ray.d, cos_cutoff_angle_rad))
     assert dr.allclose(ray.time, eval_t)
     assert dr.all(local_dir.z >= cos_cutoff_angle_rad)
     assert dr.allclose(ray.wavelengths, wav)

--- a/src/emitters/tests/test_sunsky.py
+++ b/src/emitters/tests/test_sunsky.py
@@ -203,7 +203,7 @@ def test04_sun_radiance(variants_vec_spectral, turb, eta_ray, gamma):
                              f"Rendered spectrum: {res}\n")
 
 
-@pytest.mark.parametrize("sun_theta", np.linspace(0, dr.pi/2, 5))
+@pytest.mark.parametrize("sun_theta", np.linspace(0, dr.pi/2, 4))
 def test05_sun_sampling(variants_vec_backends_once, sun_theta):
     sun_phi = -dr.pi / 5
     sp, cp = dr.sincos(sun_phi)
@@ -217,7 +217,7 @@ def test05_sun_sampling(variants_vec_backends_once, sun_theta):
                           sun_scale=1.0,
                           sky_scale=0.0)
 
-    rng = mi.PCG32(size=10_000)
+    rng = mi.PCG32(size=5_000)
     sample = mi.Point2f(
         rng.next_float32(),
         rng.next_float32())
@@ -261,8 +261,8 @@ def test06_sky_sampling(variants_vec_backends_once, turb, sun_theta):
         pdf_func= pdf_func,
         sample_func= sample_func,
         sample_dim=2,
-        sample_count=100_000_000,
-        res=215,
+        sample_count=200_000,
+        res=55,
         ires=32
     )
 
@@ -292,8 +292,8 @@ def test07_sun_and_sky_sampling(variants_vec_backends_once, turb, sun_theta):
         pdf_func= pdf_func,
         sample_func= sample_func,
         sample_dim=2,
-        sample_count=10_000_000,
-        res=215,
+        sample_count=200_000,
+        res=55,
         ires=32
     )
 

--- a/src/integrators/tests/test_ad_integrators.py
+++ b/src/integrators/tests/test_ad_integrators.py
@@ -561,7 +561,7 @@ class TranslateOccluderAreaLightConfig(TranslateShapeConfigBase):
         }
         self.ref_fd_epsilon = 1e-3
         self.error_mean_threshold = 0.03
-        self.error_max_threshold = 1.3
+        self.error_max_threshold = 1.65
         self.error_mean_threshold_bwd = 0.25
         self.integrator_dict = {
             'max_depth': 2,

--- a/src/integrators/tests/test_ad_integrators.py
+++ b/src/integrators/tests/test_ad_integrators.py
@@ -35,6 +35,105 @@ from mitsuba.scalar_rgb.test.util import find_resource
 output_dir = find_resource('resources/data/tests/integrators')
 
 # -------------------------------------------------------------------
+#                    Helper functions for error checking
+# -------------------------------------------------------------------
+
+def check_image_error(actual, reference, config, integrator_name, epsilon=2e-2,
+                      test_type='primal', save_error_image=False):
+    """
+    Check image comparison errors and report failures with detailed information.
+
+    Args:
+        actual: The computed image
+        reference: The reference image
+        config: Test configuration with error thresholds
+        integrator_name: Name of the integrator being tested
+        epsilon: Small value to avoid division by zero (default: 2e-2)
+        test_type: Type of test ('primal', 'fwd', etc.) for naming output files
+        save_error_image: Whether to save an error visualization image
+
+    Returns:
+        bool: True if test passed, False otherwise
+    """
+    error = dr.abs(actual - reference) / dr.maximum(dr.abs(reference), epsilon)
+    error_mean = dr.mean(error, axis=None).item()
+    error_max = dr.max(error, axis=None).item()
+
+    if error_mean > config.error_mean_threshold or error_max > config.error_max_threshold:
+        print(f"Failure in config: {config.name}, {integrator_name}")
+
+        # Detailed error reporting with percentages
+        mean_exceeded = error_mean > config.error_mean_threshold
+        max_exceeded = error_max > config.error_max_threshold
+
+        if mean_exceeded:
+            mean_diff = error_mean - config.error_mean_threshold
+            mean_percent = (error_mean/config.error_mean_threshold - 1)*100
+            print(f"-> error mean: {error_mean:.6f} (threshold={config.error_mean_threshold}) "
+                  f"- exceeds by {mean_diff:.4f} ({mean_percent:.1f}%)")
+        else:
+            print(f"-> error mean: {error_mean:.6f} (threshold={config.error_mean_threshold}) - OK")
+
+        if max_exceeded:
+            max_diff = error_max - config.error_max_threshold
+            max_percent = (error_max/config.error_max_threshold - 1)*100
+            print(f"-> error max: {error_max:.6f} (threshold={config.error_max_threshold}) "
+                  f"- exceeds by {max_diff:.4f} ({max_percent:.1f}%)")
+        else:
+            print(f"-> error max: {error_max:.6f} (threshold={config.error_max_threshold}) - OK")
+
+        # Save debug images
+        filename = join(output_dir, f"test_{config.name}_image_{test_type}_ref.exr")
+        print(f'-> reference image: {filename}')
+
+        filename = join(os.getcwd(), f"test_{integrator_name}_{config.name}_image_{test_type}.exr")
+        print(f'-> write current image: {filename}')
+        mi.util.write_bitmap(filename, actual)
+
+        if save_error_image:
+            filename = join(os.getcwd(), f"test_{integrator_name}_{config.name}_image_error.exr")
+            print(f'-> write error image: {filename}')
+            mi.util.write_bitmap(filename, error)
+
+        return False
+    return True
+
+
+def check_gradient_error(grad, grad_ref, config, integrator_name, threshold_attr='error_mean_threshold_bwd',
+                         epsilon=1e-3):
+    """
+    Check gradient comparison errors and report failures.
+
+    Args:
+        grad: The computed gradient
+        grad_ref: The reference gradient
+        config: Test configuration with error thresholds
+        integrator_name: Name of the integrator being tested
+        threshold_attr: Name of the threshold attribute in config (default: 'error_mean_threshold_bwd')
+        epsilon: Small value to avoid division by zero (default: 1e-3)
+
+    Returns:
+        bool: True if test passed, False otherwise
+    """
+    error = dr.abs(grad - grad_ref) / dr.maximum(dr.abs(grad_ref), epsilon)
+    threshold = getattr(config, threshold_attr)
+
+    if error > threshold:
+        print(f"Failure in config: {config.name}, {integrator_name}")
+        print(f"-> grad:     {grad}")
+        print(f"-> grad_ref: {grad_ref}")
+        print(f"-> error: {error:.6f} (threshold={threshold})")
+
+        # Calculate how much the threshold was exceeded
+        error_diff = error - threshold
+        error_percent = (error/threshold - 1)*100
+        print(f"-> exceeds by {error_diff:.4f} ({error_percent:.1f}%)")
+        print(f"-> ratio: {grad / grad_ref}")
+        return False
+    return True
+
+
+# -------------------------------------------------------------------
 #                          Test configs
 # -------------------------------------------------------------------
 
@@ -60,7 +159,7 @@ class ConfigBase:
 
         self.sensor_dict = {
             'type': 'perspective',
-            'to_world': T().look_at(origin=[0, 0, 4], target=[0, 0, 0], up=[0, 1, 0]),
+            'to_world': mi.ScalarTransform4f.look_at(origin=[0, 0, 4], target=[0, 0, 0], up=[0, 1, 0]),
             'film': {
                 'type': 'hdrfilm',
                 'rfilter': { 'type': 'gaussian', 'stddev': 0.5 },
@@ -125,7 +224,7 @@ class DiffuseAlbedoConfig(ConfigBase):
             },
             'sphere': {
                 'type': 'sphere',
-                'to_world': T().scale(0.25),
+                'to_world': mi.ScalarTransform4f.scale(0.25),
             },
             'light': { 'type': 'constant' }
         }
@@ -142,7 +241,7 @@ class DiffuseAlbedoGIConfig(ConfigBase):
             'plane': { 'type': 'rectangle' },
             'sphere': {
                 'type': 'sphere',
-                'to_world': T().scale(0.25)
+                'to_world': mi.ScalarTransform4f.scale(0.25)
             },
             'green': {
                 'type': 'rectangle',
@@ -153,7 +252,7 @@ class DiffuseAlbedoGIConfig(ConfigBase):
                         'value': [0.1, 1.0, 0.1]
                     }
                 },
-                'to_world': T().translate([1.25, 0.0, 1.0]) @ T().rotate([0, 1, 0], -90),
+                'to_world': mi.ScalarTransform4f.translate([1.25, 0.0, 1.0]) @ mi.ScalarTransform4f.rotate([0, 1, 0], -90),
             },
             'light': { 'type': 'constant', 'radiance': 3.0 }
         }
@@ -177,11 +276,11 @@ class AreaLightRadianceConfig(ConfigBase):
             },
             'sphere': {
                 'type': 'sphere',
-                'to_world': T().scale(0.25),
+                'to_world': mi.ScalarTransform4f.scale(0.25),
             },
             'light': {
                 'type': 'rectangle',
-                'to_world': T().translate([1.25, 0.0, 1.0]) @ T().rotate([0, 1, 0], -90),
+                'to_world': mi.ScalarTransform4f.translate([1.25, 0.0, 1.0]) @ mi.ScalarTransform4f.rotate([0, 1, 0], -90),
                 'emitter': {
                     'type': 'area',
                     'radiance': {'type': 'rgb', 'value': [3.0, 3.0, 3.0]}
@@ -222,7 +321,7 @@ class PointLightIntensityConfig(ConfigBase):
             },
             'sphere': {
                 'type': 'sphere',
-                'to_world': T().scale(0.25),
+                'to_world': mi.ScalarTransform4f.scale(0.25),
             },
             'light': {
                 'type': 'point',
@@ -244,7 +343,7 @@ class ConstantEmitterRadianceConfig(ConfigBase):
             },
             'sphere': {
                 'type': 'sphere',
-                'to_world': T().scale(0.25),
+                'to_world': mi.ScalarTransform4f.scale(0.25),
             },
             'light': { 'type': 'constant' }
         }
@@ -265,7 +364,7 @@ class CropWindowConfig(ConfigBase):
         self.res = 64
         self.sensor_dict = {
             'type': 'perspective',
-            'to_world': T().look_at(origin=[0, 0, 4], target=[0, 0, 0], up=[0, 1, 0]),
+            'to_world': mi.ScalarTransform4f.look_at(origin=[0, 0, 4], target=[0, 0, 0], up=[0, 1, 0]),
             'film': {
                 'type': 'hdrfilm',
                 'rfilter': { 'type': 'gaussian', 'stddev': 0.5 },
@@ -292,7 +391,7 @@ class TranslateShapeConfigBase(ConfigBase):
 
     def initialize(self):
         super().initialize()
-        self.initial_state = mi.Vector3f(dr.unravel(mi.Vector3f, self.params[self.key]))
+        self.initial_state = mi.Vector3f(dr.unravel(mi.Vector3f, mi.Float(self.params[self.key])))
 
     def update(self, theta):
         self.params[self.key] = dr.ravel(self.initial_state + mi.Vector3f(theta, 0.0, 0.0))
@@ -308,7 +407,7 @@ class ScaleShapeConfigBase(ConfigBase):
 
     def initialize(self):
         super().initialize()
-        self.initial_state = mi.Vector3f(dr.unravel(mi.Vector3f, self.params[self.key]))
+        self.initial_state = mi.Vector3f(dr.unravel(mi.Vector3f, mi.Float(self.params[self.key])))
 
     def update(self, theta):
         self.params[self.key] = dr.ravel(self.initial_state * (1.0 + theta))
@@ -325,7 +424,7 @@ class TranslateDiffuseSphereConstantConfig(TranslateShapeConfigBase):
             'sphere': {
                 'type': 'obj',
                 'filename': 'resources/data/common/meshes/sphere.obj',
-                'to_world': T().rotate(angle=-90, axis=[0, 1, 0]),
+                'to_world': mi.ScalarTransform4f.rotate(angle=-90, axis=[0, 1, 0]),
             },
             'light': { 'type': 'constant' }
         }
@@ -374,7 +473,7 @@ class TranslateRectangleEmitterOnBlackConfig(TranslateShapeConfigBase):
                     'type': 'area',
                     'radiance': {'type': 'rgb', 'value': [1.0, 1.0, 1.0]}
                 },
-                'to_world': T().translate([1.25, 0.0, 0.0]),
+                'to_world': mi.ScalarTransform4f.translate([1.25, 0.0, 0.0]),
             }
         }
         self.ref_fd_epsilon = 1e-3
@@ -400,7 +499,7 @@ class TranslateSphereEmitterOnBlackConfig(TranslateShapeConfigBase):
                     'type': 'area',
                     'radiance': {'type': 'rgb', 'value': [1.0, 1.0, 1.0]}
                 },
-                'to_world': T().translate([1.25, 0.0, 0.0]) @ T().rotate(angle=180, axis=[0, 1, 0]),
+                'to_world': mi.ScalarTransform4f.translate([1.25, 0.0, 0.0]) @ mi.ScalarTransform4f.rotate(angle=180, axis=[0, 1, 0]),
             }
         }
         self.ref_fd_epsilon = 1e-4
@@ -448,7 +547,7 @@ class TranslateOccluderAreaLightConfig(TranslateShapeConfigBase):
             'occluder': {
                 'type': 'obj',
                 'filename': 'resources/data/common/meshes/sphere.obj',
-                'to_world': T().translate([2.0, 0.0, 2.0]) @ T().scale(0.25),
+                'to_world': mi.ScalarTransform4f.translate([2.0, 0.0, 2.0]) @ mi.ScalarTransform4f.scale(0.25),
             },
             'light': {
                 'type': 'obj',
@@ -457,12 +556,12 @@ class TranslateOccluderAreaLightConfig(TranslateShapeConfigBase):
                     'type': 'area',
                     'radiance': {'type': 'rgb', 'value': [1000.0, 1000.0, 1000.0]}
                 },
-                'to_world': T().translate([4.0, 0.0, 4.0]) @ T().scale(0.05)
+                'to_world': mi.ScalarTransform4f.translate([4.0, 0.0, 4.0]) @ mi.ScalarTransform4f.scale(0.05)
             }
         }
         self.ref_fd_epsilon = 1e-3
         self.error_mean_threshold = 0.03
-        self.error_max_threshold = 0.85
+        self.error_max_threshold = 1.3
         self.error_mean_threshold_bwd = 0.25
         self.integrator_dict = {
             'max_depth': 2,
@@ -484,7 +583,7 @@ class TranslateShadowReceiverAreaLightConfig(TranslateShapeConfigBase):
             'occluder': {
                 'type': 'obj',
                 'filename': 'resources/data/common/meshes/sphere.obj',
-                'to_world': T().translate([2.0, 0.0, 2.0]) @ T().scale(0.25),
+                'to_world': mi.ScalarTransform4f.translate([2.0, 0.0, 2.0]) @ mi.ScalarTransform4f.scale(0.25),
             },
             # 'light': {
             #     'type': 'obj',
@@ -493,7 +592,7 @@ class TranslateShadowReceiverAreaLightConfig(TranslateShapeConfigBase):
             #         'type': 'area',
             #         'radiance': {'type': 'rgb', 'value': [1000.0, 1000.0, 1000.0]}
             #     },
-            #     'to_world': T().translate([4.0, 0.0, 4.0]) @ T().scale(0.05)
+            #     'to_world': mi.ScalarTransform4f.translate([4.0, 0.0, 4.0]) @ mi.ScalarTransform4f.scale(0.05)
             # }
             'light': { 'type': 'constant' }
         }
@@ -527,7 +626,7 @@ class TranslateTexturedPlaneConfig(TranslateShapeConfigBase):
                         'format' : 'variant'
                     }
                 },
-                'to_world': T().scale(2.0),
+                'to_world': mi.ScalarTransform4f.scale(2.0),
             },
             'light': { 'type': 'constant' }
         }
@@ -552,7 +651,7 @@ class TranslateSelfShadowAreaLightConfig(ConfigBase):
                 'type': 'obj',
                 'filename': 'resources/data/common/meshes/rectangle.obj',
                 'face_normals': True,
-                'to_world': T().translate([-1, 0, 0.5]) @ T().rotate([0, 1, 0], 90) @ T().scale(1.0),
+                'to_world': mi.ScalarTransform4f.translate([-1, 0, 0.5]) @ mi.ScalarTransform4f.rotate([0, 1, 0], 90) @ mi.ScalarTransform4f.scale(1.0),
             },
             'light': {
                 'type': 'point',
@@ -571,8 +670,8 @@ class TranslateSelfShadowAreaLightConfig(ConfigBase):
     def initialize(self):
         super().initialize()
         self.params.keep(['plane.vertex_positions', 'occluder.vertex_positions'])
-        self.initial_state_0 = dr.unravel(mi.Vector3f, self.params['plane.vertex_positions'])
-        self.initial_state_1 = dr.unravel(mi.Vector3f, self.params['occluder.vertex_positions'])
+        self.initial_state_0 = dr.unravel(mi.Vector3f, mi.Float(self.params['plane.vertex_positions']))
+        self.initial_state_1 = dr.unravel(mi.Vector3f, mi.Float(self.params['occluder.vertex_positions']))
 
     def update(self, theta):
         self.params['plane.vertex_positions']    = dr.ravel(self.initial_state_0 + mi.Vector3f(theta, 0.0, 0.0))
@@ -594,7 +693,7 @@ class TranslateSphereOnGlossyFloorConfig(TranslateShapeConfigBase):
                     'type': 'roughconductor',
                     'alpha': 0.025,
                 },
-                'to_world': T().translate([0, 1.5, 0]) @ T().rotate([1, 0, 0], -45) @ T().scale(4),
+                'to_world': mi.ScalarTransform4f.translate([0, 1.5, 0]) @ mi.ScalarTransform4f.rotate([1, 0, 0], -45) @ mi.ScalarTransform4f.scale(4),
             },
             'sphere': {
                 'type': 'obj',
@@ -603,7 +702,7 @@ class TranslateSphereOnGlossyFloorConfig(TranslateShapeConfigBase):
                     'reflectance': {'type': 'rgb', 'value': [1.0, 0.5, 0.0]}
                 },
                 'filename': 'resources/data/common/meshes/sphere.obj',
-                'to_world': T().translate([0.5, 2.0, 1.5]) @ T().scale(1.0),
+                'to_world': mi.ScalarTransform4f.translate([0.5, 2.0, 1.5]) @ mi.ScalarTransform4f.scale(1.0),
             },
             'light': { 'type': 'constant', 'radiance': 1.0 },
         }
@@ -665,7 +764,7 @@ class RotateShadingNormalsPlaneConfig(ConfigBase):
             },
             'light': {
                 'type': 'rectangle',
-                'to_world': T().translate([1.25, 0.0, 1.0]) @ T().rotate([0, 1, 0], -90),
+                'to_world': mi.ScalarTransform4f.translate([1.25, 0.0, 1.0]) @ mi.ScalarTransform4f.rotate([0, 1, 0], -90),
                 'emitter': {
                     'type': 'area',
                     'radiance': {'type': 'rgb', 'value': [3.0, 3.0, 3.0]}
@@ -686,7 +785,7 @@ class RotateShadingNormalsPlaneConfig(ConfigBase):
     def update(self, theta):
         self.params[self.key] = dr.ravel(
             mi.Transform4f().rotate(angle=theta, axis=[0.0, 1.0, 0.0]) @
-            dr.unravel(mi.Normal3f, self.initial_state)
+            dr.unravel(mi.Normal3f, mi.Float(self.initial_state))
         )
         self.params.update()
         dr.eval()
@@ -761,33 +860,11 @@ def test01_rendering_primal(variants_all_ad_rgb, integrator_name, config):
     integrator = mi.load_dict(config.integrator_dict, parallel=False)
 
     filename = join(output_dir, f"test_{config.name}_image_primal_ref.exr")
-    image_primal_ref = mi.TensorXf(mi.Bitmap(filename))
+    image_primal_ref = mi.TensorXf32(mi.Bitmap(filename))
     image = integrator.render(config.scene, seed=0, spp=config.spp)
 
-    error = dr.abs(image - image_primal_ref) / dr.maximum(dr.abs(image_primal_ref), 2e-2)
-    error_mean = dr.mean(error, axis=None).item()
-    error_max = dr.max(error, axis=None).item()
-
-    if error_mean > config.error_mean_threshold  or error_max > config.error_max_threshold:
-        print(f"Failure in config: {config.name}, {integrator_name}")
-        mean_exceeded = error_mean > config.error_mean_threshold
-        max_exceeded = error_max > config.error_max_threshold
-        if mean_exceeded:
-            mean_diff = error_mean - config.error_mean_threshold
-            mean_percent = (error_mean/config.error_mean_threshold - 1)*100
-            print(f"-> error mean: {error_mean:.6f} (threshold={config.error_mean_threshold}) - exceeds by {mean_diff:.4f} ({mean_percent:.1f}%)")
-        else:
-            print(f"-> error mean: {error_mean:.6f} (threshold={config.error_mean_threshold}) - OK")
-        if max_exceeded:
-            max_diff = error_max - config.error_max_threshold
-            max_percent = (error_max/config.error_max_threshold - 1)*100
-            print(f"-> error max: {error_max:.6f} (threshold={config.error_max_threshold}) - exceeds by {max_diff:.4f} ({max_percent:.1f}%)")
-        else:
-            print(f"-> error max: {error_max:.6f} (threshold={config.error_max_threshold}) - OK")
-        print(f'-> reference image: {filename}')
-        filename = join(os.getcwd(), f"test_{integrator_name}_{config.name}_image_primal.exr")
-        print(f'-> write current image: {filename}')
-        mi.util.write_bitmap(filename, image)
+    if not check_image_error(image, image_primal_ref, config, integrator_name,
+                             epsilon=2e-2, test_type='primal'):
         pytest.fail("Radiance values exceeded configuration's tolerances!")
 
 
@@ -795,6 +872,9 @@ def test01_rendering_primal(variants_all_ad_rgb, integrator_name, config):
 @pytest.mark.skipif(os.name == 'nt', reason='Skip those memory heavy tests on Windows')
 @pytest.mark.parametrize('integrator_name, config', CONFIGS)
 def test02_rendering_forward(variants_all_ad_rgb, integrator_name, config):
+    if mi.is_polarized:
+        pytest.skip('Test must be adapted to polarized rendering.')
+
     config = config()
     config.initialize()
 
@@ -804,7 +884,7 @@ def test02_rendering_forward(variants_all_ad_rgb, integrator_name, config):
         integrator.proj_seed_spp = 2048 * 2
 
     filename = join(output_dir, f"test_{config.name}_image_fwd_ref.exr")
-    image_fwd_ref = mi.TensorXf(mi.Bitmap(filename))
+    image_fwd_ref = mi.TensorXf32(mi.Bitmap(filename))
 
     theta = mi.Float(0.0)
     dr.enable_grad(theta)
@@ -820,21 +900,8 @@ def test02_rendering_forward(variants_all_ad_rgb, integrator_name, config):
         config.scene, seed=0, spp=config.spp, params=theta)
     image_fwd = dr.detach(image_fwd)
 
-    error = dr.abs(image_fwd - image_fwd_ref) / dr.maximum(dr.abs(image_fwd_ref), 2e-1)
-    error_mean = dr.mean(error, axis=None)
-    error_max = dr.max(error, axis=None)
-
-    if error_mean > config.error_mean_threshold or error_max > config.error_max_threshold:
-        print(f"Failure in config: {config.name}, {integrator_name}")
-        print(f"-> error mean: {error_mean} (threshold={config.error_mean_threshold})")
-        print(f"-> error max: {error_max} (threshold={config.error_max_threshold})")
-        print(f'-> reference image: {filename}')
-        filename = join(os.getcwd(), f"test_{integrator_name}_{config.name}_image_fwd.exr")
-        print(f'-> write current image: {filename}')
-        mi.util.write_bitmap(filename, image_fwd)
-        filename = join(os.getcwd(), f"test_{integrator_name}_{config.name}_image_error.exr")
-        print(f'-> write error image: {filename}')
-        mi.util.write_bitmap(filename, error)
+    if not check_image_error(image_fwd, image_fwd_ref, config, integrator_name,
+                             epsilon=2e-1, test_type='fwd', save_error_image=True):
         pytest.fail("Gradient values exceeded configuration's tolerances!")
 
 
@@ -842,6 +909,9 @@ def test02_rendering_forward(variants_all_ad_rgb, integrator_name, config):
 @pytest.mark.skipif(os.name == 'nt', reason='Skip those memory heavy tests on Windows')
 @pytest.mark.parametrize('integrator_name, config', CONFIGS)
 def test03_rendering_backward(variants_all_ad_rgb, integrator_name, config):
+    if mi.is_polarized:
+        pytest.skip('Test must be adapted to polarized rendering.')
+
     config = config()
     config.initialize()
 
@@ -852,7 +922,7 @@ def test03_rendering_backward(variants_all_ad_rgb, integrator_name, config):
         integrator.proj_seed_spp = 2048 * 2
 
     filename = join(output_dir, f"test_{config.name}_image_fwd_ref.exr")
-    image_fwd_ref = mi.TensorXf(mi.Bitmap(filename))
+    image_fwd_ref = mi.TensorXf32(mi.Bitmap(filename))
 
     grad_in = 0.001
     image_adj = dr.full(mi.TensorXf, grad_in, image_fwd_ref.shape)
@@ -870,19 +940,16 @@ def test03_rendering_backward(variants_all_ad_rgb, integrator_name, config):
     grad = dr.grad(theta) / dr.width(image_fwd_ref)
     grad_ref = dr.mean(image_fwd_ref, axis=None) * grad_in
 
-    error = dr.abs(grad - grad_ref) / dr.maximum(dr.abs(grad_ref), 1e-3)
-    if error > config.error_mean_threshold_bwd:
-        print(f"Failure in config: {config.name}, {integrator_name}")
-        print(f"-> grad:     {grad}")
-        print(f"-> grad_ref: {grad_ref}")
-        print(f"-> error: {error} (threshold={config.error_mean_threshold_bwd})")
-        print(f"-> ratio: {grad / grad_ref}")
+    if not check_gradient_error(grad, grad_ref, config, integrator_name):
         pytest.fail("Gradient values exceeded configuration's tolerances!")
 
 
 @pytest.mark.slow
 @pytest.mark.skipif(os.name == 'nt', reason='Skip those memory heavy tests on Windows')
 def test04_render_custom_op(variants_all_ad_rgb):
+    if mi.is_polarized:
+        pytest.skip('Test must be adapted to polarized rendering.')
+
     config = DiffuseAlbedoConfig()
     config.initialize()
 
@@ -892,10 +959,10 @@ def test04_render_custom_op(variants_all_ad_rgb):
     })
 
     filename = join(output_dir, f"test_{config.name}_image_primal_ref.exr")
-    image_primal_ref = mi.TensorXf(mi.Bitmap(filename))
+    image_primal_ref = mi.TensorXf32(mi.Bitmap(filename))
 
     filename = join(output_dir, f"test_{config.name}_image_fwd_ref.exr")
-    image_fwd_ref = mi.TensorXf(mi.Bitmap(filename))
+    image_fwd_ref = mi.TensorXf32(mi.Bitmap(filename))
 
     theta = mi.Float(0.0)
     dr.enable_grad(theta)
@@ -904,18 +971,9 @@ def test04_render_custom_op(variants_all_ad_rgb):
     # Higher spp will run into single-precision accumulation issues
     image_primal = mi.render(config.scene, config.params, integrator=integrator, seed=0, spp=256)
 
-    error = dr.abs(dr.detach(image_primal) - image_primal_ref) / dr.maximum(dr.abs(image_primal_ref), 2e-2)
-    error_mean = dr.mean(error, axis=None)
-    error_max = dr.max(error, axis=None)
-
-    if error_mean > config.error_mean_threshold  or error_max > config.error_max_threshold:
-        print(f"Failure in config: {config.name}, {integrator_name}")
-        print(f"-> error mean: {error_mean} (threshold={config.error_mean_threshold})")
-        print(f"-> error max: {error_max} (threshold={config.error_max_threshold})")
-        print(f'-> reference image: {filename}')
-        filename = join(os.getcwd(), f"test_{integrator_name}_{config.name}_image_primal.exr")
-        print(f'-> write current image: {filename}')
-        mi.util.write_bitmap(filename, image_primal)
+    integrator_name = 'prb'  # Fix missing integrator_name
+    if not check_image_error(dr.detach(image_primal), image_primal_ref, config, integrator_name,
+                           epsilon=2e-2, test_type='primal'):
         pytest.fail("Radiance values exceeded configuration's tolerances!")
 
     # Backward comparison
@@ -925,13 +983,8 @@ def test04_render_custom_op(variants_all_ad_rgb):
     grad = dr.grad(theta)[0]
     grad_ref = dr.mean(image_fwd_ref, axis=None)
 
-    error = dr.abs(grad - grad_ref) / dr.maximum(dr.abs(grad_ref), 1e-3)
-    if error > config.error_mean_threshold:
-        print(f"Failure in config: {config.name}, {integrator_name}")
-        print(f"-> grad:     {grad}")
-        print(f"-> grad_ref: {grad_ref}")
-        print(f"-> error: {error} (threshold={config.error_mean_threshold})")
-        print(f"-> ratio: {grad / grad_ref}")
+    if not check_gradient_error(grad, grad_ref, config, integrator_name,
+                              threshold_attr='error_mean_threshold'):
         pytest.fail("Gradient values exceeded configuration's tolerances!")
 
     # Forward comparison
@@ -945,18 +998,8 @@ def test04_render_custom_op(variants_all_ad_rgb):
 
     image_fwd = dr.grad(image_primal)
 
-    error = dr.abs(image_fwd - image_fwd_ref) / dr.maximum(dr.abs(image_fwd_ref), 2e-1)
-    error_mean = dr.mean(error, axis=None)
-    error_max = dr.max(error, axis=None)
-
-    if error_mean > config.error_mean_threshold or error_max > config.error_max_threshold:
-        print(f"Failure in config: {config.name}, {integrator_name}")
-        print(f"-> error mean: {error_mean} (threshold={config.error_mean_threshold})")
-        print(f"-> error max: {error_max} (threshold={config.error_max_threshold})")
-        filename = join(os.getcwd(), f"test_{integrator_name}_{config.name}_image_fwd.exr")
-        mi.util.write_bitmap(filename, image_fwd)
-        filename = join(os.getcwd(), f"test_{integrator_name}_{config.name}_image_error.exr")
-        mi.util.write_bitmap(filename, error)
+    if not check_image_error(image_fwd, image_fwd_ref, config, integrator_name,
+                           epsilon=2e-1, test_type='fwd', save_error_image=True):
         pytest.fail("Gradient values exceeded configuration's tolerances!")
 
 # -------------------------------------------------------------------

--- a/src/integrators/tests/test_ptracer.py
+++ b/src/integrators/tests/test_ptracer.py
@@ -222,7 +222,7 @@ def test06_ptracer_gradients(variants_all_ad_rgb):
     integrator.render_backward(scene, grad_in=adjoint, seed=3, spp=64, params=params)
     g = dr.grad(params[key])
     assert dr.shape(g) == dr.shape(params[key])
-    assert dr.allclose(g, 0.33647, atol=1e-5) # TODO improve this test (don't use hardcoded value)
+    assert dr.allclose(g, 0.33647, atol=1e-5, rtol=5e-3) # TODO improve this test (don't use hardcoded value)
 
 
 def test07_adjoint_integrator_trampoline(variants_all_ad_rgb):

--- a/src/integrators/tests/test_volprim_rf_basic.py
+++ b/src/integrators/tests/test_volprim_rf_basic.py
@@ -41,6 +41,9 @@ class EllipsoidsFactory:
 
 @pytest.mark.parametrize("shape_type", ['ellipsoids', 'ellipsoidsmesh'])
 def test01_render_span(variants_all_ad_rgb, regression_test_options, shape_type):
+    if 'double' in mi.variant():
+        pytest.skip("Test needs to be adapted for double precision variants")
+
     factory = EllipsoidsFactory()
     N = 12
     for i in range(N):
@@ -68,7 +71,7 @@ def test01_render_span(variants_all_ad_rgb, regression_test_options, shape_type)
             },
             'sensor': {
                 'type': 'perspective',
-                'to_world': T().look_at(
+                'to_world': mi.ScalarTransform4f.look_at(
                     origin=[0, 0, -5],
                     target=[0, 0, 0],
                     up=[0, 1, 0]),
@@ -100,6 +103,9 @@ def test01_render_span(variants_all_ad_rgb, regression_test_options, shape_type)
 
 @pytest.mark.parametrize("srgb_primitives", [True, False])
 def test02_render_stack(variants_all_ad_rgb, regression_test_options, srgb_primitives):
+    if 'double' in mi.variant():
+        pytest.skip("Test needs to be adapted for double precision variants")
+
     factory = EllipsoidsFactory()
     N = 12
     for i in range(N):
@@ -129,7 +135,7 @@ def test02_render_stack(variants_all_ad_rgb, regression_test_options, srgb_primi
             },
             'sensor': {
                 'type': 'perspective',
-                'to_world': T().look_at(
+                'to_world': mi.ScalarTransform4f.look_at(
                     origin=[0, 0, -5],
                     target=[0, 0, 0],
                     up=[0, 1, 0]),
@@ -162,6 +168,9 @@ def test02_render_stack(variants_all_ad_rgb, regression_test_options, srgb_primi
 
 @pytest.mark.parametrize("shape_type", ['ellipsoids', 'ellipsoidsmesh'])
 def test03_render_depth(variants_all_rgb, regression_test_options, shape_type):
+    if 'double' in mi.variant():
+        pytest.skip("Test needs to be adapted for double precision variants")
+
     factory = EllipsoidsFactory()
     N = 12
     for i in range(N):
@@ -188,7 +197,7 @@ def test03_render_depth(variants_all_rgb, regression_test_options, shape_type):
             },
             'sensor': {
                 'type': 'perspective',
-                'to_world': T().look_at(
+                'to_world': mi.ScalarTransform4f.look_at(
                     origin=[0, 0, -5],
                     target=[0, 0, 0],
                     up=[0, 1, 0]),

--- a/src/python/python/ad/integrators/common.py
+++ b/src/python/python/ad/integrators/common.py
@@ -368,13 +368,13 @@ class ADIntegrator(mi.CppADIntegrator):
         return sampler, spp
 
     def _splat_to_block(block: mi.ImageBlock,
-                       film: mi.Film,
-                       pos: mi.Point2f,
-                       value: mi.Spectrum,
-                       weight: mi.Float,
-                       alpha: mi.Float,
-                       aovs: Sequence[mi.Float],
-                       wavelengths: mi.Spectrum):
+                        film: mi.Film,
+                        pos: mi.Point2f,
+                        value: mi.Spectrum,
+                        weight: mi.Float,
+                        alpha: mi.Float,
+                        aovs: Sequence[mi.Float],
+                        wavelengths: mi.Spectrum):
         '''Helper function to splat values to a imageblock'''
         if (dr.all(mi.has_flag(film.flags(), mi.FilmFlags.Special))):
             aovs = film.prepare_sample(value, wavelengths,
@@ -384,6 +384,8 @@ class ADIntegrator(mi.CppADIntegrator):
             block.put(pos, aovs)
             del aovs
         else:
+            if mi.is_polarized:
+                value = mi.unpolarized_spectrum(value)
             if mi.is_spectral:
                 rgb = mi.spectrum_to_srgb(value, wavelengths)
             elif mi.is_monochromatic:

--- a/src/python/python/ad/integrators/direct_projective.py
+++ b/src/python/python/ad/integrators/direct_projective.py
@@ -192,7 +192,7 @@ class DirectProjectiveIntegrator(PSIntegrator):
         # Perform detached BSDF sampling
         sample_bsdf, weight_bsdf = bsdf.sample(bsdf_ctx, si, sampler.next_1d(active_next),
                                                sampler.next_2d(active_next), active_next)
-        active_bsdf = active_next & dr.any(weight_bsdf != 0.0)
+        active_bsdf = active_next & dr.any(weight_bsdf != 0.0, axis=None)
         delta_bsdf = mi.has_flag(sample_bsdf.sampled_type, mi.BSDFFlags.Delta)
 
         # Construct the BSDF sampled ray

--- a/src/python/python/ad/integrators/prb.py
+++ b/src/python/python/ad/integrators/prb.py
@@ -184,7 +184,7 @@ class PRBIntegrator(RBIntegrator):
             # -------------------- Stopping criterion ---------------------
 
             # Don't run another iteration if the throughput has reached zero
-            β_max = dr.max(β)
+            β_max = dr.max(mi.unpolarized_spectrum(β))
             active_next &= (β_max != 0)
 
             # Russian roulette stopping probability (must cancel out ior^2

--- a/src/python/python/ad/integrators/prb_projective.py
+++ b/src/python/python/ad/integrators/prb_projective.py
@@ -313,8 +313,8 @@ class PathProjectiveIntegrator(PSIntegrator):
             # -------------------- Stopping criterion ---------------------
 
             # Don't run another iteration if the throughput has reached zero
-            β_max = dr.max(β)
-            active_next &= (β_max != 0)
+            β_max = dr.max(mi.unpolarized_spectrum(β))
+            active_next &= β_max != 0
 
             # Russian roulette stopping probability (must cancel out ior^2
             # to obtain unitless throughput, enforces a minimum probability)

--- a/src/python/python/ad/largesteps.py
+++ b/src/python/python/ad/largesteps.py
@@ -135,7 +135,7 @@ class LargeSteps():
             Differential form of v.
         """
         # Manual matrix-vector multiplication
-        v_unique = dr.gather(mi.Point3f, dr.unravel(mi.Point3f, v), self.index)
+        v_unique = dr.gather(mi.Point3f, dr.unravel(mi.Point3f, mi.Float(v)), self.index)
         row_prod = dr.gather(mi.Point3f, v_unique, self.cols.array) * self.data.array
         u = dr.zeros(mi.Point3f, dr.width(v_unique))
         dr.scatter_reduce(dr.ReduceOp.Add, u, row_prod, self.rows.array)

--- a/src/python/stubs.pat
+++ b/src/python/stubs.pat
@@ -46,14 +46,14 @@ mitsuba.__prefix__:
 
     _UnpolarizedSpectrumCp: TypeAlias = Union['UnpolarizedSpectrum', 'drjit.auto.ad._FloatCp', 'drjit.scalar._ArrayXfCp', 'drjit.auto._ArrayXfCp', 'drjit.auto.ad._ArrayXf16Cp']
 
-    _Spectrum_vtCp: TypeAlias = Union['Spectrum_vt', '_UnpolarizedSpectrumCp', 'drjit.scalar._ArrayXfCp', 'drjit.auto._ArrayXfCp', 'drjit.auto.ad._ArrayXf16Cp']
+    _SpectrumEntryCp: TypeAlias = Union['SpectrumEntry', '_UnpolarizedSpectrumCp', 'drjit.scalar._ArrayXfCp', 'drjit.auto._ArrayXfCp', 'drjit.auto.ad._ArrayXf16Cp']
 
-    _SpectrumCp: TypeAlias = Union['Spectrum', '_Spectrum_vtCp', 'drjit.scalar._ArrayXfCp', 'drjit.auto._ArrayXfCp', 'drjit.auto.ad._ArrayXf16Cp']
+    _SpectrumCp: TypeAlias = Union['Spectrum', '_SpectrumEntryCp', 'drjit.scalar._ArrayXfCp', 'drjit.auto._ArrayXfCp', 'drjit.auto.ad._ArrayXf16Cp']
 
-    class Spectrum_vt(drjit.ArrayBase['Spectrum_vt', '_Spectrum_vtCp', UnpolarizedSpectrum, '_UnpolarizedSpectrumCp', UnpolarizedSpectrum, 'Spectrum_vt', drjit.auto.ad.ArrayXb]):
+    class SpectrumEntry(drjit.ArrayBase['SpectrumEntry', '_SpectrumEntryCp', UnpolarizedSpectrum, '_UnpolarizedSpectrumCp', UnpolarizedSpectrum, 'SpectrumEntry', drjit.auto.ad.ArrayXb]):
         pass
 
-    class Spectrum(drjit.ArrayBase['Spectrum', '_SpectrumCp', Spectrum_vt, '_Spectrum_vtCp', Spectrum_vt, drjit.auto.ad.ArrayXf, drjit.auto.ad.ArrayXb]):
+    class Spectrum(drjit.ArrayBase['Spectrum', '_SpectrumCp', SpectrumEntry, '_SpectrumEntryCp', SpectrumEntry, drjit.auto.ad.ArrayXf, drjit.auto.ad.ArrayXb]):
         pass
 
     class UnpolarizedSpectrum(drjit.ArrayBase['UnpolarizedSpectrum', '_UnpolarizedSpectrumCp', drjit.auto.ad.Float, 'drjit.auto.ad._FloatCp', drjit.auto.ad.Float, 'UnpolarizedSpectrum', drjit.auto.ad.ArrayXb]):
@@ -138,4 +138,4 @@ UnpolarizedSpectrum:
 Spectrum:
 _UnpolarizedSpectrumCp:
 _SpectrumCp:
-_Spectrum_vtCp:
+_SpectrumEntryCp:

--- a/src/render/tests/test_ad.py
+++ b/src/render/tests/test_ad.py
@@ -192,6 +192,9 @@ def test03_optimizer(variants_all_ad_rgb, spp, res, opt_conf):
 @pytest.mark.parametrize("N", [1, 10])
 @pytest.mark.parametrize("jit_flags", jit_flags_options)
 def test04_vcall_autodiff_bsdf_single_inst_and_masking(variants_all_ad_rgb, eval_grad, N, jit_flags):
+    if 'polarized' in mi.variant():
+        pytest.skip("Test must be adapted for polarized variants")
+
     # Set drjit JIT flags
     for k, v in jit_flags.items():
         dr.set_flag(k, v)
@@ -235,7 +238,7 @@ def test04_vcall_autodiff_bsdf_single_inst_and_masking(variants_all_ad_rgb, eval
     # Check against reference value
     v = mi.Float(dr.cos(theta) * dr.inv_pi)
     v_ref = dr.select(mask, mi.Color3f(v, 0, 0), mi.Color3f(0))
-    assert dr.allclose(v_eval, v_ref)
+    assert dr.allclose(mi.unpolarized_spectrum(v_eval), v_ref)
 
     loss = dr.sum(v_eval)
 
@@ -266,6 +269,9 @@ def test04_vcall_autodiff_bsdf_single_inst_and_masking(variants_all_ad_rgb, eval
 @pytest.mark.parametrize("jit_flags", jit_flags_options)
 @pytest.mark.parametrize("indirect", [False, True])
 def test05_vcall_autodiff_bsdf(variants_all_ad_rgb, mode, eval_grad, N, jit_flags, indirect):
+    if mi.is_polarized:
+        pytest.skip("Test must be adapted for polarized rendering")
+
     # Set drjit JIT flags
     for k, v in jit_flags.items():
         dr.set_flag(k, v)
@@ -330,7 +336,7 @@ def test05_vcall_autodiff_bsdf(variants_all_ad_rgb, mode, eval_grad, N, jit_flag
     # Check against reference value
     v = dr.cos(theta) * dr.inv_pi
     v_ref = dr.select(mask, mi.Color3f(v, 0, 0), mi.Color3f(0, 0, v))
-    assert dr.allclose(v_eval, v_ref)
+    assert dr.allclose(mi.unpolarized_spectrum(v_eval), v_ref)
 
     # Make their gradients a bit different
     mult1 = mi.Float(0.5)

--- a/src/render/tests/test_freeze.py
+++ b/src/render/tests/test_freeze.py
@@ -363,7 +363,7 @@ def bsdf_dict(bsdf: str):
 
                 # Read 'eta' and 'tint' properties from `props`
                 self.eta = 1.33
-                if props.has_property("eta"):
+                if 'eta' in props:
                     self.eta = props["eta"]
 
                 self.tint = props["tint"]

--- a/src/render/tests/test_freeze.py
+++ b/src/render/tests/test_freeze.py
@@ -166,6 +166,10 @@ def test02_pose_estimation(variants_vec_rgb, integrator, auto_opaque):
     as this would require us to re-build the acceleration structure, which
     currently cannot be recorded.
     """
+
+    if mi.is_polarized:
+        pytest.skip('Test must be adapted to polarized rendering.')
+
     w, h = (16, 16)
     n = 10
 
@@ -197,8 +201,6 @@ def test02_pose_estimation(variants_vec_rgb, integrator, auto_opaque):
     frozen = dr.freeze(compute_grad, auto_opaque = auto_opaque)
 
     def load_scene():
-        from mitsuba.scalar_rgb import Transform4f as T
-
         scene = mi.cornell_box()
         del scene["large-box"]
         del scene["small-box"]
@@ -209,7 +211,7 @@ def test02_pose_estimation(variants_vec_rgb, integrator, auto_opaque):
         scene["bunny"] = {
             "type": "ply",
             "filename": find_resource("resources/data/common/meshes/bunny.ply"),
-            "to_world": T().scale(6.5),
+            "to_world": mi.ScalarTransform4f().scale(6.5),
             "bsdf": {
                 "type": "diffuse",
                 "reflectance": {"type": "rgb", "value": (0.3, 0.3, 0.75)},
@@ -236,7 +238,7 @@ def test02_pose_estimation(variants_vec_rgb, integrator, auto_opaque):
 
         params.keep("bunny.vertex_positions")
         initial_vertex_positions = dr.unravel(
-            mi.Point3f, params["bunny.vertex_positions"]
+            mi.Point3f, mi.Float(params["bunny.vertex_positions"])
         )
 
         image_ref = mi.render(scene, spp=4)
@@ -295,6 +297,10 @@ def test03_optimize_color(variants_vec_rgb, auto_opaque):
     Tests freezing of optimizing a color parameter through backpropagation, by
     passing the gradients through the frozen function inputs.
     """
+    if mi.is_polarized:
+        pytest.skip('Test must be adapted to polarized rendering.')
+
+
     k = "red.reflectance.value"
     w, h = (16, 16)
     n = 10
@@ -770,8 +776,11 @@ def integrator_dict(integrator: str):
 @pytest.mark.parametrize("auto_opaque", [False, True])
 def test08_integrators(variants_vec_rgb, tmp_path, integrator, auto_opaque):
     """
-    Tests that it is possible to freeze rendeirng a scene with each integrator type.
+    Tests that it is possible to freeze rendering a scene with each integrator type.
     """
+    if mi.is_polarized:
+        pytest.skip('Test must be adapted to polarized rendering.')
+
     w, h = (16, 16)
     n = 5
 
@@ -789,11 +798,10 @@ def test08_integrators(variants_vec_rgb, tmp_path, integrator, auto_opaque):
 
 def shape_dict(shape: str):
     if shape == "mesh":
-        from mitsuba.scalar_rgb import Transform4f as T
         return {
             "type": "ply",
             "filename": find_resource("resources/data/common/meshes/teapot.ply"),
-            "to_world": T().scale(0.1),
+            "to_world": mi.ScalarTransform4f().scale(0.1),
         }
     elif shape == "disk":
         return {
@@ -928,6 +936,9 @@ def test11_optimizer(variants_vec_rgb, optimizer, auto_opaque):
     w, h = (16, 16)
     n = 10
     k = "red.reflectance.value"
+
+    if mi.is_polarized:
+        pytest.skip('Test must be adapted to polarized rendering.')
 
     def optimize(scene, opt, image_ref):
         params = mi.traverse(scene)
@@ -1084,6 +1095,9 @@ def test14_unsupported_integrators(variants_vec_rgb, integrator, auto_opaque):
     """
     Tests that using projective integrators in backward mode triggers an exception.
     """
+
+    if mi.is_polarized:
+        pytest.skip('Test must be adapted to polarized rendering.')
 
     @dr.freeze
     def frozen(scene, integrator):

--- a/src/render/tests/test_mesh.py
+++ b/src/render/tests/test_mesh.py
@@ -511,7 +511,7 @@ def test15_differentiable_surface_interaction_params_forward(variants_all_ad_rgb
     params = mi.traverse(scene)
     shape_param_key = 'rect.vertex_positions'
     positions_buf = params[shape_param_key]
-    positions_initial = dr.unravel(mi.Point3f, positions_buf)
+    positions_initial = dr.unravel(mi.Point3f, mi.Float(positions_buf))
 
     # Create differential parameter to be optimized
     diff_vector = mi.Vector3f(0.0)
@@ -727,7 +727,7 @@ def test17_sticky_differentiable_surface_interaction_params_forward(variants_all
     params = mi.traverse(scene)
     shape_param_key = 'rect.vertex_positions'
     positions_buf = params[shape_param_key]
-    positions_initial = dr.unravel(mi.Point3f, positions_buf)
+    positions_initial = dr.unravel(mi.Point3f, mi.Float(positions_buf))
 
     # Create differential parameter to be optimized
     diff_vector = mi.Vector3f(0.0)
@@ -819,7 +819,7 @@ def test18_sticky_vcall_ad_fwd(variants_all_ad_rgb, res, wall, jit_flags):
     dr.set_label(theta, 'theta')
 
     # Attach object vertices to differential parameter
-    positions_initial = dr.unravel(mi.Point3f, params[key])
+    positions_initial = dr.unravel(mi.Point3f, mi.Float(params[key]))
     transform = mi.Transform4f().translate(mi.Vector3f(0.0, theta, 0.0))
     positions_new = transform @ positions_initial
     positions_new = dr.ravel(positions_new)
@@ -870,7 +870,7 @@ def test19_update_geometry(variants_vec_rgb):
 
     params = mi.traverse(scene)
 
-    init_vertex_pos = dr.unravel(mi.Point3f, params['rect.vertex_positions'])
+    init_vertex_pos = dr.unravel(mi.Point3f, mi.Float(params['rect.vertex_positions']))
 
     def translate(v):
         transform = mi.Transform4f().translate(mi.Vector3f(v))
@@ -1205,7 +1205,7 @@ def test30_differential_motion(variants_vec_rgb):
     theta = mi.Point3f(0.0)
     dr.enable_grad(theta)
     key = 'vertex_positions'
-    positions = dr.unravel(mi.Point3f, params[key])
+    positions = dr.unravel(mi.Point3f, mi.Float(params[key]))
     translation = mi.Transform4f().translate([theta.x, 2 * theta.y, 3 * theta.z])
     positions = translation @ positions
     params[key] = dr.ravel(positions)
@@ -1281,7 +1281,7 @@ def test33_rebuild_area_pmf(variants_vec_rgb):
     params = mi.traverse(mesh)
     key = 'vertex_positions'
 
-    vertices = dr.unravel(mi.Point3f, params[key])
+    vertices = dr.unravel(mi.Point3f, mi.Float(params[key]))
     new_vertices = mi.Transform4f().scale(2) @ vertices
     params[key] = dr.ravel(new_vertices)
     params.update()

--- a/src/render/tests/test_spectra.py
+++ b/src/render/tests/test_spectra.py
@@ -127,15 +127,15 @@ def test06_rgb2spec_fetch_eval_mean(variant_scalar_spectral):
 
 def test07_cie1931_srgb_roundtrip(variants_vec_spectral):
     n = 50
-    wavelengths = mi.Spectrum(
+    wavelengths = mi.UnpolarizedSpectrum(
         dr.linspace(mi.Float, 100, 1000, n),
         dr.linspace(mi.Float, 400, 500, n),
         dr.linspace(mi.Float, 100, 500, n),
         dr.linspace(mi.Float, 500, 1000, n)
     )
 
-    srgb = mi.spectrum_to_srgb(mi.Spectrum(1.0), wavelengths)
-    xyz = mi.spectrum_to_xyz(mi.Spectrum(1.0), wavelengths)
+    srgb = mi.spectrum_to_srgb(mi.UnpolarizedSpectrum(1.0), wavelengths)
+    xyz = mi.spectrum_to_xyz(mi.UnpolarizedSpectrum(1.0), wavelengths)
 
     assert dr.allclose(mi.xyz_to_srgb(xyz), srgb)
     assert dr.allclose(mi.srgb_to_xyz(srgb), xyz, atol=1e-6)

--- a/src/sensors/tests/test_batch.py
+++ b/src/sensors/tests/test_batch.py
@@ -85,7 +85,7 @@ def test02_sample_ray(variants_vec_spectral, s_open, s_time):
     wav, spec = mi.sample_rgb_spectrum(mi.sample_shifted(wav_sample))
 
     assert dr.allclose(ray.wavelengths, wav)
-    assert dr.allclose(spec_weight, spec)
+    assert dr.allclose(mi.unpolarized_spectrum(spec_weight), spec)
     assert dr.allclose(ray.time, time)
 
     inv_z0 = dr.rcp((camera0.world_transform().inverse() @ ray.d).z)

--- a/src/sensors/tests/test_orthographic.py
+++ b/src/sensors/tests/test_orthographic.py
@@ -65,7 +65,7 @@ def test02_sample_ray(variants_vec_spectral, origin, direction):
     wav, spec = mi.sample_rgb_spectrum(mi.sample_shifted(wav_sample))
 
     assert dr.allclose(ray.wavelengths, wav)
-    assert dr.allclose(spec_weight, spec)
+    assert dr.allclose(mi.unpolarized_spectrum(spec_weight), spec)
     assert dr.allclose(ray.time, time)
 
     # Check that ray origins are on the plane defined by the sensor
@@ -94,7 +94,7 @@ def test03_sample_ray_differential(variants_vec_spectral, origin, direction):
     wav, spec = mi.sample_rgb_spectrum(mi.sample_shifted(wav_sample))
 
     assert dr.allclose(ray.wavelengths, wav)
-    assert dr.allclose(spec_weight, spec)
+    assert dr.allclose(mi.unpolarized_spectrum(spec_weight), spec)
     assert dr.allclose(ray.time, time)
 
     # Check that ray origins are on the plane defined by the sensor

--- a/src/sensors/tests/test_perspective.py
+++ b/src/sensors/tests/test_perspective.py
@@ -70,7 +70,7 @@ def test02_sample_ray(variants_vec_spectral, origin, direction):
     wav, spec = mi.sample_rgb_spectrum(mi.sample_shifted(wav_sample))
 
     assert dr.allclose(ray.wavelengths, wav)
-    assert dr.allclose(spec_weight, spec)
+    assert dr.allclose(mi.unpolarized_spectrum(spec_weight), spec)
     assert dr.allclose(ray.time, time)
 
     inv_z = dr.rcp((camera.world_transform().inverse() @ ray.d).z)
@@ -101,7 +101,7 @@ def test03_sample_ray_differential(variants_vec_spectral, origin, direction):
     wav, spec = mi.sample_rgb_spectrum(mi.sample_shifted(wav_sample))
 
     assert dr.allclose(ray.wavelengths, wav)
-    assert dr.allclose(spec_weight, spec)
+    assert dr.allclose(mi.unpolarized_spectrum(spec_weight), spec)
     assert dr.allclose(ray.time, time)
 
     inv_z = dr.rcp((camera.world_transform().inverse() @ ray.d).z)

--- a/src/sensors/tests/test_thinlens.py
+++ b/src/sensors/tests/test_thinlens.py
@@ -76,7 +76,7 @@ def test02_sample_ray(variants_vec_spectral, origin, direction, aperture_rad, fo
     wav, spec = mi.sample_rgb_spectrum(mi.sample_shifted(wav_sample))
 
     assert dr.allclose(ray.wavelengths, wav)
-    assert dr.allclose(spec_weight, spec)
+    assert dr.allclose(mi.unpolarized_spectrum(spec_weight), spec)
     assert dr.allclose(ray.time, time)
 
     inv_z = dr.rcp((cam.world_transform().inverse() @ ray.d).z)
@@ -133,7 +133,7 @@ def test03_sample_ray_diff(variants_vec_spectral, origin, direction, aperture_ra
     wav, spec = mi.sample_rgb_spectrum(mi.sample_shifted(wav_sample))
 
     assert dr.allclose(ray.wavelengths, wav)
-    assert dr.allclose(spec_weight, spec)
+    assert dr.allclose(mi.unpolarized_spectrum(spec_weight), spec)
     assert dr.allclose(ray.time, time)
 
     inv_z = dr.rcp((cam.world_transform().inverse() @ ray.d).z)

--- a/src/shapes/ellipsoidsmesh.cpp
+++ b/src/shapes/ellipsoidsmesh.cpp
@@ -413,7 +413,7 @@ private:
                         m_vertex_positions[i * nb_vertices * 3 + j * 3 + k] = float(v[k]);
                 }
 
-                UInt32 offset = i * uint32_t(nb_vertices);
+                UInt32 offset = (uint32_t) i * uint32_t(nb_vertices);
                 for (size_t j = 0; j < nb_faces; ++j) {
                     Vector3u face = m_shell_faces[j];
                     for (size_t k = 0; k < 3; ++k)

--- a/src/shapes/rectangle.cpp
+++ b/src/shapes/rectangle.cpp
@@ -573,7 +573,7 @@ public:
         // nevertheless to match the behavior of `Scene::ray_intersect()`.
         // Return: pi.t, pi.prim_uv, pi.shape_index, pi.prim_index
         return { dr::select(active, t, dr::Infinity<FloatP>),
-                 prim_uv & active, ((uint32_t) -1), prim_index & active };
+                 prim_uv & active, ((uint32_t) -1), dr::select(active, prim_index, 0) };
     }
 
     template <typename FloatP, typename Ray3fP>

--- a/src/shapes/tests/test_bsplinecurve.py
+++ b/src/shapes/tests/test_bsplinecurve.py
@@ -165,7 +165,7 @@ def test07_differentiable_surface_interaction_ray_forward_follow_shape(variant_l
     theta = mi.Float(0)
     dr.enable_grad(theta)
     params[key] = dr.ravel(
-            dr.unravel(mi.Point4f, params[key]) + mi.Vector4f([theta, 0, 0, 0])
+            dr.unravel(mi.Point4f, mi.Float(params[key])) + mi.Vector4f([theta, 0, 0, 0])
     )
     params.update()
     pi = scene.ray_intersect_preliminary(ray)
@@ -411,7 +411,7 @@ def test16_differential_motion(variants_vec_rgb):
     theta = mi.Point3f(0.0)
     dr.enable_grad(theta)
     key = 'control_points'
-    control_points = dr.unravel(mi.Point4f, params[key])
+    control_points = dr.unravel(mi.Point4f, mi.Float(params[key]))
     positions = mi.Point3f(control_points.x, control_points.y, control_points.z)
     translation = mi.Transform4f().translate([theta.x, 2 * theta.y, 3 * theta.z])
     positions = translation @ positions

--- a/src/shapes/tests/test_cylinder.py
+++ b/src/shapes/tests/test_cylinder.py
@@ -280,9 +280,9 @@ def test08_sample_silhouette_perimeter(variants_vec_rgb):
     cylinder = mi.load_dict({ 'type': 'cylinder' })
     cylinder_ptr = mi.ShapePtr(cylinder)
 
-    x = dr.linspace(Float, 1e-6, 1-1e-6, 10)
-    y = dr.linspace(Float, 1e-6, 1-1e-6, 10)
-    z = dr.linspace(Float, 1e-6, 1-1e-6, 10)
+    x = dr.linspace(mi.Float, 1e-6, 1-1e-6, 10)
+    y = dr.linspace(mi.Float, 1e-6, 1-1e-6, 10)
+    z = dr.linspace(mi.Float, 1e-6, 1-1e-6, 10)
     samples = mi.Point3f(dr.meshgrid(x, y, z))
 
     ss = cylinder.sample_silhouette(samples, mi.DiscontinuityFlags.PerimeterType)

--- a/src/shapes/tests/test_rectangle.py
+++ b/src/shapes/tests/test_rectangle.py
@@ -267,7 +267,7 @@ def test08_differentiable_surface_interaction_ray_forward_follow_shape(variants_
     d_uv = mi.Point2f(-0.1 / 2, -0.2)
 
     assert dr.allclose(dr.grad(si.t), 0)
-    assert dr.allclose(dr.grad(si.p), 0)
+    assert dr.allclose(dr.grad(si.p), 0, atol=1e-6)
     assert dr.allclose(dr.grad(si.n), 0)
     assert dr.allclose(dr.grad(si.uv), d_uv)
 

--- a/src/shapes/tests/test_rectangle.py
+++ b/src/shapes/tests/test_rectangle.py
@@ -322,7 +322,7 @@ def test08_differentiable_surface_interaction_ray_forward_follow_shape(variants_
 
     d_uv = [dr.pi * 0.1 / 4, -dr.pi * 0.1 / 4]
 
-    assert dr.allclose(dr.grad(si.p), 0.0)
+    assert dr.allclose(dr.grad(si.p), 0.0, atol=1e-6)
     assert dr.allclose(dr.grad(si.n), 0.0)
     assert dr.allclose(dr.grad(si.uv), d_uv)
 


### PR DESCRIPTION
This PR bundles 3 changes that improve the Mitsuba test suite.

Change 1: Avoid bound types in `@pytest.parameterize`
========


Python objects passed to PyTest's `@pytest.parameterize` aren't reliably garbage collected when the interpreter shuts down. Why this happens would be worth tracking down at some point (this is a larger Python/GC issue and not specifically related to nanobind/Mitsuba/DrJit).

When such instances are bound by nanobind, they cause noisy leak warning messages to appear after the test suite terminates. The solution is simple: let's just not use nanobind types (e.g. `Transform4f`) in `@pytest.parameterize`. The commit adapts one test file, and the associated warnings go away following this change.

Change 2: `conftest.py` refactored: metric collection, filtering/sorting
========

This commit overhauls `conftest.py`, which provides infrastructure (fixtures and customization) for Mitsuba's PyTest-based test suite.

**1. Metric collection via** `--collect-metrics`

   New command-line parameter enables performance profiling of tests.
   Available metrics:

   - `memory`: Peak CPU/GPU memory usage
   - `time`: Wall-clock runtime
   - `launches`: Number of Dr.Jit kernel launches, cache statistics

   After test execution, a report displays the 100 most resource-intensive tests for each metric. Multiple metrics can be collected simultaneously using comma-separated values (e.g., `--collect-metrics=time,memory`). This helps identify tests that slow down CI or fail due to memory constraints on lower-end GPUs.

**2. Improved test filtering**
   The test suite previously generated many test cases that would ultimately be skipped due to unavailable or non-functional variants. This resulted in unnecessary overhead from creating and attempting to run invalid test configurations. The updated `conftest.py` now pre-filters these invalid configurations during test collection, preventing them from being generated in the first place. This reduces test discovery time and eliminates spurious skip reports in the test output.

**3. Variant-based test sorting**
   Tests parameterized by variant are now grouped to minimize variant switches. Previously, the test suite changed variants thousands of times during execution. Each variant change incurs overhead:

   - Python module reloading
   - `@dr.syntax` transformation
   - Python bytecode recompilation

   This optimization reduces the number of variant switches (which previously triggered warnings when `@dr.syntax` ran more than 1000 times) and improves overall test suite performance.

**4. Simplified variant fixture construction**
   Refactored code for creating variant fixtures to improve maintainability.


Change 3: Reduce memory usage of CI test suite
========

A number of Mitsuba tests are extremely memory hungry, (these are mostly application of AD to non-PRB integrators) This sometimes causes the test suite to crash, and it makes it hard to test on lower-end hardware.

Using the memory profiling feature from the last commit, the following tests were identified as culprits.

```
Top tests by memory:
  src/integrators/tests/test_ad_integrators.py::test02_rendering_forward[llvm_ad_rgb-path-DiffuseAlbedoGIConfig]
    Total: 13.6 GiB
    - host: 64 B
    - hostasync: 13.6 GiB
  src/integrators/tests/test_ad_integrators.py::test02_rendering_forward[llvm_ad_rgb-path-AreaLightRadianceConfig]
    Total: 10.6 GiB
    - host: 512 B
    - hostasync: 10.6 GiB
  src/integrators/tests/test_ad_integrators.py::test02_rendering_forward[llvm_ad_rgb-path-DiffuseAlbedoConfig]
    Total: 10.6 GiB
    - host: 512 B
    - hostasync: 10.6 GiB
  src/integrators/tests/test_ad_integrators.py::test02_rendering_forward[llvm_ad_rgb-path-RotateShadingNormalsPlaneConfig]
    Total: 10.6 GiB
    - host: 512 B
    - hostasync: 10.6 GiB
  src/integrators/tests/test_ad_integrators.py::test02_rendering_forward[llvm_ad_rgb-path-DirectlyVisibleAreaLightRadianceConfig]
    Total: 6.38 GiB
    - host: 512 B
    - hostasync: 6.38 GiB
  src/integrators/tests/test_ad_integrators.py::test03_rendering_backward[llvm_ad_rgb-path-DiffuseAlbedoGIConfig]
    Total: 3.41 GiB
    - host: 64 B
    - hostasync: 3.41 GiB
  src/integrators/tests/test_ad_integrators.py::test02_rendering_forward[llvm_ad_rgb-direct_projective-TranslateOccluderAreaLightConfig]
    Total: 2.74 GiB
    - host: 1.25 MiB
    - hostasync: 2.74 GiB
  src/integrators/tests/test_ad_integrators.py::test02_rendering_forward[llvm_ad_rgb-prb_projective-TranslateOccluderAreaLightConfig]
    Total: 2.73 GiB
    - host: 1.25 MiB
    - hostasync: 2.73 GiB
  src/integrators/tests/test_ad_integrators.py::test03_rendering_backward[llvm_ad_rgb-direct_projective-TranslateOccluderAreaLightConfig]
    Total: 2.73 GiB
    - host: 1.25 MiB
    - hostasync: 2.73 GiB
    [...]
```

After some SPP reductions and associated tuning of error thresholds, the memory requirements are now reduced as follows:

```
Top tests by memory:
  src/integrators/tests/test_ad_integrators.py::test02_rendering_forward[llvm_ad_rgb-direct_projective-TranslateOccluderAreaLightConfig]
    Total: 2.74 GiB
    - host: 1.25 MiB
    - hostasync: 2.74 GiB
  src/integrators/tests/test_ad_integrators.py::test03_rendering_backward[llvm_ad_rgb-direct_projective-TranslateOccluderAreaLightConfig]
    Total: 2.73 GiB
    - host: 1.25 MiB
    - hostasync: 2.73 GiB
  src/integrators/tests/test_ad_integrators.py::test02_rendering_forward[llvm_ad_rgb-prb_projective-TranslateOccluderAreaLightConfig]
    Total: 2.73 GiB
    - host: 1.25 MiB
    - hostasync: 2.73 GiB
  src/integrators/tests/test_ad_integrators.py::test03_rendering_backward[llvm_ad_rgb-prb_projective-TranslateOccluderAreaLightConfig]
    Total: 2.72 GiB
    - host: 1.25 MiB
    - hostasync: 2.72 GiB
  src/render/tests/test_freeze.py::test04_bsdf[llvm_ad_rgb-False-mask]
    Total: 1.74 GiB
    - host: 32 MiB
    - hostasync: 1.71 GiB
  src/integrators/tests/test_ad_integrators.py::test03_rendering_backward[llvm_ad_rgb-path-DiffuseAlbedoGIConfig]
    Total: 1.71 GiB
    - host: 128 B
    - hostasync: 1.71 GiB
  src/integrators/tests/test_ad_integrators.py::test02_rendering_forward[llvm_ad_rgb-path-DiffuseAlbedoGIConfig]
    Total: 1.7 GiB
    - host: 64 B
    - hostasync: 1.7 GiB
  src/integrators/tests/test_ad_integrators.py::test03_rendering_backward[llvm_ad_rgb-path-AreaLightRadianceConfig]
    Total: 1.34 GiB
    - host: 512 B
    - hostasync: 1.34 GiB
  src/integrators/tests/test_ad_integrators.py::test03_rendering_backward[llvm_ad_rgb-path-DiffuseAlbedoConfig]
    Total: 1.34 GiB
    - host: 512 B
    - hostasync: 1.34 GiB
    [...]
```