### PR TITLE
Reduce memory usage of sunsky tests

### DIFF
--- a/src/emitters/tests/test_sunsky.py
+++ b/src/emitters/tests/test_sunsky.py
@@ -193,7 +193,7 @@ def test04_sun_radiance(variants_vec_spectral, turb, eta_ray, gamma):
                              f"Rendered spectrum: {res}\n")
 
 
-@pytest.mark.parametrize("sun_theta", np.linspace(0, dr.pi/2, 5))
+@pytest.mark.parametrize("sun_theta", np.linspace(0, dr.pi/2, 4))
 def test05_sun_sampling(variants_vec_backends_once, sun_theta):
     sun_phi = -dr.pi / 5
     sp, cp = dr.sincos(sun_phi)
@@ -207,7 +207,7 @@ def test05_sun_sampling(variants_vec_backends_once, sun_theta):
                           sun_scale=1.0,
                           sky_scale=0.0)
 
-    rng = mi.PCG32(size=10_000)
+    rng = mi.PCG32(size=5_000)
     sample = mi.Point2f(
         rng.next_float32(),
         rng.next_float32())
@@ -251,8 +251,8 @@ def test06_sky_sampling(variants_vec_backends_once, turb, sun_theta):
         pdf_func= pdf_func,
         sample_func= sample_func,
         sample_dim=2,
-        sample_count=100_000_000,
-        res=215,
+        sample_count=200_000,
+        res=55,
         ires=32
     )
 
@@ -282,8 +282,8 @@ def test07_sun_and_sky_sampling(variants_vec_backends_once, turb, sun_theta):
         pdf_func= pdf_func,
         sample_func= sample_func,
         sample_dim=2,
-        sample_count=10_000_000,
-        res=215,
+        sample_count=200_000,
+        res=55,
         ires=32
     )
 


### PR DESCRIPTION
Reduces memory usage and running time of the Sunsky test suite by dialing down the number of samples and resolution for Chi2 tests

<details>
<summary>Before the changes: </summary>
<br>
=== Test Metrics Report ===

Top tests by memory:
  src/emitters/tests/test_sunsky.py::test07_sun_and_sky_sampling[llvm_ad_rgb-0.3490658503988659-2.2]
    Total: 150 MiB
    - host: 256 KiB
    - hostasync: 149 MiB
    - device: 2 KiB
  src/emitters/tests/test_sunsky.py::test07_sun_and_sky_sampling[llvm_ad_rgb-0.3490658503988659-4.8]
    Total: 150 MiB
    - host: 256 KiB
    - hostasync: 149 MiB
    - device: 2 KiB
  src/emitters/tests/test_sunsky.py::test07_sun_and_sky_sampling[llvm_ad_rgb-0.3490658503988659-6.0]
    Total: 150 MiB
    - host: 256 KiB
    - hostasync: 149 MiB
    - device: 2 KiB
  src/emitters/tests/test_sunsky.py::test07_sun_and_sky_sampling[llvm_ad_rgb-0.8726646259971648-2.2]
    Total: 150 MiB
    - host: 256 KiB
    - hostasync: 149 MiB
    - device: 2 KiB
  src/emitters/tests/test_sunsky.py::test07_sun_and_sky_sampling[llvm_ad_rgb-0.8726646259971648-4.8]
    Total: 150 MiB
    - host: 256 KiB
    - hostasync: 149 MiB
    - device: 2 KiB
  src/emitters/tests/test_sunsky.py::test07_sun_and_sky_sampling[llvm_ad_rgb-0.8726646259971648-6.0]
    Total: 150 MiB
    - host: 256 KiB
    - hostasync: 149 MiB
    - device: 2 KiB
  src/emitters/tests/test_sunsky.py::test07_sun_and_sky_sampling[cuda_ad_rgb-0.3490658503988659-2.2]
    Total: 146 MiB
    - hostpinned: 422 KiB
    - device: 145 MiB
  src/emitters/tests/test_sunsky.py::test07_sun_and_sky_sampling[cuda_ad_rgb-0.3490658503988659-4.8]
    Total: 146 MiB
    - hostpinned: 422 KiB
    - device: 145 MiB
  src/emitters/tests/test_sunsky.py::test07_sun_and_sky_sampling[cuda_ad_rgb-0.3490658503988659-6.0]
    Total: 146 MiB
    - hostpinned: 422 KiB
    - device: 145 MiB
  src/emitters/tests/test_sunsky.py::test07_sun_and_sky_sampling[cuda_ad_rgb-0.8726646259971648-2.2]
    Total: 146 MiB
    - hostpinned: 422 KiB
    - device: 145 MiB
  src/emitters/tests/test_sunsky.py::test07_sun_and_sky_sampling[cuda_ad_rgb-0.8726646259971648-4.8]
    Total: 146 MiB
    - hostpinned: 422 KiB
    - device: 145 MiB
  src/emitters/tests/test_sunsky.py::test07_sun_and_sky_sampling[cuda_ad_rgb-0.8726646259971648-6.0]
    Total: 146 MiB
    - hostpinned: 422 KiB
    - device: 145 MiB
  src/emitters/tests/test_sunsky.py::test06_sky_sampling[llvm_ad_rgb-0.3490658503988659-2.2]
    Total: 134 MiB
    - host: 256 KiB
    - hostasync: 133 MiB
    - device: 2 KiB
  src/emitters/tests/test_sunsky.py::test06_sky_sampling[llvm_ad_rgb-0.3490658503988659-4.8]
    Total: 134 MiB
    - host: 256 KiB
    - hostasync: 133 MiB
    - device: 2 KiB
  src/emitters/tests/test_sunsky.py::test06_sky_sampling[llvm_ad_rgb-0.3490658503988659-6.0]
    Total: 134 MiB
    - host: 256 KiB
    - hostasync: 133 MiB
    - device: 2 KiB
  src/emitters/tests/test_sunsky.py::test06_sky_sampling[llvm_ad_rgb-0.8726646259971648-2.2]
    Total: 134 MiB
    - host: 256 KiB
    - hostasync: 133 MiB
    - device: 2 KiB
  src/emitters/tests/test_sunsky.py::test06_sky_sampling[llvm_ad_rgb-0.8726646259971648-4.8]
    Total: 134 MiB
    - host: 256 KiB
    - hostasync: 133 MiB
    - device: 2 KiB
  src/emitters/tests/test_sunsky.py::test06_sky_sampling[llvm_ad_rgb-0.8726646259971648-6.0]
    Total: 134 MiB
    - host: 256 KiB
    - hostasync: 133 MiB
    - device: 2 KiB
  src/emitters/tests/test_sunsky.py::test06_sky_sampling[cuda_ad_rgb-0.3490658503988659-2.2]
    Total: 130 MiB
    - hostpinned: 422 KiB
    - device: 129 MiB
  src/emitters/tests/test_sunsky.py::test06_sky_sampling[cuda_ad_rgb-0.3490658503988659-4.8]
    Total: 130 MiB
    - hostpinned: 422 KiB
    - device: 129 MiB
  src/emitters/tests/test_sunsky.py::test06_sky_sampling[cuda_ad_rgb-0.3490658503988659-6.0]
    Total: 130 MiB
    - hostpinned: 422 KiB
    - device: 129 MiB
  src/emitters/tests/test_sunsky.py::test06_sky_sampling[cuda_ad_rgb-0.8726646259971648-2.2]
    Total: 130 MiB
    - hostpinned: 422 KiB
    - device: 129 MiB
  src/emitters/tests/test_sunsky.py::test06_sky_sampling[cuda_ad_rgb-0.8726646259971648-4.8]
    Total: 130 MiB
    - hostpinned: 422 KiB
    - device: 129 MiB
  src/emitters/tests/test_sunsky.py::test06_sky_sampling[cuda_ad_rgb-0.8726646259971648-6.0]
    Total: 130 MiB
    - hostpinned: 422 KiB
    - device: 129 MiB
  src/emitters/tests/test_sunsky.py::test03_sky_radiance_spectral_albedo[llvm_ad_spectral]
    Total: 3.52 MiB
    - host: 256 KiB
    - hostasync: 3.27 MiB
    - device: 2 KiB
  src/emitters/tests/test_sunsky.py::test02_sky_radiance_spectral[llvm_ad_spectral-render_params0]
    Total: 3.52 MiB
    - host: 256 KiB
    - hostasync: 3.27 MiB
    - device: 2 KiB
  src/emitters/tests/test_sunsky.py::test02_sky_radiance_spectral[llvm_ad_spectral-render_params1]
    Total: 3.52 MiB
    - host: 256 KiB
    - hostasync: 3.27 MiB
    - device: 2 KiB
  src/emitters/tests/test_sunsky.py::test02_sky_radiance_spectral[llvm_ad_spectral-render_params2]
    Total: 3.52 MiB
    - host: 256 KiB
    - hostasync: 3.27 MiB
    - device: 2 KiB
  src/emitters/tests/test_sunsky.py::test04_sun_radiance[llvm_ad_spectral-0.0-0.0001-1.0]
    Total: 3.27 MiB
    - host: 256 KiB
    - hostasync: 3.02 MiB
    - device: 2 KiB
  src/emitters/tests/test_sunsky.py::test04_sun_radiance[llvm_ad_spectral-0.0-0.0001-10.0]
    Total: 3.27 MiB
    - host: 256 KiB
    - hostasync: 3.02 MiB
    - device: 2 KiB
...

Top tests by time:
  src/emitters/tests/test_sunsky.py::test06_sky_sampling[llvm_ad_rgb-0.8726646259971648-2.2]
    1.0 seconds
  src/emitters/tests/test_sunsky.py::test06_sky_sampling[llvm_ad_rgb-0.8726646259971648-4.8]
    1.0 seconds
  src/emitters/tests/test_sunsky.py::test06_sky_sampling[llvm_ad_rgb-0.3490658503988659-6.0]
    0.9 seconds
  src/emitters/tests/test_sunsky.py::test06_sky_sampling[llvm_ad_rgb-0.3490658503988659-4.8]
    0.9 seconds
  src/emitters/tests/test_sunsky.py::test06_sky_sampling[llvm_ad_rgb-0.3490658503988659-2.2]
    0.9 seconds
  src/emitters/tests/test_sunsky.py::test06_sky_sampling[llvm_ad_rgb-0.8726646259971648-6.0]
    0.8 seconds
  src/emitters/tests/test_sunsky.py::test07_sun_and_sky_sampling[llvm_ad_rgb-0.3490658503988659-2.2]
    0.3 seconds
  src/emitters/tests/test_sunsky.py::test07_sun_and_sky_sampling[llvm_ad_rgb-0.3490658503988659-4.8]
    0.3 seconds
  src/emitters/tests/test_sunsky.py::test07_sun_and_sky_sampling[llvm_ad_rgb-0.8726646259971648-2.2]
    0.2 seconds
  src/emitters/tests/test_sunsky.py::test07_sun_and_sky_sampling[llvm_ad_rgb-0.8726646259971648-4.8]
    0.2 seconds
  src/emitters/tests/test_sunsky.py::test07_sun_and_sky_sampling[llvm_ad_rgb-0.8726646259971648-6.0]
    0.2 seconds
  src/emitters/tests/test_sunsky.py::test07_sun_and_sky_sampling[llvm_ad_rgb-0.3490658503988659-6.0]
    0.2 seconds
  src/emitters/tests/test_sunsky.py::test02_sky_radiance_spectral[llvm_ad_spectral-render_params0]
    0.1 seconds
  src/emitters/tests/test_sunsky.py::test01_sky_radiance_rgb[llvm_ad_rgb-render_params0]
    0.1 seconds
  src/emitters/tests/test_sunsky.py::test01_sky_radiance_rgb[cuda_ad_rgb-render_params0]
    0.1 seconds
  src/emitters/tests/test_sunsky.py::test06_sky_sampling[cuda_ad_rgb-0.3490658503988659-6.0]
    0.1 seconds
  src/emitters/tests/test_sunsky.py::test06_sky_sampling[cuda_ad_rgb-0.8726646259971648-2.2]
    0.1 seconds
  src/emitters/tests/test_sunsky.py::test06_sky_sampling[cuda_ad_rgb-0.3490658503988659-4.8]
    0.1 seconds
  src/emitters/tests/test_sunsky.py::test06_sky_sampling[cuda_ad_rgb-0.3490658503988659-2.2]
    0.1 seconds
  src/emitters/tests/test_sunsky.py::test03_sky_radiance_spectral_albedo[llvm_ad_spectral]
    0.1 seconds
  src/emitters/tests/test_sunsky.py::test01_sky_radiance_rgb[llvm_ad_rgb-render_params1]
    0.1 seconds
  src/emitters/tests/test_sunsky.py::test02_sky_radiance_spectral[llvm_ad_spectral-render_params2]
    0.1 seconds
  src/emitters/tests/test_sunsky.py::test06_sky_sampling[cuda_ad_rgb-0.8726646259971648-6.0]
    0.1 seconds
  src/emitters/tests/test_sunsky.py::test06_sky_sampling[cuda_ad_rgb-0.8726646259971648-4.8]
    0.1 seconds
  src/emitters/tests/test_sunsky.py::test02_sky_radiance_spectral[llvm_ad_spectral-render_params1]
    0.1 seconds
  src/emitters/tests/test_sunsky.py::test01_sky_radiance_rgb[llvm_ad_rgb-render_params2]
    0.1 seconds
  src/emitters/tests/test_sunsky.py::test04_sun_radiance[llvm_ad_spectral-0.004601917004872723-0.0001-10.0]
    0.1 seconds
  src/emitters/tests/test_sunsky.py::test04_sun_radiance[llvm_ad_spectral-0.004601917004872723-0.0001-1.0]
    0.0 seconds
  src/emitters/tests/test_sunsky.py::test04_sun_radiance[llvm_ad_spectral-0.003067944669915149-1.5706963267948966-7.75]
    0.0 seconds
...
</details>
<details>
<summary>Post changes: </summary>
<br>
=== Test Metrics Report ===

Top tests by memory:
  src/emitters/tests/test_sunsky.py::test06_sky_sampling[llvm_ad_rgb-0.3490658503988659-2.2]
    Total: 9.56 MiB
    - host: 256 KiB
    - hostasync: 9.31 MiB
    - device: 2 KiB
  src/emitters/tests/test_sunsky.py::test06_sky_sampling[llvm_ad_rgb-0.3490658503988659-4.8]
    Total: 9.56 MiB
    - host: 256 KiB
    - hostasync: 9.31 MiB
    - device: 2 KiB
  src/emitters/tests/test_sunsky.py::test06_sky_sampling[llvm_ad_rgb-0.3490658503988659-6.0]
    Total: 9.56 MiB
    - host: 256 KiB
    - hostasync: 9.31 MiB
    - device: 2 KiB
  src/emitters/tests/test_sunsky.py::test06_sky_sampling[llvm_ad_rgb-0.8726646259971648-2.2]
    Total: 9.56 MiB
    - host: 256 KiB
    - hostasync: 9.31 MiB
    - device: 2 KiB
  src/emitters/tests/test_sunsky.py::test06_sky_sampling[llvm_ad_rgb-0.8726646259971648-4.8]
    Total: 9.56 MiB
    - host: 256 KiB
    - hostasync: 9.31 MiB
    - device: 2 KiB
  src/emitters/tests/test_sunsky.py::test06_sky_sampling[llvm_ad_rgb-0.8726646259971648-6.0]
    Total: 9.56 MiB
    - host: 256 KiB
    - hostasync: 9.31 MiB
    - device: 2 KiB
  src/emitters/tests/test_sunsky.py::test07_sun_and_sky_sampling[llvm_ad_rgb-0.3490658503988659-2.2]
    Total: 9.56 MiB
    - host: 256 KiB
    - hostasync: 9.31 MiB
    - device: 2 KiB
  src/emitters/tests/test_sunsky.py::test07_sun_and_sky_sampling[llvm_ad_rgb-0.3490658503988659-4.8]
    Total: 9.56 MiB
    - host: 256 KiB
    - hostasync: 9.31 MiB
    - device: 2 KiB
  src/emitters/tests/test_sunsky.py::test07_sun_and_sky_sampling[llvm_ad_rgb-0.3490658503988659-6.0]
    Total: 9.56 MiB
    - host: 256 KiB
    - hostasync: 9.31 MiB
    - device: 2 KiB
  src/emitters/tests/test_sunsky.py::test07_sun_and_sky_sampling[llvm_ad_rgb-0.8726646259971648-2.2]
    Total: 9.56 MiB
    - host: 256 KiB
    - hostasync: 9.31 MiB
    - device: 2 KiB
  src/emitters/tests/test_sunsky.py::test07_sun_and_sky_sampling[llvm_ad_rgb-0.8726646259971648-4.8]
    Total: 9.56 MiB
    - host: 256 KiB
    - hostasync: 9.31 MiB
    - device: 2 KiB
  src/emitters/tests/test_sunsky.py::test07_sun_and_sky_sampling[llvm_ad_rgb-0.8726646259971648-6.0]
    Total: 9.56 MiB
    - host: 256 KiB
    - hostasync: 9.31 MiB
    - device: 2 KiB
  src/emitters/tests/test_sunsky.py::test06_sky_sampling[cuda_ad_rgb-0.3490658503988659-2.2]
    Total: 9.27 MiB
    - hostpinned: 302 KiB
    - device: 8.98 MiB
  src/emitters/tests/test_sunsky.py::test06_sky_sampling[cuda_ad_rgb-0.3490658503988659-4.8]
    Total: 9.27 MiB
    - hostpinned: 302 KiB
    - device: 8.98 MiB
  src/emitters/tests/test_sunsky.py::test06_sky_sampling[cuda_ad_rgb-0.3490658503988659-6.0]
    Total: 9.27 MiB
    - hostpinned: 302 KiB
    - device: 8.98 MiB
  src/emitters/tests/test_sunsky.py::test06_sky_sampling[cuda_ad_rgb-0.8726646259971648-2.2]
    Total: 9.27 MiB
    - hostpinned: 302 KiB
    - device: 8.98 MiB
  src/emitters/tests/test_sunsky.py::test06_sky_sampling[cuda_ad_rgb-0.8726646259971648-4.8]
    Total: 9.27 MiB
    - hostpinned: 302 KiB
    - device: 8.98 MiB
  src/emitters/tests/test_sunsky.py::test06_sky_sampling[cuda_ad_rgb-0.8726646259971648-6.0]
    Total: 9.27 MiB
    - hostpinned: 302 KiB
    - device: 8.98 MiB
  src/emitters/tests/test_sunsky.py::test07_sun_and_sky_sampling[cuda_ad_rgb-0.3490658503988659-2.2]
    Total: 9.27 MiB
    - hostpinned: 302 KiB
    - device: 8.98 MiB
  src/emitters/tests/test_sunsky.py::test07_sun_and_sky_sampling[cuda_ad_rgb-0.3490658503988659-4.8]
    Total: 9.27 MiB
    - hostpinned: 302 KiB
    - device: 8.98 MiB
  src/emitters/tests/test_sunsky.py::test07_sun_and_sky_sampling[cuda_ad_rgb-0.3490658503988659-6.0]
    Total: 9.27 MiB
    - hostpinned: 302 KiB
    - device: 8.98 MiB
  src/emitters/tests/test_sunsky.py::test07_sun_and_sky_sampling[cuda_ad_rgb-0.8726646259971648-2.2]
    Total: 9.27 MiB
    - hostpinned: 302 KiB
    - device: 8.98 MiB
  src/emitters/tests/test_sunsky.py::test07_sun_and_sky_sampling[cuda_ad_rgb-0.8726646259971648-4.8]
    Total: 9.27 MiB
    - hostpinned: 302 KiB
    - device: 8.98 MiB
  src/emitters/tests/test_sunsky.py::test07_sun_and_sky_sampling[cuda_ad_rgb-0.8726646259971648-6.0]
    Total: 9.27 MiB
    - hostpinned: 302 KiB
    - device: 8.98 MiB
  src/emitters/tests/test_sunsky.py::test03_sky_radiance_spectral_albedo[llvm_ad_spectral]
    Total: 3.52 MiB
    - host: 256 KiB
    - hostasync: 3.27 MiB
    - device: 2 KiB
  src/emitters/tests/test_sunsky.py::test02_sky_radiance_spectral[llvm_ad_spectral-render_params0]
    Total: 3.52 MiB
    - host: 256 KiB
    - hostasync: 3.27 MiB
    - device: 2 KiB
  src/emitters/tests/test_sunsky.py::test02_sky_radiance_spectral[llvm_ad_spectral-render_params1]
    Total: 3.52 MiB
    - host: 256 KiB
    - hostasync: 3.27 MiB
    - device: 2 KiB
  src/emitters/tests/test_sunsky.py::test02_sky_radiance_spectral[llvm_ad_spectral-render_params2]
    Total: 3.52 MiB
    - host: 256 KiB
    - hostasync: 3.27 MiB
    - device: 2 KiB
  src/emitters/tests/test_sunsky.py::test04_sun_radiance[llvm_ad_spectral-0.0-0.0001-1.0]
    Total: 3.27 MiB
    - host: 256 KiB
    - hostasync: 3.02 MiB
    - device: 2 KiB
  src/emitters/tests/test_sunsky.py::test04_sun_radiance[llvm_ad_spectral-0.0-0.0001-10.0]
    Total: 3.27 MiB
    - host: 256 KiB
    - hostasync: 3.02 MiB
    - device: 2 KiB
...

Top tests by time:
  src/emitters/tests/test_sunsky.py::test02_sky_radiance_spectral[llvm_ad_spectral-render_params0]
    0.1 seconds
  src/emitters/tests/test_sunsky.py::test06_sky_sampling[llvm_ad_rgb-0.3490658503988659-2.2]
    0.1 seconds
  src/emitters/tests/test_sunsky.py::test06_sky_sampling[llvm_ad_rgb-0.8726646259971648-4.8]
    0.1 seconds
  src/emitters/tests/test_sunsky.py::test07_sun_and_sky_sampling[llvm_ad_rgb-0.8726646259971648-4.8]
    0.1 seconds
  src/emitters/tests/test_sunsky.py::test06_sky_sampling[llvm_ad_rgb-0.8726646259971648-6.0]
    0.1 seconds
  src/emitters/tests/test_sunsky.py::test06_sky_sampling[llvm_ad_rgb-0.8726646259971648-2.2]
    0.1 seconds
  src/emitters/tests/test_sunsky.py::test07_sun_and_sky_sampling[llvm_ad_rgb-0.8726646259971648-2.2]
    0.1 seconds
  src/emitters/tests/test_sunsky.py::test07_sun_and_sky_sampling[llvm_ad_rgb-0.3490658503988659-2.2]
    0.1 seconds
  src/emitters/tests/test_sunsky.py::test07_sun_and_sky_sampling[llvm_ad_rgb-0.3490658503988659-4.8]
    0.1 seconds
  src/emitters/tests/test_sunsky.py::test06_sky_sampling[llvm_ad_rgb-0.3490658503988659-4.8]
    0.1 seconds
  src/emitters/tests/test_sunsky.py::test07_sun_and_sky_sampling[llvm_ad_rgb-0.8726646259971648-6.0]
    0.1 seconds
  src/emitters/tests/test_sunsky.py::test06_sky_sampling[llvm_ad_rgb-0.3490658503988659-6.0]
    0.1 seconds
  src/emitters/tests/test_sunsky.py::test07_sun_and_sky_sampling[llvm_ad_rgb-0.3490658503988659-6.0]
    0.1 seconds
  src/emitters/tests/test_sunsky.py::test03_sky_radiance_spectral_albedo[llvm_ad_spectral]
    0.1 seconds
  src/emitters/tests/test_sunsky.py::test01_sky_radiance_rgb[llvm_ad_rgb-render_params0]
    0.1 seconds
  src/emitters/tests/test_sunsky.py::test01_sky_radiance_rgb[llvm_ad_rgb-render_params2]
    0.1 seconds
  src/emitters/tests/test_sunsky.py::test01_sky_radiance_rgb[llvm_ad_rgb-render_params1]
    0.1 seconds
  src/emitters/tests/test_sunsky.py::test02_sky_radiance_spectral[llvm_ad_spectral-render_params1]
    0.1 seconds
  src/emitters/tests/test_sunsky.py::test02_sky_radiance_spectral[llvm_ad_spectral-render_params2]
    0.1 seconds
  src/emitters/tests/test_sunsky.py::test05_sun_sampling[llvm_ad_rgb-0.0]
    0.1 seconds
  src/emitters/tests/test_sunsky.py::test01_sky_radiance_rgb[cuda_ad_rgb-render_params0]
    0.1 seconds
  src/emitters/tests/test_sunsky.py::test05_sun_sampling[llvm_ad_rgb-0.5235987755982988]
    0.1 seconds
  src/emitters/tests/test_sunsky.py::test05_sun_sampling[llvm_ad_rgb-1.5707963267948966]
    0.1 seconds
  src/emitters/tests/test_sunsky.py::test05_sun_sampling[llvm_ad_rgb-1.0471975511965976]
    0.1 seconds
  src/emitters/tests/test_sunsky.py::test04_sun_radiance[llvm_ad_spectral-0.003067944669915149-1.0471642178632643-3.25]
    0.1 seconds
  src/emitters/tests/test_sunsky.py::test04_sun_radiance[llvm_ad_spectral-0.0015339723349575745-0.0001-1.0]
    0.1 seconds
  src/emitters/tests/test_sunsky.py::test04_sun_radiance[llvm_ad_spectral-0.0-0.0001-10.0]
    0.1 seconds
  src/emitters/tests/test_sunsky.py::test04_sun_radiance[llvm_ad_spectral-0.003067944669915149-0.0001-10.0]
    0.1 seconds
  src/emitters/tests/test_sunsky.py::test04_sun_radiance[llvm_ad_spectral-0.004601917004872723-0.0001-3.25]
    0.1 seconds
  src/emitters/tests/test_sunsky.py::test04_sun_radiance[llvm_ad_spectral-0.004601917004872723-0.0001-7.75]
    0.1 seconds
  src/emitters/tests/test_sunsky.py::test04_sun_radiance[llvm_ad_spectral-0.003067944669915149-1.0471642178632643-7.75]
    0.0 seconds
  src/emitters/tests/test_sunsky.py::test04_sun_radiance[llvm_ad_spectral-0.0-0.0001-1.0]
    0.0 seconds
  ...
</details>