### PR TITLE
Add back set_id method and test its use in load_dict

### DIFF
--- a/include/mitsuba/core/object.h
+++ b/include/mitsuba/core/object.h
@@ -158,6 +158,9 @@ public:
     /// Return an identifier of the current instance (or empty if none)
     virtual std::string_view id() const;
 
+    /// Set the identifier of the current instance (no-op if not supported)
+    virtual void set_id(std::string_view id);
+
     /// Return the C++ class name of this object (e.g. "SmoothDiffuse")
     virtual std::string_view class_name() const;
 
@@ -277,6 +280,9 @@ class JitObject : public Object {
 public:
     /// Return the identifier of this instance
     std::string_view id() const override { return m_id; }
+
+    /// Set the identifier of this instance
+    void set_id(std::string_view id) override { m_id = id; }
 
 protected:
     /// Constructor with ID and optional ObjectType

--- a/src/core/object.cpp
+++ b/src/core/object.cpp
@@ -34,6 +34,10 @@ std::string_view Object::id() const {
     return "";
 }
 
+void Object::set_id(std::string_view /*id*/) {
+    // The base Object class does not hold a unique ID - do nothing.
+}
+
 std::string_view Object::class_name() const {
     return "Object";
 }

--- a/src/core/python/object.cpp
+++ b/src/core/python/object.cpp
@@ -51,6 +51,7 @@ MI_PY_EXPORT(Object) {
         .def(nb::init<>(), D(Object, Object))
         .def(nb::init<const Object &>(), D(Object, Object, 2))
         .def_method(Object, id)
+        .def_method(Object, set_id, "id"_a)
         .def_method(Object, class_name)
         .def("variant_name", &Object::variant_name, D(Object, variant_name))
         .def("expand", [=](const Object &o) -> nb::list {

--- a/src/core/python/xml_v.cpp
+++ b/src/core/python/xml_v.cpp
@@ -390,6 +390,7 @@ void parse_dictionary(DictParseContext &ctx,
         // Try to cast entry to an object
         Object* obj_ptr;
         if (nb::try_cast<Object*>(value, obj_ptr)) {
+            obj_ptr->set_id(key);
             expand_and_set_object(props, key, ref<Object>(obj_ptr));
             continue;
         }

--- a/src/core/tests/test_dict.py
+++ b/src/core/tests/test_dict.py
@@ -518,3 +518,17 @@ def test12_dict_spectrum(variant_scalar_spectral):
     """)
 
     assert str(s1) == str(s2)
+
+
+def test13_dict_load_sets_object_id(variant_scalar_rgb):
+    scene = mi.load_dict({
+        "type": "scene",
+        "my_sphere": {"type": "sphere"}
+    })
+    assert scene.shapes()[0].id() == "my_sphere"
+
+    scene = mi.load_dict({
+        "type": "scene",
+        "my_other_sphere": mi.load_dict({"type": "sphere"})
+    })
+    assert scene.shapes()[0].id() == "my_other_sphere"


### PR DESCRIPTION
Adds back the `set_id` method and calls it during `load_dict`. This makes it such that plugins that already were instantiated and then used in a dict get the ID of the dictionary key (reproducing the previous behavior)