### PR TITLE
MergeShape: restore `set_id()` feature

### DIFF
--- a/src/shapes/merge.cpp
+++ b/src/shapes/merge.cpp
@@ -44,6 +44,8 @@ public:
         }
 
         for (auto &kv : tbl) {
+            if (tbl.size() == 1)
+                kv.second->set_id(props.id());
             m_objects.push_back((ref<Object>) kv.second);
         }
 

--- a/src/shapes/tests/test_merge.py
+++ b/src/shapes/tests/test_merge.py
@@ -20,6 +20,7 @@ def test01_merge_single_shape(variants_all_backends_once):
         "child1": example_mesh(),
     })
     assert isinstance(m, mi.Mesh)
+    assert m.id() == "__root__"
 
     # One shape in a scene, no BSDF
     m = mi.load_dict({
@@ -30,6 +31,7 @@ def test01_merge_single_shape(variants_all_backends_once):
         },
     })
     assert len(m.shapes()) == 1
+    assert m.shapes()[0].id() == "parent"
 
     # One shape in a scene, with a BSDF
     m = mi.load_dict({
@@ -40,6 +42,7 @@ def test01_merge_single_shape(variants_all_backends_once):
         },
     })
     assert len(m.shapes()) == 1
+    assert m.shapes()[0].id() == "parent"
 
     # Non-mesh --> should be just passed through
     m = mi.load_dict({
@@ -49,6 +52,7 @@ def test01_merge_single_shape(variants_all_backends_once):
         },
     })
     assert isinstance(m, mi.Shape)
+    assert m.id() == "child1"
 
 
 @fresolver_append_path
@@ -60,6 +64,7 @@ def test02_two_shapes(variants_all_rgb):
         "child2": example_mesh(),
     })
     assert len(m) == 2
+    assert set([m[0].id(), m[1].id()]) == {"child1", "child2"}
 
     # No BSDF --> doesn't merge
     m = mi.load_dict({
@@ -68,6 +73,7 @@ def test02_two_shapes(variants_all_rgb):
         "child2": example_mesh(),
     })
     assert len(m) == 2
+    assert set([m[0].id(), m[1].id()]) == {"child1", "child2"}
 
     # Same BSDF: merge
     m = mi.load_dict({
@@ -80,6 +86,7 @@ def test02_two_shapes(variants_all_rgb):
         }
     })
     assert len(m.shapes()) == 1
+    assert m.shapes()[0].id() == "parent"
 
     # Non-mesh --> doesn't merge
     m = mi.load_dict({
@@ -95,3 +102,4 @@ def test02_two_shapes(variants_all_rgb):
         }
     })
     assert len(m.shapes()) == 2
+    assert set([m.shapes()[0].id(), m.shapes()[1].id()]) == {"parent", "child2"}


### PR DESCRIPTION
## Description

Related to #1664. Restores the behavior of `MergeShape` with IDs prior to #1630.

## Testing

Added ID checks to the related unit tests.

## Checklist

<!-- Please make sure to complete this checklist before requesting a review. -->

- [x] My code follows the [style guidelines](https://mitsuba.readthedocs.io/en/latest/src/developer_guide.html#coding-style) of this project
- [x] My changes generate no new warnings
- [x] My code also compiles for `cuda_*` and `llvm_*` variants. If you can't test this, please leave below
- [ ] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 3 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba/blob/master/LICENSE)