### PR TITLE
Mitsuba documentation typo fix

### DIFF
--- a/docs/docs_api/list_api.rst
+++ b/docs/docs_api/list_api.rst
@@ -10,15 +10,21 @@
 
 .. autoclass:: mitsuba.ArrayXf
 
+.. autoclass:: mitsuba.ArrayXf32
+
+.. autoclass:: mitsuba.ArrayXf64
+
 .. autoclass:: mitsuba.ArrayXi
+
+.. autoclass:: mitsuba.ArrayXi32
 
 .. autoclass:: mitsuba.ArrayXi64
 
 .. autoclass:: mitsuba.ArrayXu
 
-.. autoclass:: mitsuba.ArrayXu64
+.. autoclass:: mitsuba.ArrayXu32
 
-.. autoclass:: mitsuba.AtomicFloat
+.. autoclass:: mitsuba.ArrayXu64
 
 .. autoclass:: mitsuba.BSDF
 
@@ -42,8 +48,6 @@
 
 .. autoclass:: mitsuba.BoundingSphere3f
 
-.. autoclass:: mitsuba.Class
-
 .. autoclass:: mitsuba.Color0d
 
 .. autoclass:: mitsuba.Color0f
@@ -59,6 +63,10 @@
 .. autoclass:: mitsuba.Complex2d
 
 .. autoclass:: mitsuba.Complex2f
+
+.. autoclass:: mitsuba.Complex2f32
+
+.. autoclass:: mitsuba.Complex2f64
 
 .. autoclass:: mitsuba.ContinuousDistribution
 
@@ -182,13 +190,25 @@
 
 .. autoclass:: mitsuba.Matrix2f
 
+.. autoclass:: mitsuba.Matrix2f32
+
+.. autoclass:: mitsuba.Matrix2f64
+
 .. autoclass:: mitsuba.Matrix3d
 
 .. autoclass:: mitsuba.Matrix3f
 
+.. autoclass:: mitsuba.Matrix3f32
+
+.. autoclass:: mitsuba.Matrix3f64
+
 .. autoclass:: mitsuba.Matrix4d
 
 .. autoclass:: mitsuba.Matrix4f
+
+.. autoclass:: mitsuba.Matrix4f32
+
+.. autoclass:: mitsuba.Matrix4f64
 
 .. autoclass:: mitsuba.Medium
 
@@ -216,7 +236,7 @@
 
 .. autoclass:: mitsuba.Object
 
-.. autoclass:: mitsuba.ObjectPtr
+.. autoclass:: mitsuba.ObjectType
 
 .. autoclass:: mitsuba.OptixDenoiser
 
@@ -285,6 +305,10 @@
 .. autoclass:: mitsuba.Quaternion4d
 
 .. autoclass:: mitsuba.Quaternion4f
+
+.. autoclass:: mitsuba.Quaternion4f32
+
+.. autoclass:: mitsuba.Quaternion4f64
 
 .. autoclass:: mitsuba.RadicalInverse
 
@@ -422,8 +446,6 @@
 
 .. autoclass:: mitsuba.SceneParameters
 
-.. autoclass:: mitsuba.ScopedSetThreadEnvironment
-
 .. autoclass:: mitsuba.Sensor
 
 .. autoclass:: mitsuba.SensorPtr
@@ -456,11 +478,19 @@
 
 .. autoclass:: mitsuba.TensorXf
 
+.. autoclass:: mitsuba.TensorXf32
+
+.. autoclass:: mitsuba.TensorXf64
+
 .. autoclass:: mitsuba.TensorXi
+
+.. autoclass:: mitsuba.TensorXi32
 
 .. autoclass:: mitsuba.TensorXi64
 
 .. autoclass:: mitsuba.TensorXu
+
+.. autoclass:: mitsuba.TensorXu32
 
 .. autoclass:: mitsuba.TensorXu64
 
@@ -470,17 +500,27 @@
 
 .. autoclass:: mitsuba.Texture1f
 
+.. autoclass:: mitsuba.Texture1f32
+
+.. autoclass:: mitsuba.Texture1f64
+
 .. autoclass:: mitsuba.Texture2d
 
 .. autoclass:: mitsuba.Texture2f
+
+.. autoclass:: mitsuba.Texture2f32
+
+.. autoclass:: mitsuba.Texture2f64
 
 .. autoclass:: mitsuba.Texture3d
 
 .. autoclass:: mitsuba.Texture3f
 
-.. autoclass:: mitsuba.Thread
+.. autoclass:: mitsuba.Texture3f32
 
-.. autoclass:: mitsuba.ThreadEnvironment
+.. autoclass:: mitsuba.Texture3f64
+
+.. autoclass:: mitsuba.Thread
 
 .. autoclass:: mitsuba.Timer
 
@@ -608,15 +648,21 @@
 
 .. autofunction:: mitsuba.depolarizer
 
+.. autoclass:: mitsuba.detail.TransformWrapper
+
 .. autofunction:: mitsuba.detail.add_variant_callback
 
 .. autofunction:: mitsuba.detail.clear_variant_callbacks
+
+.. autofunction:: mitsuba.detail.patch_transform
 
 .. autofunction:: mitsuba.detail.remove_variant_callback
 
 .. autofunction:: mitsuba.dir_to_sph
 
 .. autofunction:: mitsuba.eval_reflectance
+
+.. autofunction:: mitsuba.file_resolver
 
 .. autofunction:: mitsuba.filesystem.absolute
 
@@ -669,6 +715,8 @@
 .. autofunction:: mitsuba.load_string
 
 .. autofunction:: mitsuba.log_level
+
+.. autofunction:: mitsuba.logger
 
 .. autofunction:: mitsuba.lookup_ior
 
@@ -792,17 +840,17 @@
 
 .. autofunction:: mitsuba.register_medium
 
-.. autofunction:: mitsuba.register_mesh
+.. autofunction:: mitsuba.register_phase
 
-.. autofunction:: mitsuba.register_phasefunction
+.. autofunction:: mitsuba.register_rfilter
 
 .. autofunction:: mitsuba.register_sampler
 
 .. autofunction:: mitsuba.register_sensor
 
-.. autofunction:: mitsuba.register_texture
+.. autofunction:: mitsuba.register_shape
 
-.. autofunction:: mitsuba.register_volume
+.. autofunction:: mitsuba.register_texture
 
 .. autofunction:: mitsuba.render
 
@@ -820,7 +868,11 @@
 
 .. autofunction:: mitsuba.scoped_set_variant
 
+.. autofunction:: mitsuba.set_file_resolver
+
 .. autofunction:: mitsuba.set_log_level
+
+.. autofunction:: mitsuba.set_logger
 
 .. autofunction:: mitsuba.set_variant
 

--- a/docs/generated/extracted_rst_api.rst
+++ b/docs/generated/extracted_rst_api.rst
@@ -129,8 +129,7 @@
 
         Parameter ``ptr`` (typing_extensions.CapsuleType | None):
             Custom pointer payload. This is used to express the context of a
-            progress message. When rendering a scene, it will usually contain
-            a pointer to the associated ``RenderJob``.
+            progress message.
 
         Returns → None:
             *no description available*
@@ -206,6 +205,8 @@
 
 .. py:class:: mitsuba.ArrayXf
 
+.. py:class:: mitsuba.ArrayXf64
+
 .. py:class:: mitsuba.ArrayXi
 
 .. py:class:: mitsuba.ArrayXi64
@@ -214,24 +215,6 @@
 
 .. py:class:: mitsuba.ArrayXu64
 
-.. py:class:: mitsuba.AtomicFloat
-
-    Atomic floating point data type
-
-    The class implements an an atomic floating point data type (which is
-    not possible with the existing overloads provided by ``std::atomic``).
-    It internally casts floating point values to an integer storage format
-    and uses atomic integer compare and exchange operations to perform
-    changes.
-
-    .. py:method:: __init__(self, arg)
-
-        Initialize the AtomicFloat with a given floating point value
-
-        Parameter ``arg`` (float, /):
-            *no description available*
-
-        
 .. py:class:: mitsuba.BSDF
 
     Base class: :py:obj:`mitsuba.Object`
@@ -286,7 +269,7 @@
 
         Based on the information in the supplied query context ``ctx``, this
         method will either evaluate the entire BSDF or query individual
-        components (e.g. the diffuse lobe). Only smooth (i.e. non Dirac-delta)
+        components (e.g. the diffuse lobe). Only smooth (i.e. non-Dirac-delta)
         components are supported: calling ``eval()`` on a perfectly specular
         material will return zero.
 
@@ -420,7 +403,7 @@
 
         Based on the information in the supplied query context ``ctx``, this
         method will either evaluate the entire BSDF or query individual
-        components (e.g. the diffuse lobe). Only smooth (i.e. non Dirac-delta)
+        components (e.g. the diffuse lobe). Only smooth (i.e. non-Dirac-delta)
         components are supported: calling ``eval()`` on a perfectly specular
         material will return zero.
 
@@ -460,7 +443,7 @@
 
         Based on the information in the supplied query context ``ctx``, this
         method will either evaluate the entire BSDF or query individual
-        components (e.g. the diffuse lobe). Only smooth (i.e. non Dirac-delta)
+        components (e.g. the diffuse lobe). Only smooth (i.e. non-Dirac-delta)
         components are supported: calling ``eval()`` on a perfectly specular
         material will return zero.
 
@@ -530,13 +513,6 @@
             Mask to specify active lanes.
 
         Returns → drjit.llvm.ad.Bool:
-            *no description available*
-
-    .. py:method:: mitsuba.BSDF.id()
-
-        Return a string identifier
-
-        Returns → str:
             *no description available*
 
     .. py:property:: mitsuba.BSDF.m_components
@@ -643,8 +619,8 @@
     BSDF models in Mitsuba can be queried and sampled using a variety of
     different modes -- for instance, a rendering algorithm can indicate
     whether radiance or importance is being transported, and it can also
-    restrict evaluation and sampling to a subset of lobes in a a multi-
-    lobe BSDF model.
+    restrict evaluation and sampling to a subset of lobes in a multi-lobe
+    BSDF model.
 
     The BSDFContext data structure encodes these preferences and is
     supplied to most BSDF methods.
@@ -673,8 +649,8 @@
 
     .. py:method:: mitsuba.BSDFContext.is_enabled(self, type, component=0)
 
-        Checks whether a given BSDF component type and BSDF component index
-        are enabled in this context.
+        Checks whether a given BSDF component type and index are enabled in
+        this context.
 
         Parameter ``type`` (:py:obj:`mitsuba.BSDFFlags`):
             *no description available*
@@ -806,7 +782,7 @@
 
         Based on the information in the supplied query context ``ctx``, this
         method will either evaluate the entire BSDF or query individual
-        components (e.g. the diffuse lobe). Only smooth (i.e. non Dirac-delta)
+        components (e.g. the diffuse lobe). Only smooth (i.e. non-Dirac-delta)
         components are supported: calling ``eval()`` on a perfectly specular
         material will return zero.
 
@@ -940,7 +916,7 @@
 
         Based on the information in the supplied query context ``ctx``, this
         method will either evaluate the entire BSDF or query individual
-        components (e.g. the diffuse lobe). Only smooth (i.e. non Dirac-delta)
+        components (e.g. the diffuse lobe). Only smooth (i.e. non-Dirac-delta)
         components are supported: calling ``eval()`` on a perfectly specular
         material will return zero.
 
@@ -980,7 +956,7 @@
 
         Based on the information in the supplied query context ``ctx``, this
         method will either evaluate the entire BSDF or query individual
-        components (e.g. the diffuse lobe). Only smooth (i.e. non Dirac-delta)
+        components (e.g. the diffuse lobe). Only smooth (i.e. non-Dirac-delta)
         components are supported: calling ``eval()`` on a perfectly specular
         material will return zero.
 
@@ -1262,11 +1238,11 @@
 
         .. py:data:: Premultiply
 
-            No transformation (default)
+            Premultiply alpha channel
 
         .. py:data:: Unpremultiply
 
-            No transformation (default)
+            Unpremultiply alpha channel
 
     .. py:class:: mitsuba.Bitmap.FileFormat
 
@@ -1480,7 +1456,7 @@
         values, etc.)
 
         Note that the alpha channel is assumed to be linear in both the source
-        and target bitmap, hence it won't be affected by any gamma-related
+        and target bitmap, therefore it won't be affected by any gamma-related
         transformations.
 
         Remark:
@@ -2455,7 +2431,7 @@
 
     .. py:method:: mitsuba.BoundingSphere3f.expand(self, arg)
 
-        Expand the bounding sphere radius to contain another point.
+        Expand the bounding sphere radius to contain another point
 
         Parameter ``arg`` (:py:obj:`mitsuba.Point3f`, /):
             *no description available*
@@ -2477,53 +2453,6 @@
         Returns → tuple[drjit.llvm.ad.Bool, drjit.llvm.ad.Float, drjit.llvm.ad.Float]:
             *no description available*
 
-.. py:class:: mitsuba.Class
-
-    Stores meta-information about Object instances.
-
-    This class provides a thin layer of RTTI (run-time type information),
-    which is useful for doing things like:
-
-    * Checking if an object derives from a certain class
-
-    * Determining the parent of a class at runtime
-
-    * Instantiating a class by name
-
-    * Unserializing a class from a binary data stream
-
-    See also:
-        ref, Object
-
-    .. py:method:: mitsuba.Class.alias()
-
-        Return the scene description-specific alias, if applicable
-
-        Returns → str:
-            *no description available*
-
-    .. py:method:: mitsuba.Class.name()
-
-        Return the name of the class
-
-        Returns → str:
-            *no description available*
-
-    .. py:method:: mitsuba.Class.parent()
-
-        Return the Class object associated with the parent class of nullptr if
-        it does not have one.
-
-        Returns → :py:obj:`mitsuba.Class`:
-            *no description available*
-
-    .. py:method:: mitsuba.Class.variant()
-
-        Return the variant of the class
-
-        Returns → str:
-            *no description available*
-
 .. py:class:: mitsuba.Color0d
 
 .. py:class:: mitsuba.Color0f
@@ -2537,6 +2466,8 @@
 .. py:class:: mitsuba.Color3f
 
 .. py:class:: mitsuba.Complex2f
+
+.. py:class:: mitsuba.Complex2f64
 
 .. py:class:: mitsuba.ContinuousDistribution
 
@@ -2683,7 +2614,7 @@
 
     .. py:method:: mitsuba.ContinuousDistribution.sample(self, value, active=True)
 
-        %Transform a uniformly distributed sample to the stored distribution
+        Transform a uniformly distributed sample to the stored distribution
 
         Parameter ``sample``:
             A uniformly distributed sample on the interval [0, 1].
@@ -2699,7 +2630,7 @@
 
     .. py:method:: mitsuba.ContinuousDistribution.sample_pdf(self, value, active=True)
 
-        %Transform a uniformly distributed sample to the stored distribution
+        Transform a uniformly distributed sample to the stored distribution
 
         Parameter ``sample``:
             A uniformly distributed sample on the interval [0, 1].
@@ -2736,7 +2667,7 @@
 
 .. py:data:: mitsuba.DEBUG
     :type: bool
-    :value: True
+    :value: False
 
 .. py:class:: mitsuba.DefaultFormatter
 
@@ -3043,7 +2974,7 @@
 
     .. py:method:: mitsuba.DiscreteDistribution.sample(self, value, active=True)
 
-        %Transform a uniformly distributed sample to the stored distribution
+        Transform a uniformly distributed sample to the stored distribution
 
         Parameter ``sample``:
             A uniformly distributed sample on the interval [0, 1].
@@ -3059,7 +2990,7 @@
 
     .. py:method:: mitsuba.DiscreteDistribution.sample_pmf(self, value, active=True)
 
-        %Transform a uniformly distributed sample to the stored distribution
+        Transform a uniformly distributed sample to the stored distribution
 
         Parameter ``value`` (drjit.llvm.ad.Float):
             A uniformly distributed sample on the interval [0, 1].
@@ -3075,7 +3006,7 @@
 
     .. py:method:: mitsuba.DiscreteDistribution.sample_reuse(self, value, active=True)
 
-        %Transform a uniformly distributed sample to the stored distribution
+        Transform a uniformly distributed sample to the stored distribution
 
         The original sample is value adjusted so that it can be reused as a
         uniform variate.
@@ -3094,7 +3025,7 @@
 
     .. py:method:: mitsuba.DiscreteDistribution.sample_reuse_pmf(self, value, active=True)
 
-        %Transform a uniformly distributed sample to the stored distribution.
+        Transform a uniformly distributed sample to the stored distribution.
 
         The original sample is value adjusted so that it can be reused as a
         uniform variate.
@@ -3330,7 +3261,7 @@
 
     .. py:method:: mitsuba.EmitterPtr.get_shape()
 
-        Return the shape, to which the emitter is currently attached
+        Return the shape to which the emitter is currently attached
 
         Returns → :py:obj:`mitsuba.ShapePtr`:
             *no description available*
@@ -3644,7 +3575,7 @@
 
     .. py:method:: mitsuba.Endpoint.get_shape()
 
-        Return the shape, to which the emitter is currently attached
+        Return the shape to which the emitter is currently attached
 
         Returns → :py:obj:`mitsuba.Shape`:
             *no description available*
@@ -3998,7 +3929,7 @@
 
     .. py:method:: mitsuba.Film.base_channels_count()
 
-        Return the number of channels for the developed image (excluding AOVS)
+        Return the number of channels for the developed image (excluding AOVs)
 
         Returns → int:
             *no description available*
@@ -4084,7 +4015,7 @@
     .. py:method:: mitsuba.Film.prepare(self, aovs)
 
         Configure the film for rendering a specified set of extra channels
-        (AOVS). Returns the total number of channels that the film will store
+        (AOVs). Returns the total number of channels that the film will store
 
         Parameter ``aovs`` (collections.abc.Sequence[str]):
             *no description available*
@@ -4258,24 +4189,21 @@
     .. py:method:: __init__()
 
 
-    .. py:method:: mitsuba.Formatter.format(self, level, class_, thread, file, line, msg)
+    .. py:method:: mitsuba.Formatter.format(self, level, cname, fname, line, msg)
 
         Turn a log message into a human-readable format
 
         Parameter ``level`` (:py:obj:`mitsuba.LogLevel`):
             The importance of the debug message
 
-        Parameter ``class_`` (:py:obj:`mitsuba.Class`):
-            Originating class or ``nullptr``
+        Parameter ``cname`` (str | None):
+            Name of the class (if present)
 
-        Parameter ``thread`` (:py:obj:`mitsuba.Thread`):
-            Thread, which is responsible for creating the message
-
-        Parameter ``file`` (str):
-            File, which is responsible for creating the message
+        Parameter ``fname`` (str):
+            Source location (file)
 
         Parameter ``line`` (int):
-            Associated line within the source file
+            Source location (line number)
 
         Parameter ``msg`` (str):
             Text content associated with the log message
@@ -5474,7 +5402,7 @@
 
     .. py:method:: mitsuba.IrregularContinuousDistribution.sample(self, value, active=True)
 
-        %Transform a uniformly distributed sample to the stored distribution
+        Transform a uniformly distributed sample to the stored distribution
 
         Parameter ``sample``:
             A uniformly distributed sample on the interval [0, 1].
@@ -5490,7 +5418,7 @@
 
     .. py:method:: mitsuba.IrregularContinuousDistribution.sample_pdf(self, value, active=True)
 
-        %Transform a uniformly distributed sample to the stored distribution
+        Transform a uniformly distributed sample to the stored distribution
 
         Parameter ``sample``:
             A uniformly distributed sample on the interval [0, 1].
@@ -5650,8 +5578,7 @@
 
         Parameter ``ptr`` (typing_extensions.CapsuleType | None):
             Custom pointer payload. This is used to express the context of a
-            progress message. When rendering a scene, it will usually contain
-            a pointer to the associated ``RenderJob``.
+            progress message.
 
         Returns → None:
             *no description available*
@@ -6764,9 +6691,15 @@
 
 .. py:class:: mitsuba.Matrix2f
 
+.. py:class:: mitsuba.Matrix2f64
+
 .. py:class:: mitsuba.Matrix3f
 
+.. py:class:: mitsuba.Matrix3f64
+
 .. py:class:: mitsuba.Matrix4f
+
+.. py:class:: mitsuba.Matrix4f64
 
 .. py:class:: mitsuba.Medium
 
@@ -6804,13 +6737,6 @@
         Returns whether this medium has a spectrally varying extinction
 
         Returns → bool:
-            *no description available*
-
-    .. py:method:: mitsuba.Medium.id()
-
-        Return a string identifier
-
-        Returns → str:
             *no description available*
 
     .. py:method:: mitsuba.Medium.intersect_aabb(self, ray)
@@ -6875,16 +6801,6 @@
             This method returns a MediumInteraction. The MediumInteraction
             will always be valid, except if the ray missed the Medium's
             bounding box.
-
-    .. py:method:: mitsuba.Medium.set_id(self, arg)
-
-        Set a string identifier
-
-        Parameter ``arg`` (str, /):
-            *no description available*
-
-        Returns → None:
-            *no description available*
 
     .. py:method:: mitsuba.Medium.transmittance_eval_pdf(self, mi, si, active)
 
@@ -7590,6 +7506,13 @@
         Returns → drjit.llvm.ad.Bool:
             *no description available*
 
+    .. py:method:: mitsuba.MeshPtr.has_flipped_normals()
+
+        Does this shape have flipped normals?
+
+        Returns → drjit.llvm.ad.Bool:
+            *no description available*
+
     .. py:method:: mitsuba.MeshPtr.has_mesh_attributes()
 
         Does this mesh have additional mesh attributes?
@@ -7900,26 +7823,23 @@
 
     This class (in conjunction with the ``ref`` reference counter)
     constitutes the foundation of an efficient reference-counted object
-    hierarchy. The implementation here is an alternative to standard
-    mechanisms for reference counting such as ``std::shared_ptr`` from the
-    STL.
+    hierarchy.
 
-    Why not simply use ``std::shared_ptr``? To be spec-compliant, such
-    shared pointers must associate a special record with every instance,
-    which stores at least two counters plus a deletion function.
-    Allocating this record naturally incurs further overheads to maintain
-    data structures within the memory allocator. In addition to this, the
-    size of an individual ``shared_ptr`` references is at least two data
-    words. All of this quickly adds up and leads to significant overheads
-    for large collections of instances, hence the need for an alternative
-    in Mitsuba.
+    We use an intrusive reference counting approach to avoid various
+    gnarly issues that arise in combined Python/C++ codebase, see the
+    following page for details:
+    https://nanobind.readthedocs.io/en/latest/ownership_adv.html
 
-    In contrast, the ``Object`` class allows for a highly efficient
-    implementation that only adds 64 bits to the base object (for the
-    counter) and has no overhead for references. In addition, when using
-    Mitsuba in Python, this counter is shared with Python such that the
-    ownerhsip and lifetime of any ``Object`` instance across C++ and
-    Python is managed by it.
+    The counter provided by ``drjit::TraversableBase`` establishes a
+    unified reference count that is consistent across both C++ and Python.
+    It is more efficient than ``std::shared_ptr<T>`` (as no external
+    control block is needed) and works without Python actually being
+    present.
+
+    Object subclasses are *traversable*, that is, they expose methods that
+    Dr.Jit can use to walk through object graphs, discover attributes, and
+    potentially change them. This enables function freezing (@dr.freeze)
+    that must detect and apply changes when executing frozen functions.
 
     .. py:method:: __init__()
 
@@ -7927,22 +7847,16 @@
         
         1. ``__init__(self) -> None``
         
-        Default constructor
+        Import default constructors
         
         2. ``__init__(self, arg: :py:obj:`mitsuba.Object`) -> None``
-        
-        Copy constructor
 
         
-    .. py:method:: mitsuba.Object.class_()
+    .. py:method:: mitsuba.Object.class_name()
 
-        Return a Class instance containing run-time type information about
-        this Object
+        Return the C++ class name of this object (e.g. "SmoothDiffuse")
 
-        See also:
-            Class
-
-        Returns → :py:obj:`mitsuba.Class`:
+        Returns → str:
             *no description available*
 
     .. py:method:: mitsuba.Object.expand()
@@ -7960,7 +7874,7 @@
 
     .. py:method:: mitsuba.Object.id()
 
-        Return an identifier of the current instance (if available)
+        Return an identifier of the current instance (or empty if none)
 
         Returns → str:
             *no description available*
@@ -7996,7 +7910,7 @@
 
     .. py:method:: mitsuba.Object.set_id(self, id)
 
-        Set an identifier to the current instance (if applicable)
+        Set the identifier of the current instance (no-op if not supported)
 
         Parameter ``id`` (str):
             *no description available*
@@ -8024,7 +7938,81 @@
         Returns → None:
             *no description available*
 
-.. py:class:: mitsuba.ObjectPtr
+    .. py:method:: mitsuba.Object.variant_name()
+
+        Return the instance variant (empty if this is not a variant object)
+
+        Returns → str:
+            *no description available*
+
+.. py:class:: mitsuba.ObjectType
+
+    Available scene object types
+
+    This enumeration lists high-level interfaces that can be implemented
+    by Mitsuba scene objects. The scene loader uses these to ensure that a
+    loaded object matches the expected interface.
+
+    Note: This enum is forward-declared at the beginning of the file to
+    allow its usage in macros that appear before the full definition.
+
+    Valid values are as follows:
+
+    .. py:data:: Unknown
+
+        The default returned by Object subclasses
+
+    .. py:data:: Scene
+
+        The top-level scene object. No subclasses exist
+
+    .. py:data:: Sensor
+
+        Carries out radiance measurements, subclasses Sensor
+
+    .. py:data:: Film
+
+        Storage representation of the sensor
+
+    .. py:data:: Emitter
+
+        Emits radiance, subclasses Emitter
+
+    .. py:data:: Sampler
+
+        Generates sample positions and directions, subclasses Sampler
+
+    .. py:data:: Shape
+
+        Denotes an arbitrary shape (including meshes)
+
+    .. py:data:: Texture
+
+        A 2D texture data source
+
+    .. py:data:: Volume
+
+        A 3D volume data source
+
+    .. py:data:: Medium
+
+        A participating medium
+
+    .. py:data:: BSDF
+
+        A bidirectional reflectance distribution function
+
+    .. py:data:: Integrator
+
+        A rendering algorithm aka. Integrator
+
+    .. py:data:: PhaseFunction
+
+        A phase function characterizing scattering in volumes
+
+    .. py:data:: ReconstructionFilter
+
+        A filter used to reconstruct/resample images
 
 .. py:class:: mitsuba.OptixDenoiser
 
@@ -8101,7 +8089,7 @@
             With temporal denoising, this parameter is the optical flow
             between the previous frame and the current one. It should capture
             the 2D motion of each individual pixel. When this parameter is
-            unknown, it can been set to a zero-initialized TensorXf of the
+            unknown, it can be set to a zero-initialized TensorXf of the
             correct size and still produce convincing results. This parameter
             is optional unless the OptixDenoiser was built with temporal
             denoising support. (tensor shape: (width, height, 2))
@@ -8148,7 +8136,7 @@
             the ``noisy`` parameter which contains the optical flow between
             the previous frame and the current one. It should capture the 2D
             motion of each individual pixel. When this parameter is unknown,
-            it can been set to a zero-initialized TensorXf of the correct size
+            it can be set to a zero-initialized TensorXf of the correct size
             and still produce convincing results. This parameter is optional
             unless the OptixDenoiser was built with temporal denoising
             support.
@@ -8691,6 +8679,18 @@
 
     Base class: :py:obj:`mitsuba.Object`
 
+    Abstract phase function base-class.
+
+    This class provides an abstract interface to all Phase function
+    plugins in Mitsuba. It exposes functions for evaluating and sampling
+    the model.
+
+    .. py:method:: __init__(self, arg)
+
+        Parameter ``arg`` (:py:obj:`mitsuba.Properties`, /):
+            *no description available*
+
+
     .. py:method:: mitsuba.PhaseFunction.component_count(self, active=True)
 
         Number of components this phase function is comprised of.
@@ -8746,13 +8746,6 @@
             Mask to specify active lanes.
 
         Returns → int:
-            *no description available*
-
-    .. py:method:: mitsuba.PhaseFunction.id()
-
-        Return a string identifier
-
-        Returns → str:
             *no description available*
 
     .. py:property:: mitsuba.PhaseFunction.m_flags
@@ -8976,58 +8969,46 @@
 
 .. py:class:: mitsuba.PluginManager
 
-    The object factory is responsible for loading plugin modules and
-    instantiating object instances.
+    Plugin manager
 
-    Ordinarily, this class will be used by making repeated calls to the
-    create_object() methods. The generated instances are then assembled
-    into a final object graph, such as a scene. One such examples is the
-    SceneHandler class, which parses an XML scene file by essentially
-    translating the XML elements into calls to create_object().
+    The plugin manager's main feature is the create_object() function that
+    instantiates scene objects. To do its job, it loads external Mitsuba
+    plugins as needed.
 
-    .. py:method:: mitsuba.PluginManager.create_object(self, arg)
+    When used from Python, it is also possible to register external
+    plugins so that they can be instantiated analogously.
 
-        Instantiate a plugin, verify its type, and return the newly created
-        object instance.
+    .. py:method:: mitsuba.PluginManager.create_object(self, props)
 
-        Parameter ``props``:
+        Create a plugin object with the provided information
+
+        This function potentially loads an external plugin module (if not
+        already present), creates an instance, verifies its type, and finally
+        returns the newly created object instance.
+
+        Parameter ``props`` (:py:obj:`mitsuba.Properties`):
             A Properties instance containing all information required to find
             and construct the plugin.
 
-        Parameter ``class_type``:
-            Expected type of the instance. An exception will be thrown if it
-            turns out not to derive from this class.
+        Parameter ``variant``:
+            The variant (e.g. 'scalar_rgb') of the plugin to instantiate
 
-        Parameter ``arg`` (:py:obj:`mitsuba._Properties`, /):
-            *no description available*
+        Parameter ``type``:
+            The expected interface of the instantiated plugin. Mismatches here
+            will produce an error message. Pass `ObjectType::Unknown` to
+            disable this check.
 
         Returns → object:
             *no description available*
 
-    .. py:method:: mitsuba.PluginManager.get_plugin_class(self, name, variant)
+    .. py:method:: mitsuba.PluginManager.plugin_type(self, name)
 
-        Return the class corresponding to a plugin for a specific variant
+        Get the ObjectType of a plugin by name
 
         Parameter ``name`` (str):
             *no description available*
 
-        Parameter ``variant`` (str):
-            *no description available*
-
-        Returns → :py:obj:`mitsuba.Class`:
-            *no description available*
-
-    .. py:method:: mitsuba.PluginManager.get_plugin_type(self, plugin_name)
-
-        Parameter ``plugin_name`` (str):
-            *no description available*
-
-        Returns → str:
-            *no description available*
-
-    .. py:method:: mitsuba.PluginManager.loaded_plugins()
-
-        Returns → list[str]:
+        Returns → :py:obj:`mitsuba.ObjectType`:
             *no description available*
 
 .. py:class:: mitsuba.Point0d
@@ -9276,21 +9257,33 @@
 
 .. py:class:: mitsuba.Properties
 
-    Base class: :py:obj:`mitsuba._Properties`
 
-    Overloaded function.
+    .. py:method:: ``__init__()
 
-    1. ``__init__(self) -> None``
+        Construct an empty and unnamed properties object
 
-    Construct an empty property container
+        Returns → None``:
+            *no description available*
 
-    2. ``__init__(self, arg: str, /) -> None``
+    .. py:method:: ``__init__(self, arg)
 
-    Construct an empty property container with a specific plugin name
+        Construct an empty properties object with a specific plugin name
 
-    3. ``__init__(self, arg: :py:obj:`mitsuba.Properties`) -> None``
+        Parameter ``arg`` (str, /):
+            *no description available*
 
-    Copy constructor
+        Returns → None``:
+            *no description available*
+
+    .. py:method:: ``__init__(self, arg)
+
+        Copy constructor
+
+        Parameter ``arg`` (:py:obj:`mitsuba.Properties`):
+            *no description available*
+
+        Returns → None``:
+            *no description available*
 
     .. py:class:: mitsuba.Properties.Type
 
@@ -9300,7 +9293,7 @@
 
             Boolean value (true/false)
 
-        .. py:data:: Long
+        .. py:data:: Integer
 
             64-bit signed integer
 
@@ -9308,25 +9301,13 @@
 
             Floating point value
 
-        .. py:data:: Array3f
+        .. py:data:: Vector
 
             3D array
 
-        .. py:data:: Transform3f
+        .. py:data:: Transform
 
-            3x3 transform for homogeneous coordinates
-
-        .. py:data:: Transform4f
-
-            4x4 transform for homogeneous coordinates
-
-        .. py:data:: AnimatedTransform
-
-            An animated 4x4 transformation
-
-        .. py:data:: TensorHandle
-
-            A tensor of arbitrary shape
+            3x3 or 4x4 homogeneous coordinate transform
 
         .. py:data:: Color
 
@@ -9336,48 +9317,54 @@
 
             String
 
-        .. py:data:: NamedReference
+        .. py:data:: Reference
 
-            Named reference to another named object
+            Indirect dependence to another object (referenced by name)
 
         .. py:data:: Object
 
-            Arbitrary object
+            An arbitrary Mitsuba scene object
 
-        .. py:data:: Pointer
+        .. py:data:: Any
 
-            const void* pointer (for internal communication between plugins)
+            Generic type wrapper for arbitrary data exchange between plugins
 
-    .. py:method:: mitsuba.Properties.as_string(self, arg)
+    .. py:method:: mitsuba.Properties.as_string(self, key)
 
         Return one of the parameters (converting it to a string if necessary)
 
-        Parameter ``arg`` (str, /):
+        Parameter ``key`` (str):
             *no description available*
 
         Returns → str:
             *no description available*
 
-    .. py:method:: mitsuba.Properties.copy_attribute(self, arg0, arg1, arg2)
-
-        Copy a single attribute from another Properties object and potentially
-        rename it
-
-        Parameter ``arg0`` (:py:obj:`mitsuba._Properties`):
-            *no description available*
-
-        Parameter ``arg1`` (str):
-            *no description available*
-
-        Parameter ``arg2`` (str, /):
-            *no description available*
-
-        Returns → None:
-            *no description available*
-
     .. py:method:: mitsuba.Properties.get(self, key, def_value=None)
 
-        Return the value for the specified key it exists, otherwise return default value
+        Retrieve a scalar parameter by name
+
+        Look up the property ``name``. Raises an exception if the property
+        cannot be found, or when it has an incompatible type. Accessing the
+        parameter automatically marks it as queried (see was_queried).
+
+        The template parameter ``T`` may refer to:
+
+        - Strings (``std::string``)
+
+        - Arithmetic types (``bool``, ``float``, ``double``, ``uint32_t``,
+        ``int32_t``, ``uint64_t``, ``int64_t``, ``size_t``).
+
+        - Points/vectors (``ScalarPoint2f``, ``ScalarPoint3f``,
+        `ScalarVector2f``, or ``ScalarVector3f``).
+
+        - Tri-stimulus color values (``ScalarColor3f``).
+
+        - Affine transformations (``ScalarTransform3f``,
+        ``ScalarTransform4f``)
+
+        Both single/double precision versions of these are supported; the
+        function will convert them as needed. The function cannot be used to
+        obtain vectorized (e.g. JIT-compiled) arrays.
 
         Parameter ``key`` (str):
             *no description available*
@@ -9388,11 +9375,11 @@
         Returns → object:
             *no description available*
 
-    .. py:method:: mitsuba.Properties.has_property(self, arg)
+    .. py:method:: mitsuba.Properties.has_property(self, key)
 
-        Verify if a value with the specified name exists
+        Deprecated: use 'key in props' instead
 
-        Parameter ``arg`` (str, /):
+        Parameter ``key`` (str):
             *no description available*
 
         Returns → bool:
@@ -9403,7 +9390,23 @@
         Returns a unique identifier associated with this instance (or an empty
         string)
 
+        The ID is used to enable named references by other plugins
+
         Returns → str:
+            *no description available*
+
+    .. py:method:: mitsuba.Properties.items()
+
+        Return a list of (key, value) tuples
+
+        Returns → list:
+            *no description available*
+
+    .. py:method:: mitsuba.Properties.keys()
+
+        Return a list of property names
+
+        Returns → list[str]:
             *no description available*
 
     .. py:method:: mitsuba.Properties.mark_queried(self, arg)
@@ -9423,40 +9426,50 @@
         Existing properties will be overwritten with the values from ``props``
         if they have the same name.
 
-        Parameter ``arg`` (:py:obj:`mitsuba._Properties`, /):
+        Parameter ``arg`` (:py:obj:`mitsuba.Properties`, /):
             *no description available*
 
         Returns → None:
             *no description available*
 
-    .. py:method:: mitsuba.Properties.named_references()
+    .. py:method:: mitsuba.Properties.objects(self, mark_queried=True)
 
-        Returns → list[tuple[str, str]]:
+        Return all object properties
+
+        Parameter ``mark_queried`` (bool):
+            *no description available*
+
+        Returns → list[tuple[str, :py:obj:`mitsuba.Object`]]:
             *no description available*
 
     .. py:method:: mitsuba.Properties.plugin_name()
 
-        Get the associated plugin name
+        Get the plugin name
 
         Returns → str:
             *no description available*
 
     .. py:method:: mitsuba.Properties.property_names()
 
-        Return an array containing the names of all stored properties
+        Deprecated: use 'props.keys()' instead
 
         Returns → list[str]:
             *no description available*
 
-    .. py:method:: mitsuba.Properties.remove_property(self, arg)
+    .. py:method:: mitsuba.Properties.references()
 
-        Remove a property with the specified name
+        Returns → list[tuple[str, str]]:
+            *no description available*
 
-        Parameter ``arg`` (str, /):
+    .. py:method:: mitsuba.Properties.remove_property(self, key)
+
+        Deprecated: use 'del props[key]' instead
+
+        Parameter ``key`` (str):
             *no description available*
 
         Returns → bool:
-            ``True`` upon success
+            *no description available*
 
     .. py:method:: mitsuba.Properties.set_id(self, arg)
 
@@ -9470,7 +9483,7 @@
 
     .. py:method:: mitsuba.Properties.set_plugin_name(self, arg)
 
-        Set the associated plugin name
+        Set the plugin name
 
         Parameter ``arg`` (str, /):
             *no description available*
@@ -9478,23 +9491,11 @@
         Returns → None:
             *no description available*
 
-    .. py:method:: mitsuba.Properties.string(self, arg0, arg1)
-
-        Retrieve a string value (use default value if no entry exists)
-
-        Parameter ``arg0`` (str):
-            *no description available*
-
-        Parameter ``arg1`` (str, /):
-            *no description available*
-
-        Returns → object:
-            *no description available*
-
     .. py:method:: mitsuba.Properties.type(self, arg)
 
-        Returns the type of an existing property. If no property exists under
-        that name, an error is logged and type ``void`` is returned.
+        Returns the type of an existing property.
+
+        Raises an exception if the property does not exist.
 
         Parameter ``arg`` (str, /):
             *no description available*
@@ -9504,7 +9505,7 @@
 
     .. py:method:: mitsuba.Properties.unqueried()
 
-        Return the list of un-queried attributed
+        Return the list of unqueried attributed
 
         Returns → list[str]:
             *no description available*
@@ -9513,6 +9514,10 @@
 
         Check if a certain property was queried
 
+        Mitsuba assigns a queried bit with every parameter. Unqueried
+        parameters are detected to issue warnings, since this is usually
+        indicative of typos.
+
         Parameter ``arg`` (str, /):
             *no description available*
 
@@ -9520,6 +9525,8 @@
             *no description available*
 
 .. py:class:: mitsuba.Quaternion4f
+
+.. py:class:: mitsuba.Quaternion4f64
 
 .. py:class:: mitsuba.RadicalInverse
 
@@ -9563,7 +9570,7 @@
 
     .. py:method:: mitsuba.RadicalInverse.eval(self, base_index, index)
 
-        Calculate the radical inverse function
+        Calculate the value of the radical inverse function
 
         This function is used as a building block to construct Halton and
         Hammersley sequences. Roughly, it computes a b-ary representation of
@@ -10023,8 +10030,8 @@
         
         This constructor precomputes all information needed to efficiently
         perform the desired resampling operation. For that reason, it is most
-        efficient if it can be used over and over again (e.g. to resample the
-        equal-sized rows of a bitmap)
+        efficient if it can be used repeatedly (e.g. to resample the equal-
+        sized rows of a bitmap)
         
         Parameter ``source_res`` (int):
             Source resolution
@@ -10128,7 +10135,7 @@
     .. py:method:: ``__init__(self, arg0, arg1)
 
         Construct from a pair of 3D vectors [S_xx, S_yy, S_zz] and [S_xy,
-        S_xz, S_yz] that correspond to the entries of a symmetric positive
+        S_xz, S_yz] that correspond to the entries of a symmetric positive-
         definite 3x3 matrix.
 
         Parameter ``arg0`` (drjit.llvm.ad.Array3f):
@@ -10446,7 +10453,7 @@
         Returns → tuple[:py:obj:`mitsuba.Color3f`, drjit.llvm.ad.Bool, list[drjit.llvm.ad.Float]]:
             A pair containing a spectrum and a mask specifying whether a
             surface or medium interaction was sampled. False mask entries
-            indicate that the ray "escaped" the scene, in which case the the
+            indicate that the ray "escaped" the scene, in which case the
             returned spectrum contains the contribution of environment maps,
             if present. The mask can be used to estimate a suitable alpha
             channel of a rendered image.
@@ -11076,7 +11083,7 @@
 
     .. py:method:: mitsuba.ScalarBoundingSphere3f.expand(self, arg)
 
-        Expand the bounding sphere radius to contain another point.
+        Expand the bounding sphere radius to contain another point
 
         Parameter ``arg`` (:py:obj:`mitsuba.ScalarPoint3f`, /):
             *no description available*
@@ -11225,27 +11232,6 @@
 
         (self) -> drjit.scalar.Matrix3f64
 
-    .. py:method:: mitsuba.ScalarTransform3d.rotate(self, angle)
-
-        Create a rotation transformation in 2D. The angle is specified in
-        degrees
-
-        Parameter ``angle`` (float):
-            *no description available*
-
-        Returns → :py:obj:`mitsuba.ScalarTransform3d`:
-            *no description available*
-
-    .. py:method:: mitsuba.ScalarTransform3d.scale(self, v)
-
-        Create a scale transformation
-
-        Parameter ``v`` (:py:obj:`mitsuba.ScalarPoint2d`):
-            *no description available*
-
-        Returns → :py:obj:`mitsuba.ScalarTransform3d`:
-            *no description available*
-
     .. py:method:: mitsuba.ScalarTransform3d.transform_affine(self, p)
 
         Transform a 3D vector/point/normal/ray by a transformation that is
@@ -11255,16 +11241,6 @@
             *no description available*
 
         Returns → :py:obj:`mitsuba.ScalarPoint2d`:
-            *no description available*
-
-    .. py:method:: mitsuba.ScalarTransform3d.translate(self, v)
-
-        Create a translation transformation
-
-        Parameter ``v`` (:py:obj:`mitsuba.ScalarPoint2d`):
-            *no description available*
-
-        Returns → :py:obj:`mitsuba.ScalarTransform3d`:
             *no description available*
 
     .. py:method:: mitsuba.ScalarTransform3d.translation()
@@ -11345,27 +11321,6 @@
 
         (self) -> drjit.scalar.Matrix3f
 
-    .. py:method:: mitsuba.ScalarTransform3f.rotate(self, angle)
-
-        Create a rotation transformation in 2D. The angle is specified in
-        degrees
-
-        Parameter ``angle`` (float):
-            *no description available*
-
-        Returns → :py:obj:`mitsuba.ScalarTransform3f`:
-            *no description available*
-
-    .. py:method:: mitsuba.ScalarTransform3f.scale(self, v)
-
-        Create a scale transformation
-
-        Parameter ``v`` (:py:obj:`mitsuba.ScalarPoint2f`):
-            *no description available*
-
-        Returns → :py:obj:`mitsuba.ScalarTransform3f`:
-            *no description available*
-
     .. py:method:: mitsuba.ScalarTransform3f.transform_affine(self, p)
 
         Transform a 3D vector/point/normal/ray by a transformation that is
@@ -11375,16 +11330,6 @@
             *no description available*
 
         Returns → :py:obj:`mitsuba.ScalarPoint2f`:
-            *no description available*
-
-    .. py:method:: mitsuba.ScalarTransform3f.translate(self, v)
-
-        Create a translation transformation
-
-        Parameter ``v`` (:py:obj:`mitsuba.ScalarPoint2f`):
-            *no description available*
-
-        Returns → :py:obj:`mitsuba.ScalarTransform3f`:
             *no description available*
 
     .. py:method:: mitsuba.ScalarTransform3f.translation()
@@ -11447,17 +11392,6 @@
         Returns → :py:obj:`mitsuba.ScalarTransform3d`:
             *no description available*
 
-    .. py:method:: mitsuba.ScalarTransform4d.from_frame(self, frame)
-
-        Creates a transformation that converts from 'frame' to the standard
-        basis
-
-        Parameter ``frame`` (:py:obj:`mitsuba.Frame`):
-            *no description available*
-
-        Returns → :py:obj:`mitsuba.ScalarTransform4d`:
-            *no description available*
-
     .. py:method:: mitsuba.ScalarTransform4d.has_scale()
 
         Test for a scale component in each transform matrix by checking
@@ -11479,97 +11413,9 @@
 
         (self) -> drjit.scalar.Matrix4f64
 
-    .. py:method:: mitsuba.ScalarTransform4d.look_at(self, origin, target, up)
-
-        Create a look-at camera transformation
-
-        Parameter ``origin`` (:py:obj:`mitsuba.ScalarPoint3d`):
-            Camera position
-
-        Parameter ``target`` (:py:obj:`mitsuba.ScalarPoint3d`):
-            Target vector
-
-        Parameter ``up`` (:py:obj:`mitsuba.ScalarPoint3d`):
-            Up vector
-
-        Returns → :py:obj:`mitsuba.ScalarTransform4d`:
-            *no description available*
-
     .. py:property:: mitsuba.ScalarTransform4d.matrix
 
         (self) -> drjit.scalar.Matrix4f64
-
-    .. py:method:: mitsuba.ScalarTransform4d.orthographic(self, near, far)
-
-        Create an orthographic transformation, which maps Z to [0,1] and
-        leaves the X and Y coordinates untouched.
-
-        Parameter ``near`` (float):
-            Near clipping plane
-
-        Parameter ``far`` (float):
-            Far clipping plane
-
-        Returns → :py:obj:`mitsuba.ScalarTransform4d`:
-            *no description available*
-
-    .. py:method:: mitsuba.ScalarTransform4d.perspective(self, fov, near, far)
-
-        Create a perspective transformation. (Maps [near, far] to [0, 1])
-
-        Projects vectors in camera space onto a plane at z=1:
-
-        x_proj = x / z y_proj = y / z z_proj = (far * (z - near)) / (z * (far-
-        near))
-
-        Camera-space depths are not mapped linearly!
-
-        Parameter ``fov`` (float):
-            Field of view in degrees
-
-        Parameter ``near`` (float):
-            Near clipping plane
-
-        Parameter ``far`` (float):
-            Far clipping plane
-
-        Returns → :py:obj:`mitsuba.ScalarTransform4d`:
-            *no description available*
-
-    .. py:method:: mitsuba.ScalarTransform4d.rotate(self, axis, angle)
-
-        Create a rotation transformation around an arbitrary axis in 3D. The
-        angle is specified in degrees
-
-        Parameter ``axis`` (:py:obj:`mitsuba.ScalarPoint3d`):
-            *no description available*
-
-        Parameter ``angle`` (float):
-            *no description available*
-
-        Returns → :py:obj:`mitsuba.ScalarTransform4d`:
-            *no description available*
-
-    .. py:method:: mitsuba.ScalarTransform4d.scale(self, v)
-
-        Create a scale transformation
-
-        Parameter ``v`` (:py:obj:`mitsuba.ScalarPoint3d`):
-            *no description available*
-
-        Returns → :py:obj:`mitsuba.ScalarTransform4d`:
-            *no description available*
-
-    .. py:method:: mitsuba.ScalarTransform4d.to_frame(self, frame)
-
-        Creates a transformation that converts from the standard basis to
-        'frame'
-
-        Parameter ``frame`` (:py:obj:`mitsuba.Frame`):
-            *no description available*
-
-        Returns → :py:obj:`mitsuba.ScalarTransform4d`:
-            *no description available*
 
     .. py:method:: mitsuba.ScalarTransform4d.transform_affine(self, p)
 
@@ -11580,16 +11426,6 @@
             *no description available*
 
         Returns → :py:obj:`mitsuba.ScalarPoint3d`:
-            *no description available*
-
-    .. py:method:: mitsuba.ScalarTransform4d.translate(self, v)
-
-        Create a translation transformation
-
-        Parameter ``v`` (:py:obj:`mitsuba.ScalarPoint3d`):
-            *no description available*
-
-        Returns → :py:obj:`mitsuba.ScalarTransform4d`:
             *no description available*
 
     .. py:method:: mitsuba.ScalarTransform4d.translation()
@@ -11652,17 +11488,6 @@
         Returns → :py:obj:`mitsuba.ScalarTransform3f`:
             *no description available*
 
-    .. py:method:: mitsuba.ScalarTransform4f.from_frame(self, frame)
-
-        Creates a transformation that converts from 'frame' to the standard
-        basis
-
-        Parameter ``frame`` (:py:obj:`mitsuba.Frame`):
-            *no description available*
-
-        Returns → :py:obj:`mitsuba.ScalarTransform4f`:
-            *no description available*
-
     .. py:method:: mitsuba.ScalarTransform4f.has_scale()
 
         Test for a scale component in each transform matrix by checking
@@ -11684,97 +11509,9 @@
 
         (self) -> drjit.scalar.Matrix4f
 
-    .. py:method:: mitsuba.ScalarTransform4f.look_at(self, origin, target, up)
-
-        Create a look-at camera transformation
-
-        Parameter ``origin`` (:py:obj:`mitsuba.ScalarPoint3f`):
-            Camera position
-
-        Parameter ``target`` (:py:obj:`mitsuba.ScalarPoint3f`):
-            Target vector
-
-        Parameter ``up`` (:py:obj:`mitsuba.ScalarPoint3f`):
-            Up vector
-
-        Returns → :py:obj:`mitsuba.ScalarTransform4f`:
-            *no description available*
-
     .. py:property:: mitsuba.ScalarTransform4f.matrix
 
         (self) -> drjit.scalar.Matrix4f
-
-    .. py:method:: mitsuba.ScalarTransform4f.orthographic(self, near, far)
-
-        Create an orthographic transformation, which maps Z to [0,1] and
-        leaves the X and Y coordinates untouched.
-
-        Parameter ``near`` (float):
-            Near clipping plane
-
-        Parameter ``far`` (float):
-            Far clipping plane
-
-        Returns → :py:obj:`mitsuba.ScalarTransform4f`:
-            *no description available*
-
-    .. py:method:: mitsuba.ScalarTransform4f.perspective(self, fov, near, far)
-
-        Create a perspective transformation. (Maps [near, far] to [0, 1])
-
-        Projects vectors in camera space onto a plane at z=1:
-
-        x_proj = x / z y_proj = y / z z_proj = (far * (z - near)) / (z * (far-
-        near))
-
-        Camera-space depths are not mapped linearly!
-
-        Parameter ``fov`` (float):
-            Field of view in degrees
-
-        Parameter ``near`` (float):
-            Near clipping plane
-
-        Parameter ``far`` (float):
-            Far clipping plane
-
-        Returns → :py:obj:`mitsuba.ScalarTransform4f`:
-            *no description available*
-
-    .. py:method:: mitsuba.ScalarTransform4f.rotate(self, axis, angle)
-
-        Create a rotation transformation around an arbitrary axis in 3D. The
-        angle is specified in degrees
-
-        Parameter ``axis`` (:py:obj:`mitsuba.ScalarPoint3f`):
-            *no description available*
-
-        Parameter ``angle`` (float):
-            *no description available*
-
-        Returns → :py:obj:`mitsuba.ScalarTransform4f`:
-            *no description available*
-
-    .. py:method:: mitsuba.ScalarTransform4f.scale(self, v)
-
-        Create a scale transformation
-
-        Parameter ``v`` (:py:obj:`mitsuba.ScalarPoint3f`):
-            *no description available*
-
-        Returns → :py:obj:`mitsuba.ScalarTransform4f`:
-            *no description available*
-
-    .. py:method:: mitsuba.ScalarTransform4f.to_frame(self, frame)
-
-        Creates a transformation that converts from the standard basis to
-        'frame'
-
-        Parameter ``frame`` (:py:obj:`mitsuba.Frame`):
-            *no description available*
-
-        Returns → :py:obj:`mitsuba.ScalarTransform4f`:
-            *no description available*
 
     .. py:method:: mitsuba.ScalarTransform4f.transform_affine(self, p)
 
@@ -11785,16 +11522,6 @@
             *no description available*
 
         Returns → :py:obj:`mitsuba.ScalarPoint3f`:
-            *no description available*
-
-    .. py:method:: mitsuba.ScalarTransform4f.translate(self, v)
-
-        Create a translation transformation
-
-        Parameter ``v`` (:py:obj:`mitsuba.ScalarPoint3f`):
-            *no description available*
-
-        Returns → :py:obj:`mitsuba.ScalarTransform4f`:
             *no description available*
 
     .. py:method:: mitsuba.ScalarTransform4f.translation()
@@ -11871,7 +11598,7 @@
 
     .. py:method:: __init__(self, arg)
 
-        Parameter ``arg`` (:py:obj:`mitsuba._Properties`, /):
+        Parameter ``arg`` (:py:obj:`mitsuba.Properties`, /):
             *no description available*
 
 
@@ -12013,7 +11740,7 @@
         This method is a convenience wrapper of the generalized version of
         ``ray_intersect``() below. It assumes that incoherent rays are being
         traced, that the user desires access to all fields of the
-        SurfaceInteraction, and that no thread reodering is requested. In
+        SurfaceInteraction, and that no thread reordering is requested. In
         other words, it simply invokes the general ``ray_intersect``()
         overload with ``coherent=false``, ``ray_flags`` equal to
         RayFlags::All, and ``reorder=false``.
@@ -12147,7 +11874,7 @@
         used by the combination of ``llvm_*`` variants and the Embree ray
         tracing backend.
 
-        The ``reoder`` flag is a trigger for the Shader Execution Reordering
+        The ``reorder`` flag is a trigger for the Shader Execution Reordering
         (SER) feature on NVIDIA GPUs. It can improve performance in highly
         divergent workloads by shuffling threads into coherent warps. This
         shuffling operation uses the result of the intersection (the shape ID)
@@ -12182,7 +11909,7 @@
 
         Parameter ``reorder_hint_bits``:
             Number of bits from the ``reorder_hint`` to use (starting from the
-            least signifcant bit). It is recommended to use as few as
+            least significant bit). It is recommended to use as few as
             possible. At most, 16 bits can be used. This flag has no effect in
             scalar or LLVM variants, or if the ``reorder`` parameter is
             ``False``.
@@ -12292,7 +12019,7 @@
         used by the combination of ``llvm_*`` variants and the Embree ray
         intersector.
 
-        The ``reoder`` flag is a trigger for the Shader Execution Reordering
+        The ``reorder`` flag is a trigger for the Shader Execution Reordering
         (SER) feature on NVIDIA GPUs. It can improve performance in highly
         divergent workloads by shuffling threads into coherent warps. This
         shuffling operation uses the result of the intersection (the shape ID)
@@ -12323,7 +12050,7 @@
 
         Parameter ``reorder_hint_bits``:
             Number of bits from the ``reorder_hint`` to use (starting from the
-            least signifcant bit). It is recommended to use as few as
+            least significant bit). It is recommended to use as few as
             possible. At most, 16 bits can be used. This flag has no effect in
             scalar or LLVM variants, or if the ``reorder`` parameter is
             ``False``.
@@ -12458,8 +12185,6 @@
         provides further detail about the sampled emitter position (e.g. its
         surface normal, solid angle density, whether Dirac delta distributions
         were involved, etc.)
-
-        *
 
         * ``spec`` is a Monte Carlo sampling weight specifying the ratio of
         the radiance incident from the emitter and the sample probability per
@@ -12668,17 +12393,6 @@
         Returns → None:
             *no description available*
 
-.. py:class:: mitsuba.ScopedSetThreadEnvironment
-
-    RAII-style class to temporarily switch to another thread's logger/file
-    resolver
-
-    .. py:method:: __init__(self, arg)
-
-        Parameter ``arg`` (:py:obj:`mitsuba.ThreadEnvironment`, /):
-            *no description available*
-
-
 .. py:class:: mitsuba.Sensor
 
     Base class: :py:obj:`mitsuba.Endpoint`
@@ -12750,7 +12464,7 @@
 
     .. py:method:: mitsuba.Sensor.get_shape()
 
-        Return the shape, to which the emitter is currently attached
+        Return the shape to which the emitter is currently attached
 
         Returns → :py:obj:`mitsuba.Shape`:
             *no description available*
@@ -12919,7 +12633,7 @@
         wavelength, surface position, and direction. This function takes a
         given time value and five uniformly distributed samples on the
         interval [0, 1] and warps them so that the returned ray the profile.
-        Any discrepancies between ideal and actual sampled profile are
+        Any discrepancies between ideal and actual sampled profiles are
         absorbed into a spectral importance weight that is returned along with
         the ray.
 
@@ -13077,7 +12791,7 @@
 
     .. py:method:: mitsuba.SensorPtr.get_shape()
 
-        Return the shape, to which the emitter is currently attached
+        Return the shape to which the emitter is currently attached
 
         Returns → :py:obj:`mitsuba.ShapePtr`:
             *no description available*
@@ -13226,7 +12940,7 @@
         wavelength, surface position, and direction. This function takes a
         given time value and five uniformly distributed samples on the
         interval [0, 1] and warps them so that the returned ray the profile.
-        Any discrepancies between ideal and actual sampled profile are
+        Any discrepancies between ideal and actual sampled profiles are
         absorbed into a spectral importance weight that is returned along with
         the ray.
 
@@ -13502,7 +13216,7 @@
             Mask to specify active lanes.
 
         Returns → :py:obj:`mitsuba.Color3f`:
-            An trichromatic intensity or reflectance value
+            A trichromatic intensity or reflectance value
 
     .. py:method:: mitsuba.Shape.eval_attribute_x(self, name, si, active=True)
 
@@ -13519,7 +13233,7 @@
             Mask to specify active lanes.
 
         Returns → drjit.llvm.ad.ArrayXf:
-            An dynamic array of attribute values
+            A dynamic array of attribute values
 
     .. py:method:: mitsuba.Shape.eval_parameterization(self, uv, ray_flags=14, active=True)
 
@@ -13561,11 +13275,11 @@
         Returns → drjit.llvm.ad.Bool:
             *no description available*
 
-    .. py:method:: mitsuba.Shape.id()
+    .. py:method:: mitsuba.Shape.has_flipped_normals()
 
-        Return a string identifier
+        Does this shape have flipped normals?
 
-        Returns → str:
+        Returns → bool:
             *no description available*
 
     .. py:method:: mitsuba.Shape.interior_medium()
@@ -13884,8 +13598,8 @@
 
     .. py:method:: mitsuba.Shape.sample_precomputed_silhouette(self, viewpoint, sample1, sample2, active=True)
 
-        Samples a boundary segement on the shape's silhouette using
-        precomputed information computed in precompute_silhouette.
+        Samples a boundary segment on the shape's silhouette using precomputed
+        information computed in precompute_silhouette.
 
         This method is meant to be used for silhouettes that are shared
         between all threads, as is the case for primarily visible derivatives.
@@ -14134,7 +13848,7 @@
             Mask to specify active lanes.
 
         Returns → :py:obj:`mitsuba.Color3f`:
-            An trichromatic intensity or reflectance value
+            A trichromatic intensity or reflectance value
 
     .. py:method:: mitsuba.ShapePtr.eval_attribute_x(self, name, si, active=True)
 
@@ -14151,7 +13865,7 @@
             Mask to specify active lanes.
 
         Returns → drjit.llvm.ad.ArrayXf:
-            An dynamic array of attribute values
+            A dynamic array of attribute values
 
     .. py:method:: mitsuba.ShapePtr.eval_parameterization(self, uv, ray_flags=14, active=True)
 
@@ -14189,6 +13903,13 @@
 
         Parameter ``active`` (drjit.llvm.ad.Bool):
             Mask to specify active lanes.
+
+        Returns → drjit.llvm.ad.Bool:
+            *no description available*
+
+    .. py:method:: mitsuba.ShapePtr.has_flipped_normals()
+
+        Does this shape have flipped normals?
 
         Returns → drjit.llvm.ad.Bool:
             *no description available*
@@ -14454,8 +14175,8 @@
 
     .. py:method:: mitsuba.ShapePtr.sample_precomputed_silhouette(self, viewpoint, sample1, sample2, active=True)
 
-        Samples a boundary segement on the shape's silhouette using
-        precomputed information computed in precompute_silhouette.
+        Samples a boundary segment on the shape's silhouette using precomputed
+        information computed in precompute_silhouette.
 
         This method is meant to be used for silhouettes that are shared
         between all threads, as is the case for primarily visible derivatives.
@@ -14641,7 +14362,7 @@
 
     .. py:method:: mitsuba.SilhouetteSample3f.is_valid()
 
-        Is the current boundary segment valid=
+        Is the current boundary segment valid?
 
         Returns → drjit.llvm.ad.Bool:
             *no description available*
@@ -14684,8 +14405,8 @@
 
         Spawn a ray on the silhouette point in the direction of d
 
-        The ray origin is offset in the direction of the segment (d) aswell as
-        in the in the direction of the silhouette normal (n). Without this
+        The ray origin is offset in the direction of the segment (d) as well
+        as in the direction of the silhouette normal (n). Without this
         offsetting, during a ray intersection, the ray could potentially find
         an intersection point at its origin due to numerical instabilities in
         the intersection routines.
@@ -15894,6 +15615,8 @@
 
 .. py:class:: mitsuba.TensorXf
 
+.. py:class:: mitsuba.TensorXf64
+
 .. py:class:: mitsuba.TensorXi
 
 .. py:class:: mitsuba.TensorXi64
@@ -16432,6 +16155,307 @@
         Returns → drjit.WrapMode:
             *no description available*
 
+.. py:class:: mitsuba.Texture1f64
+
+
+    .. py:method:: ``__init__(self, shape, channels, use_accel=True, filter_mode=FilterMode.Linear, wrap_mode=WrapMode.Clamp)
+
+        Create a new texture with the specified size and channel count
+
+        On CUDA, this is a slow operation that synchronizes the GPU pipeline, so
+        texture objects should be reused/updated via :py:func:`set_value()` and
+        :py:func:`set_tensor()` as much as possible.
+
+        When ``use_accel`` is set to ``False`` on CUDA mode, the texture will not
+        use hardware acceleration (allocation and evaluation). In other modes
+        this argument has no effect.
+
+        The ``filter_mode`` parameter defines the interpolation method to be used
+        in all evaluation routines. By default, the texture is linearly
+        interpolated. Besides nearest/linear filtering, the implementation also
+        provides a clamped cubic B-spline interpolation scheme in case a
+        higher-order interpolation is needed. In CUDA mode, this is done using a
+        series of linear lookups to optimally use the hardware (hence, linear
+        filtering must be enabled to use this feature).
+
+        When evaluating the texture outside of its boundaries, the ``wrap_mode``
+        defines the wrapping method. The default behavior is ``drjit.WrapMode.Clamp``,
+        which indefinitely extends the colors on the boundary along each dimension.
+
+        Parameter ``shape`` (collections.abc.Sequence[int]):
+            *no description available*
+
+        Parameter ``channels`` (int):
+            *no description available*
+
+        Parameter ``use_accel`` (bool):
+            *no description available*
+
+        Parameter ``filter_mode`` (drjit.FilterMode):
+            *no description available*
+
+        Parameter ``wrap_mode`` (drjit.WrapMode):
+            *no description available*
+
+        Returns → None``:
+            *no description available*
+
+    .. py:method:: ``__init__(self, tensor, use_accel=True, migrate=True, filter_mode=FilterMode.Linear, wrap_mode=WrapMode.Clamp)
+
+        Construct a new texture from a given tensor.
+
+        This constructor allocates texture memory with the shape information
+        deduced from ``tensor``. It subsequently invokes :py:func:`set_tensor(tensor)`
+        to fill the texture memory with the provided tensor.
+
+        When both ``migrate`` and ``use_accel`` are set to ``True`` in CUDA mode, the texture
+        exclusively stores a copy of the input data as a CUDA texture to avoid
+        redundant storage. Note that the texture is still differentiable even when migrated.
+
+        Parameter ``tensor`` (drjit.llvm.ad.TensorXf64):
+            *no description available*
+
+        Parameter ``use_accel`` (bool):
+            *no description available*
+
+        Parameter ``migrate`` (bool):
+            *no description available*
+
+        Parameter ``filter_mode`` (drjit.FilterMode):
+            *no description available*
+
+        Parameter ``wrap_mode`` (drjit.WrapMode):
+            *no description available*
+
+        Returns → None``:
+            *no description available*
+
+    .. py:method:: mitsuba.Texture1f64.eval(self, pos, active=Bool(True))
+
+        Evaluate the linear interpolant represented by this texture.
+
+        Parameter ``pos`` (drjit.llvm.ad.Array1f):
+            *no description available*
+
+        Parameter ``active`` (drjit.llvm.ad.Bool | None):
+            Mask to specify active lanes.
+
+        Returns → list[drjit.llvm.ad.Float]:
+            *no description available*
+
+    .. py:method:: mitsuba.Texture1f64.eval_cubic(self, pos, active=Bool(True), force_nonaccel=False)
+
+        Evaluate a clamped cubic B-Spline interpolant represented by this
+        texture
+
+        Instead of interpolating the texture via B-Spline basis functions, the
+        implementation transforms this calculation into an equivalent weighted
+        sum of several linear interpolant evaluations. In CUDA mode, this can
+        then be accelerated by hardware texture units, which runs faster than
+        a naive implementation. More information can be found in:
+
+            GPU Gems 2, Chapter 20, "Fast Third-Order Texture Filtering"
+            by Christian Sigg.
+
+        When the underlying grid data and the query position are differentiable,
+        this transformation cannot be used as it is not linear with respect to position
+        (thus the default AD graph gives incorrect results). The implementation
+        calls :py:func:`eval_cubic_helper()` function to replace the AD graph with a
+        direct evaluation of the B-Spline basis functions in that case.
+
+        Parameter ``pos`` (drjit.llvm.ad.Array1f):
+            *no description available*
+
+        Parameter ``active`` (drjit.llvm.ad.Bool | None):
+            Mask to specify active lanes.
+
+        Parameter ``force_nonaccel`` (bool):
+            *no description available*
+
+        Returns → list[drjit.llvm.ad.Float]:
+            *no description available*
+
+    .. py:method:: mitsuba.Texture1f64.eval_cubic_grad(self, pos, active=Bool(True))
+
+        Evaluate the positional gradient of a cubic B-Spline
+
+        This implementation computes the result directly from explicit
+        differentiated basis functions. It has no autodiff support.
+
+        The resulting gradient and hessian have been multiplied by the spatial extents
+        to count for the transformation from the unit size volume to the size of its
+        shape.
+
+        Parameter ``pos`` (drjit.llvm.ad.Array1f):
+            *no description available*
+
+        Parameter ``active`` (drjit.llvm.ad.Bool | None):
+            Mask to specify active lanes.
+
+        Returns → tuple:
+            *no description available*
+
+    .. py:method:: mitsuba.Texture1f64.eval_cubic_helper(self, pos, active=Bool(True))
+
+        Helper function to evaluate a clamped cubic B-Spline interpolant
+
+        This is an implementation detail and should only be called by the
+        :py:func:`eval_cubic()` function to construct an AD graph. When only the cubic
+        evaluation result is desired, the :py:func:`eval_cubic()` function is faster
+        than this simple implementation
+
+        Parameter ``pos`` (drjit.llvm.ad.Array1f):
+            *no description available*
+
+        Parameter ``active`` (drjit.llvm.ad.Bool | None):
+            Mask to specify active lanes.
+
+        Returns → list[drjit.llvm.ad.Float]:
+            *no description available*
+
+    .. py:method:: mitsuba.Texture1f64.eval_cubic_hessian(self, pos, active=Bool(True))
+
+        Evaluate the positional gradient and hessian matrix of a cubic B-Spline
+
+        This implementation computes the result directly from explicit
+        differentiated basis functions. It has no autodiff support.
+
+        The resulting gradient and hessian have been multiplied by the spatial extents
+        to count for the transformation from the unit size volume to the size of its
+        shape.
+
+        Parameter ``pos`` (drjit.llvm.ad.Array1f):
+            *no description available*
+
+        Parameter ``active`` (drjit.llvm.ad.Bool | None):
+            Mask to specify active lanes.
+
+        Returns → tuple:
+            *no description available*
+
+    .. py:method:: mitsuba.Texture1f64.eval_fetch(self, pos, active=Bool(True))
+
+        Fetch the texels that would be referenced in a texture lookup with
+        linear interpolation without actually performing this interpolation.
+
+        Parameter ``pos`` (drjit.llvm.ad.Array1f):
+            *no description available*
+
+        Parameter ``active`` (drjit.llvm.ad.Bool | None):
+            Mask to specify active lanes.
+
+        Returns → list[list[drjit.llvm.ad.Float]]:
+            *no description available*
+
+    .. py:method:: mitsuba.Texture1f64.filter_mode()
+
+        Return the filter mode
+
+        Returns → drjit.FilterMode:
+            *no description available*
+
+    .. py:method:: mitsuba.Texture1f64.migrated()
+
+        Return whether textures with :py:func:`use_accel()` set to ``True`` only store
+        the data as a hardware-accelerated CUDA texture.
+
+        If ``False`` then a copy of the array data will additionally be retained .
+
+        Returns → bool:
+            *no description available*
+
+    .. py:method:: mitsuba.Texture1f64.set_tensor(self, tensor, migrate=False)
+
+        Override the texture contents with the provided tensor.
+
+        This method updates the values of all texels. Changing the texture
+        resolution or its number of channels is also supported. However, on CUDA,
+        such operations have a significantly larger overhead (the GPU pipeline
+        needs to be synchronized for new texture objects to be created).
+
+        In CUDA mode, when both the argument ``migrate`` and :py:func:`use_accel()` are ``True``,
+        the texture exclusively stores a copy of the input data as a CUDA texture to avoid
+        redundant storage.Note that the texture is still differentiable even when migrated.
+
+        Parameter ``tensor`` (drjit.llvm.ad.TensorXf64):
+            *no description available*
+
+        Parameter ``migrate`` (bool):
+            *no description available*
+
+        Returns → None:
+            *no description available*
+
+    .. py:method:: mitsuba.Texture1f64.set_value(self, value, migrate=False)
+
+        Override the texture contents with the provided linearized 1D array.
+
+        In CUDA mode, when both the argument ``migrate`` and :py:func:`use_accel()` are ``True``,
+        the texture exclusively stores a copy of the input data as a CUDA texture to avoid
+        redundant storage.Note that the texture is still differentiable even when migrated.
+
+        Parameter ``value`` (drjit.llvm.ad.Float64):
+            *no description available*
+
+        Parameter ``migrate`` (bool):
+            *no description available*
+
+        Returns → None:
+            *no description available*
+
+    .. py:property:: mitsuba.Texture1f64.shape
+
+        Return the texture shape
+
+    .. py:method:: mitsuba.Texture1f64.tensor()
+
+        Return the texture data as a tensor object
+
+        Returns → drjit.llvm.ad.TensorXf64:
+            *no description available*
+
+    .. py:method:: mitsuba.Texture1f64.update_inplace(self, migrate=False)
+
+        Update the texture after applying an indirect update to its tensor
+        representation (obtained with py:func:`tensor()`).
+
+        A tensor representation of this texture object can be retrived with
+        py:func:`tensor()`. That representation can be modified, but in order to apply
+        it succesfuly to the texture, this method must also be called. In short,
+        this method will use the tensor representation to update the texture's
+        internal state.
+
+        In CUDA mode, when both the argument ``migrate`` and :py:func:`use_accel()` are ``True``,
+        the texture exclusively stores a copy of the input data as a CUDA texture to avoid
+        redundant storage.)
+
+        Parameter ``migrate`` (bool):
+            *no description available*
+
+        Returns → None:
+            *no description available*
+
+    .. py:method:: mitsuba.Texture1f64.use_accel()
+
+        Return whether texture uses the GPU for storage and evaluation
+
+        Returns → bool:
+            *no description available*
+
+    .. py:method:: mitsuba.Texture1f64.value()
+
+        Return the texture data as an array object
+
+        Returns → drjit.llvm.ad.Float64:
+            *no description available*
+
+    .. py:method:: mitsuba.Texture1f64.wrap_mode()
+
+        Return the wrap mode
+
+        Returns → drjit.WrapMode:
+            *no description available*
+
 .. py:class:: mitsuba.Texture2f
 
 
@@ -16727,6 +16751,307 @@
             *no description available*
 
     .. py:method:: mitsuba.Texture2f.wrap_mode()
+
+        Return the wrap mode
+
+        Returns → drjit.WrapMode:
+            *no description available*
+
+.. py:class:: mitsuba.Texture2f64
+
+
+    .. py:method:: ``__init__(self, shape, channels, use_accel=True, filter_mode=FilterMode.Linear, wrap_mode=WrapMode.Clamp)
+
+        Create a new texture with the specified size and channel count
+
+        On CUDA, this is a slow operation that synchronizes the GPU pipeline, so
+        texture objects should be reused/updated via :py:func:`set_value()` and
+        :py:func:`set_tensor()` as much as possible.
+
+        When ``use_accel`` is set to ``False`` on CUDA mode, the texture will not
+        use hardware acceleration (allocation and evaluation). In other modes
+        this argument has no effect.
+
+        The ``filter_mode`` parameter defines the interpolation method to be used
+        in all evaluation routines. By default, the texture is linearly
+        interpolated. Besides nearest/linear filtering, the implementation also
+        provides a clamped cubic B-spline interpolation scheme in case a
+        higher-order interpolation is needed. In CUDA mode, this is done using a
+        series of linear lookups to optimally use the hardware (hence, linear
+        filtering must be enabled to use this feature).
+
+        When evaluating the texture outside of its boundaries, the ``wrap_mode``
+        defines the wrapping method. The default behavior is ``drjit.WrapMode.Clamp``,
+        which indefinitely extends the colors on the boundary along each dimension.
+
+        Parameter ``shape`` (collections.abc.Sequence[int]):
+            *no description available*
+
+        Parameter ``channels`` (int):
+            *no description available*
+
+        Parameter ``use_accel`` (bool):
+            *no description available*
+
+        Parameter ``filter_mode`` (drjit.FilterMode):
+            *no description available*
+
+        Parameter ``wrap_mode`` (drjit.WrapMode):
+            *no description available*
+
+        Returns → None``:
+            *no description available*
+
+    .. py:method:: ``__init__(self, tensor, use_accel=True, migrate=True, filter_mode=FilterMode.Linear, wrap_mode=WrapMode.Clamp)
+
+        Construct a new texture from a given tensor.
+
+        This constructor allocates texture memory with the shape information
+        deduced from ``tensor``. It subsequently invokes :py:func:`set_tensor(tensor)`
+        to fill the texture memory with the provided tensor.
+
+        When both ``migrate`` and ``use_accel`` are set to ``True`` in CUDA mode, the texture
+        exclusively stores a copy of the input data as a CUDA texture to avoid
+        redundant storage. Note that the texture is still differentiable even when migrated.
+
+        Parameter ``tensor`` (drjit.llvm.ad.TensorXf64):
+            *no description available*
+
+        Parameter ``use_accel`` (bool):
+            *no description available*
+
+        Parameter ``migrate`` (bool):
+            *no description available*
+
+        Parameter ``filter_mode`` (drjit.FilterMode):
+            *no description available*
+
+        Parameter ``wrap_mode`` (drjit.WrapMode):
+            *no description available*
+
+        Returns → None``:
+            *no description available*
+
+    .. py:method:: mitsuba.Texture2f64.eval(self, pos, active=Bool(True))
+
+        Evaluate the linear interpolant represented by this texture.
+
+        Parameter ``pos`` (drjit.llvm.ad.Array2f):
+            *no description available*
+
+        Parameter ``active`` (drjit.llvm.ad.Bool | None):
+            Mask to specify active lanes.
+
+        Returns → list[drjit.llvm.ad.Float]:
+            *no description available*
+
+    .. py:method:: mitsuba.Texture2f64.eval_cubic(self, pos, active=Bool(True), force_nonaccel=False)
+
+        Evaluate a clamped cubic B-Spline interpolant represented by this
+        texture
+
+        Instead of interpolating the texture via B-Spline basis functions, the
+        implementation transforms this calculation into an equivalent weighted
+        sum of several linear interpolant evaluations. In CUDA mode, this can
+        then be accelerated by hardware texture units, which runs faster than
+        a naive implementation. More information can be found in:
+
+            GPU Gems 2, Chapter 20, "Fast Third-Order Texture Filtering"
+            by Christian Sigg.
+
+        When the underlying grid data and the query position are differentiable,
+        this transformation cannot be used as it is not linear with respect to position
+        (thus the default AD graph gives incorrect results). The implementation
+        calls :py:func:`eval_cubic_helper()` function to replace the AD graph with a
+        direct evaluation of the B-Spline basis functions in that case.
+
+        Parameter ``pos`` (drjit.llvm.ad.Array2f):
+            *no description available*
+
+        Parameter ``active`` (drjit.llvm.ad.Bool | None):
+            Mask to specify active lanes.
+
+        Parameter ``force_nonaccel`` (bool):
+            *no description available*
+
+        Returns → list[drjit.llvm.ad.Float]:
+            *no description available*
+
+    .. py:method:: mitsuba.Texture2f64.eval_cubic_grad(self, pos, active=Bool(True))
+
+        Evaluate the positional gradient of a cubic B-Spline
+
+        This implementation computes the result directly from explicit
+        differentiated basis functions. It has no autodiff support.
+
+        The resulting gradient and hessian have been multiplied by the spatial extents
+        to count for the transformation from the unit size volume to the size of its
+        shape.
+
+        Parameter ``pos`` (drjit.llvm.ad.Array2f):
+            *no description available*
+
+        Parameter ``active`` (drjit.llvm.ad.Bool | None):
+            Mask to specify active lanes.
+
+        Returns → tuple:
+            *no description available*
+
+    .. py:method:: mitsuba.Texture2f64.eval_cubic_helper(self, pos, active=Bool(True))
+
+        Helper function to evaluate a clamped cubic B-Spline interpolant
+
+        This is an implementation detail and should only be called by the
+        :py:func:`eval_cubic()` function to construct an AD graph. When only the cubic
+        evaluation result is desired, the :py:func:`eval_cubic()` function is faster
+        than this simple implementation
+
+        Parameter ``pos`` (drjit.llvm.ad.Array2f):
+            *no description available*
+
+        Parameter ``active`` (drjit.llvm.ad.Bool | None):
+            Mask to specify active lanes.
+
+        Returns → list[drjit.llvm.ad.Float]:
+            *no description available*
+
+    .. py:method:: mitsuba.Texture2f64.eval_cubic_hessian(self, pos, active=Bool(True))
+
+        Evaluate the positional gradient and hessian matrix of a cubic B-Spline
+
+        This implementation computes the result directly from explicit
+        differentiated basis functions. It has no autodiff support.
+
+        The resulting gradient and hessian have been multiplied by the spatial extents
+        to count for the transformation from the unit size volume to the size of its
+        shape.
+
+        Parameter ``pos`` (drjit.llvm.ad.Array2f):
+            *no description available*
+
+        Parameter ``active`` (drjit.llvm.ad.Bool | None):
+            Mask to specify active lanes.
+
+        Returns → tuple:
+            *no description available*
+
+    .. py:method:: mitsuba.Texture2f64.eval_fetch(self, pos, active=Bool(True))
+
+        Fetch the texels that would be referenced in a texture lookup with
+        linear interpolation without actually performing this interpolation.
+
+        Parameter ``pos`` (drjit.llvm.ad.Array2f):
+            *no description available*
+
+        Parameter ``active`` (drjit.llvm.ad.Bool | None):
+            Mask to specify active lanes.
+
+        Returns → list[list[drjit.llvm.ad.Float]]:
+            *no description available*
+
+    .. py:method:: mitsuba.Texture2f64.filter_mode()
+
+        Return the filter mode
+
+        Returns → drjit.FilterMode:
+            *no description available*
+
+    .. py:method:: mitsuba.Texture2f64.migrated()
+
+        Return whether textures with :py:func:`use_accel()` set to ``True`` only store
+        the data as a hardware-accelerated CUDA texture.
+
+        If ``False`` then a copy of the array data will additionally be retained .
+
+        Returns → bool:
+            *no description available*
+
+    .. py:method:: mitsuba.Texture2f64.set_tensor(self, tensor, migrate=False)
+
+        Override the texture contents with the provided tensor.
+
+        This method updates the values of all texels. Changing the texture
+        resolution or its number of channels is also supported. However, on CUDA,
+        such operations have a significantly larger overhead (the GPU pipeline
+        needs to be synchronized for new texture objects to be created).
+
+        In CUDA mode, when both the argument ``migrate`` and :py:func:`use_accel()` are ``True``,
+        the texture exclusively stores a copy of the input data as a CUDA texture to avoid
+        redundant storage.Note that the texture is still differentiable even when migrated.
+
+        Parameter ``tensor`` (drjit.llvm.ad.TensorXf64):
+            *no description available*
+
+        Parameter ``migrate`` (bool):
+            *no description available*
+
+        Returns → None:
+            *no description available*
+
+    .. py:method:: mitsuba.Texture2f64.set_value(self, value, migrate=False)
+
+        Override the texture contents with the provided linearized 1D array.
+
+        In CUDA mode, when both the argument ``migrate`` and :py:func:`use_accel()` are ``True``,
+        the texture exclusively stores a copy of the input data as a CUDA texture to avoid
+        redundant storage.Note that the texture is still differentiable even when migrated.
+
+        Parameter ``value`` (drjit.llvm.ad.Float64):
+            *no description available*
+
+        Parameter ``migrate`` (bool):
+            *no description available*
+
+        Returns → None:
+            *no description available*
+
+    .. py:property:: mitsuba.Texture2f64.shape
+
+        Return the texture shape
+
+    .. py:method:: mitsuba.Texture2f64.tensor()
+
+        Return the texture data as a tensor object
+
+        Returns → drjit.llvm.ad.TensorXf64:
+            *no description available*
+
+    .. py:method:: mitsuba.Texture2f64.update_inplace(self, migrate=False)
+
+        Update the texture after applying an indirect update to its tensor
+        representation (obtained with py:func:`tensor()`).
+
+        A tensor representation of this texture object can be retrived with
+        py:func:`tensor()`. That representation can be modified, but in order to apply
+        it succesfuly to the texture, this method must also be called. In short,
+        this method will use the tensor representation to update the texture's
+        internal state.
+
+        In CUDA mode, when both the argument ``migrate`` and :py:func:`use_accel()` are ``True``,
+        the texture exclusively stores a copy of the input data as a CUDA texture to avoid
+        redundant storage.)
+
+        Parameter ``migrate`` (bool):
+            *no description available*
+
+        Returns → None:
+            *no description available*
+
+    .. py:method:: mitsuba.Texture2f64.use_accel()
+
+        Return whether texture uses the GPU for storage and evaluation
+
+        Returns → bool:
+            *no description available*
+
+    .. py:method:: mitsuba.Texture2f64.value()
+
+        Return the texture data as an array object
+
+        Returns → drjit.llvm.ad.Float64:
+            *no description available*
+
+    .. py:method:: mitsuba.Texture2f64.wrap_mode()
 
         Return the wrap mode
 
@@ -17034,213 +17359,317 @@
         Returns → drjit.WrapMode:
             *no description available*
 
+.. py:class:: mitsuba.Texture3f64
+
+
+    .. py:method:: ``__init__(self, shape, channels, use_accel=True, filter_mode=FilterMode.Linear, wrap_mode=WrapMode.Clamp)
+
+        Create a new texture with the specified size and channel count
+
+        On CUDA, this is a slow operation that synchronizes the GPU pipeline, so
+        texture objects should be reused/updated via :py:func:`set_value()` and
+        :py:func:`set_tensor()` as much as possible.
+
+        When ``use_accel`` is set to ``False`` on CUDA mode, the texture will not
+        use hardware acceleration (allocation and evaluation). In other modes
+        this argument has no effect.
+
+        The ``filter_mode`` parameter defines the interpolation method to be used
+        in all evaluation routines. By default, the texture is linearly
+        interpolated. Besides nearest/linear filtering, the implementation also
+        provides a clamped cubic B-spline interpolation scheme in case a
+        higher-order interpolation is needed. In CUDA mode, this is done using a
+        series of linear lookups to optimally use the hardware (hence, linear
+        filtering must be enabled to use this feature).
+
+        When evaluating the texture outside of its boundaries, the ``wrap_mode``
+        defines the wrapping method. The default behavior is ``drjit.WrapMode.Clamp``,
+        which indefinitely extends the colors on the boundary along each dimension.
+
+        Parameter ``shape`` (collections.abc.Sequence[int]):
+            *no description available*
+
+        Parameter ``channels`` (int):
+            *no description available*
+
+        Parameter ``use_accel`` (bool):
+            *no description available*
+
+        Parameter ``filter_mode`` (drjit.FilterMode):
+            *no description available*
+
+        Parameter ``wrap_mode`` (drjit.WrapMode):
+            *no description available*
+
+        Returns → None``:
+            *no description available*
+
+    .. py:method:: ``__init__(self, tensor, use_accel=True, migrate=True, filter_mode=FilterMode.Linear, wrap_mode=WrapMode.Clamp)
+
+        Construct a new texture from a given tensor.
+
+        This constructor allocates texture memory with the shape information
+        deduced from ``tensor``. It subsequently invokes :py:func:`set_tensor(tensor)`
+        to fill the texture memory with the provided tensor.
+
+        When both ``migrate`` and ``use_accel`` are set to ``True`` in CUDA mode, the texture
+        exclusively stores a copy of the input data as a CUDA texture to avoid
+        redundant storage. Note that the texture is still differentiable even when migrated.
+
+        Parameter ``tensor`` (drjit.llvm.ad.TensorXf64):
+            *no description available*
+
+        Parameter ``use_accel`` (bool):
+            *no description available*
+
+        Parameter ``migrate`` (bool):
+            *no description available*
+
+        Parameter ``filter_mode`` (drjit.FilterMode):
+            *no description available*
+
+        Parameter ``wrap_mode`` (drjit.WrapMode):
+            *no description available*
+
+        Returns → None``:
+            *no description available*
+
+    .. py:method:: mitsuba.Texture3f64.eval(self, pos, active=Bool(True))
+
+        Evaluate the linear interpolant represented by this texture.
+
+        Parameter ``pos`` (drjit.llvm.ad.Array3f):
+            *no description available*
+
+        Parameter ``active`` (drjit.llvm.ad.Bool | None):
+            Mask to specify active lanes.
+
+        Returns → list[drjit.llvm.ad.Float]:
+            *no description available*
+
+    .. py:method:: mitsuba.Texture3f64.eval_cubic(self, pos, active=Bool(True), force_nonaccel=False)
+
+        Evaluate a clamped cubic B-Spline interpolant represented by this
+        texture
+
+        Instead of interpolating the texture via B-Spline basis functions, the
+        implementation transforms this calculation into an equivalent weighted
+        sum of several linear interpolant evaluations. In CUDA mode, this can
+        then be accelerated by hardware texture units, which runs faster than
+        a naive implementation. More information can be found in:
+
+            GPU Gems 2, Chapter 20, "Fast Third-Order Texture Filtering"
+            by Christian Sigg.
+
+        When the underlying grid data and the query position are differentiable,
+        this transformation cannot be used as it is not linear with respect to position
+        (thus the default AD graph gives incorrect results). The implementation
+        calls :py:func:`eval_cubic_helper()` function to replace the AD graph with a
+        direct evaluation of the B-Spline basis functions in that case.
+
+        Parameter ``pos`` (drjit.llvm.ad.Array3f):
+            *no description available*
+
+        Parameter ``active`` (drjit.llvm.ad.Bool | None):
+            Mask to specify active lanes.
+
+        Parameter ``force_nonaccel`` (bool):
+            *no description available*
+
+        Returns → list[drjit.llvm.ad.Float]:
+            *no description available*
+
+    .. py:method:: mitsuba.Texture3f64.eval_cubic_grad(self, pos, active=Bool(True))
+
+        Evaluate the positional gradient of a cubic B-Spline
+
+        This implementation computes the result directly from explicit
+        differentiated basis functions. It has no autodiff support.
+
+        The resulting gradient and hessian have been multiplied by the spatial extents
+        to count for the transformation from the unit size volume to the size of its
+        shape.
+
+        Parameter ``pos`` (drjit.llvm.ad.Array3f):
+            *no description available*
+
+        Parameter ``active`` (drjit.llvm.ad.Bool | None):
+            Mask to specify active lanes.
+
+        Returns → tuple:
+            *no description available*
+
+    .. py:method:: mitsuba.Texture3f64.eval_cubic_helper(self, pos, active=Bool(True))
+
+        Helper function to evaluate a clamped cubic B-Spline interpolant
+
+        This is an implementation detail and should only be called by the
+        :py:func:`eval_cubic()` function to construct an AD graph. When only the cubic
+        evaluation result is desired, the :py:func:`eval_cubic()` function is faster
+        than this simple implementation
+
+        Parameter ``pos`` (drjit.llvm.ad.Array3f):
+            *no description available*
+
+        Parameter ``active`` (drjit.llvm.ad.Bool | None):
+            Mask to specify active lanes.
+
+        Returns → list[drjit.llvm.ad.Float]:
+            *no description available*
+
+    .. py:method:: mitsuba.Texture3f64.eval_cubic_hessian(self, pos, active=Bool(True))
+
+        Evaluate the positional gradient and hessian matrix of a cubic B-Spline
+
+        This implementation computes the result directly from explicit
+        differentiated basis functions. It has no autodiff support.
+
+        The resulting gradient and hessian have been multiplied by the spatial extents
+        to count for the transformation from the unit size volume to the size of its
+        shape.
+
+        Parameter ``pos`` (drjit.llvm.ad.Array3f):
+            *no description available*
+
+        Parameter ``active`` (drjit.llvm.ad.Bool | None):
+            Mask to specify active lanes.
+
+        Returns → tuple:
+            *no description available*
+
+    .. py:method:: mitsuba.Texture3f64.eval_fetch(self, pos, active=Bool(True))
+
+        Fetch the texels that would be referenced in a texture lookup with
+        linear interpolation without actually performing this interpolation.
+
+        Parameter ``pos`` (drjit.llvm.ad.Array3f):
+            *no description available*
+
+        Parameter ``active`` (drjit.llvm.ad.Bool | None):
+            Mask to specify active lanes.
+
+        Returns → list[list[drjit.llvm.ad.Float]]:
+            *no description available*
+
+    .. py:method:: mitsuba.Texture3f64.filter_mode()
+
+        Return the filter mode
+
+        Returns → drjit.FilterMode:
+            *no description available*
+
+    .. py:method:: mitsuba.Texture3f64.migrated()
+
+        Return whether textures with :py:func:`use_accel()` set to ``True`` only store
+        the data as a hardware-accelerated CUDA texture.
+
+        If ``False`` then a copy of the array data will additionally be retained .
+
+        Returns → bool:
+            *no description available*
+
+    .. py:method:: mitsuba.Texture3f64.set_tensor(self, tensor, migrate=False)
+
+        Override the texture contents with the provided tensor.
+
+        This method updates the values of all texels. Changing the texture
+        resolution or its number of channels is also supported. However, on CUDA,
+        such operations have a significantly larger overhead (the GPU pipeline
+        needs to be synchronized for new texture objects to be created).
+
+        In CUDA mode, when both the argument ``migrate`` and :py:func:`use_accel()` are ``True``,
+        the texture exclusively stores a copy of the input data as a CUDA texture to avoid
+        redundant storage.Note that the texture is still differentiable even when migrated.
+
+        Parameter ``tensor`` (drjit.llvm.ad.TensorXf64):
+            *no description available*
+
+        Parameter ``migrate`` (bool):
+            *no description available*
+
+        Returns → None:
+            *no description available*
+
+    .. py:method:: mitsuba.Texture3f64.set_value(self, value, migrate=False)
+
+        Override the texture contents with the provided linearized 1D array.
+
+        In CUDA mode, when both the argument ``migrate`` and :py:func:`use_accel()` are ``True``,
+        the texture exclusively stores a copy of the input data as a CUDA texture to avoid
+        redundant storage.Note that the texture is still differentiable even when migrated.
+
+        Parameter ``value`` (drjit.llvm.ad.Float64):
+            *no description available*
+
+        Parameter ``migrate`` (bool):
+            *no description available*
+
+        Returns → None:
+            *no description available*
+
+    .. py:property:: mitsuba.Texture3f64.shape
+
+        Return the texture shape
+
+    .. py:method:: mitsuba.Texture3f64.tensor()
+
+        Return the texture data as a tensor object
+
+        Returns → drjit.llvm.ad.TensorXf64:
+            *no description available*
+
+    .. py:method:: mitsuba.Texture3f64.update_inplace(self, migrate=False)
+
+        Update the texture after applying an indirect update to its tensor
+        representation (obtained with py:func:`tensor()`).
+
+        A tensor representation of this texture object can be retrived with
+        py:func:`tensor()`. That representation can be modified, but in order to apply
+        it succesfuly to the texture, this method must also be called. In short,
+        this method will use the tensor representation to update the texture's
+        internal state.
+
+        In CUDA mode, when both the argument ``migrate`` and :py:func:`use_accel()` are ``True``,
+        the texture exclusively stores a copy of the input data as a CUDA texture to avoid
+        redundant storage.)
+
+        Parameter ``migrate`` (bool):
+            *no description available*
+
+        Returns → None:
+            *no description available*
+
+    .. py:method:: mitsuba.Texture3f64.use_accel()
+
+        Return whether texture uses the GPU for storage and evaluation
+
+        Returns → bool:
+            *no description available*
+
+    .. py:method:: mitsuba.Texture3f64.value()
+
+        Return the texture data as an array object
+
+        Returns → drjit.llvm.ad.Float64:
+            *no description available*
+
+    .. py:method:: mitsuba.Texture3f64.wrap_mode()
+
+        Return the wrap mode
+
+        Returns → drjit.WrapMode:
+            *no description available*
+
 .. py:class:: mitsuba.Thread
 
     Base class: :py:obj:`mitsuba.Object`
 
-    Cross-platform thread implementation
-
-    Mitsuba threads are internally implemented via the ``std::thread``
-    class defined in C++11. This wrapper class is needed to attach
-    additional state (Loggers, Path resolvers, etc.) that is inherited
-    when a thread launches another thread.
-
-    .. py:method:: __init__(self, name)
-
-        Parameter ``name`` (str):
-            *no description available*
-
-
-    .. py:class:: mitsuba.Thread.EPriority
-
-        Possible priority values for Thread::set_priority()
-
-        Valid values are as follows:
-
-        .. py:data:: EIdlePriority
-
-            
-
-        .. py:data:: ELowestPriority
-
-            
-
-        .. py:data:: ELowPriority
-
-            
-
-        .. py:data:: ENormalPriority
-
-            
-
-        .. py:data:: EHighPriority
-
-            
-
-        .. py:data:: EHighestPriority
-
-            
-
-        .. py:data:: ERealtimePriority
-
-            
-
-    .. py:method:: mitsuba.Thread.core_affinity()
-
-        Return the core affinity
-
-        Returns → int:
-            *no description available*
-
-    .. py:method:: mitsuba.Thread.detach()
-
-        Detach the thread and release resources
-
-        After a call to this function, join() cannot be used anymore. This
-        releases resources, which would otherwise be held until a call to
-        join().
-
-        Returns → None:
-            *no description available*
-
-    .. py:method:: mitsuba.Thread.file_resolver()
-
-        Return the file resolver associated with the current thread
-
-        Returns → :py:obj:`mitsuba.FileResolver`:
-            *no description available*
-
-    .. py:method:: mitsuba.Thread.is_critical()
-
-        Return the value of the critical flag
-
-        Returns → bool:
-            *no description available*
-
-    .. py:method:: mitsuba.Thread.is_running()
-
-        Is this thread still running?
-
-        Returns → bool:
-            *no description available*
-
-    .. py:method:: mitsuba.Thread.join()
-
-        Wait until the thread finishes
-
-        Returns → None:
-            *no description available*
-
-    .. py:method:: mitsuba.Thread.logger()
-
-        Return the thread's logger instance
-
-        Returns → :py:obj:`mitsuba.Logger`:
-            *no description available*
-
-    .. py:method:: mitsuba.Thread.name()
-
-        Return the name of this thread
-
-        Returns → str:
-            *no description available*
-
-    .. py:method:: mitsuba.Thread.parent()
-
-        Return the parent thread
-
-        Returns → :py:obj:`mitsuba.Thread`:
-            *no description available*
-
-    .. py:method:: mitsuba.Thread.priority()
-
-        Return the thread priority
-
-        Returns → :py:obj:`mitsuba.Thread.EPriority`:
-            *no description available*
-
-    .. py:method:: mitsuba.Thread.set_core_affinity(self, arg)
-
-        Set the core affinity
-
-        This function provides a hint to the operating system scheduler that
-        the thread should preferably run on the specified processor core. By
-        default, the parameter is set to -1, which means that there is no
-        affinity.
-
-        Parameter ``arg`` (int, /):
-            *no description available*
-
-        Returns → None:
-            *no description available*
-
-    .. py:method:: mitsuba.Thread.set_critical(self, arg)
-
-        Specify whether or not this thread is critical
-
-        When an thread marked critical crashes from an uncaught exception, the
-        whole process is brought down. The default is ``False``.
-
-        Parameter ``arg`` (bool, /):
-            *no description available*
-
-        Returns → None:
-            *no description available*
-
-    .. py:method:: mitsuba.Thread.set_file_resolver(self, arg)
-
-        Set the file resolver associated with the current thread
-
-        Parameter ``arg`` (:py:obj:`mitsuba.FileResolver`, /):
-            *no description available*
-
-        Returns → None:
-            *no description available*
-
-    .. py:method:: mitsuba.Thread.set_logger(self, arg)
-
-        Set the logger instance used to process log messages from this thread
-
-        Parameter ``arg`` (:py:obj:`mitsuba.Logger`, /):
-            *no description available*
-
-        Returns → None:
-            *no description available*
-
-    .. py:method:: mitsuba.Thread.set_name(self, arg)
-
-        Set the name of this thread
-
-        Parameter ``arg`` (str, /):
-            *no description available*
-
-        Returns → None:
-            *no description available*
-
-    .. py:method:: mitsuba.Thread.set_priority(self, arg)
-
-        Set the thread priority
-
-        This does not always work -- for instance, Linux requires root
-        privileges for this operation.
-
-        Parameter ``arg`` (:py:obj:`mitsuba.Thread.EPriority`, /):
-            *no description available*
-
-        Returns → bool:
-            ``True`` upon success.
-
-    .. py:method:: mitsuba.Thread.start()
-
-        Start the thread
-
-        Returns → None:
-            *no description available*
-
-.. py:class:: mitsuba.ThreadEnvironment
-
-    Captures a thread environment (logger and file resolver). Used with
-    ScopedSetThreadEnvironment
+    Dummy thread class for backward compatibility
+
+    This class has been largely stripped down and only maintains essential
+    methods for file resolver and logger access, plus static
+    initialization. Use std::thread or the nanothread-based thread pool
+    for actual threading needs.
 
     .. py:method:: __init__()
 
@@ -17348,27 +17777,6 @@
 
         (self) -> drjit.llvm.ad.Matrix3f64
 
-    .. py:method:: mitsuba.Transform3d.rotate(self, angle)
-
-        Create a rotation transformation in 2D. The angle is specified in
-        degrees
-
-        Parameter ``angle`` (drjit.llvm.ad.Float64):
-            *no description available*
-
-        Returns → :py:obj:`mitsuba.Transform3d`:
-            *no description available*
-
-    .. py:method:: mitsuba.Transform3d.scale(self, v)
-
-        Create a scale transformation
-
-        Parameter ``v`` (:py:obj:`mitsuba.Point2d`):
-            *no description available*
-
-        Returns → :py:obj:`mitsuba.Transform3d`:
-            *no description available*
-
     .. py:method:: mitsuba.Transform3d.transform_affine(self, p)
 
         Transform a 3D vector/point/normal/ray by a transformation that is
@@ -17378,16 +17786,6 @@
             *no description available*
 
         Returns → :py:obj:`mitsuba.Point2d`:
-            *no description available*
-
-    .. py:method:: mitsuba.Transform3d.translate(self, v)
-
-        Create a translation transformation
-
-        Parameter ``v`` (:py:obj:`mitsuba.Point2d`):
-            *no description available*
-
-        Returns → :py:obj:`mitsuba.Transform3d`:
             *no description available*
 
     .. py:method:: mitsuba.Transform3d.translation()
@@ -17472,27 +17870,6 @@
 
         (self) -> drjit.llvm.ad.Matrix3f
 
-    .. py:method:: mitsuba.Transform3f.rotate(self, angle)
-
-        Create a rotation transformation in 2D. The angle is specified in
-        degrees
-
-        Parameter ``angle`` (drjit.llvm.ad.Float):
-            *no description available*
-
-        Returns → :py:obj:`mitsuba.Transform3f`:
-            *no description available*
-
-    .. py:method:: mitsuba.Transform3f.scale(self, v)
-
-        Create a scale transformation
-
-        Parameter ``v`` (:py:obj:`mitsuba.Point2f`):
-            *no description available*
-
-        Returns → :py:obj:`mitsuba.Transform3f`:
-            *no description available*
-
     .. py:method:: mitsuba.Transform3f.transform_affine(self, p)
 
         Transform a 3D vector/point/normal/ray by a transformation that is
@@ -17502,16 +17879,6 @@
             *no description available*
 
         Returns → :py:obj:`mitsuba.Point2f`:
-            *no description available*
-
-    .. py:method:: mitsuba.Transform3f.translate(self, v)
-
-        Create a translation transformation
-
-        Parameter ``v`` (:py:obj:`mitsuba.Point2f`):
-            *no description available*
-
-        Returns → :py:obj:`mitsuba.Transform3f`:
             *no description available*
 
     .. py:method:: mitsuba.Transform3f.translation()
@@ -17578,17 +17945,6 @@
         Returns → :py:obj:`mitsuba.Transform3d`:
             *no description available*
 
-    .. py:method:: mitsuba.Transform4d.from_frame(self, frame)
-
-        Creates a transformation that converts from 'frame' to the standard
-        basis
-
-        Parameter ``frame`` (mitsuba::Frame<drjit::DiffArray<(JitBackend)2, double> >):
-            *no description available*
-
-        Returns → :py:obj:`mitsuba.Transform4d`:
-            *no description available*
-
     .. py:method:: mitsuba.Transform4d.has_scale()
 
         Test for a scale component in each transform matrix by checking
@@ -17610,97 +17966,9 @@
 
         (self) -> drjit.llvm.ad.Matrix4f64
 
-    .. py:method:: mitsuba.Transform4d.look_at(self, origin, target, up)
-
-        Create a look-at camera transformation
-
-        Parameter ``origin`` (:py:obj:`mitsuba.Point3d`):
-            Camera position
-
-        Parameter ``target`` (:py:obj:`mitsuba.Point3d`):
-            Target vector
-
-        Parameter ``up`` (:py:obj:`mitsuba.Point3d`):
-            Up vector
-
-        Returns → :py:obj:`mitsuba.Transform4d`:
-            *no description available*
-
     .. py:property:: mitsuba.Transform4d.matrix
 
         (self) -> drjit.llvm.ad.Matrix4f64
-
-    .. py:method:: mitsuba.Transform4d.orthographic(self, near, far)
-
-        Create an orthographic transformation, which maps Z to [0,1] and
-        leaves the X and Y coordinates untouched.
-
-        Parameter ``near`` (drjit.llvm.ad.Float64):
-            Near clipping plane
-
-        Parameter ``far`` (drjit.llvm.ad.Float64):
-            Far clipping plane
-
-        Returns → :py:obj:`mitsuba.Transform4d`:
-            *no description available*
-
-    .. py:method:: mitsuba.Transform4d.perspective(self, fov, near, far)
-
-        Create a perspective transformation. (Maps [near, far] to [0, 1])
-
-        Projects vectors in camera space onto a plane at z=1:
-
-        x_proj = x / z y_proj = y / z z_proj = (far * (z - near)) / (z * (far-
-        near))
-
-        Camera-space depths are not mapped linearly!
-
-        Parameter ``fov`` (drjit.llvm.ad.Float64):
-            Field of view in degrees
-
-        Parameter ``near`` (drjit.llvm.ad.Float64):
-            Near clipping plane
-
-        Parameter ``far`` (drjit.llvm.ad.Float64):
-            Far clipping plane
-
-        Returns → :py:obj:`mitsuba.Transform4d`:
-            *no description available*
-
-    .. py:method:: mitsuba.Transform4d.rotate(self, axis, angle)
-
-        Create a rotation transformation around an arbitrary axis in 3D. The
-        angle is specified in degrees
-
-        Parameter ``axis`` (:py:obj:`mitsuba.Point3d`):
-            *no description available*
-
-        Parameter ``angle`` (drjit.llvm.ad.Float64):
-            *no description available*
-
-        Returns → :py:obj:`mitsuba.Transform4d`:
-            *no description available*
-
-    .. py:method:: mitsuba.Transform4d.scale(self, v)
-
-        Create a scale transformation
-
-        Parameter ``v`` (:py:obj:`mitsuba.Point3d`):
-            *no description available*
-
-        Returns → :py:obj:`mitsuba.Transform4d`:
-            *no description available*
-
-    .. py:method:: mitsuba.Transform4d.to_frame(self, frame)
-
-        Creates a transformation that converts from the standard basis to
-        'frame'
-
-        Parameter ``frame`` (mitsuba::Frame<drjit::DiffArray<(JitBackend)2, double> >):
-            *no description available*
-
-        Returns → :py:obj:`mitsuba.Transform4d`:
-            *no description available*
 
     .. py:method:: mitsuba.Transform4d.transform_affine(self, p)
 
@@ -17711,16 +17979,6 @@
             *no description available*
 
         Returns → :py:obj:`mitsuba.Point3d`:
-            *no description available*
-
-    .. py:method:: mitsuba.Transform4d.translate(self, v)
-
-        Create a translation transformation
-
-        Parameter ``v`` (:py:obj:`mitsuba.Point3d`):
-            *no description available*
-
-        Returns → :py:obj:`mitsuba.Transform4d`:
             *no description available*
 
     .. py:method:: mitsuba.Transform4d.translation()
@@ -17787,17 +18045,6 @@
         Returns → :py:obj:`mitsuba.Transform3f`:
             *no description available*
 
-    .. py:method:: mitsuba.Transform4f.from_frame(self, frame)
-
-        Creates a transformation that converts from 'frame' to the standard
-        basis
-
-        Parameter ``frame`` (:py:obj:`mitsuba.Frame3f`):
-            *no description available*
-
-        Returns → :py:obj:`mitsuba.Transform4f`:
-            *no description available*
-
     .. py:method:: mitsuba.Transform4f.has_scale()
 
         Test for a scale component in each transform matrix by checking
@@ -17819,97 +18066,9 @@
 
         (self) -> drjit.llvm.ad.Matrix4f
 
-    .. py:method:: mitsuba.Transform4f.look_at(self, origin, target, up)
-
-        Create a look-at camera transformation
-
-        Parameter ``origin`` (:py:obj:`mitsuba.Point3f`):
-            Camera position
-
-        Parameter ``target`` (:py:obj:`mitsuba.Point3f`):
-            Target vector
-
-        Parameter ``up`` (:py:obj:`mitsuba.Point3f`):
-            Up vector
-
-        Returns → :py:obj:`mitsuba.Transform4f`:
-            *no description available*
-
     .. py:property:: mitsuba.Transform4f.matrix
 
         (self) -> drjit.llvm.ad.Matrix4f
-
-    .. py:method:: mitsuba.Transform4f.orthographic(self, near, far)
-
-        Create an orthographic transformation, which maps Z to [0,1] and
-        leaves the X and Y coordinates untouched.
-
-        Parameter ``near`` (drjit.llvm.ad.Float):
-            Near clipping plane
-
-        Parameter ``far`` (drjit.llvm.ad.Float):
-            Far clipping plane
-
-        Returns → :py:obj:`mitsuba.Transform4f`:
-            *no description available*
-
-    .. py:method:: mitsuba.Transform4f.perspective(self, fov, near, far)
-
-        Create a perspective transformation. (Maps [near, far] to [0, 1])
-
-        Projects vectors in camera space onto a plane at z=1:
-
-        x_proj = x / z y_proj = y / z z_proj = (far * (z - near)) / (z * (far-
-        near))
-
-        Camera-space depths are not mapped linearly!
-
-        Parameter ``fov`` (drjit.llvm.ad.Float):
-            Field of view in degrees
-
-        Parameter ``near`` (drjit.llvm.ad.Float):
-            Near clipping plane
-
-        Parameter ``far`` (drjit.llvm.ad.Float):
-            Far clipping plane
-
-        Returns → :py:obj:`mitsuba.Transform4f`:
-            *no description available*
-
-    .. py:method:: mitsuba.Transform4f.rotate(self, axis, angle)
-
-        Create a rotation transformation around an arbitrary axis in 3D. The
-        angle is specified in degrees
-
-        Parameter ``axis`` (:py:obj:`mitsuba.Point3f`):
-            *no description available*
-
-        Parameter ``angle`` (drjit.llvm.ad.Float):
-            *no description available*
-
-        Returns → :py:obj:`mitsuba.Transform4f`:
-            *no description available*
-
-    .. py:method:: mitsuba.Transform4f.scale(self, v)
-
-        Create a scale transformation
-
-        Parameter ``v`` (:py:obj:`mitsuba.Point3f`):
-            *no description available*
-
-        Returns → :py:obj:`mitsuba.Transform4f`:
-            *no description available*
-
-    .. py:method:: mitsuba.Transform4f.to_frame(self, frame)
-
-        Creates a transformation that converts from the standard basis to
-        'frame'
-
-        Parameter ``frame`` (:py:obj:`mitsuba.Frame3f`):
-            *no description available*
-
-        Returns → :py:obj:`mitsuba.Transform4f`:
-            *no description available*
 
     .. py:method:: mitsuba.Transform4f.transform_affine(self, p)
 
@@ -17920,16 +18079,6 @@
             *no description available*
 
         Returns → :py:obj:`mitsuba.Point3f`:
-            *no description available*
-
-    .. py:method:: mitsuba.Transform4f.translate(self, v)
-
-        Create a translation transformation
-
-        Parameter ``v`` (:py:obj:`mitsuba.Point3f`):
-            *no description available*
-
-        Returns → :py:obj:`mitsuba.Transform4f`:
             *no description available*
 
     .. py:method:: mitsuba.Transform4f.translation()
@@ -17960,15 +18109,70 @@
 
     This interface can be implemented either in C++ or in Python, to be
     used in conjunction with Object::traverse() to traverse a scene graph.
-    Mitsuba currently uses this mechanism to determine a scene's
-    differentiable parameters.
+    Mitsuba uses this mechanism for two primary purposes:
+
+    1. **Dynamic scene modification**: After a scene is loaded, the
+    traversal mechanism allows programmatic access to modify scene
+    parameters without rebuilding the entire scene. This enables workflows
+    where parameters are adjusted and the scene is re-rendered with
+    different settings.
+
+    2. **Differentiable parameter discovery**: The traversal callback can
+    discover all differentiable parameters in a scene (e.g., material
+    properties, transformation matrices, emission values). These
+    parameters can then be exposed to gradient-based optimizers for
+    inverse rendering tasks, which in practice involves the
+    ``SceneParameters`` Python class.
+
+    The callback receives information about each traversed object's
+    parameters through the put() methods, which distinguish between
+    regular parameters and references to other scene objects that are
+    handled recursively.
 
     .. py:method:: __init__()
 
 
     .. py:method:: mitsuba.TraversalCallback.put(self, name, value, flags)
 
-        Inform the traversal callback about an attribute or sub-object of an instance
+        Unified method to register both objects and values with the traversal callback
+
+        Parameter ``name`` (str):
+            *no description available*
+
+        Parameter ``value`` (object):
+            *no description available*
+
+        Parameter ``flags`` (int):
+            *no description available*
+
+        Returns → None:
+            *no description available*
+
+    .. py:method:: mitsuba.TraversalCallback.put_object(self, name, obj, flags)
+
+        Register an object with the traversal callback.
+
+        .. deprecated:: 3.7.0
+           Use :py:meth:`~:py:obj:`mitsuba.TraversalCallback.put`` instead.
+
+        Parameter ``name`` (str):
+            *no description available*
+
+        Parameter ``obj`` (:py:obj:`mitsuba.Object`):
+            *no description available*
+
+        Parameter ``flags`` (int):
+            *no description available*
+
+        Returns → None:
+            *no description available*
+
+    .. py:method:: mitsuba.TraversalCallback.put_value(self, name, value, flags)
+
+        Register a value with the traversal callback.
+
+        .. deprecated:: 3.7.0
+           Use :py:meth:`~:py:obj:`mitsuba.TraversalCallback.put`` instead.
 
         Parameter ``name`` (str):
             *no description available*
@@ -18173,22 +18377,34 @@
 
     Base class: :py:obj:`mitsuba.Object`
 
-    Overloaded function.
+    Class to read and write 3D volume grids
 
-    1. ``__init__(self, path: :py:obj:`mitsuba.filesystem.path`) -> None``
+    This class handles loading of volumes in the Mitsuba volume file
+    format Please see the documentation of gridvolume (grid3d.cpp) for the
+    file format specification.
 
+    .. py:method:: __init__(self, path)
 
-    2. ``__init__(self, stream: :py:obj:`mitsuba.Stream`) -> None``
+        Overloaded function.
+        
+        1. ``__init__(self, path: :py:obj:`mitsuba.filesystem.path`) -> None``
+        
+        
+        2. ``__init__(self, stream: :py:obj:`mitsuba.Stream`) -> None``
+        
+        
+        3. ``__init__(self, array: ndarray[dtype=float32, order='C', device='cpu'], compute_max: bool = True) -> None``
+        
+        Initialize a VolumeGrid from a CPU-visible ndarray
+        
+        4. ``__init__(self, array: drjit.llvm.ad.TensorXf, compute_max: bool = True) -> None``
+        
+        Initialize a VolumeGrid from a drjit tensor
 
+        Parameter ``path`` (:py:obj:`mitsuba.filesystem.path`):
+            *no description available*
 
-    3. ``__init__(self, array: ndarray[dtype=float32, order='C', device='cpu'], compute_max: bool = True) -> None``
-
-    Initialize a VolumeGrid from a CPU-visible ndarray
-
-    4. ``__init__(self, array: drjit.llvm.ad.TensorXf, compute_max: bool = True) -> None``
-
-    Initialize a VolumeGrid from a drjit tensor
-
+        
     .. py:method:: mitsuba.VolumeGrid.buffer_size()
 
         Return the volume grid size in bytes (excluding metadata)
@@ -19798,6 +20014,14 @@
     Returns → :py:obj:`mitsuba.Color3f`:
         *no description available*
 
+.. py:class:: mitsuba.detail.TransformWrapper
+
+    Helper functor that wraps Transform3f/Transform4f methods so that the following two
+    calling conventions are equivalent:
+
+     - Transform4f().translate().scale()...
+     - Transform4f.translate().scale()...
+
 .. py:function:: mitsuba.detail.add_variant_callback(arg)
 
     Parameter ``arg`` (collections.abc.Callable, /):
@@ -19810,6 +20034,8 @@
 
     Returns → None:
         *no description available*
+
+.. py:function:: mitsuba.detail.patch_transform()
 
 .. py:function:: mitsuba.detail.remove_variant_callback(arg)
 
@@ -19847,6 +20073,11 @@
         *no description available*
 
     Returns → drjit.llvm.ad.Float:
+        *no description available*
+
+.. py:function:: mitsuba.file_resolver()
+
+    Returns → :py:obj:`mitsuba.FileResolver`:
         *no description available*
 
 .. py:function:: mitsuba.filesystem.absolute(arg)
@@ -19963,8 +20194,8 @@
         
         3. ``__init__(self, arg: str, /) -> None``
         
-        Construct a path from a string with native type. On Windows, the path
-        can use both '/' or '\\' as a delimiter.
+        Construct a path from a string view with native type. On Windows, the
+        path can use both '/' or '\\' as a delimiter.
 
         
     .. py:method:: mitsuba.filesystem.path.clear()
@@ -20274,11 +20505,16 @@
     Returns → :py:obj:`mitsuba.LogLevel`:
         *no description available*
 
+.. py:function:: mitsuba.logger()
+
+    Returns → :py:obj:`mitsuba.Logger`:
+        *no description available*
+
 .. py:function:: mitsuba.lookup_ior(properties, name, default)
 
     Lookup IOR value in table.
 
-    Parameter ``properties`` (:py:obj:`mitsuba._Properties`):
+    Parameter ``properties`` (:py:obj:`mitsuba.Properties`):
         *no description available*
 
     Parameter ``name`` (str):
@@ -20920,7 +21156,7 @@
 
     Helper function to parse the field of view field of a camera
 
-    Parameter ``props`` (:py:obj:`mitsuba._Properties`):
+    Parameter ``props`` (:py:obj:`mitsuba.Properties`):
         *no description available*
 
     Parameter ``aspect`` (float):
@@ -21190,122 +21426,144 @@
     Returns → :py:obj:`mitsuba.Vector3f`:
         *no description available*
 
-.. py:function:: mitsuba.register_bsdf(arg0, arg1)
+.. py:function:: mitsuba.register_bsdf(name, constructor)
 
-    Parameter ``arg0`` (str):
+    Register a Python BSDF plugin
+
+    Parameter ``name`` (str):
         *no description available*
 
-    Parameter ``arg1`` (collections.abc.Callable[[:py:obj:`mitsuba.Properties`], object], /):
-        *no description available*
-
-    Returns → None:
-        *no description available*
-
-.. py:function:: mitsuba.register_emitter(arg0, arg1)
-
-    Parameter ``arg0`` (str):
-        *no description available*
-
-    Parameter ``arg1`` (collections.abc.Callable[[:py:obj:`mitsuba.Properties`], object], /):
+    Parameter ``constructor`` (object):
         *no description available*
 
     Returns → None:
         *no description available*
 
-.. py:function:: mitsuba.register_film(arg0, arg1)
+.. py:function:: mitsuba.register_emitter(name, constructor)
 
-    Parameter ``arg0`` (str):
+    Register a Python emitter plugin
+
+    Parameter ``name`` (str):
         *no description available*
 
-    Parameter ``arg1`` (collections.abc.Callable[[:py:obj:`mitsuba.Properties`], object], /):
-        *no description available*
-
-    Returns → None:
-        *no description available*
-
-.. py:function:: mitsuba.register_integrator(arg0, arg1)
-
-    Parameter ``arg0`` (str):
-        *no description available*
-
-    Parameter ``arg1`` (collections.abc.Callable[[:py:obj:`mitsuba.Properties`], object], /):
+    Parameter ``constructor`` (object):
         *no description available*
 
     Returns → None:
         *no description available*
 
-.. py:function:: mitsuba.register_medium(arg0, arg1)
+.. py:function:: mitsuba.register_film(name, constructor)
 
-    Parameter ``arg0`` (str):
+    Register a Python film plugin
+
+    Parameter ``name`` (str):
         *no description available*
 
-    Parameter ``arg1`` (collections.abc.Callable[[:py:obj:`mitsuba.Properties`], object], /):
-        *no description available*
-
-    Returns → None:
-        *no description available*
-
-.. py:function:: mitsuba.register_mesh(arg0, arg1)
-
-    Parameter ``arg0`` (str):
-        *no description available*
-
-    Parameter ``arg1`` (collections.abc.Callable[[:py:obj:`mitsuba.Properties`], object], /):
+    Parameter ``constructor`` (object):
         *no description available*
 
     Returns → None:
         *no description available*
 
-.. py:function:: mitsuba.register_phasefunction(arg0, arg1)
+.. py:function:: mitsuba.register_integrator(name, constructor)
 
-    Parameter ``arg0`` (str):
+    Register a Python integrator plugin
+
+    Parameter ``name`` (str):
         *no description available*
 
-    Parameter ``arg1`` (collections.abc.Callable[[:py:obj:`mitsuba.Properties`], object], /):
-        *no description available*
-
-    Returns → None:
-        *no description available*
-
-.. py:function:: mitsuba.register_sampler(arg0, arg1)
-
-    Parameter ``arg0`` (str):
-        *no description available*
-
-    Parameter ``arg1`` (collections.abc.Callable[[:py:obj:`mitsuba.Properties`], object], /):
+    Parameter ``constructor`` (object):
         *no description available*
 
     Returns → None:
         *no description available*
 
-.. py:function:: mitsuba.register_sensor(arg0, arg1)
+.. py:function:: mitsuba.register_medium(name, constructor)
 
-    Parameter ``arg0`` (str):
+    Register a Python medium plugin
+
+    Parameter ``name`` (str):
         *no description available*
 
-    Parameter ``arg1`` (collections.abc.Callable[[:py:obj:`mitsuba.Properties`], object], /):
-        *no description available*
-
-    Returns → None:
-        *no description available*
-
-.. py:function:: mitsuba.register_texture(arg0, arg1)
-
-    Parameter ``arg0`` (str):
-        *no description available*
-
-    Parameter ``arg1`` (collections.abc.Callable[[:py:obj:`mitsuba.Properties`], object], /):
+    Parameter ``constructor`` (object):
         *no description available*
 
     Returns → None:
         *no description available*
 
-.. py:function:: mitsuba.register_volume(arg0, arg1)
+.. py:function:: mitsuba.register_phase(name, constructor)
 
-    Parameter ``arg0`` (str):
+    Register a Python phase function plugin
+
+    Parameter ``name`` (str):
         *no description available*
 
-    Parameter ``arg1`` (collections.abc.Callable[[:py:obj:`mitsuba.Properties`], object], /):
+    Parameter ``constructor`` (object):
+        *no description available*
+
+    Returns → None:
+        *no description available*
+
+.. py:function:: mitsuba.register_rfilter(name, constructor)
+
+    Register a Python reconstruction filter plugin
+
+    Parameter ``name`` (str):
+        *no description available*
+
+    Parameter ``constructor`` (object):
+        *no description available*
+
+    Returns → None:
+        *no description available*
+
+.. py:function:: mitsuba.register_sampler(name, constructor)
+
+    Register a Python sampler plugin
+
+    Parameter ``name`` (str):
+        *no description available*
+
+    Parameter ``constructor`` (object):
+        *no description available*
+
+    Returns → None:
+        *no description available*
+
+.. py:function:: mitsuba.register_sensor(name, constructor)
+
+    Register a Python sensor plugin
+
+    Parameter ``name`` (str):
+        *no description available*
+
+    Parameter ``constructor`` (object):
+        *no description available*
+
+    Returns → None:
+        *no description available*
+
+.. py:function:: mitsuba.register_shape(name, constructor)
+
+    Register a Python shape plugin
+
+    Parameter ``name`` (str):
+        *no description available*
+
+    Parameter ``constructor`` (object):
+        *no description available*
+
+    Returns → None:
+        *no description available*
+
+.. py:function:: mitsuba.register_texture(name, constructor)
+
+    Register a Python texture plugin
+
+    Parameter ``name`` (str):
+        *no description available*
+
+    Parameter ``constructor`` (object):
         *no description available*
 
     Returns → None:
@@ -21548,11 +21806,27 @@
     Returns → None:
         *no description available*
 
+.. py:function:: mitsuba.set_file_resolver(arg)
+
+    Parameter ``arg`` (:py:obj:`mitsuba.FileResolver`, /):
+        *no description available*
+
+    Returns → None:
+        *no description available*
+
 .. py:function:: mitsuba.set_log_level(arg)
 
     Sets the log level.
 
     Parameter ``arg`` (:py:obj:`mitsuba.LogLevel`, /):
+        *no description available*
+
+    Returns → None:
+        *no description available*
+
+.. py:function:: mitsuba.set_logger(logger)
+
+    Parameter ``logger`` (:py:obj:`mitsuba.Logger`):
         *no description available*
 
     Returns → None:
@@ -22270,10 +22544,10 @@
         Parameter ``name`` (str):
             *no description available*
 
-        Parameter ``scene`` (mi.Scene):
+        Parameter ``scene`` (~:py:obj:`mitsuba.Scene`):
             *no description available*
 
-        Parameter ``sensor`` (Union[int, mi.Sensor]):
+        Parameter ``sensor`` (int | ~:py:obj:`mitsuba.Sensor`):
             *no description available*
 
         Parameter ``generate_ref`` (bool):

--- a/docs/generated/mitsuba_api.rst
+++ b/docs/generated/mitsuba_api.rst
@@ -2,326 +2,308 @@ Core
 ----
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 21330
-  :end-line: 21426
+  :start-line: 21571
+  :end-line: 21667
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 21577
-  :end-line: 21581
+  :start-line: 21834
+  :end-line: 21838
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 22387
-  :end-line: 22391
+  :start-line: 22644
+  :end-line: 22648
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 22312
-  :end-line: 22324
+  :start-line: 22569
+  :end-line: 22581
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 12583
-  :end-line: 12669
+  :start-line: 12308
+  :end-line: 12394
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 22400
-  :end-line: 22404
+  :start-line: 22657
+  :end-line: 22661
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 21567
-  :end-line: 21576
+  :start-line: 21816
+  :end-line: 21825
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 137
-  :end-line: 203
+  :start-line: 136
+  :end-line: 202
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 216
-  :end-line: 233
+  :start-line: 2671
+  :end-line: 2752
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 2740
-  :end-line: 2821
+  :start-line: 3100
+  :end-line: 3111
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 3169
-  :end-line: 3180
+  :start-line: 3879
+  :end-line: 3911
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 3948
-  :end-line: 3980
+  :start-line: 7109
+  :end-line: 7148
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 7193
-  :end-line: 7232
+  :start-line: 14478
+  :end-line: 14960
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 14757
-  :end-line: 15239
+  :start-line: 14961
+  :end-line: 14992
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 15240
-  :end-line: 15271
+  :start-line: 18494
+  :end-line: 18525
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 18295
-  :end-line: 18326
+  :start-line: 3818
+  :end-line: 3878
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 3887
-  :end-line: 3947
+  :start-line: 4181
+  :end-line: 4212
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 4250
-  :end-line: 4284
+  :start-line: 5452
+  :end-line: 5462
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 5524
-  :end-line: 5534
+  :start-line: 7036
+  :end-line: 7108
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 7120
-  :end-line: 7192
+  :start-line: 8650
+  :end-line: 8676
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 8662
-  :end-line: 8688
+  :start-line: 8969
+  :end-line: 9012
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 8976
-  :end-line: 9031
+  :start-line: 14419
+  :end-line: 14477
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 12670
-  :end-line: 12680
+  :start-line: 14993
+  :end-line: 15247
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 14698
-  :end-line: 14756
+  :start-line: 15248
+  :end-line: 15344
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 15272
-  :end-line: 15526
+  :start-line: 17662
+  :end-line: 17675
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 15527
-  :end-line: 15623
+  :start-line: 17676
+  :end-line: 17703
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 17036
-  :end-line: 17238
-
-------------
-
-.. include:: generated/extracted_rst_api.rst
-  :start-line: 17239
-  :end-line: 17246
-
-------------
-
-.. include:: generated/extracted_rst_api.rst
-  :start-line: 17247
-  :end-line: 17274
-
-------------
-
-.. include:: generated/extracted_rst_api.rst
-  :start-line: 19868
-  :end-line: 19881
-
-------------
-
-.. include:: generated/extracted_rst_api.rst
-  :start-line: 19882
-  :end-line: 19894
-
-------------
-
-.. include:: generated/extracted_rst_api.rst
-  :start-line: 19895
-  :end-line: 19901
-
-------------
-
-.. include:: generated/extracted_rst_api.rst
-  :start-line: 19902
-  :end-line: 19916
-
-------------
-
-.. include:: generated/extracted_rst_api.rst
-  :start-line: 19917
-  :end-line: 19926
-
-------------
-
-.. include:: generated/extracted_rst_api.rst
-  :start-line: 19927
-  :end-line: 19938
-
-------------
-
-.. include:: generated/extracted_rst_api.rst
-  :start-line: 19939
-  :end-line: 19948
-
-------------
-
-.. include:: generated/extracted_rst_api.rst
-  :start-line: 19949
-  :end-line: 19959
-
-------------
-
-.. include:: generated/extracted_rst_api.rst
-  :start-line: 19960
-  :end-line: 20065
-
-------------
-
-.. include:: generated/extracted_rst_api.rst
-  :start-line: 20066
-  :end-line: 20069
-
-------------
-
-.. include:: generated/extracted_rst_api.rst
-  :start-line: 20070
-  :end-line: 20080
-
-------------
-
-.. include:: generated/extracted_rst_api.rst
-  :start-line: 20081
+  :start-line: 20082
   :end-line: 20095
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 20196
-  :end-line: 20206
+  :start-line: 20096
+  :end-line: 20108
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 21209
-  :end-line: 21219
+  :start-line: 20109
+  :end-line: 20115
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 21220
-  :end-line: 21230
+  :start-line: 20116
+  :end-line: 20130
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 21231
-  :end-line: 21241
+  :start-line: 20131
+  :end-line: 20140
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 21242
-  :end-line: 21252
+  :start-line: 20141
+  :end-line: 20152
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 21253
-  :end-line: 21263
+  :start-line: 20153
+  :end-line: 20162
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 21264
-  :end-line: 21274
+  :start-line: 20163
+  :end-line: 20173
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 21275
-  :end-line: 21285
+  :start-line: 20174
+  :end-line: 20279
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 21286
-  :end-line: 21296
+  :start-line: 20280
+  :end-line: 20283
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 21297
-  :end-line: 21307
+  :start-line: 20284
+  :end-line: 20294
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 21308
-  :end-line: 21318
+  :start-line: 20295
+  :end-line: 20309
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 21319
-  :end-line: 21329
+  :start-line: 20410
+  :end-line: 20420
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 17956
-  :end-line: 18000
+  :start-line: 21428
+  :end-line: 21440
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 21441
+  :end-line: 21453
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 21454
+  :end-line: 21466
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 21467
+  :end-line: 21479
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 21480
+  :end-line: 21492
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 21493
+  :end-line: 21505
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 21506
+  :end-line: 21518
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 21519
+  :end-line: 21531
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 21532
+  :end-line: 21544
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 21545
+  :end-line: 21557
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 21558
+  :end-line: 21570
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 18105
+  :end-line: 18187
 
 ------------
 
@@ -329,32 +311,32 @@ Parsing
 -------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 20234
-  :end-line: 20246
+  :start-line: 20448
+  :end-line: 20460
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 20247
-  :end-line: 20272
+  :start-line: 20461
+  :end-line: 20486
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 20273
-  :end-line: 20285
+  :start-line: 20487
+  :end-line: 20499
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 23430
-  :end-line: 23440
+  :start-line: 23687
+  :end-line: 23697
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 23441
-  :end-line: 23450
+  :start-line: 23698
+  :end-line: 23707
 
 ------------
 
@@ -362,20 +344,14 @@ Object
 ------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 7896
-  :end-line: 8025
+  :start-line: 7819
+  :end-line: 7946
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 8026
-  :end-line: 8027
-
-------------
-
-.. include:: generated/extracted_rst_api.rst
-  :start-line: 2479
-  :end-line: 2525
+  :start-line: 7947
+  :end-line: 8015
 
 ------------
 
@@ -383,8 +359,8 @@ Properties
 ----------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 9276
-  :end-line: 9520
+  :start-line: 9257
+  :end-line: 9525
 
 ------------
 
@@ -392,20 +368,20 @@ Bitmap
 ------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 1187
-  :end-line: 1775
+  :start-line: 1163
+  :end-line: 1751
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 1776
-  :end-line: 1838
+  :start-line: 1752
+  :end-line: 1814
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 10009
-  :end-line: 10123
+  :start-line: 10016
+  :end-line: 10130
 
 ------------
 
@@ -413,277 +389,145 @@ Warp
 ----
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 22405
-  :end-line: 22417
+  :start-line: 22662
+  :end-line: 22674
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 22418
-  :end-line: 22439
+  :start-line: 22675
+  :end-line: 22696
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 22440
-  :end-line: 22449
+  :start-line: 22697
+  :end-line: 22706
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 22450
-  :end-line: 22470
+  :start-line: 22707
+  :end-line: 22727
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 22471
-  :end-line: 22490
+  :start-line: 22728
+  :end-line: 22747
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 22491
-  :end-line: 22504
+  :start-line: 22748
+  :end-line: 22761
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 22505
-  :end-line: 22514
+  :start-line: 22762
+  :end-line: 22771
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 22515
-  :end-line: 22530
+  :start-line: 22772
+  :end-line: 22787
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 22531
-  :end-line: 22543
-
-------------
-
-.. include:: generated/extracted_rst_api.rst
-  :start-line: 22544
-  :end-line: 22556
-
-------------
-
-.. include:: generated/extracted_rst_api.rst
-  :start-line: 22557
-  :end-line: 22590
-
-------------
-
-.. include:: generated/extracted_rst_api.rst
-  :start-line: 22591
-  :end-line: 22610
-
-------------
-
-.. include:: generated/extracted_rst_api.rst
-  :start-line: 22611
-  :end-line: 22621
-
-------------
-
-.. include:: generated/extracted_rst_api.rst
-  :start-line: 22622
-  :end-line: 22631
-
-------------
-
-.. include:: generated/extracted_rst_api.rst
-  :start-line: 22632
-  :end-line: 22651
-
-------------
-
-.. include:: generated/extracted_rst_api.rst
-  :start-line: 22652
-  :end-line: 22670
-
-------------
-
-.. include:: generated/extracted_rst_api.rst
-  :start-line: 22671
-  :end-line: 22681
-
-------------
-
-.. include:: generated/extracted_rst_api.rst
-  :start-line: 22682
-  :end-line: 22689
-
-------------
-
-.. include:: generated/extracted_rst_api.rst
-  :start-line: 22690
-  :end-line: 22699
-
-------------
-
-.. include:: generated/extracted_rst_api.rst
-  :start-line: 22700
-  :end-line: 22709
-
-------------
-
-.. include:: generated/extracted_rst_api.rst
-  :start-line: 22710
-  :end-line: 22726
-
-------------
-
-.. include:: generated/extracted_rst_api.rst
-  :start-line: 22727
-  :end-line: 22739
-
-------------
-
-.. include:: generated/extracted_rst_api.rst
-  :start-line: 22740
-  :end-line: 22749
-
-------------
-
-.. include:: generated/extracted_rst_api.rst
-  :start-line: 22750
-  :end-line: 22759
-
-------------
-
-.. include:: generated/extracted_rst_api.rst
-  :start-line: 22760
-  :end-line: 22769
-
-------------
-
-.. include:: generated/extracted_rst_api.rst
-  :start-line: 22770
-  :end-line: 22779
-
-------------
-
-.. include:: generated/extracted_rst_api.rst
-  :start-line: 22780
-  :end-line: 22790
-
-------------
-
-.. include:: generated/extracted_rst_api.rst
-  :start-line: 22791
+  :start-line: 22788
   :end-line: 22800
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
   :start-line: 22801
-  :end-line: 22811
+  :end-line: 22813
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 22812
-  :end-line: 22821
+  :start-line: 22814
+  :end-line: 22847
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 22822
-  :end-line: 22839
+  :start-line: 22848
+  :end-line: 22867
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 22840
-  :end-line: 22855
+  :start-line: 22868
+  :end-line: 22878
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 22856
-  :end-line: 22866
+  :start-line: 22879
+  :end-line: 22888
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 22867
-  :end-line: 22877
+  :start-line: 22889
+  :end-line: 22908
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 22878
-  :end-line: 22887
-
-------------
-
-.. include:: generated/extracted_rst_api.rst
-  :start-line: 22888
-  :end-line: 22901
-
-------------
-
-.. include:: generated/extracted_rst_api.rst
-  :start-line: 22902
-  :end-line: 22914
-
-------------
-
-.. include:: generated/extracted_rst_api.rst
-  :start-line: 22915
+  :start-line: 22909
   :end-line: 22927
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
   :start-line: 22928
-  :end-line: 22937
+  :end-line: 22938
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 22938
-  :end-line: 22947
+  :start-line: 22939
+  :end-line: 22946
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 22948
-  :end-line: 22960
+  :start-line: 22947
+  :end-line: 22956
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 22961
-  :end-line: 22970
+  :start-line: 22957
+  :end-line: 22966
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 22971
-  :end-line: 22980
+  :start-line: 22967
+  :end-line: 22983
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 22981
-  :end-line: 22990
+  :start-line: 22984
+  :end-line: 22996
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 22991
-  :end-line: 23000
+  :start-line: 22997
+  :end-line: 23006
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 23001
+  :start-line: 23007
   :end-line: 23016
 
 ------------
@@ -696,7 +540,139 @@ Warp
 
 .. include:: generated/extracted_rst_api.rst
   :start-line: 23027
-  :end-line: 23039
+  :end-line: 23036
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 23037
+  :end-line: 23047
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 23048
+  :end-line: 23057
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 23058
+  :end-line: 23068
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 23069
+  :end-line: 23078
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 23079
+  :end-line: 23096
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 23097
+  :end-line: 23112
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 23113
+  :end-line: 23123
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 23124
+  :end-line: 23134
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 23135
+  :end-line: 23144
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 23145
+  :end-line: 23158
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 23159
+  :end-line: 23171
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 23172
+  :end-line: 23184
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 23185
+  :end-line: 23194
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 23195
+  :end-line: 23204
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 23205
+  :end-line: 23217
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 23218
+  :end-line: 23227
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 23228
+  :end-line: 23237
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 23238
+  :end-line: 23247
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 23248
+  :end-line: 23257
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 23258
+  :end-line: 23273
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 23274
+  :end-line: 23283
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 23284
+  :end-line: 23296
 
 ------------
 
@@ -704,104 +680,104 @@ Distributions
 -------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 2540
-  :end-line: 2731
+  :start-line: 2471
+  :end-line: 2662
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 2930
-  :end-line: 3133
+  :start-line: 2861
+  :end-line: 3064
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 3134
-  :end-line: 3168
+  :start-line: 3065
+  :end-line: 3099
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 5327
-  :end-line: 5523
+  :start-line: 5255
+  :end-line: 5451
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 7687
-  :end-line: 7865
+  :start-line: 7610
+  :end-line: 7788
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 4352
-  :end-line: 4470
+  :start-line: 4280
+  :end-line: 4398
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 4471
-  :end-line: 4589
+  :start-line: 4399
+  :end-line: 4517
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 4590
-  :end-line: 4708
+  :start-line: 4518
+  :end-line: 4636
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 4709
-  :end-line: 4827
+  :start-line: 4637
+  :end-line: 4755
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 5764
-  :end-line: 5888
+  :start-line: 5691
+  :end-line: 5815
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 5889
-  :end-line: 6013
+  :start-line: 5816
+  :end-line: 5940
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 6014
-  :end-line: 6138
+  :start-line: 5941
+  :end-line: 6065
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 6139
-  :end-line: 6263
+  :start-line: 6066
+  :end-line: 6190
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 6264
-  :end-line: 6388
+  :start-line: 6191
+  :end-line: 6315
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 6389
-  :end-line: 6513
+  :start-line: 6316
+  :end-line: 6440
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 6514
-  :end-line: 6638
+  :start-line: 6441
+  :end-line: 6565
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 6639
-  :end-line: 6763
+  :start-line: 6566
+  :end-line: 6690
 
 ------------
 
@@ -809,254 +785,254 @@ Math
 ----
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 20323
-  :end-line: 20326
+  :start-line: 20542
+  :end-line: 20545
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 20327
-  :end-line: 20330
+  :start-line: 20546
+  :end-line: 20549
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 20331
-  :end-line: 20334
+  :start-line: 20550
+  :end-line: 20553
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 20335
-  :end-line: 20368
+  :start-line: 20554
+  :end-line: 20587
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 20369
-  :end-line: 20410
+  :start-line: 20588
+  :end-line: 20629
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 20411
-  :end-line: 20420
+  :start-line: 20630
+  :end-line: 20639
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 20421
-  :end-line: 20433
+  :start-line: 20640
+  :end-line: 20652
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 20434
-  :end-line: 20447
+  :start-line: 20653
+  :end-line: 20666
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 20448
-  :end-line: 20460
+  :start-line: 20667
+  :end-line: 20679
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 20461
-  :end-line: 20470
+  :start-line: 20680
+  :end-line: 20689
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 20471
-  :end-line: 20478
+  :start-line: 20690
+  :end-line: 20697
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 20479
-  :end-line: 20486
+  :start-line: 20698
+  :end-line: 20705
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 20487
-  :end-line: 20494
+  :start-line: 20706
+  :end-line: 20713
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 20495
-  :end-line: 20502
+  :start-line: 20714
+  :end-line: 20721
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 20503
-  :end-line: 20512
+  :start-line: 20722
+  :end-line: 20731
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 20513
-  :end-line: 20528
+  :start-line: 20732
+  :end-line: 20747
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 20529
-  :end-line: 20538
+  :start-line: 20748
+  :end-line: 20757
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 20539
-  :end-line: 20552
+  :start-line: 20758
+  :end-line: 20771
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 21730
-  :end-line: 21814
+  :start-line: 21987
+  :end-line: 22071
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 21815
-  :end-line: 21865
+  :start-line: 22072
+  :end-line: 22122
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 21866
-  :end-line: 21889
+  :start-line: 22123
+  :end-line: 22146
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 21890
-  :end-line: 21913
+  :start-line: 22147
+  :end-line: 22170
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 21914
-  :end-line: 21937
+  :start-line: 22171
+  :end-line: 22194
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 21938
-  :end-line: 22018
+  :start-line: 22195
+  :end-line: 22275
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 22019
-  :end-line: 22084
+  :start-line: 22276
+  :end-line: 22341
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 22085
-  :end-line: 22144
+  :start-line: 22342
+  :end-line: 22401
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 22145
-  :end-line: 22215
+  :start-line: 22402
+  :end-line: 22472
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 21052
-  :end-line: 21064
+  :start-line: 21271
+  :end-line: 21283
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 21065
-  :end-line: 21082
+  :start-line: 21284
+  :end-line: 21301
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 21083
-  :end-line: 21100
+  :start-line: 21302
+  :end-line: 21319
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 21101
-  :end-line: 21122
+  :start-line: 21320
+  :end-line: 21341
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 21123
-  :end-line: 21146
+  :start-line: 21342
+  :end-line: 21365
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 9523
-  :end-line: 9612
+  :start-line: 9530
+  :end-line: 9619
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 21147
-  :end-line: 21159
+  :start-line: 21366
+  :end-line: 21378
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 19795
-  :end-line: 19804
+  :start-line: 19994
+  :end-line: 20003
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 21160
-  :end-line: 21177
+  :start-line: 21379
+  :end-line: 21396
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 21178
-  :end-line: 21208
+  :start-line: 21397
+  :end-line: 21427
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 20096
-  :end-line: 20123
+  :start-line: 20310
+  :end-line: 20337
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 20124
-  :end-line: 20144
+  :start-line: 20338
+  :end-line: 20358
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 20145
-  :end-line: 20158
+  :start-line: 20359
+  :end-line: 20372
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 20159
-  :end-line: 20195
+  :start-line: 20373
+  :end-line: 20409
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 21026
-  :end-line: 21051
+  :start-line: 21245
+  :end-line: 21270
 
 ------------
 
@@ -1064,56 +1040,56 @@ Random
 ------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 21443
-  :end-line: 21464
+  :start-line: 21684
+  :end-line: 21705
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 21465
-  :end-line: 21486
+  :start-line: 21706
+  :end-line: 21727
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 21487
-  :end-line: 21512
+  :start-line: 21728
+  :end-line: 21753
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 21513
-  :end-line: 21535
+  :start-line: 21754
+  :end-line: 21776
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 21536
-  :end-line: 21558
+  :start-line: 21777
+  :end-line: 21799
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 8170
-  :end-line: 8661
+  :start-line: 8158
+  :end-line: 8649
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 20961
-  :end-line: 20989
+  :start-line: 21180
+  :end-line: 21208
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 20990
-  :end-line: 21025
+  :start-line: 21209
+  :end-line: 21244
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 21642
-  :end-line: 21654
+  :start-line: 21899
+  :end-line: 21911
 
 ------------
 
@@ -1121,20 +1097,20 @@ Log
 ---
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 5535
-  :end-line: 5560
+  :start-line: 5463
+  :end-line: 5488
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 5561
-  :end-line: 5711
+  :start-line: 5489
+  :end-line: 5638
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
   :start-line: 90
-  :end-line: 136
+  :end-line: 135
 
 ------------
 
@@ -1142,830 +1118,878 @@ Types
 -----
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 10462
-  :end-line: 10732
+  :start-line: 10469
+  :end-line: 10739
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 10733
-  :end-line: 11023
+  :start-line: 10740
+  :end-line: 11030
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 11024
-  :end-line: 11099
+  :start-line: 11031
+  :end-line: 11106
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 11100
-  :end-line: 11101
+  :start-line: 11107
+  :end-line: 11108
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 11102
-  :end-line: 11103
+  :start-line: 11109
+  :end-line: 11110
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 11104
-  :end-line: 11105
+  :start-line: 11111
+  :end-line: 11112
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 11106
-  :end-line: 11107
+  :start-line: 11113
+  :end-line: 11114
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 11108
-  :end-line: 11109
+  :start-line: 11115
+  :end-line: 11116
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 11110
-  :end-line: 11111
+  :start-line: 11117
+  :end-line: 11118
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 11112
-  :end-line: 11113
+  :start-line: 11119
+  :end-line: 11120
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 11114
-  :end-line: 11115
+  :start-line: 11121
+  :end-line: 11122
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 11116
-  :end-line: 11117
+  :start-line: 11123
+  :end-line: 11124
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 11118
-  :end-line: 11119
+  :start-line: 11125
+  :end-line: 11126
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 11120
-  :end-line: 11121
+  :start-line: 11127
+  :end-line: 11128
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 11122
-  :end-line: 11123
+  :start-line: 11129
+  :end-line: 11130
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 11124
-  :end-line: 11125
+  :start-line: 11131
+  :end-line: 11132
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 11126
-  :end-line: 11127
+  :start-line: 11133
+  :end-line: 11134
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 11128
-  :end-line: 11129
+  :start-line: 11135
+  :end-line: 11136
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 11130
-  :end-line: 11131
+  :start-line: 11137
+  :end-line: 11138
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 11132
-  :end-line: 11133
+  :start-line: 11139
+  :end-line: 11140
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 11134
-  :end-line: 11135
+  :start-line: 11141
+  :end-line: 11142
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 11136
-  :end-line: 11137
+  :start-line: 11143
+  :end-line: 11144
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 11138
-  :end-line: 11139
+  :start-line: 11145
+  :end-line: 11146
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 11140
-  :end-line: 11141
+  :start-line: 11147
+  :end-line: 11148
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 11142
-  :end-line: 11143
+  :start-line: 11149
+  :end-line: 11150
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 11144
-  :end-line: 11145
+  :start-line: 11151
+  :end-line: 11152
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 11146
-  :end-line: 11147
+  :start-line: 11153
+  :end-line: 11154
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 11148
-  :end-line: 11149
+  :start-line: 11155
+  :end-line: 11156
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 11150
-  :end-line: 11151
+  :start-line: 11157
+  :end-line: 11158
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 11152
-  :end-line: 11153
+  :start-line: 11159
+  :end-line: 11160
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 11154
-  :end-line: 11155
+  :start-line: 11161
+  :end-line: 11162
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 11156
-  :end-line: 11275
+  :start-line: 11163
+  :end-line: 11251
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 11276
-  :end-line: 11395
+  :start-line: 11252
+  :end-line: 11340
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 11396
-  :end-line: 11600
+  :start-line: 11341
+  :end-line: 11436
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 11601
-  :end-line: 11805
+  :start-line: 11437
+  :end-line: 11532
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 11806
-  :end-line: 11807
+  :start-line: 11533
+  :end-line: 11534
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 11808
-  :end-line: 11809
+  :start-line: 11535
+  :end-line: 11536
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 11810
-  :end-line: 11811
+  :start-line: 11537
+  :end-line: 11538
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 11812
-  :end-line: 11813
+  :start-line: 11539
+  :end-line: 11540
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 11814
-  :end-line: 11815
+  :start-line: 11541
+  :end-line: 11542
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 11816
-  :end-line: 11817
+  :start-line: 11543
+  :end-line: 11544
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 11818
-  :end-line: 11819
+  :start-line: 11545
+  :end-line: 11546
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 11820
-  :end-line: 11821
+  :start-line: 11547
+  :end-line: 11548
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 11822
-  :end-line: 11823
+  :start-line: 11549
+  :end-line: 11550
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 11824
-  :end-line: 11825
+  :start-line: 11551
+  :end-line: 11552
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 11826
-  :end-line: 11827
+  :start-line: 11553
+  :end-line: 11554
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 11828
-  :end-line: 11829
+  :start-line: 11555
+  :end-line: 11556
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 11830
-  :end-line: 11831
+  :start-line: 11557
+  :end-line: 11558
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 11832
-  :end-line: 11833
+  :start-line: 11559
+  :end-line: 11560
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 11834
-  :end-line: 11835
+  :start-line: 11561
+  :end-line: 11562
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 11836
-  :end-line: 11837
+  :start-line: 11563
+  :end-line: 11564
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 11838
-  :end-line: 11839
+  :start-line: 11565
+  :end-line: 11566
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 11840
-  :end-line: 11841
+  :start-line: 11567
+  :end-line: 11568
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 11842
-  :end-line: 11843
+  :start-line: 11569
+  :end-line: 11570
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 11844
-  :end-line: 11845
+  :start-line: 11571
+  :end-line: 11572
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 1839
-  :end-line: 1840
+  :start-line: 1815
+  :end-line: 1816
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 18001
-  :end-line: 18002
+  :start-line: 18188
+  :end-line: 18189
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 18003
-  :end-line: 18004
+  :start-line: 18190
+  :end-line: 18191
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 5124
-  :end-line: 5125
+  :start-line: 5052
+  :end-line: 5053
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 5126
-  :end-line: 5127
+  :start-line: 5054
+  :end-line: 5055
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 5128
-  :end-line: 5230
+  :start-line: 5056
+  :end-line: 5158
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 5231
-  :end-line: 5326
+  :start-line: 5159
+  :end-line: 5254
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 4246
-  :end-line: 4247
+  :start-line: 4177
+  :end-line: 4178
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 4248
-  :end-line: 4249
+  :start-line: 4179
+  :end-line: 4180
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 15892
-  :end-line: 15893
+  :start-line: 15613
+  :end-line: 15614
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 15894
-  :end-line: 15895
+  :start-line: 15615
+  :end-line: 15616
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 15896
-  :end-line: 15897
+  :start-line: 15617
+  :end-line: 15618
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 15898
-  :end-line: 15899
+  :start-line: 15619
+  :end-line: 15620
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 15900
-  :end-line: 15901
+  :start-line: 15621
+  :end-line: 15622
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 15902
-  :end-line: 15903
+  :start-line: 15623
+  :end-line: 15624
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 18005
-  :end-line: 18006
+  :start-line: 15625
+  :end-line: 15626
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 18007
-  :end-line: 18008
+  :start-line: 18192
+  :end-line: 18193
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 18009
-  :end-line: 18010
+  :start-line: 18194
+  :end-line: 18195
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 18011
-  :end-line: 18012
+  :start-line: 18196
+  :end-line: 18197
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 18013
-  :end-line: 18014
+  :start-line: 18198
+  :end-line: 18199
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 18015
-  :end-line: 18016
+  :start-line: 18200
+  :end-line: 18201
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 18017
-  :end-line: 18018
+  :start-line: 18202
+  :end-line: 18203
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 18019
-  :end-line: 18020
+  :start-line: 18204
+  :end-line: 18205
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 18021
-  :end-line: 18022
+  :start-line: 18206
+  :end-line: 18207
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 18023
-  :end-line: 18024
+  :start-line: 18208
+  :end-line: 18209
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 18025
-  :end-line: 18026
+  :start-line: 18210
+  :end-line: 18211
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 18027
-  :end-line: 18028
+  :start-line: 18212
+  :end-line: 18213
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 18029
-  :end-line: 18030
+  :start-line: 18214
+  :end-line: 18215
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 18031
-  :end-line: 18032
+  :start-line: 18216
+  :end-line: 18217
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 18033
-  :end-line: 18034
+  :start-line: 18218
+  :end-line: 18219
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 18035
-  :end-line: 18036
+  :start-line: 18220
+  :end-line: 18221
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 18037
-  :end-line: 18038
+  :start-line: 18222
+  :end-line: 18223
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 18039
-  :end-line: 18040
+  :start-line: 18224
+  :end-line: 18225
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 18041
-  :end-line: 18042
+  :start-line: 18226
+  :end-line: 18227
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 18043
-  :end-line: 18044
+  :start-line: 18228
+  :end-line: 18229
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 9032
-  :end-line: 9033
+  :start-line: 18230
+  :end-line: 18231
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 9034
-  :end-line: 9035
+  :start-line: 9013
+  :end-line: 9014
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 9036
-  :end-line: 9037
+  :start-line: 9015
+  :end-line: 9016
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 9038
-  :end-line: 9039
+  :start-line: 9017
+  :end-line: 9018
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 9040
-  :end-line: 9041
+  :start-line: 9019
+  :end-line: 9020
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 9042
-  :end-line: 9043
+  :start-line: 9021
+  :end-line: 9022
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 9044
-  :end-line: 9045
+  :start-line: 9023
+  :end-line: 9024
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 9046
-  :end-line: 9047
+  :start-line: 9025
+  :end-line: 9026
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 9048
-  :end-line: 9049
+  :start-line: 9027
+  :end-line: 9028
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 9050
-  :end-line: 9051
+  :start-line: 9029
+  :end-line: 9030
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 9052
-  :end-line: 9053
+  :start-line: 9031
+  :end-line: 9032
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 9054
-  :end-line: 9055
+  :start-line: 9033
+  :end-line: 9034
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 9056
-  :end-line: 9057
+  :start-line: 9035
+  :end-line: 9036
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 9058
-  :end-line: 9059
+  :start-line: 9037
+  :end-line: 9038
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 9060
-  :end-line: 9061
+  :start-line: 9039
+  :end-line: 9040
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 9062
-  :end-line: 9063
+  :start-line: 9041
+  :end-line: 9042
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 9064
-  :end-line: 9065
+  :start-line: 9043
+  :end-line: 9044
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 9066
-  :end-line: 9067
+  :start-line: 9045
+  :end-line: 9046
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 9068
-  :end-line: 9069
+  :start-line: 9047
+  :end-line: 9048
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 9070
-  :end-line: 9071
+  :start-line: 9049
+  :end-line: 9050
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 7892
-  :end-line: 7893
+  :start-line: 9051
+  :end-line: 9052
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 7894
-  :end-line: 7895
+  :start-line: 7815
+  :end-line: 7816
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 6764
-  :end-line: 6765
+  :start-line: 7817
+  :end-line: 7818
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 6766
-  :end-line: 6767
+  :start-line: 6691
+  :end-line: 6692
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 6768
-  :end-line: 6769
+  :start-line: 6693
+  :end-line: 6694
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 9521
-  :end-line: 9522
+  :start-line: 6695
+  :end-line: 6696
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 16133
-  :end-line: 16433
+  :start-line: 6697
+  :end-line: 6698
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 16434
-  :end-line: 16734
+  :start-line: 6699
+  :end-line: 6700
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 16735
-  :end-line: 17035
+  :start-line: 6701
+  :end-line: 6702
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 1841
-  :end-line: 2111
+  :start-line: 9526
+  :end-line: 9527
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 2112
-  :end-line: 2402
+  :start-line: 9528
+  :end-line: 9529
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 2403
-  :end-line: 2478
+  :start-line: 15856
+  :end-line: 16156
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 17275
-  :end-line: 17398
+  :start-line: 16157
+  :end-line: 16457
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 17399
-  :end-line: 17522
+  :start-line: 16458
+  :end-line: 16758
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 17523
-  :end-line: 17731
+  :start-line: 16759
+  :end-line: 17059
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 17732
-  :end-line: 17940
+  :start-line: 17060
+  :end-line: 17360
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 4285
-  :end-line: 4351
+  :start-line: 17361
+  :end-line: 17661
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 2526
-  :end-line: 2527
+  :start-line: 1817
+  :end-line: 2087
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 2528
-  :end-line: 2529
+  :start-line: 2088
+  :end-line: 2378
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 2530
-  :end-line: 2531
+  :start-line: 2379
+  :end-line: 2454
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 2532
-  :end-line: 2533
+  :start-line: 17704
+  :end-line: 17796
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 2534
-  :end-line: 2535
+  :start-line: 17797
+  :end-line: 17889
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 2536
-  :end-line: 2537
+  :start-line: 17890
+  :end-line: 17989
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 9613
-  :end-line: 9683
+  :start-line: 17990
+  :end-line: 18089
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 9684
-  :end-line: 9754
+  :start-line: 4213
+  :end-line: 4279
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 9755
-  :end-line: 9825
+  :start-line: 2455
+  :end-line: 2456
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 9826
-  :end-line: 9890
+  :start-line: 2457
+  :end-line: 2458
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 9891
-  :end-line: 9945
+  :start-line: 2459
+  :end-line: 2460
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 2461
+  :end-line: 2462
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 2463
+  :end-line: 2464
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 2465
+  :end-line: 2466
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 9620
+  :end-line: 9690
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 9691
+  :end-line: 9761
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 9762
+  :end-line: 9832
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 9833
+  :end-line: 9897
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 9898
+  :end-line: 9952
 
 ------------
 
@@ -1973,110 +1997,110 @@ Constants
 ---------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 5712
-  :end-line: 5715
+  :start-line: 5639
+  :end-line: 5642
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 5716
-  :end-line: 5719
+  :start-line: 5643
+  :end-line: 5646
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 5720
-  :end-line: 5723
+  :start-line: 5647
+  :end-line: 5650
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 5724
-  :end-line: 5727
+  :start-line: 5651
+  :end-line: 5654
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 5728
-  :end-line: 5731
+  :start-line: 5655
+  :end-line: 5658
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 5732
-  :end-line: 5735
+  :start-line: 5659
+  :end-line: 5662
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 5736
-  :end-line: 5739
+  :start-line: 5663
+  :end-line: 5666
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 5740
-  :end-line: 5743
+  :start-line: 5667
+  :end-line: 5670
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 5744
-  :end-line: 5747
+  :start-line: 5671
+  :end-line: 5674
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 5748
-  :end-line: 5751
+  :start-line: 5675
+  :end-line: 5678
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 5752
-  :end-line: 5755
+  :start-line: 5679
+  :end-line: 5682
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 5756
-  :end-line: 5759
+  :start-line: 5683
+  :end-line: 5686
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 5760
-  :end-line: 5763
+  :start-line: 5687
+  :end-line: 5690
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 20207
-  :end-line: 20210
+  :start-line: 20421
+  :end-line: 20424
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 20211
-  :end-line: 20214
+  :start-line: 20425
+  :end-line: 20428
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 20215
-  :end-line: 20218
+  :start-line: 20429
+  :end-line: 20432
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 20219
-  :end-line: 20222
+  :start-line: 20433
+  :end-line: 20436
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 2736
-  :end-line: 2739
+  :start-line: 2667
+  :end-line: 2670
 
 ------------
 
@@ -2084,8 +2108,8 @@ Denoiser
 --------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 8028
-  :end-line: 8169
+  :start-line: 8016
+  :end-line: 8157
 
 ------------
 
@@ -2093,50 +2117,50 @@ BSDF
 ----
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 234
-  :end-line: 637
+  :start-line: 217
+  :end-line: 613
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 638
-  :end-line: 704
+  :start-line: 614
+  :end-line: 680
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 705
-  :end-line: 798
+  :start-line: 681
+  :end-line: 774
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 799
-  :end-line: 1128
+  :start-line: 775
+  :end-line: 1104
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 1129
-  :end-line: 1186
+  :start-line: 1105
+  :end-line: 1162
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 17941
-  :end-line: 17955
+  :start-line: 18090
+  :end-line: 18104
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 7687
-  :end-line: 7865
+  :start-line: 7610
+  :end-line: 7788
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 7866
-  :end-line: 7879
+  :start-line: 7789
+  :end-line: 7802
 
 ------------
 
@@ -2150,50 +2174,50 @@ Integrator
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 2732
-  :end-line: 2735
+  :start-line: 2663
+  :end-line: 2666
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 5128
-  :end-line: 5230
+  :start-line: 5056
+  :end-line: 5158
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 7880
-  :end-line: 7891
+  :start-line: 7803
+  :end-line: 7814
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 10350
-  :end-line: 10461
+  :start-line: 10357
+  :end-line: 10468
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 18658
-  :end-line: 18946
+  :start-line: 18857
+  :end-line: 19145
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 18947
-  :end-line: 19229
+  :start-line: 19146
+  :end-line: 19428
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 19230
-  :end-line: 19381
+  :start-line: 19429
+  :end-line: 19580
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 19387
-  :end-line: 19504
+  :start-line: 19586
+  :end-line: 19703
 
 ------------
 
@@ -2201,8 +2225,8 @@ Endpoint
 --------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 3524
-  :end-line: 3886
+  :start-line: 3455
+  :end-line: 3817
 
 ------------
 
@@ -2210,20 +2234,20 @@ Emitter
 -------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 3181
-  :end-line: 3220
+  :start-line: 3112
+  :end-line: 3151
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 3221
-  :end-line: 3255
+  :start-line: 3152
+  :end-line: 3186
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 3256
-  :end-line: 3523
+  :start-line: 3187
+  :end-line: 3454
 
 ------------
 
@@ -2231,26 +2255,26 @@ Sensor
 ------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 12681
-  :end-line: 13016
+  :start-line: 12395
+  :end-line: 12730
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 13017
-  :end-line: 13297
+  :start-line: 12731
+  :end-line: 13011
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 9238
-  :end-line: 9275
+  :start-line: 9219
+  :end-line: 9256
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 20935
-  :end-line: 20947
+  :start-line: 21154
+  :end-line: 21166
 
 ------------
 
@@ -2258,38 +2282,38 @@ Medium
 ------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 6770
-  :end-line: 6919
+  :start-line: 6703
+  :end-line: 6835
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 6920
-  :end-line: 7000
+  :start-line: 6836
+  :end-line: 6916
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 7001
-  :end-line: 7119
+  :start-line: 6917
+  :end-line: 7035
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 8816
-  :end-line: 8845
+  :start-line: 8809
+  :end-line: 8838
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 8846
-  :end-line: 8872
+  :start-line: 8839
+  :end-line: 8865
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 8873
-  :end-line: 8975
+  :start-line: 8866
+  :end-line: 8968
 
 ------------
 
@@ -2297,32 +2321,32 @@ Shape
 -----
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 13298
-  :end-line: 13992
+  :start-line: 13012
+  :end-line: 13706
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 13993
-  :end-line: 14542
+  :start-line: 13707
+  :end-line: 14263
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 14543
-  :end-line: 14592
+  :start-line: 14264
+  :end-line: 14313
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 7233
-  :end-line: 7532
+  :start-line: 7149
+  :end-line: 7448
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 7533
-  :end-line: 7686
+  :start-line: 7449
+  :end-line: 7609
 
 ------------
 
@@ -2330,8 +2354,8 @@ Texture
 -------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 15904
-  :end-line: 16132
+  :start-line: 15627
+  :end-line: 15855
 
 ------------
 
@@ -2339,14 +2363,14 @@ Volume
 ------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 18045
-  :end-line: 18187
+  :start-line: 18232
+  :end-line: 18374
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 18188
-  :end-line: 18294
+  :start-line: 18375
+  :end-line: 18493
 
 ------------
 
@@ -2354,26 +2378,26 @@ PhaseFunction
 -------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 8689
-  :end-line: 8815
+  :start-line: 8677
+  :end-line: 8808
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 8816
-  :end-line: 8845
+  :start-line: 8809
+  :end-line: 8838
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 8846
-  :end-line: 8872
+  :start-line: 8839
+  :end-line: 8865
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 8873
-  :end-line: 8975
+  :start-line: 8866
+  :end-line: 8968
 
 ------------
 
@@ -2381,20 +2405,20 @@ Film
 ----
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 3981
-  :end-line: 4192
+  :start-line: 3912
+  :end-line: 4123
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 4193
-  :end-line: 4214
+  :start-line: 4124
+  :end-line: 4145
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 4828
-  :end-line: 5123
+  :start-line: 4756
+  :end-line: 5051
 
 ------------
 
@@ -2402,20 +2426,20 @@ Filter
 ------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 1776
-  :end-line: 1838
+  :start-line: 1752
+  :end-line: 1814
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 4215
-  :end-line: 4245
+  :start-line: 4146
+  :end-line: 4176
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 9946
-  :end-line: 10008
+  :start-line: 9953
+  :end-line: 10015
 
 ------------
 
@@ -2423,8 +2447,8 @@ Sampler
 -------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 10176
-  :end-line: 10349
+  :start-line: 10183
+  :end-line: 10356
 
 ------------
 
@@ -2432,14 +2456,14 @@ Scene
 -----
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 11846
-  :end-line: 12582
+  :start-line: 11573
+  :end-line: 12307
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 19805
-  :end-line: 19808
+  :start-line: 20004
+  :end-line: 20007
 
 ------------
 
@@ -2447,32 +2471,32 @@ Record
 ------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 9072
-  :end-line: 9142
+  :start-line: 9053
+  :end-line: 9123
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 2822
-  :end-line: 2894
+  :start-line: 2753
+  :end-line: 2825
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 6920
-  :end-line: 7000
+  :start-line: 6836
+  :end-line: 6916
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 15624
-  :end-line: 15891
+  :start-line: 15345
+  :end-line: 15612
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 9143
-  :end-line: 9237
+  :start-line: 9124
+  :end-line: 9218
 
 ------------
 
@@ -2480,98 +2504,98 @@ Spectrum
 --------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 21655
-  :end-line: 21678
+  :start-line: 21912
+  :end-line: 21935
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 21679
-  :end-line: 21695
+  :start-line: 21936
+  :end-line: 21952
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 21696
-  :end-line: 21716
+  :start-line: 21953
+  :end-line: 21973
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 22216
-  :end-line: 22226
+  :start-line: 22473
+  :end-line: 22483
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 22227
-  :end-line: 22239
+  :start-line: 22484
+  :end-line: 22496
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 22240
-  :end-line: 22247
+  :start-line: 22497
+  :end-line: 22504
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 22248
-  :end-line: 22260
+  :start-line: 22505
+  :end-line: 22517
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 19761
-  :end-line: 19771
+  :start-line: 19960
+  :end-line: 19970
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 19772
-  :end-line: 19782
+  :start-line: 19971
+  :end-line: 19981
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 19783
-  :end-line: 19794
+  :start-line: 19982
+  :end-line: 19993
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 23451
-  :end-line: 23464
+  :start-line: 23708
+  :end-line: 23721
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 20948
-  :end-line: 20960
+  :start-line: 21167
+  :end-line: 21179
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 20309
-  :end-line: 20322
+  :start-line: 20528
+  :end-line: 20541
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 19848
-  :end-line: 19867
+  :start-line: 20057
+  :end-line: 20076
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 20223
-  :end-line: 20233
+  :start-line: 20437
+  :end-line: 20447
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 21427
-  :end-line: 21442
+  :start-line: 21668
+  :end-line: 21683
 
 ------------
 
@@ -2579,116 +2603,116 @@ Polarization
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 20599
-  :end-line: 20608
-
-------------
-
-.. include:: generated/extracted_rst_api.rst
-  :start-line: 20609
-  :end-line: 20618
-
-------------
-
-.. include:: generated/extracted_rst_api.rst
-  :start-line: 20619
-  :end-line: 20633
-
-------------
-
-.. include:: generated/extracted_rst_api.rst
-  :start-line: 20634
-  :end-line: 20642
-
-------------
-
-.. include:: generated/extracted_rst_api.rst
-  :start-line: 20643
-  :end-line: 20656
-
-------------
-
-.. include:: generated/extracted_rst_api.rst
-  :start-line: 20657
-  :end-line: 20675
-
-------------
-
-.. include:: generated/extracted_rst_api.rst
-  :start-line: 20676
-  :end-line: 20684
-
-------------
-
-.. include:: generated/extracted_rst_api.rst
-  :start-line: 20685
-  :end-line: 20724
-
-------------
-
-.. include:: generated/extracted_rst_api.rst
-  :start-line: 20725
-  :end-line: 20753
-
-------------
-
-.. include:: generated/extracted_rst_api.rst
-  :start-line: 20754
-  :end-line: 20783
-
-------------
-
-.. include:: generated/extracted_rst_api.rst
-  :start-line: 20784
-  :end-line: 20813
-
-------------
-
-.. include:: generated/extracted_rst_api.rst
-  :start-line: 20814
+  :start-line: 20818
   :end-line: 20827
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
   :start-line: 20828
-  :end-line: 20846
+  :end-line: 20837
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 20847
-  :end-line: 20863
+  :start-line: 20838
+  :end-line: 20852
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 20864
-  :end-line: 20880
+  :start-line: 20853
+  :end-line: 20861
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 20881
-  :end-line: 20900
+  :start-line: 20862
+  :end-line: 20875
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 20901
-  :end-line: 20911
+  :start-line: 20876
+  :end-line: 20894
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 19809
-  :end-line: 19816
+  :start-line: 20895
+  :end-line: 20903
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 22325
-  :end-line: 22332
+  :start-line: 20904
+  :end-line: 20943
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 20944
+  :end-line: 20972
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 20973
+  :end-line: 21002
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 21003
+  :end-line: 21032
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 21033
+  :end-line: 21046
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 21047
+  :end-line: 21065
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 21066
+  :end-line: 21082
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 21083
+  :end-line: 21099
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 21100
+  :end-line: 21119
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 21120
+  :end-line: 21130
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 20008
+  :end-line: 20015
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 22582
+  :end-line: 22589
 
 ------------
 
@@ -2696,32 +2720,32 @@ Util
 ----
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 22333
-  :end-line: 22344
+  :start-line: 22590
+  :end-line: 22601
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 22345
-  :end-line: 22350
+  :start-line: 22602
+  :end-line: 22607
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 22351
-  :end-line: 22377
+  :start-line: 22608
+  :end-line: 22634
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 22378
-  :end-line: 22382
+  :start-line: 22635
+  :end-line: 22639
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 22383
-  :end-line: 22386
+  :start-line: 22640
+  :end-line: 22643
 
 ------------
 
@@ -2729,56 +2753,56 @@ Chi2
 ----
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 19596
-  :end-line: 19609
+  :start-line: 19795
+  :end-line: 19808
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 19610
-  :end-line: 19713
+  :start-line: 19809
+  :end-line: 19912
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 19714
-  :end-line: 19724
+  :start-line: 19913
+  :end-line: 19923
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 19725
-  :end-line: 19728
+  :start-line: 19924
+  :end-line: 19927
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 19729
-  :end-line: 19733
+  :start-line: 19928
+  :end-line: 19932
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 19734
-  :end-line: 19747
+  :start-line: 19933
+  :end-line: 19946
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 19748
-  :end-line: 19751
+  :start-line: 19947
+  :end-line: 19950
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 19752
-  :end-line: 19756
+  :start-line: 19951
+  :end-line: 19955
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 19757
-  :end-line: 19760
+  :start-line: 19956
+  :end-line: 19959
 
 ------------
 
@@ -2786,44 +2810,44 @@ Autodiff
 --------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 18327
-  :end-line: 18333
+  :start-line: 18526
+  :end-line: 18532
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 18334
-  :end-line: 18372
+  :start-line: 18533
+  :end-line: 18571
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 18373
-  :end-line: 18437
+  :start-line: 18572
+  :end-line: 18636
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 18438
-  :end-line: 18440
+  :start-line: 18637
+  :end-line: 18639
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 18441
-  :end-line: 18501
+  :start-line: 18640
+  :end-line: 18700
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 18502
-  :end-line: 18648
+  :start-line: 18701
+  :end-line: 18847
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 18649
-  :end-line: 18657
+  :start-line: 18848
+  :end-line: 18856
 
 ------------
 
@@ -2831,206 +2855,254 @@ Other
 -----
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 204
-  :end-line: 205
+  :start-line: 203
+  :end-line: 204
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 206
-  :end-line: 207
+  :start-line: 205
+  :end-line: 206
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 208
-  :end-line: 209
+  :start-line: 207
+  :end-line: 208
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 210
-  :end-line: 211
+  :start-line: 209
+  :end-line: 210
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 212
-  :end-line: 213
+  :start-line: 211
+  :end-line: 212
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 214
-  :end-line: 215
+  :start-line: 213
+  :end-line: 214
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 2538
-  :end-line: 2539
+  :start-line: 215
+  :end-line: 216
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 2895
-  :end-line: 2929
+  :start-line: 2467
+  :end-line: 2468
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 10124
-  :end-line: 10175
+  :start-line: 2469
+  :end-line: 2470
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 14593
-  :end-line: 14697
+  :start-line: 2826
+  :end-line: 2860
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 19382
-  :end-line: 19386
+  :start-line: 10131
+  :end-line: 10182
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 19505
-  :end-line: 19590
+  :start-line: 14314
+  :end-line: 14418
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 19591
-  :end-line: 19595
+  :start-line: 19581
+  :end-line: 19585
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 19817
-  :end-line: 19824
+  :start-line: 19704
+  :end-line: 19789
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 19825
-  :end-line: 19829
+  :start-line: 19790
+  :end-line: 19794
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 19830
-  :end-line: 19837
+  :start-line: 20016
+  :end-line: 20023
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 19838
-  :end-line: 19847
+  :start-line: 20024
+  :end-line: 20031
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 20286
-  :end-line: 20292
+  :start-line: 20032
+  :end-line: 20036
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 20293
-  :end-line: 20308
+  :start-line: 20037
+  :end-line: 20038
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 20553
-  :end-line: 20556
+  :start-line: 20039
+  :end-line: 20046
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 20557
-  :end-line: 20563
+  :start-line: 20047
+  :end-line: 20056
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 20564
-  :end-line: 20576
+  :start-line: 20077
+  :end-line: 20081
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 20577
-  :end-line: 20590
+  :start-line: 20500
+  :end-line: 20506
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 20591
-  :end-line: 20598
+  :start-line: 20507
+  :end-line: 20511
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 20912
-  :end-line: 20934
+  :start-line: 20512
+  :end-line: 20527
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 21559
-  :end-line: 21566
+  :start-line: 20772
+  :end-line: 20775
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 21582
-  :end-line: 21598
+  :start-line: 20776
+  :end-line: 20782
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 21599
-  :end-line: 21614
+  :start-line: 20783
+  :end-line: 20795
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 21615
-  :end-line: 21641
+  :start-line: 20796
+  :end-line: 20809
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 21717
-  :end-line: 21729
+  :start-line: 20810
+  :end-line: 20817
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 22261
-  :end-line: 22309
+  :start-line: 21131
+  :end-line: 21153
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 22310
-  :end-line: 22311
+  :start-line: 21800
+  :end-line: 21807
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 22392
-  :end-line: 22399
+  :start-line: 21808
+  :end-line: 21815
 
 ------------
 
 .. include:: generated/extracted_rst_api.rst
-  :start-line: 23040
-  :end-line: 23429
+  :start-line: 21826
+  :end-line: 21833
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 21839
+  :end-line: 21855
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 21856
+  :end-line: 21871
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 21872
+  :end-line: 21898
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 21974
+  :end-line: 21986
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 22518
+  :end-line: 22566
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 22567
+  :end-line: 22568
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 22649
+  :end-line: 22656
+
+------------
+
+.. include:: generated/extracted_rst_api.rst
+  :start-line: 23297
+  :end-line: 23686
 
 ------------
 

--- a/docs/porting_3_6.rst
+++ b/docs/porting_3_6.rst
@@ -137,10 +137,8 @@ longer needed.
   expensive, branch-specific computations when the condition for evaluating a 
   particular branch is relatively rare.
 
-..
-
-  Bitmap textures: Half-precision storage by default where possible
-  -----------------------------------------------------------------
+Bitmap textures: Half-precision storage by default where possible
+------------------------------------------------------------------
 
   .. _dr_texture: https://drjit.readthedocs.io/en/latest/textures.html
   .. _spec_up: https://rgl.epfl.ch/publications/Jakob2019Spectral

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -12,3 +12,4 @@ sphinx-copybutton==0.5.2
 sphinx-hoverxref==1.4.1
 sphinx_tabs==3.4.5
 sphinx-toolbox==3.8.1
+pybind11_mkdoc

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -12,4 +12,4 @@ sphinx-copybutton==0.5.2
 sphinx-hoverxref==1.4.1
 sphinx_tabs==3.4.5
 sphinx-toolbox==3.8.1
-pybind11_mkdoc
+pybind11_mkdoc==2.6.2

--- a/docs/src/developer_guide.rst
+++ b/docs/src/developer_guide.rst
@@ -8,7 +8,7 @@ Developer's Guide
 Overview
 --------
 
-This section is addressed to the users interesting in modifying the core of the
+This section is addressed to the users interested in modifying the core of the
 system or even contributing to the codebase.
 
 New developers will want to begin by thoroughly reading the documentation of
@@ -26,7 +26,7 @@ The Mitsuba codebase is split into 3 basic support folders:
   cross-platform file and bitmap I/O, data structures, scheduling, as well as
   logging and plugin management.
 
-* The rendering folder (in `src/render``) contains abstractions needed to
+* The rendering folder (in `src/render`) contains abstractions needed to
   load and represent scenes containing light sources, shapes, materials, and
   participating media.
 

--- a/docs/src/developer_guide/documentation.rst
+++ b/docs/src/developer_guide/documentation.rst
@@ -3,39 +3,57 @@
 Writing documentation
 =====================
 
-Additional packages are required to generate the HTML documentation which can
-be installed running the following command:
+Mitsuba uses a multi-stage documentation generation process that combines C++ docstring extraction, plugin documentation generation, and Sphinx-based HTML generation. This guide explains how the system works and how to build documentation.
+
+Prerequisites
+-------------
+
+Install required Python packages:
 
 .. code-block:: bash
 
     pip install -r docs/requirements.txt
 
-If not already done, run `cmake` in the build folder to generate the build
-targets related to the documentation:
+Documentation sources
+---------------------
+
+Documentation comes from several sources:
+
+1. **C++ headers** (``include/mitsuba/{core,render}/*.h``): API documentation extracted via docstrings
+2. **C++ plugin sources** (``src/{bsdfs,shapes,emitters,...}/*.cpp``): Plugin descriptions and parameters
+3. **RST files** (``docs/src/``): User guides, tutorials, and manual content
+4. **Jupyter notebooks** (``docs/tutorials/``): Interactive tutorials rendered with nbsphinx
+
+Build process overview
+----------------------
+
+The complete documentation build requires multiple steps in a specific order:
 
 .. code-block:: bash
 
-  cd build
-  cmake -GNinja ..
+    ninja docstrings    # Extract C++ docstrings → include/mitsuba/python/docstr.h
+    ninja               # Build main library and Python bindings
+    ninja mkdoc-api     # Generate API reference documentation
+    ninja mkdoc         # Build final HTML documentation
 
-To generate the HTML documentation, build the `mkdoc` target as follow:
+Detailed build steps
+--------------------
 
-.. code-block:: bash
+1. **Docstring extraction** (``ninja docstrings``): Parses C++ headers in ``include/mitsuba/`` using ``pybind11_mkdoc`` to generate ``include/mitsuba/python/docstr.h`` for Python bindings.
 
-    ninja mkdoc
+2. **Main build** (``ninja``): Compiles the C++ library, plugins, and Python bindings with embedded docstrings—required before generating API documentation.
 
-This process will generate the documentation HTML files into the `build/html`
-folder.
+3. **API documentation** (``ninja mkdoc-api``): Introspects Python modules to generate API reference in ``build/html_api/``.
 
-API references generation
--------------------------
+4. **Main documentation** (``ninja mkdoc``): Builds the complete documentation website in ``build/html/`` by running plugin extraction, processing notebooks, and combining all sources.
 
-The API references need to be generated manually executing the following command:
+Output locations
+----------------
 
-.. code-block:: bash
-
-    ninja mkdoc-api
-    ninja mkdoc # Rebuild the documentation to update the API references
+- **Main documentation**: ``build/html/index.html``
+- **API documentation**: ``build/html_api/``
+- **Generated docstrings**: ``include/mitsuba/python/docstr.h``
+- **Plugin documentation**: ``docs/generated/plugins_*.rst`` (gitignored!)
 
 Notebook tutorials
 ------------------

--- a/docs/src/developer_guide/documentation.rst
+++ b/docs/src/developer_guide/documentation.rst
@@ -47,14 +47,6 @@ Detailed build steps
 
 4. **Main documentation** (``ninja mkdoc``): Builds the complete documentation website in ``build/html/`` by running plugin extraction, processing notebooks, and combining all sources.
 
-Output locations
-----------------
-
-- **Main documentation**: ``build/html/index.html``
-- **API documentation**: ``build/html_api/``
-- **Generated docstrings**: ``include/mitsuba/python/docstr.h``
-- **Plugin documentation**: ``docs/generated/plugins_*.rst`` (gitignored!)
-
 Notebook tutorials
 ------------------
 

--- a/docs/src/how_to_guides.rst
+++ b/docs/src/how_to_guides.rst
@@ -8,9 +8,9 @@ How-to Guides
 Overview
 --------
 
-The following guides explain important features of the library in details and
-are dedicated to users with some experience. Unlike the :ref:`sec-api <reference
-API>`, they are by step-by-step guide that explore what it is possible to do
+The following guides explain important features of the library in detail and
+are dedicated to users with some experience. Unlike the :ref:`API reference <sec-api>`, 
+they are step-by-step guides that explore what it is possible to do
 with specific abstractions of Mitsuba.
 
 Guides
@@ -21,6 +21,5 @@ Guides
     :glob:
 
     how_to_guides/transformation_toolbox
-    how_to_guides/image_io_and_manipulation
     how_to_guides/mesh_io_and_manipulation
     how_to_guides/use_optimizers

--- a/docs/src/key_topics/differences.rst
+++ b/docs/src/key_topics/differences.rst
@@ -13,9 +13,9 @@ scene compatibility with Mitsuba 2.
 Enoki → Dr.Jit
 ^^^^^^^^^^^^^^^
 
-One of the biggest change is the replacement of the Enoki backend with Dr.Jit.
+One of the biggest changes is the replacement of the Enoki backend with Dr.Jit.
 To account for this in your code, simply replace the namespace definition and
-aliases as follow:
+aliases as follows:
 
 .. tabs::
     .. code-tab:: c++
@@ -74,11 +74,9 @@ different set of goals.
 Missing features
 ^^^^^^^^^^^^^^^^
 
-A number of Mitsuba 0.6 features are missing in Mitsuba 2. We plan to port some
+A number of Mitsuba 0.6 features are missing in Mitsuba 3. We plan to port some
 of these features in the future and discard others. The following list provides
-an overview:
-
-In the following, we list the main missing features:
+an overview of the main missing features:
 
 - **Shapes**: the basic shapes (PLY/OBJ/Serialized triangle meshes, rectangles, spheres, cylinders) are all supported. However, instancing and assemblies of
   hair fibers are still missing.

--- a/docs/src/key_topics/variants.rst
+++ b/docs/src/key_topics/variants.rst
@@ -9,7 +9,7 @@ instance replace the representation of color to support monochromatic, RGB,
 spectral, or even polarized illumination. Similarly, the numerical
 representation underlying the simulation can be exchanged to perform renderings
 using a higher amount of precision, process many light paths at once on the GPU,
-or it can be mathematically differentiated to to solve inverse problems. All
+or it can be mathematically differentiated to solve inverse problems. All
 variants are automatically created from a single generic codebase. Each variant
 is associated with an identifying name that is composed of several parts:
 

--- a/docs/src/plugin_reference/section_bsdfs.rst
+++ b/docs/src/plugin_reference/section_bsdfs.rst
@@ -42,7 +42,7 @@ The following fragment shows an example of both kinds of usages:
 .. tabs::
     .. code-tab:: xml
 
-        <scene version=3.0.0>
+        <scene version="3.0.0">
             <!-- Creating a named BSDF for later use -->
             <bsdf type=".. BSDF type .." id="my_named_material">
                 <!-- BSDF parameters go here -->
@@ -71,7 +71,7 @@ The following fragment shows an example of both kinds of usages:
         },
 
         'shape_id_0': {
-            # Example of instantiating a named material
+            # Example of referencing a named material
             'bsdf' : {
                 'type' : 'ref',
                 'id' : 'my_named_material'
@@ -124,7 +124,7 @@ away from the glass.
     :caption: Some of the scattering models in Mitsuba need to know the indices of refraction on the exterior and
               interior-facing side of a surface. It is therefore important to decompose the mesh into meaningful
               separate surfaces corresponding to each index of refraction change. The example here shows such a
-              decomposition for a water-filled Glass.
+              decomposition for a water-filled glass.
     :alt: Glass interfaces explanation
 
     .. figure:: ../../resources/data/docs/images/bsdf/glass_explanation.svg

--- a/docs/src/plugin_reference/section_emitters.rst
+++ b/docs/src/plugin_reference/section_emitters.rst
@@ -7,7 +7,7 @@ Emitters
         :width: 70%
         :align: center
 
-    Schematic overview of the emitters in 3. The arrows indicate
+    Schematic overview of the emitters in Mitsuba 3. The arrows indicate
     the directional distribution of light.
 
 Mitsuba 3 supports a number of different emitters/light sources, which can be
@@ -19,7 +19,7 @@ the following snippet instantiates a point light emitter that illuminates a sphe
 .. tabs::
     .. code-tab:: xml
 
-        <scene version=3.0.0>
+        <scene version="3.0.0">
             <!-- .. scene contents .. -->
 
             <emitter type="point">
@@ -37,7 +37,7 @@ the following snippet instantiates a point light emitter that illuminates a sphe
         # .. scene contents ..
 
         'emitter_id': {
-            'type': 'point'
+            'type': 'point',
             'position': [0, 0, -2],
             'intensity': {
                 'type': 'spectrum',
@@ -55,7 +55,7 @@ These are specified as children of the corresponding ``<shape>`` element:
 .. tabs::
     .. code-tab:: xml
 
-        <scene version=3.0.0>
+        <scene version="3.0.0">
             <!-- .. scene contents .. -->
 
             <shape type="sphere">
@@ -71,12 +71,14 @@ These are specified as children of the corresponding ``<shape>`` element:
 
         # .. scene contents ..
 
-        'type': 'sphere',
-        'emitter': {
-            'type': 'area',
-            'radiance': {
-                'type': 'rgb',
-                'value': 1.0,
+        'shape_id': {
+            'type': 'sphere',
+            'emitter': {
+                'type': 'area',
+                'radiance': {
+                    'type': 'rgb',
+                    'value': 1.0,
+                }
             }
         }
 

--- a/docs/src/plugin_reference/section_films.rst
+++ b/docs/src/plugin_reference/section_films.rst
@@ -12,7 +12,7 @@ as follows:
 .. tabs::
     .. code-tab:: xml
 
-        <scene version=3.0.0>
+        <scene version="3.0.0">
             <!-- .. scene contents -->
 
             <sensor type=".. sensor type ..">
@@ -37,7 +37,7 @@ as follows:
         # .. scene contents ..
 
         'sensor_id': {
-            'type': '<sensor_type>'
+            'type': '<sensor_type>',
 
             # Write to a high dynamic range EXR image
             'film_id': {
@@ -50,7 +50,7 @@ as follows:
             }
         }
 
-The ``<film>`` plugin should be instantiated nested inside a ``<sensor>``
+The ``<film>`` plugin should be instantiated inside a ``<sensor>``
 declaration. Note how the output filename is never specified---it is automatically
 inferred from the scene filename and can be manually overridden by passing the
 configuration parameter ``-o`` to the ``mitsuba`` executable when rendering

--- a/docs/src/plugin_reference/section_integrators.rst
+++ b/docs/src/plugin_reference/section_integrators.rst
@@ -17,7 +17,7 @@ declaring it at the top level within the scene, e.g.
 .. tabs::
     .. code-tab:: xml
 
-        <scene version=3.0.0>
+        <scene version="3.0.0">
             <!-- Instantiate a unidirectional path tracer,
                 which renders paths up to a depth of 5 -->
             <integrator type="path">
@@ -56,7 +56,7 @@ a chain of scattering events that starts at the light source and ends at the
 camera. It is often useful to limit the path depth when rendering scenes for
 preview purposes, since this reduces the amount of computation that is necessary
 per pixel. Furthermore, such renderings usually converge faster and therefore
-need fewer samples per pixel. Then reference-quality is desired, one should always
+need fewer samples per pixel. When reference-quality is desired, one should always
 leave the path depth unlimited.
 
 The Cornell box renderings below demonstrate the visual effect of a maximum path
@@ -79,7 +79,7 @@ time, the computation time increases.
 
 Mitsuba counts depths starting at 1, which corresponds to visible light sources
 (i.e. a path that starts at the light source and ends at the camera without any
-scattering interaction in between.) A depth-2 path (also known as "direct
+scattering interaction in between). A depth-2 path (also known as "direct
 illumination") includes a single scattering event like shown here:
 
 .. image:: ../../resources/data/docs/images/integrator/path_explanation.jpg

--- a/docs/src/plugin_reference/section_media.rst
+++ b/docs/src/plugin_reference/section_media.rst
@@ -19,7 +19,7 @@ assume the exterior medium (e.g., air) to not influence the light transport.
 .. tabs::
     .. code-tab:: xml
 
-        <scene version=3.0.0>
+        <scene version="3.0.0">
             <shape type=".. shape type ..">
                 .. shape parameters ..
 
@@ -62,7 +62,7 @@ the referencing mechanism:
 .. tabs::
     .. code-tab:: xml
 
-        <scene version=3.0.0>
+        <scene version="3.0.0">
             <!-- .. scene contents .. -->
 
             <medium type="homogeneous" id="fog">

--- a/docs/src/plugin_reference/section_sensors.rst
+++ b/docs/src/plugin_reference/section_sensors.rst
@@ -62,14 +62,14 @@ sensor's :monosp:`to_world` parameter.
 
 .. _explanation_srf_sensor:
 
-**Spectral sensitivity** . Furthermore, sensors can define a custom sensor
+**Spectral sensitivity**. Furthermore, sensors can define a custom sensor
 response function (:monosp:`SRF`) defined as a spectral response function
 ``<spectrum name="srf" filename="..."/>`` (it is possible to load a spectrum from a
 file, see the :ref:`Spectrum definition <color-spectra>` section). In other words,
 it can be used to focus computation into several wavelengths. Note that this
 parameter only works for ``spectral`` variants.
 
-When no spectral sensitivity is set, it fallbacks to the ``rgb`` sensitivity curves.
+When no spectral sensitivity is set, it falls back to the ``rgb`` sensitivity curves.
 On the other hand, it modifies the sampling of wavelengths to one according to the
 new spectral sensitivity multiplied by the ``rgb`` sensitivity curves. Notice that
 while using the :ref:`High dynamic range film <film-hdrfilm>`, the output will
@@ -87,7 +87,7 @@ be a ``rgb`` image containing only information of the visible range of the spect
 .. subfigend::
    :label: fig-srf_sensors
 
-Another option is to use :ref:`Spectral Film <film-specfilm>`. By using it is
+Another option is to use :ref:`Spectral Film <film-specfilm>`. By using it, it is
 possible to define an arbitrary number of sensor sensitivities (:monosp:`SRF`)
 which do not need to be constrained to the visible range of the spectrum
 (``rgb`` sensitivity curves are not taken into account).

--- a/docs/src/plugin_reference/section_shapes.rst
+++ b/docs/src/plugin_reference/section_shapes.rst
@@ -16,7 +16,7 @@ Shapes are usually declared along with a surface scattering model named *BSDF* (
 .. tabs::
     .. code-tab:: xml
 
-        <scene version=3.0.0>
+        <scene version="3.0.0">
             <!-- .. scene contents .. -->
 
             <shape type=".. shape type ..">
@@ -48,10 +48,10 @@ Shapes are usually declared along with a surface scattering model named *BSDF* (
             }
 
             # Alternatively, reference a named BSDF that had been declared previously
-            'bsdf_id' : {
-                'type' : 'ref',
-                'id' : 'some_bsdf_id'
-            }
+            # 'bsdf_id' : {
+            #     'type' : 'ref',
+            #     'id' : 'some_bsdf_id'
+            # }
         }
 
 The following subsections discuss the available shape types in greater detail.

--- a/docs/src/plugin_reference/section_spectra.rst
+++ b/docs/src/plugin_reference/section_spectra.rst
@@ -4,7 +4,7 @@ Spectra
 =======
 
 This section describes the plugins behind spectral reflectance or emission used
-in 3. On an implementation level, these behave very similarly to the
+in Mitsuba 3. On an implementation level, these behave very similarly to the
 :ref:`texture plugins <sec-textures>` described earlier (but lacking their
 spatially varying property) and can thus be used similarly as either BSDF or
 emitter parameters:
@@ -12,7 +12,7 @@ emitter parameters:
 .. tabs::
     .. code-tab:: xml
 
-        <scene version=3.0.0>
+        <scene version="3.0.0">
             <bsdf type=".. BSDF type ..">
                 <!-- Explicitly add a uniform spectrum plugin -->
                 <spectrum type=".. spectrum type .." name=".. parameter name ..">
@@ -35,7 +35,7 @@ emitter parameters:
 
 In practice, it is however discouraged to instantiate plugins in this explicit way
 and the XML scene description parser directly parses a number of common (shorter)
-``<spectrum>`` and ``<rgb>`` tags See the corresponding section about the
+``<spectrum>`` and ``<rgb>`` tags. See the corresponding section about the
 :ref:`scene file format <sec-file-format>` for details.
 
 The following two tables summarize which underlying plugins get instantiated
@@ -120,6 +120,6 @@ and the BSDF reflectance (here using a :ref:`diffuse <bsdf-diffuse>` BSDF).
     While it is possible to define unbounded RGB properties (such as the ``eta``
     value for a :ref:`conductor BSDF <bsdf-conductor>`) using ``<rgb name=".." value=".."/>``
     tag, it is highly recommended to directly define a spectrum curve (or use a
-    material from :num:`conductor-ior-list>`) as the spectral uplifting algorithm
+    material from :numref:`conductor-ior-list`) as the spectral uplifting algorithm
     implemented in Mitsuba won't be able to guarantee that the produced spectrum
     will behave consistently in both RGB and spectral modes.

--- a/docs/src/plugin_reference/section_textures.rst
+++ b/docs/src/plugin_reference/section_textures.rst
@@ -12,12 +12,12 @@ as supporting the :paramtype:`texture` type. See the last sections about
 Textures take an (optional) ``<transform>`` called :paramtype:`to_uv` which can
 be used to translate, scale, or rotate the lookup into the texture accordingly.
 
-An example in XML looks the following:
+An example in XML looks as follows:
 
 .. tabs::
     .. code-tab:: xml
 
-        <scene version=3.0.0>
+        <scene version="3.0.0">
             <!-- Create a BSDF that supports textured parameters -->
             <bsdf type=".. BSDF type .." id="my_textured_material">
                 <texture type=".. texture type .." name=".. parameter name ..">
@@ -45,7 +45,7 @@ An example in XML looks the following:
         'my_textured_material': {
             'type': '<bsdf_type>',
             '<parameter_name>' : {
-                'type': '<texture_type>':
+                'type': '<texture_type>',
                 # .. texture parameters ..
                 'to_uv': mi.scalar_rgb.ScalarTransform4f.scale([2, 2, 0]).translate([0.5, 1.0, 0]) # Third dimension is ignored
             }
@@ -53,14 +53,14 @@ An example in XML looks the following:
             # .. non-spatially varying BSDF parameters ..
         }
 
-Similar to BSDFs, named textures can alternatively defined at the top level of the scene
+Similar to BSDFs, named textures can alternatively be defined at the top level of the scene
 and later referenced. This is particularly useful if the same texture would be loaded
 many times otherwise.
 
 .. tabs::
     .. code-tab:: xml
 
-        <scene version=3.0.0>
+        <scene version="3.0.0">
             <!-- Create a named texture at the top level -->
             <texture type=".. texture type .." id="my_named_texture">
                 <!-- .. Texture parameters go here .. -->
@@ -82,7 +82,7 @@ many times otherwise.
         # .. scene contents ..
 
         'texture_id': {
-            'type': '<texture_type>':
+            'type': '<texture_type>',
             # .. texture parameters ..
         },
 

--- a/include/mitsuba/core/bitmap.h
+++ b/include/mitsuba/core/bitmap.h
@@ -172,10 +172,10 @@ public:
         /// No transformation (default)
         Empty,
 
-        // Premultiply channels by alpha
+        /// Premultiply alpha channel
         Premultiply,
 
-        // Unpremultiply (divide) channels by alpha
+        /// Unpremultiply alpha channel
         Unpremultiply
     };
 
@@ -493,7 +493,7 @@ public:
      * values, etc.)
      *
      * Note that the alpha channel is assumed to be linear in both
-     * the source and target bitmap, hence it won't be affected by
+     * the source and target bitmap, therefore it won't be affected by
      * any gamma-related transformations.
      *
      * \remark This <tt>convert()</tt> variant usually returns a new

--- a/include/mitsuba/core/bsphere.h
+++ b/include/mitsuba/core/bsphere.h
@@ -39,7 +39,7 @@ template <typename Point_> struct BoundingSphere: drjit::TraversableBase {
         return radius <= 0.f;
     }
 
-    /// Expand the bounding sphere radius to contain another point.
+    /// Expand the bounding sphere radius to contain another point
     void expand(const Point &p) {
         radius = dr::maximum(radius, dr::norm(p - center));
     }

--- a/include/mitsuba/core/distr_1d.h
+++ b/include/mitsuba/core/distr_1d.h
@@ -105,7 +105,7 @@ public:
     }
 
     /**
-     * \brief %Transform a uniformly distributed sample to the stored
+     * \brief Transform a uniformly distributed sample to the stored
      * distribution
      *
      * \param sample
@@ -135,7 +135,7 @@ public:
     }
 
     /**
-     * \brief %Transform a uniformly distributed sample to the stored
+     * \brief Transform a uniformly distributed sample to the stored
      * distribution
      *
      * \param value
@@ -155,7 +155,7 @@ public:
     }
 
     /**
-     * \brief %Transform a uniformly distributed sample to the stored
+     * \brief Transform a uniformly distributed sample to the stored
      * distribution
      *
      * The original sample is value adjusted so that it can be reused as a
@@ -183,7 +183,7 @@ public:
     }
 
     /**
-     * \brief %Transform a uniformly distributed sample to the stored
+     * \brief Transform a uniformly distributed sample to the stored
      * distribution.
      *
      * The original sample is value adjusted so that it can be reused as a
@@ -417,7 +417,7 @@ public:
     }
 
     /**
-     * \brief %Transform a uniformly distributed sample to the stored
+     * \brief Transform a uniformly distributed sample to the stored
      * distribution
      *
      * \param sample
@@ -459,7 +459,7 @@ public:
     }
 
     /**
-     * \brief %Transform a uniformly distributed sample to the stored
+     * \brief Transform a uniformly distributed sample to the stored
      * distribution
      *
      * \param sample 
@@ -777,7 +777,7 @@ public:
     }
 
     /**
-     * \brief %Transform a uniformly distributed sample to the stored
+     * \brief Transform a uniformly distributed sample to the stored
      * distribution
      *
      * \param sample
@@ -822,7 +822,7 @@ public:
     }
 
     /**
-     * \brief %Transform a uniformly distributed sample to the stored
+     * \brief Transform a uniformly distributed sample to the stored
      * distribution
      *
      * \param sample

--- a/include/mitsuba/core/object.h
+++ b/include/mitsuba/core/object.h
@@ -42,7 +42,7 @@ enum class ObjectType : uint32_t {
     /// Emits radiance, subclasses \ref Emitter
     Emitter,
 
-    /// Sensor,
+    /// Generates sample positions and directions, subclasses \ref Sampler
     Sampler,
 
     /// Denotes an arbitrary shape (including meshes)

--- a/include/mitsuba/core/qmc.h
+++ b/include/mitsuba/core/qmc.h
@@ -51,7 +51,7 @@ public:
     int scramble() const { return m_scramble; }
 
     /**
-     * \brief Calculate the radical inverse function
+     * \brief Calculate the value of the radical inverse function
      *
      * This function is used as a building block to construct Halton and Hammersley
      * sequences. Roughly, it computes a b-ary representation of the input value

--- a/include/mitsuba/core/rfilter.h
+++ b/include/mitsuba/core/rfilter.h
@@ -108,7 +108,7 @@ template <typename Scalar_> struct Resampler {
      *
      * This constructor precomputes all information needed to efficiently perform the
      * desired resampling operation. For that reason, it is most efficient if it can
-     * be used over and over again (e.g. to resample the equal-sized rows of a bitmap)
+     * be used repeatedly (e.g. to resample the equal-sized rows of a bitmap)
      *
      * \param source_res
      *      Source resolution

--- a/include/mitsuba/python/docstr.h
+++ b/include/mitsuba/python/docstr.h
@@ -745,7 +745,7 @@ R"doc(Context data structure for BSDF evaluation and sampling
 BSDF models in Mitsuba can be queried and sampled using a variety of
 different modes -- for instance, a rendering algorithm can indicate
 whether radiance or importance is being transported, and it can also
-restrict evaluation and sampling to a subset of lobes in a a multi-
+restrict evaluation and sampling to a subset of lobes in a multi-
 lobe BSDF model.
 
 The BSDFContext data structure encodes these preferences and is
@@ -1902,7 +1902,7 @@ Remark:
 
 static const char *__doc_mitsuba_Class_derives_from = R"doc(Check whether this class derives from *class_*)doc";
 
-static const char *__doc_mitsuba_Class_for_name = R"doc(Look up a class by its name)doc";
+static const char *__doc_mitsuba_Class_for_name = R"doc(Look up a class by name)doc";
 
 static const char *__doc_mitsuba_Class_initialize_once = R"doc(Initialize a class - called by static_initialization())doc";
 
@@ -1939,7 +1939,7 @@ classes)doc";
 static const char *__doc_mitsuba_Class_static_remove_functors =
 R"doc(\brif Remove all constructors and unserializers of all classes
 
-This sets the the construction and unserialization functions of all
+This sets the construction and unserialization functions of all
 classes to nullptr. This should only be necessary if these functions
 capture variables that need to be deallocated before calling the
 static_shutdown method.)doc";
@@ -3841,7 +3841,7 @@ Before calling this function, you must first enable gradient tracking
 for one or more scene parameters, or the function will not do
 anything. This is typically done by invoking ``dr.enable_grad()`` on
 elements of the ``SceneParameters`` data structure that can be
-obtained obtained via a call to ``mi.traverse()``. Use ``dr.grad()``
+obtained via a call to ``mi.traverse()``. Use ``dr.grad()``
 to query the resulting gradients of these parameters once
 ``render_backward()`` returns.
 
@@ -5247,7 +5247,7 @@ In contrast, the ``Object`` class allows for a highly efficient
 implementation that only adds 64 bits to the base object (for the
 counter) and has no overhead for references. In addition, when using
 Mitsuba in Python, this counter is shared with Python such that the
-ownerhsip and lifetime of any ``Object`` instance across C++ and
+ownership and lifetime of any ``Object`` instance across C++ and
 Python is managed by it.)doc";
 
 static const char *__doc_mitsuba_Object_Object = R"doc(Default constructor)doc";
@@ -6127,7 +6127,7 @@ static const char *__doc_mitsuba_Properties_Type_NamedReference = R"doc(Named re
 
 static const char *__doc_mitsuba_Properties_Type_Object = R"doc(Arbitrary object)doc";
 
-static const char *__doc_mitsuba_Properties_Type_Pointer = R"doc(const void* pointer (for internal communication between plugins))doc";
+static const char *__doc_mitsuba_Properties_Type_Pointer = R"doc(const void\* pointer (for internal communication between plugins))doc";
 
 static const char *__doc_mitsuba_Properties_Type_String = R"doc(String)doc";
 
@@ -6890,7 +6890,7 @@ Parameter ``active``:
 Returns:
     A pair containing a spectrum and a mask specifying whether a
     surface or medium interaction was sampled. False mask entries
-    indicate that the ray "escaped" the scene, in which case the the
+    indicate that the ray "escaped" the scene, in which case the
     returned spectrum contains the contribution of environment maps,
     if present. The mask can be used to estimate a suitable alpha
     channel of a rendered image.

--- a/include/mitsuba/python/docstr.h
+++ b/include/mitsuba/python/docstr.h
@@ -541,11 +541,9 @@ static const char *__doc_mitsuba_AdjointIntegrator_5 = R"doc()doc";
 
 static const char *__doc_mitsuba_AdjointIntegrator_6 = R"doc()doc";
 
-static const char *__doc_mitsuba_AdjointIntegrator_7 = R"doc()doc";
-
 static const char *__doc_mitsuba_AdjointIntegrator_AdjointIntegrator = R"doc(Create an integrator)doc";
 
-static const char *__doc_mitsuba_AdjointIntegrator_class = R"doc()doc";
+static const char *__doc_mitsuba_AdjointIntegrator_class_name = R"doc(//! @})doc";
 
 static const char *__doc_mitsuba_AdjointIntegrator_m_max_depth =
 R"doc(Longest visualized path depth (\c -1 = infinite). A value of ``1``
@@ -582,13 +580,78 @@ Parameter ``sample_scale``:
     A scale factor that must be applied to each sample to account for
     the film resolution and number of samples.)doc";
 
+static const char *__doc_mitsuba_AdjointIntegrator_traverse_1_cb_ro = R"doc()doc";
+
+static const char *__doc_mitsuba_AdjointIntegrator_traverse_1_cb_rw = R"doc()doc";
+
+static const char *__doc_mitsuba_Any =
+R"doc(Type-erased storage for arbitrary objects
+
+This class resembles ``std::any`` but supports advanced customization
+by exposing the underlying type-erased storage implementation
+Any::Base. The Mitsuba Property class uses Any when it needs to store
+things that aren't part of the supported set of property types, such
+as Dr.Jit tensor objects or other specialized types. The main reason
+for using Any (as opposed to the builtin ``std::any``) is to enable
+seamless use in Python bindings, which requires access to Any::Base
+(see ``src/core/python/properties.cpp`` for what this entails).
+
+Instances of this type are copyable with reference semantics. The
+class is not thread-safe (i.e., it may not be copied concurrently).)doc";
+
+static const char *__doc_mitsuba_Any_Any = R"doc()doc";
+
+static const char *__doc_mitsuba_Any_Any_2 = R"doc()doc";
+
+static const char *__doc_mitsuba_Any_Any_3 = R"doc()doc";
+
+static const char *__doc_mitsuba_Any_Any_4 = R"doc()doc";
+
+static const char *__doc_mitsuba_Any_Any_5 = R"doc()doc";
+
+static const char *__doc_mitsuba_Any_Base = R"doc()doc";
+
+static const char *__doc_mitsuba_Any_Base_dec_ref = R"doc()doc";
+
+static const char *__doc_mitsuba_Any_Base_inc_ref = R"doc()doc";
+
+static const char *__doc_mitsuba_Any_Base_ptr = R"doc()doc";
+
+static const char *__doc_mitsuba_Any_Base_ref_count = R"doc()doc";
+
+static const char *__doc_mitsuba_Any_Base_type = R"doc()doc";
+
+static const char *__doc_mitsuba_Any_Storage = R"doc()doc";
+
+static const char *__doc_mitsuba_Any_Storage_Storage = R"doc()doc";
+
+static const char *__doc_mitsuba_Any_Storage_ptr = R"doc()doc";
+
+static const char *__doc_mitsuba_Any_Storage_type = R"doc()doc";
+
+static const char *__doc_mitsuba_Any_Storage_value = R"doc()doc";
+
+static const char *__doc_mitsuba_Any_data = R"doc()doc";
+
+static const char *__doc_mitsuba_Any_data_2 = R"doc()doc";
+
+static const char *__doc_mitsuba_Any_operator_assign = R"doc()doc";
+
+static const char *__doc_mitsuba_Any_operator_assign_2 = R"doc()doc";
+
+static const char *__doc_mitsuba_Any_p = R"doc()doc";
+
+static const char *__doc_mitsuba_Any_release = R"doc()doc";
+
+static const char *__doc_mitsuba_Any_type = R"doc()doc";
+
 static const char *__doc_mitsuba_Appender =
 R"doc(This class defines an abstract destination for logging-relevant
 information)doc";
 
 static const char *__doc_mitsuba_Appender_append = R"doc(Append a line of text with the given log level)doc";
 
-static const char *__doc_mitsuba_Appender_class = R"doc()doc";
+static const char *__doc_mitsuba_Appender_class_name = R"doc()doc";
 
 static const char *__doc_mitsuba_Appender_log_progress =
 R"doc(Process a progress message
@@ -607,8 +670,7 @@ Parameter ``eta``:
 
 Parameter ``ptr``:
     Custom pointer payload. This is used to express the context of a
-    progress message. When rendering a scene, it will usually contain
-    a pointer to the associated ``RenderJob``.)doc";
+    progress message.)doc";
 
 static const char *__doc_mitsuba_ArgParser =
 R"doc(Minimal command line argument parser
@@ -737,16 +799,14 @@ static const char *__doc_mitsuba_BSDF_5 = R"doc()doc";
 
 static const char *__doc_mitsuba_BSDF_6 = R"doc()doc";
 
-static const char *__doc_mitsuba_BSDF_7 = R"doc()doc";
-
 static const char *__doc_mitsuba_BSDFContext =
 R"doc(Context data structure for BSDF evaluation and sampling
 
 BSDF models in Mitsuba can be queried and sampled using a variety of
 different modes -- for instance, a rendering algorithm can indicate
 whether radiance or importance is being transported, and it can also
-restrict evaluation and sampling to a subset of lobes in a multi-
-lobe BSDF model.
+restrict evaluation and sampling to a subset of lobes in a multi-lobe
+BSDF model.
 
 The BSDFContext data structure encodes these preferences and is
 supplied to most BSDF methods.)doc";
@@ -760,8 +820,8 @@ R"doc(Integer value of requested BSDF component index to be
 sampled/evaluated.)doc";
 
 static const char *__doc_mitsuba_BSDFContext_is_enabled =
-R"doc(Checks whether a given BSDF component type and BSDF component index
-are enabled in this context.)doc";
+R"doc(Checks whether a given BSDF component type and index are enabled in
+this context.)doc";
 
 static const char *__doc_mitsuba_BSDFContext_mode = R"doc(Transported mode (radiance or importance))doc";
 
@@ -855,13 +915,13 @@ static const char *__doc_mitsuba_BSDFSample3_BSDFSample3_4 = R"doc(//! @})doc";
 
 static const char *__doc_mitsuba_BSDFSample3_eta = R"doc(Relative index of refraction in the sampled direction)doc";
 
-static const char *__doc_mitsuba_BSDFSample3_fields = R"doc()doc";
+static const char *__doc_mitsuba_BSDFSample3_fields = R"doc(//! @})doc";
 
-static const char *__doc_mitsuba_BSDFSample3_fields_2 = R"doc()doc";
+static const char *__doc_mitsuba_BSDFSample3_fields_2 = R"doc(//! @})doc";
 
-static const char *__doc_mitsuba_BSDFSample3_labels = R"doc()doc";
+static const char *__doc_mitsuba_BSDFSample3_labels = R"doc(//! @})doc";
 
-static const char *__doc_mitsuba_BSDFSample3_name = R"doc()doc";
+static const char *__doc_mitsuba_BSDFSample3_name = R"doc(//! @})doc";
 
 static const char *__doc_mitsuba_BSDFSample3_operator_assign = R"doc(//! @})doc";
 
@@ -877,7 +937,7 @@ static const char *__doc_mitsuba_BSDFSample3_wo = R"doc(Normalized outgoing dire
 
 static const char *__doc_mitsuba_BSDF_BSDF = R"doc(//! @})doc";
 
-static const char *__doc_mitsuba_BSDF_class = R"doc()doc";
+static const char *__doc_mitsuba_BSDF_class_name = R"doc(//! @})doc";
 
 static const char *__doc_mitsuba_BSDF_component_count = R"doc(Number of components this BSDF is comprised of.)doc";
 
@@ -887,7 +947,7 @@ multiply by the cosine foreshortening term.
 
 Based on the information in the supplied query context ``ctx``, this
 method will either evaluate the entire BSDF or query individual
-components (e.g. the diffuse lobe). Only smooth (i.e. non Dirac-delta)
+components (e.g. the diffuse lobe). Only smooth (i.e. non-Dirac-delta)
 components are supported: calling ``eval()`` on a perfectly specular
 material will return zero.
 
@@ -988,7 +1048,7 @@ BSDF is multiplied by the cosine foreshortening term.
 
 Based on the information in the supplied query context ``ctx``, this
 method will either evaluate the entire BSDF or query individual
-components (e.g. the diffuse lobe). Only smooth (i.e. non Dirac-delta)
+components (e.g. the diffuse lobe). Only smooth (i.e. non-Dirac-delta)
 components are supported: calling ``eval()`` on a perfectly specular
 material will return zero.
 
@@ -1020,9 +1080,9 @@ angle of sampling the given direction ``wo`` and importance sample the
 BSDF model.
 
 This is simply a wrapper around two separate function calls to
-eval_pdf() and sample(). The function exists to perform a smaller
-number of virtual function calls, which has some performance benefits
-on highly vectorized JIT variants of the renderer. (A ~20% performance
+eval_pdf() and sample(). This function exists to reduce the number of
+virtual function calls, which has some performance benefits on highly
+vectorized JIT variants of the renderer. (A ~20% performance
 improvement for the basic path tracer on CUDA)
 
 Parameter ``ctx``:
@@ -1055,13 +1115,9 @@ R"doc(Returns whether this BSDF contains the specified attribute.
 Parameter ``name``:
     Name of the attribute)doc";
 
-static const char *__doc_mitsuba_BSDF_id = R"doc(Return a string identifier)doc";
-
 static const char *__doc_mitsuba_BSDF_m_components = R"doc(Flags for each component of this BSDF.)doc";
 
 static const char *__doc_mitsuba_BSDF_m_flags = R"doc(Combined flags for all components of this BSDF.)doc";
-
-static const char *__doc_mitsuba_BSDF_m_id = R"doc(Identifier (if available))doc";
 
 static const char *__doc_mitsuba_BSDF_needs_differentials = R"doc(Does the implementation require access to texture-space differentials?)doc";
 
@@ -1136,8 +1192,6 @@ value: The BSDF value divided by the probability (multiplied by the
 cosine foreshortening factor when a non-delta component is sampled). A
 zero spectrum indicates that sampling failed.)doc";
 
-static const char *__doc_mitsuba_BSDF_set_id = R"doc(Set a string identifier)doc";
-
 static const char *__doc_mitsuba_BSDF_sh_frame =
 R"doc(Returns the shading frame accounting for any pertubations that may
 performed by the BSDF during evaluation.
@@ -1150,6 +1204,14 @@ Returns:
     interaction shading frame.)doc";
 
 static const char *__doc_mitsuba_BSDF_to_string = R"doc(Return a human-readable representation of the BSDF)doc";
+
+static const char *__doc_mitsuba_BSDF_traverse_1_cb_ro = R"doc()doc";
+
+static const char *__doc_mitsuba_BSDF_traverse_1_cb_rw = R"doc()doc";
+
+static const char *__doc_mitsuba_BSDF_type = R"doc(//! @})doc";
+
+static const char *__doc_mitsuba_BSDF_variant_name = R"doc(//! @})doc";
 
 static const char *__doc_mitsuba_Bitmap =
 R"doc(General-purpose bitmap class with read and write support for several
@@ -1166,9 +1228,9 @@ static const char *__doc_mitsuba_Bitmap_AlphaTransform = R"doc(Type of alpha tra
 
 static const char *__doc_mitsuba_Bitmap_AlphaTransform_Empty = R"doc(No transformation (default))doc";
 
-static const char *__doc_mitsuba_Bitmap_AlphaTransform_Premultiply = R"doc(No transformation (default))doc";
+static const char *__doc_mitsuba_Bitmap_AlphaTransform_Premultiply = R"doc(Premultiply alpha channel)doc";
 
-static const char *__doc_mitsuba_Bitmap_AlphaTransform_Unpremultiply = R"doc(No transformation (default))doc";
+static const char *__doc_mitsuba_Bitmap_AlphaTransform_Unpremultiply = R"doc(Unpremultiply alpha channel)doc";
 
 static const char *__doc_mitsuba_Bitmap_Bitmap =
 R"doc(Create a bitmap of the specified type and allocate the necessary
@@ -1373,7 +1435,7 @@ static const char *__doc_mitsuba_Bitmap_bytes_per_pixel = R"doc(Return the numbe
 
 static const char *__doc_mitsuba_Bitmap_channel_count = R"doc(Return the number of channels used by this bitmap)doc";
 
-static const char *__doc_mitsuba_Bitmap_class = R"doc()doc";
+static const char *__doc_mitsuba_Bitmap_class_name = R"doc()doc";
 
 static const char *__doc_mitsuba_Bitmap_clear = R"doc(Clear the bitmap to zero)doc";
 
@@ -1406,7 +1468,7 @@ conversions (e.g. spectrum to rgb, luminance to uniform spectrum
 values, etc.)
 
 Note that the alpha channel is assumed to be linear in both the source
-and target bitmap, hence it won't be affected by any gamma-related
+and target bitmap, therefore it won't be affected by any gamma-related
 transformations.
 
 Remark:
@@ -1576,6 +1638,10 @@ R"doc(Return a ``Struct`` instance describing the contents of the bitmap
 static const char *__doc_mitsuba_Bitmap_struct_2 = R"doc(Return a ``Struct`` instance describing the contents of the bitmap)doc";
 
 static const char *__doc_mitsuba_Bitmap_to_string = R"doc(Return a human-readable summary of this bitmap)doc";
+
+static const char *__doc_mitsuba_Bitmap_traverse_1_cb_ro = R"doc()doc";
+
+static const char *__doc_mitsuba_Bitmap_traverse_1_cb_rw = R"doc()doc";
 
 static const char *__doc_mitsuba_Bitmap_uint8_data = R"doc(Return a pointer to the underlying data)doc";
 
@@ -1840,7 +1906,7 @@ Remark:
 
 static const char *__doc_mitsuba_BoundingSphere_empty = R"doc(Return whether this bounding sphere has a radius of zero or less.)doc";
 
-static const char *__doc_mitsuba_BoundingSphere_expand = R"doc(Expand the bounding sphere radius to contain another point.)doc";
+static const char *__doc_mitsuba_BoundingSphere_expand = R"doc(Expand the bounding sphere radius to contain another point)doc";
 
 static const char *__doc_mitsuba_BoundingSphere_operator_eq = R"doc(Equality test against another bounding sphere)doc";
 
@@ -1850,109 +1916,9 @@ static const char *__doc_mitsuba_BoundingSphere_radius = R"doc()doc";
 
 static const char *__doc_mitsuba_BoundingSphere_ray_intersect = R"doc(Check if a ray intersects a bounding box)doc";
 
-static const char *__doc_mitsuba_Class =
-R"doc(Stores meta-information about Object instances.
+static const char *__doc_mitsuba_BoundingSphere_traverse_1_cb_ro = R"doc()doc";
 
-This class provides a thin layer of RTTI (run-time type information),
-which is useful for doing things like:
-
-* Checking if an object derives from a certain class
-
-* Determining the parent of a class at runtime
-
-* Instantiating a class by name
-
-* Unserializing a class from a binary data stream
-
-See also:
-    ref, Object)doc";
-
-static const char *__doc_mitsuba_Class_Class =
-R"doc(Construct a new class descriptor
-
-This method should never be called manually. Instead, use the
-MI_DECLARE_CLASS macro to automatically do this for you.
-
-Parameter ``name``:
-    Name of the class
-
-Parameter ``parent``:
-    Name of the parent class
-
-Parameter ``constr``:
-    Pointer to a default construction function
-
-Parameter ``unser``:
-    Pointer to a unserialization construction function
-
-Parameter ``alias``:
-    Optional: name used to refer to instances of this type in
-    Mitsuba's scene description language)doc";
-
-static const char *__doc_mitsuba_Class_alias = R"doc(Return the scene description-specific alias, if applicable)doc";
-
-static const char *__doc_mitsuba_Class_construct =
-R"doc(Generate an instance of this class
-
-Parameter ``props``:
-    A list of extra parameters that are supplied to the constructor
-
-Remark:
-    Throws an exception if the class is not constructible)doc";
-
-static const char *__doc_mitsuba_Class_derives_from = R"doc(Check whether this class derives from *class_*)doc";
-
-static const char *__doc_mitsuba_Class_for_name = R"doc(Look up a class by name)doc";
-
-static const char *__doc_mitsuba_Class_initialize_once = R"doc(Initialize a class - called by static_initialization())doc";
-
-static const char *__doc_mitsuba_Class_is_constructible = R"doc(Does the class support instantiation over RTTI?)doc";
-
-static const char *__doc_mitsuba_Class_is_serializable = R"doc(Does the class support serialization?)doc";
-
-static const char *__doc_mitsuba_Class_m_alias = R"doc()doc";
-
-static const char *__doc_mitsuba_Class_m_construct = R"doc()doc";
-
-static const char *__doc_mitsuba_Class_m_name = R"doc()doc";
-
-static const char *__doc_mitsuba_Class_m_parent = R"doc()doc";
-
-static const char *__doc_mitsuba_Class_m_parent_name = R"doc()doc";
-
-static const char *__doc_mitsuba_Class_m_unserialize = R"doc()doc";
-
-static const char *__doc_mitsuba_Class_m_variant_name = R"doc()doc";
-
-static const char *__doc_mitsuba_Class_name = R"doc(Return the name of the class)doc";
-
-static const char *__doc_mitsuba_Class_parent =
-R"doc(Return the Class object associated with the parent class of nullptr if
-it does not have one.)doc";
-
-static const char *__doc_mitsuba_Class_rtti_is_initialized = R"doc(Check if the RTTI layer has been initialized)doc";
-
-static const char *__doc_mitsuba_Class_static_initialization =
-R"doc(Initializes the built-in RTTI and creates a list of all compiled
-classes)doc";
-
-static const char *__doc_mitsuba_Class_static_remove_functors =
-R"doc(\brif Remove all constructors and unserializers of all classes
-
-This sets the construction and unserialization functions of all
-classes to nullptr. This should only be necessary if these functions
-capture variables that need to be deallocated before calling the
-static_shutdown method.)doc";
-
-static const char *__doc_mitsuba_Class_static_shutdown = R"doc(Free the memory taken by static_initialization())doc";
-
-static const char *__doc_mitsuba_Class_unserialize =
-R"doc(Unserialize an instance of the class
-
-Remark:
-    Throws an exception if the class is not unserializable)doc";
-
-static const char *__doc_mitsuba_Class_variant = R"doc(Return the variant of the class)doc";
+static const char *__doc_mitsuba_BoundingSphere_traverse_1_cb_rw = R"doc()doc";
 
 static const char *__doc_mitsuba_Color = R"doc(//! @{ \name Data types for RGB data)doc";
 
@@ -2072,7 +2038,7 @@ static const char *__doc_mitsuba_ContinuousDistribution_range = R"doc(Return the
 static const char *__doc_mitsuba_ContinuousDistribution_range_2 = R"doc(Return the range of the distribution (const version))doc";
 
 static const char *__doc_mitsuba_ContinuousDistribution_sample =
-R"doc(%Transform a uniformly distributed sample to the stored distribution
+R"doc(Transform a uniformly distributed sample to the stored distribution
 
 Parameter ``sample``:
     A uniformly distributed sample on the interval [0, 1].
@@ -2081,7 +2047,7 @@ Returns:
     The sampled position.)doc";
 
 static const char *__doc_mitsuba_ContinuousDistribution_sample_pdf =
-R"doc(%Transform a uniformly distributed sample to the stored distribution
+R"doc(Transform a uniformly distributed sample to the stored distribution
 
 Parameter ``sample``:
     A uniformly distributed sample on the interval [0, 1].
@@ -2093,6 +2059,10 @@ Returns:
 sample.)doc";
 
 static const char *__doc_mitsuba_ContinuousDistribution_size = R"doc(Return the number of discretizations)doc";
+
+static const char *__doc_mitsuba_ContinuousDistribution_traverse_1_cb_ro = R"doc()doc";
+
+static const char *__doc_mitsuba_ContinuousDistribution_traverse_1_cb_rw = R"doc()doc";
 
 static const char *__doc_mitsuba_ContinuousDistribution_update = R"doc(Update the internal state. Must be invoked when changing the pdf.)doc";
 
@@ -2130,7 +2100,7 @@ form)doc";
 
 static const char *__doc_mitsuba_DefaultFormatter_DefaultFormatter = R"doc(Create a new default formatter)doc";
 
-static const char *__doc_mitsuba_DefaultFormatter_class = R"doc()doc";
+static const char *__doc_mitsuba_DefaultFormatter_class_name = R"doc()doc";
 
 static const char *__doc_mitsuba_DefaultFormatter_format = R"doc()doc";
 
@@ -2187,7 +2157,7 @@ R"doc(Create a direct sampling record, which can be used to *query* the
 density of a surface position with respect to a given reference
 position.
 
-Direction `s` is set so that it points from the reference surface to
+Direction 's' is set so that it points from the reference surface to
 the intersected surface, as required when using e.g. the Endpoint
 interface to compute PDF values.
 
@@ -2223,13 +2193,13 @@ choosing one of several objects (shapes, emitters, ..) on which the
 position lies. In that case, the ``object`` attribute stores a pointer
 to this object.)doc";
 
-static const char *__doc_mitsuba_DirectionSample_fields = R"doc()doc";
+static const char *__doc_mitsuba_DirectionSample_fields = R"doc(//! @})doc";
 
-static const char *__doc_mitsuba_DirectionSample_fields_2 = R"doc()doc";
+static const char *__doc_mitsuba_DirectionSample_fields_2 = R"doc(//! @})doc";
 
-static const char *__doc_mitsuba_DirectionSample_labels = R"doc()doc";
+static const char *__doc_mitsuba_DirectionSample_labels = R"doc(//! @})doc";
 
-static const char *__doc_mitsuba_DirectionSample_name = R"doc()doc";
+static const char *__doc_mitsuba_DirectionSample_name = R"doc(//! @})doc";
 
 static const char *__doc_mitsuba_DirectionSample_operator_array = R"doc(Convenience operator for masking)doc";
 
@@ -2358,6 +2328,10 @@ steps.)doc";
 
 static const char *__doc_mitsuba_DiscreteDistribution2D_to_string = R"doc()doc";
 
+static const char *__doc_mitsuba_DiscreteDistribution2D_traverse_1_cb_ro = R"doc()doc";
+
+static const char *__doc_mitsuba_DiscreteDistribution2D_traverse_1_cb_rw = R"doc()doc";
+
 static const char *__doc_mitsuba_DiscreteDistribution_DiscreteDistribution = R"doc(Create an uninitialized DiscreteDistribution instance)doc";
 
 static const char *__doc_mitsuba_DiscreteDistribution_DiscreteDistribution_2 = R"doc(Initialize from a given probability mass function)doc";
@@ -2411,7 +2385,7 @@ static const char *__doc_mitsuba_DiscreteDistribution_pmf = R"doc(Return the unn
 static const char *__doc_mitsuba_DiscreteDistribution_pmf_2 = R"doc(Return the unnormalized probability mass function (const version))doc";
 
 static const char *__doc_mitsuba_DiscreteDistribution_sample =
-R"doc(%Transform a uniformly distributed sample to the stored distribution
+R"doc(Transform a uniformly distributed sample to the stored distribution
 
 Parameter ``sample``:
     A uniformly distributed sample on the interval [0, 1].
@@ -2420,7 +2394,7 @@ Returns:
     The discrete index associated with the sample)doc";
 
 static const char *__doc_mitsuba_DiscreteDistribution_sample_pmf =
-R"doc(%Transform a uniformly distributed sample to the stored distribution
+R"doc(Transform a uniformly distributed sample to the stored distribution
 
 Parameter ``value``:
     A uniformly distributed sample on the interval [0, 1].
@@ -2432,7 +2406,7 @@ Returns:
 normalized probability value of the sample.)doc";
 
 static const char *__doc_mitsuba_DiscreteDistribution_sample_reuse =
-R"doc(%Transform a uniformly distributed sample to the stored distribution
+R"doc(Transform a uniformly distributed sample to the stored distribution
 
 The original sample is value adjusted so that it can be reused as a
 uniform variate.
@@ -2447,7 +2421,7 @@ Returns:
 sample value.)doc";
 
 static const char *__doc_mitsuba_DiscreteDistribution_sample_reuse_pmf =
-R"doc(%Transform a uniformly distributed sample to the stored distribution.
+R"doc(Transform a uniformly distributed sample to the stored distribution.
 
 The original sample is value adjusted so that it can be reused as a
 uniform variate.
@@ -2464,6 +2438,10 @@ sample value 3. the normalized probability value of the sample)doc";
 static const char *__doc_mitsuba_DiscreteDistribution_size = R"doc(Return the number of entries)doc";
 
 static const char *__doc_mitsuba_DiscreteDistribution_sum = R"doc(Return the original sum of PMF entries before normalization)doc";
+
+static const char *__doc_mitsuba_DiscreteDistribution_traverse_1_cb_ro = R"doc()doc";
+
+static const char *__doc_mitsuba_DiscreteDistribution_traverse_1_cb_rw = R"doc()doc";
 
 static const char *__doc_mitsuba_DiscreteDistribution_update = R"doc(Update the internal state. Must be invoked when changing the pmf.)doc";
 
@@ -2485,6 +2463,10 @@ static const char *__doc_mitsuba_Distribution2D_m_patch_size = R"doc(Size of a b
 
 static const char *__doc_mitsuba_Distribution2D_m_slices = R"doc(Total number of slices (in case Dimension > 1))doc";
 
+static const char *__doc_mitsuba_Distribution2D_traverse_1_cb_ro = R"doc()doc";
+
+static const char *__doc_mitsuba_Distribution2D_traverse_1_cb_rw = R"doc()doc";
+
 static const char *__doc_mitsuba_DummyStream =
 R"doc(Stream implementation that never writes to disk, but keeps track of
 the size of the content being written. It can be used, for example, to
@@ -2497,7 +2479,7 @@ static const char *__doc_mitsuba_DummyStream_can_read = R"doc()doc";
 
 static const char *__doc_mitsuba_DummyStream_can_write = R"doc()doc";
 
-static const char *__doc_mitsuba_DummyStream_class = R"doc()doc";
+static const char *__doc_mitsuba_DummyStream_class_name = R"doc(//! @})doc";
 
 static const char *__doc_mitsuba_DummyStream_close =
 R"doc(Closes the stream. No further read or write operations are permitted.
@@ -2549,8 +2531,6 @@ static const char *__doc_mitsuba_Emitter_5 = R"doc()doc";
 
 static const char *__doc_mitsuba_Emitter_6 = R"doc()doc";
 
-static const char *__doc_mitsuba_Emitter_7 = R"doc()doc";
-
 static const char *__doc_mitsuba_EmitterFlags =
 R"doc(This list of flags is used to classify the different types of
 emitters.)doc";
@@ -2569,9 +2549,9 @@ static const char *__doc_mitsuba_EmitterFlags_SpatiallyVarying = R"doc(The emiss
 
 static const char *__doc_mitsuba_EmitterFlags_Surface = R"doc(The emitter is attached to a surface (e.g. area emitters))doc";
 
-static const char *__doc_mitsuba_Emitter_Emitter = R"doc()doc";
+static const char *__doc_mitsuba_Emitter_Emitter = R"doc(This is both a class and the base of various Mitsuba plugins)doc";
 
-static const char *__doc_mitsuba_Emitter_class = R"doc()doc";
+static const char *__doc_mitsuba_Emitter_class_name = R"doc(This is both a class and the base of various Mitsuba plugins)doc";
 
 static const char *__doc_mitsuba_Emitter_dirty = R"doc(Return whether the emitter parameters have changed)doc";
 
@@ -2579,7 +2559,7 @@ static const char *__doc_mitsuba_Emitter_flags = R"doc(Flags for all components 
 
 static const char *__doc_mitsuba_Emitter_is_environment = R"doc(Is this an environment map light emitter?)doc";
 
-static const char *__doc_mitsuba_Emitter_m_dirty = R"doc(True if the emitters's parameters have changed)doc";
+static const char *__doc_mitsuba_Emitter_m_dirty = R"doc(True if the emitter's parameters have changed)doc";
 
 static const char *__doc_mitsuba_Emitter_m_flags = R"doc(Combined flags for all properties of this emitter.)doc";
 
@@ -2592,6 +2572,14 @@ static const char *__doc_mitsuba_Emitter_sampling_weight = R"doc(The emitter's s
 static const char *__doc_mitsuba_Emitter_set_dirty = R"doc(Modify the emitter's "dirty" flag)doc";
 
 static const char *__doc_mitsuba_Emitter_traverse = R"doc()doc";
+
+static const char *__doc_mitsuba_Emitter_traverse_1_cb_ro = R"doc()doc";
+
+static const char *__doc_mitsuba_Emitter_traverse_1_cb_rw = R"doc()doc";
+
+static const char *__doc_mitsuba_Emitter_type = R"doc(This is both a class and the base of various Mitsuba plugins)doc";
+
+static const char *__doc_mitsuba_Emitter_variant_name = R"doc(This is both a class and the base of various Mitsuba plugins)doc";
 
 static const char *__doc_mitsuba_Endpoint =
 R"doc(Abstract interface subsuming emitters and sensors in Mitsuba.
@@ -2648,13 +2636,13 @@ static const char *__doc_mitsuba_Endpoint_5 = R"doc()doc";
 
 static const char *__doc_mitsuba_Endpoint_6 = R"doc()doc";
 
-static const char *__doc_mitsuba_Endpoint_7 = R"doc()doc";
-
 static const char *__doc_mitsuba_Endpoint_Endpoint = R"doc()doc";
+
+static const char *__doc_mitsuba_Endpoint_Endpoint_2 = R"doc()doc";
 
 static const char *__doc_mitsuba_Endpoint_bbox = R"doc(Return an axis-aligned box bounding the spatial extents of the emitter)doc";
 
-static const char *__doc_mitsuba_Endpoint_class = R"doc()doc";
+static const char *__doc_mitsuba_Endpoint_class_name = R"doc()doc";
 
 static const char *__doc_mitsuba_Endpoint_eval =
 R"doc(Given a ray-surface intersection, return the emitted radiance or
@@ -2702,10 +2690,6 @@ Parameter ``ds``:
 Returns:
     The incident direct radiance/importance associated with the
     sample.)doc";
-
-static const char *__doc_mitsuba_Endpoint_id = R"doc(Return a string identifier)doc";
-
-static const char *__doc_mitsuba_Endpoint_m_id = R"doc()doc";
 
 static const char *__doc_mitsuba_Endpoint_m_medium = R"doc()doc";
 
@@ -2883,8 +2867,6 @@ Returns:
     In the case of emitters, the weight will include the emitted
     radiance.)doc";
 
-static const char *__doc_mitsuba_Endpoint_set_id = R"doc(Set a string identifier)doc";
-
 static const char *__doc_mitsuba_Endpoint_set_medium = R"doc(Set the medium that surrounds the emitter.)doc";
 
 static const char *__doc_mitsuba_Endpoint_set_scene =
@@ -2896,13 +2878,21 @@ function is invoked by the Scene constructor.)doc";
 
 static const char *__doc_mitsuba_Endpoint_set_shape = R"doc(Set the shape associated with this endpoint.)doc";
 
-static const char *__doc_mitsuba_Endpoint_shape = R"doc(Return the shape, to which the emitter is currently attached)doc";
+static const char *__doc_mitsuba_Endpoint_shape = R"doc(Return the shape to which the emitter is currently attached)doc";
 
 static const char *__doc_mitsuba_Endpoint_shape_2 =
-R"doc(Return the shape, to which the emitter is currently attached (const
+R"doc(Return the shape to which the emitter is currently attached (const
 version))doc";
 
 static const char *__doc_mitsuba_Endpoint_traverse = R"doc(//! @})doc";
+
+static const char *__doc_mitsuba_Endpoint_traverse_1_cb_fields = R"doc()doc";
+
+static const char *__doc_mitsuba_Endpoint_traverse_1_cb_fields_2 = R"doc()doc";
+
+static const char *__doc_mitsuba_Endpoint_traverse_1_cb_ro = R"doc()doc";
+
+static const char *__doc_mitsuba_Endpoint_traverse_1_cb_rw = R"doc()doc";
 
 static const char *__doc_mitsuba_Endpoint_world_transform = R"doc(Return the local space to world space transformation)doc";
 
@@ -2925,7 +2915,7 @@ static const char *__doc_mitsuba_FileResolver_begin_2 =
 R"doc(Return an iterator at the beginning of the list of search paths
 (const))doc";
 
-static const char *__doc_mitsuba_FileResolver_class = R"doc()doc";
+static const char *__doc_mitsuba_FileResolver_class_name = R"doc()doc";
 
 static const char *__doc_mitsuba_FileResolver_clear = R"doc(Clear the list of search paths)doc";
 
@@ -2982,7 +2972,7 @@ static const char *__doc_mitsuba_FileStream_can_read = R"doc(True except if the 
 
 static const char *__doc_mitsuba_FileStream_can_write = R"doc(Whether the field was open in write-mode (and was not closed))doc";
 
-static const char *__doc_mitsuba_FileStream_class = R"doc()doc";
+static const char *__doc_mitsuba_FileStream_class_name = R"doc(//! @})doc";
 
 static const char *__doc_mitsuba_FileStream_close =
 R"doc(Closes the stream and the underlying file. No further read or write
@@ -3052,8 +3042,6 @@ static const char *__doc_mitsuba_Film_5 = R"doc()doc";
 
 static const char *__doc_mitsuba_Film_6 = R"doc()doc";
 
-static const char *__doc_mitsuba_Film_7 = R"doc()doc";
-
 static const char *__doc_mitsuba_FilmFlags = R"doc(This list of flags is used to classify the different types of films.)doc";
 
 static const char *__doc_mitsuba_FilmFlags_Alpha = R"doc(The film stores an alpha channel)doc";
@@ -3069,11 +3057,11 @@ static const char *__doc_mitsuba_FilmFlags_Spectral = R"doc(The film stores a sp
 
 static const char *__doc_mitsuba_Film_Film = R"doc(Create a film)doc";
 
-static const char *__doc_mitsuba_Film_base_channels_count = R"doc(Return the number of channels for the developed image (excluding AOVS))doc";
+static const char *__doc_mitsuba_Film_base_channels_count = R"doc(Return the number of channels for the developed image (excluding AOVs))doc";
 
 static const char *__doc_mitsuba_Film_bitmap = R"doc(Return a bitmap object storing the developed contents of the film)doc";
 
-static const char *__doc_mitsuba_Film_class = R"doc()doc";
+static const char *__doc_mitsuba_Film_class_name = R"doc()doc";
 
 static const char *__doc_mitsuba_Film_clear = R"doc(Clear the film contents to zero.)doc";
 
@@ -3122,7 +3110,7 @@ static const char *__doc_mitsuba_Film_parameters_changed = R"doc()doc";
 
 static const char *__doc_mitsuba_Film_prepare =
 R"doc(Configure the film for rendering a specified set of extra channels
-(AOVS). Returns the total number of channels that the film will store)doc";
+(AOVs). Returns the total number of channels that the film will store)doc";
 
 static const char *__doc_mitsuba_Film_prepare_sample =
 R"doc(Prepare spectrum samples to be in the format expected by the film
@@ -3206,6 +3194,18 @@ static const char *__doc_mitsuba_Film_to_string = R"doc(//! @})doc";
 
 static const char *__doc_mitsuba_Film_traverse = R"doc()doc";
 
+static const char *__doc_mitsuba_Film_traverse_1_cb_fields = R"doc()doc";
+
+static const char *__doc_mitsuba_Film_traverse_1_cb_fields_2 = R"doc()doc";
+
+static const char *__doc_mitsuba_Film_traverse_1_cb_ro = R"doc()doc";
+
+static const char *__doc_mitsuba_Film_traverse_1_cb_rw = R"doc()doc";
+
+static const char *__doc_mitsuba_Film_type = R"doc()doc";
+
+static const char *__doc_mitsuba_Film_variant_name = R"doc()doc";
+
 static const char *__doc_mitsuba_Film_write = R"doc(Write the developed contents of the film to a file on disk)doc";
 
 static const char *__doc_mitsuba_FilterBoundaryCondition =
@@ -3232,7 +3232,7 @@ static const char *__doc_mitsuba_Formatter =
 R"doc(Abstract interface for converting log information into a human-
 readable format)doc";
 
-static const char *__doc_mitsuba_Formatter_class = R"doc()doc";
+static const char *__doc_mitsuba_Formatter_class_name = R"doc()doc";
 
 static const char *__doc_mitsuba_Formatter_format =
 R"doc(Turn a log message into a human-readable format
@@ -3240,17 +3240,14 @@ R"doc(Turn a log message into a human-readable format
 Parameter ``level``:
     The importance of the debug message
 
-Parameter ``class_``:
-    Originating class or ``nullptr``
+Parameter ``cname``:
+    Name of the class (if present)
 
-Parameter ``thread``:
-    Thread, which is responsible for creating the message
-
-Parameter ``file``:
-    File, which is responsible for creating the message
+Parameter ``fname``:
+    Source location (file)
 
 Parameter ``line``:
-    Associated line within the source file
+    Source location (line number)
 
 Parameter ``msg``:
     Text content associated with the log message)doc";
@@ -3426,16 +3423,32 @@ static const char *__doc_mitsuba_Hierarchical2D_Level_Level = R"doc()doc";
 
 static const char *__doc_mitsuba_Hierarchical2D_Level_Level_2 = R"doc()doc";
 
+static const char *__doc_mitsuba_Hierarchical2D_Level_Level_3 = R"doc()doc";
+
+static const char *__doc_mitsuba_Hierarchical2D_Level_Level_4 = R"doc()doc";
+
 static const char *__doc_mitsuba_Hierarchical2D_Level_data = R"doc()doc";
+
+static const char *__doc_mitsuba_Hierarchical2D_Level_fields = R"doc()doc";
+
+static const char *__doc_mitsuba_Hierarchical2D_Level_fields_2 = R"doc()doc";
 
 static const char *__doc_mitsuba_Hierarchical2D_Level_index =
 R"doc(Convert from 2D pixel coordinates to an index indicating how the data
 is laid out in memory.
 
-The implementation stores 2x2 patches contigously in memory to improve
-cache locality during hierarchical traversals)doc";
+The implementation stores 2x2 patches contiguously in memory to
+improve cache locality during hierarchical traversals)doc";
+
+static const char *__doc_mitsuba_Hierarchical2D_Level_labels = R"doc()doc";
 
 static const char *__doc_mitsuba_Hierarchical2D_Level_lookup = R"doc()doc";
+
+static const char *__doc_mitsuba_Hierarchical2D_Level_name = R"doc()doc";
+
+static const char *__doc_mitsuba_Hierarchical2D_Level_operator_assign = R"doc()doc";
+
+static const char *__doc_mitsuba_Hierarchical2D_Level_operator_assign_2 = R"doc()doc";
 
 static const char *__doc_mitsuba_Hierarchical2D_Level_ready = R"doc()doc";
 
@@ -3460,6 +3473,10 @@ distribution (parameterized by ``param`` if applicable)
 Returns the warped sample and associated probability density.)doc";
 
 static const char *__doc_mitsuba_Hierarchical2D_to_string = R"doc()doc";
+
+static const char *__doc_mitsuba_Hierarchical2D_traverse_1_cb_ro = R"doc()doc";
+
+static const char *__doc_mitsuba_Hierarchical2D_traverse_1_cb_rw = R"doc()doc";
 
 static const char *__doc_mitsuba_IOREntry = R"doc()doc";
 
@@ -3500,8 +3517,6 @@ static const char *__doc_mitsuba_ImageBlock_4 = R"doc()doc";
 static const char *__doc_mitsuba_ImageBlock_5 = R"doc()doc";
 
 static const char *__doc_mitsuba_ImageBlock_6 = R"doc()doc";
-
-static const char *__doc_mitsuba_ImageBlock_7 = R"doc()doc";
 
 static const char *__doc_mitsuba_ImageBlock_ImageBlock =
 R"doc(Construct a zero-initialized image block with the desired shape and
@@ -3607,7 +3622,7 @@ static const char *__doc_mitsuba_ImageBlock_border_size = R"doc(Return the borde
 
 static const char *__doc_mitsuba_ImageBlock_channel_count = R"doc(Return the number of channels stored by the image block)doc";
 
-static const char *__doc_mitsuba_ImageBlock_class = R"doc()doc";
+static const char *__doc_mitsuba_ImageBlock_class_name = R"doc()doc";
 
 static const char *__doc_mitsuba_ImageBlock_clear = R"doc(Clear the image block contents to zero.)doc";
 
@@ -3726,6 +3741,10 @@ static const char *__doc_mitsuba_ImageBlock_tensor_2 = R"doc(Return the underlyi
 
 static const char *__doc_mitsuba_ImageBlock_to_string = R"doc(//! @})doc";
 
+static const char *__doc_mitsuba_ImageBlock_traverse_1_cb_ro = R"doc()doc";
+
+static const char *__doc_mitsuba_ImageBlock_traverse_1_cb_rw = R"doc()doc";
+
 static const char *__doc_mitsuba_ImageBlock_warn_invalid = R"doc(Warn when writing invalid (NaN, +/- infinity) sample values?)doc";
 
 static const char *__doc_mitsuba_ImageBlock_warn_negative = R"doc(Warn when writing negative sample values?)doc";
@@ -3759,8 +3778,6 @@ static const char *__doc_mitsuba_Integrator_5 = R"doc()doc";
 
 static const char *__doc_mitsuba_Integrator_6 = R"doc()doc";
 
-static const char *__doc_mitsuba_Integrator_7 = R"doc()doc";
-
 static const char *__doc_mitsuba_Integrator_Integrator = R"doc(Create an integrator)doc";
 
 static const char *__doc_mitsuba_Integrator_aov_names =
@@ -3770,9 +3787,7 @@ The default implementation simply returns an empty vector.)doc";
 
 static const char *__doc_mitsuba_Integrator_cancel = R"doc(Cancel a running render job (e.g. after receiving Ctrl-C))doc";
 
-static const char *__doc_mitsuba_Integrator_class = R"doc()doc";
-
-static const char *__doc_mitsuba_Integrator_id = R"doc(Return a string identifier)doc";
+static const char *__doc_mitsuba_Integrator_class_name = R"doc()doc";
 
 static const char *__doc_mitsuba_Integrator_m_hide_emitters = R"doc(Flag for disabling direct visibility of emitters)doc";
 
@@ -3832,18 +3847,18 @@ R"doc(Evaluates the reverse-mode derivative of the rendering step.
 
 Reverse-mode differentiation transforms image-space gradients into
 scene parameter gradients, enabling simultaneous optimization of
-scenes with millions of free parameters. The function is invoked with
-an input *gradient image* (``grad_in``) and transforms and accumulates
-these into the gradient arrays of scene parameters that previously had
-gradient tracking enabled.
+scenes with millions of differentiable parameters. The function is
+invoked with an input *gradient image* (``grad_in``) and transforms
+and accumulates these into the gradient arrays of scene parameters
+that previously had gradient tracking enabled.
 
 Before calling this function, you must first enable gradient tracking
 for one or more scene parameters, or the function will not do
 anything. This is typically done by invoking ``dr.enable_grad()`` on
 elements of the ``SceneParameters`` data structure that can be
-obtained via a call to ``mi.traverse()``. Use ``dr.grad()``
-to query the resulting gradients of these parameters once
-``render_backward()`` returns.
+obtained via a call to ``mi.traverse()``. Use ``dr.grad()`` to query
+the resulting gradients of these parameters once ``render_backward()``
+returns.
 
 Note the default implementation of this functionality relies on naive
 automatic differentiation (AD), which records a computation graph of
@@ -3917,8 +3932,8 @@ and furthermore associate concrete input gradients with one or more
 scene parameters, or the function will just return a zero-valued
 gradient image. This is typically done by invoking
 ``dr.enable_grad()`` and ``dr.set_grad()`` on elements of the
-``SceneParameters`` data structure that can be obtained obtained via a
-call to ``mi.traverse()``.
+``SceneParameters`` data structure that can be obtained via a call to
+``mi.traverse()``.
 
 Note the default implementation of this functionality relies on naive
 automatic differentiation (AD), which records a computation graph of
@@ -3969,8 +3984,6 @@ This function is just a thin wrapper around the previous
 render_forward() function. It accepts a sensor *index* instead and
 renders the scene using sensor 0 by default.)doc";
 
-static const char *__doc_mitsuba_Integrator_set_id = R"doc(Set a string identifier)doc";
-
 static const char *__doc_mitsuba_Integrator_should_stop =
 R"doc(Indicates whether cancel() or a timeout have occurred. Should be
 checked regularly in the integrator's main loop so that timeouts are
@@ -3978,6 +3991,14 @@ enforced accurately.
 
 Note that accurate timeouts rely on m_render_timer, which needs to be
 reset at the beginning of the rendering phase.)doc";
+
+static const char *__doc_mitsuba_Integrator_traverse_1_cb_ro = R"doc()doc";
+
+static const char *__doc_mitsuba_Integrator_traverse_1_cb_rw = R"doc()doc";
+
+static const char *__doc_mitsuba_Integrator_type = R"doc()doc";
+
+static const char *__doc_mitsuba_Integrator_variant_name = R"doc()doc";
 
 static const char *__doc_mitsuba_Interaction = R"doc(Generic surface interaction data structure)doc";
 
@@ -3989,17 +4010,17 @@ static const char *__doc_mitsuba_Interaction_Interaction_3 = R"doc(//! @})doc";
 
 static const char *__doc_mitsuba_Interaction_Interaction_4 = R"doc(//! @})doc";
 
-static const char *__doc_mitsuba_Interaction_fields = R"doc()doc";
+static const char *__doc_mitsuba_Interaction_fields = R"doc(//! @})doc";
 
-static const char *__doc_mitsuba_Interaction_fields_2 = R"doc()doc";
+static const char *__doc_mitsuba_Interaction_fields_2 = R"doc(//! @})doc";
 
 static const char *__doc_mitsuba_Interaction_is_valid = R"doc(Is the current interaction valid?)doc";
 
-static const char *__doc_mitsuba_Interaction_labels = R"doc()doc";
+static const char *__doc_mitsuba_Interaction_labels = R"doc(//! @})doc";
 
 static const char *__doc_mitsuba_Interaction_n = R"doc(Geometric normal (only valid for ``SurfaceInteraction``))doc";
 
-static const char *__doc_mitsuba_Interaction_name = R"doc()doc";
+static const char *__doc_mitsuba_Interaction_name = R"doc(//! @})doc";
 
 static const char *__doc_mitsuba_Interaction_offset_p =
 R"doc(Compute an offset position, used when spawning a ray from this
@@ -4123,7 +4144,7 @@ static const char *__doc_mitsuba_IrregularContinuousDistribution_range = R"doc(R
 static const char *__doc_mitsuba_IrregularContinuousDistribution_range_2 = R"doc(Return the range of the distribution (const version))doc";
 
 static const char *__doc_mitsuba_IrregularContinuousDistribution_sample =
-R"doc(%Transform a uniformly distributed sample to the stored distribution
+R"doc(Transform a uniformly distributed sample to the stored distribution
 
 Parameter ``sample``:
     A uniformly distributed sample on the interval [0, 1].
@@ -4132,7 +4153,7 @@ Returns:
     The sampled position.)doc";
 
 static const char *__doc_mitsuba_IrregularContinuousDistribution_sample_pdf =
-R"doc(%Transform a uniformly distributed sample to the stored distribution
+R"doc(Transform a uniformly distributed sample to the stored distribution
 
 Parameter ``sample``:
     A uniformly distributed sample on the interval [0, 1].
@@ -4145,11 +4166,43 @@ sample.)doc";
 
 static const char *__doc_mitsuba_IrregularContinuousDistribution_size = R"doc(Return the number of discretizations)doc";
 
+static const char *__doc_mitsuba_IrregularContinuousDistribution_traverse_1_cb_ro = R"doc()doc";
+
+static const char *__doc_mitsuba_IrregularContinuousDistribution_traverse_1_cb_rw = R"doc()doc";
+
 static const char *__doc_mitsuba_IrregularContinuousDistribution_update =
 R"doc(Update the internal state. Must be invoked when changing the pdf or
 range.)doc";
 
 static const char *__doc_mitsuba_Jit = R"doc()doc";
+
+static const char *__doc_mitsuba_JitObject =
+R"doc(CRTP base class for JIT-registered objects
+
+This class provides automatic registration/deregistration with
+Dr.Jit's instance registry for JIT-compiled variants. It uses the
+Curiously Recurring Template Pattern (CRTP) to access static members
+of the derived class.
+
+The derived class must provide: - `static constexpr const char
+*Variant`: variant name string - `static constexpr ObjectType Type`:
+object type enumeration value - `using UInt32 = ...`: type that
+indicates whether this is a JIT variant
+
+The `MI_DECLARE_PLUGIN_BASE_CLASS()` macro ensures that these
+attributes are present.)doc";
+
+static const char *__doc_mitsuba_JitObject_JitObject = R"doc(Constructor with ID and optional ObjectType)doc";
+
+static const char *__doc_mitsuba_JitObject_JitObject_2 = R"doc(Copy constructor (registers the new instance))doc";
+
+static const char *__doc_mitsuba_JitObject_JitObject_3 = R"doc(Move constructor (registers the new instance))doc";
+
+static const char *__doc_mitsuba_JitObject_id = R"doc(Return the identifier of this instance)doc";
+
+static const char *__doc_mitsuba_JitObject_m_id = R"doc(Stores the identifier of this instance)doc";
+
+static const char *__doc_mitsuba_JitObject_set_id = R"doc(Set the identifier of this instance)doc";
 
 static const char *__doc_mitsuba_Jit_Jit = R"doc()doc";
 
@@ -4211,7 +4264,7 @@ static const char *__doc_mitsuba_Logger_appender_2 = R"doc(Return one of the app
 
 static const char *__doc_mitsuba_Logger_appender_count = R"doc(Return the number of registered appenders)doc";
 
-static const char *__doc_mitsuba_Logger_class = R"doc()doc";
+static const char *__doc_mitsuba_Logger_class_name = R"doc()doc";
 
 static const char *__doc_mitsuba_Logger_clear_appenders = R"doc(Remove all appenders from this logger)doc";
 
@@ -4229,17 +4282,17 @@ R"doc(Process a log message
 Parameter ``level``:
     Log level of the message
 
-Parameter ``class_``:
-    Class descriptor of the message creator
+Parameter ``cname``:
+    Name of the class (if present)
 
-Parameter ``filename``:
-    Source file of the message creator
+Parameter ``fname``:
+    Source filename
 
 Parameter ``line``:
-    Source line number of the message creator
+    Source line number
 
-Parameter ``fmt``:
-    printf-style string formatter
+Parameter ``msg``:
+    Log message
 
 \note This function is not exposed in the Python bindings. Instead,
 please use \cc mitsuba.core.Log)doc";
@@ -4263,8 +4316,7 @@ Parameter ``eta``:
 
 Parameter ``ptr``:
     Custom pointer payload. This is used to express the context of a
-    progress message. When rendering a scene, it will usually contain
-    a pointer to the associated ``RenderJob``.)doc";
+    progress message.)doc";
 
 static const char *__doc_mitsuba_Logger_m_log_level = R"doc()doc";
 
@@ -4389,6 +4441,10 @@ static const char *__doc_mitsuba_Marginal2D_sample_segment = R"doc()doc";
 
 static const char *__doc_mitsuba_Marginal2D_to_string = R"doc()doc";
 
+static const char *__doc_mitsuba_Marginal2D_traverse_1_cb_ro = R"doc()doc";
+
+static const char *__doc_mitsuba_Marginal2D_traverse_1_cb_rw = R"doc()doc";
+
 static const char *__doc_mitsuba_Medium = R"doc()doc";
 
 static const char *__doc_mitsuba_Medium_2 = R"doc()doc";
@@ -4401,8 +4457,6 @@ static const char *__doc_mitsuba_Medium_5 = R"doc()doc";
 
 static const char *__doc_mitsuba_Medium_6 = R"doc()doc";
 
-static const char *__doc_mitsuba_Medium_7 = R"doc()doc";
-
 static const char *__doc_mitsuba_MediumInteraction = R"doc(Stores information related to a medium scattering interaction)doc";
 
 static const char *__doc_mitsuba_MediumInteraction_MediumInteraction = R"doc(//! @})doc";
@@ -4413,17 +4467,17 @@ static const char *__doc_mitsuba_MediumInteraction_MediumInteraction_3 = R"doc(/
 
 static const char *__doc_mitsuba_MediumInteraction_combined_extinction = R"doc()doc";
 
-static const char *__doc_mitsuba_MediumInteraction_fields = R"doc()doc";
+static const char *__doc_mitsuba_MediumInteraction_fields = R"doc(//! @})doc";
 
-static const char *__doc_mitsuba_MediumInteraction_fields_2 = R"doc()doc";
+static const char *__doc_mitsuba_MediumInteraction_fields_2 = R"doc(//! @})doc";
 
-static const char *__doc_mitsuba_MediumInteraction_labels = R"doc()doc";
+static const char *__doc_mitsuba_MediumInteraction_labels = R"doc(//! @})doc";
 
 static const char *__doc_mitsuba_MediumInteraction_medium = R"doc(Pointer to the associated medium)doc";
 
 static const char *__doc_mitsuba_MediumInteraction_mint = R"doc(mint used when sampling the given distance ``t``)doc";
 
-static const char *__doc_mitsuba_MediumInteraction_name = R"doc()doc";
+static const char *__doc_mitsuba_MediumInteraction_name = R"doc(//! @})doc";
 
 static const char *__doc_mitsuba_MediumInteraction_operator_assign = R"doc(//! @})doc";
 
@@ -4455,7 +4509,7 @@ static const char *__doc_mitsuba_Medium_Medium = R"doc()doc";
 
 static const char *__doc_mitsuba_Medium_Medium_2 = R"doc()doc";
 
-static const char *__doc_mitsuba_Medium_class = R"doc()doc";
+static const char *__doc_mitsuba_Medium_class_name = R"doc()doc";
 
 static const char *__doc_mitsuba_Medium_get_majorant = R"doc(Returns the medium's majorant used for delta tracking)doc";
 
@@ -4465,15 +4519,11 @@ at a given MediumInteraction mi)doc";
 
 static const char *__doc_mitsuba_Medium_has_spectral_extinction = R"doc(Returns whether this medium has a spectrally varying extinction)doc";
 
-static const char *__doc_mitsuba_Medium_id = R"doc(Return a string identifier)doc";
-
 static const char *__doc_mitsuba_Medium_intersect_aabb = R"doc(Intersects a ray with the medium's bounding box)doc";
 
 static const char *__doc_mitsuba_Medium_is_homogeneous = R"doc(Returns whether this medium is homogeneous)doc";
 
 static const char *__doc_mitsuba_Medium_m_has_spectral_extinction = R"doc()doc";
-
-static const char *__doc_mitsuba_Medium_m_id = R"doc(Identifier (if available))doc";
 
 static const char *__doc_mitsuba_Medium_m_is_homogeneous = R"doc()doc";
 
@@ -4506,8 +4556,6 @@ Returns:
     will always be valid, except if the ray missed the Medium's
     bounding box.)doc";
 
-static const char *__doc_mitsuba_Medium_set_id = R"doc(Set a string identifier)doc";
-
 static const char *__doc_mitsuba_Medium_to_string = R"doc(Return a human-readable representation of the Medium)doc";
 
 static const char *__doc_mitsuba_Medium_transmittance_eval_pdf =
@@ -4527,7 +4575,19 @@ Returns:
 
 static const char *__doc_mitsuba_Medium_traverse = R"doc()doc";
 
+static const char *__doc_mitsuba_Medium_traverse_1_cb_fields = R"doc()doc";
+
+static const char *__doc_mitsuba_Medium_traverse_1_cb_fields_2 = R"doc()doc";
+
+static const char *__doc_mitsuba_Medium_traverse_1_cb_ro = R"doc()doc";
+
+static const char *__doc_mitsuba_Medium_traverse_1_cb_rw = R"doc()doc";
+
+static const char *__doc_mitsuba_Medium_type = R"doc()doc";
+
 static const char *__doc_mitsuba_Medium_use_emitter_sampling = R"doc(Returns whether this specific medium instance uses emitter sampling)doc";
+
+static const char *__doc_mitsuba_Medium_variant_name = R"doc()doc";
 
 static const char *__doc_mitsuba_MemoryMappedFile =
 R"doc(Basic cross-platform abstraction for memory mapped files
@@ -4547,7 +4607,7 @@ static const char *__doc_mitsuba_MemoryMappedFile_MemoryMappedFilePrivate = R"do
 
 static const char *__doc_mitsuba_MemoryMappedFile_can_write = R"doc(Return whether the mapped memory region can be modified)doc";
 
-static const char *__doc_mitsuba_MemoryMappedFile_class = R"doc()doc";
+static const char *__doc_mitsuba_MemoryMappedFile_class_name = R"doc()doc";
 
 static const char *__doc_mitsuba_MemoryMappedFile_create_temporary =
 R"doc(Create a temporary memory-mapped file
@@ -4605,7 +4665,7 @@ static const char *__doc_mitsuba_MemoryStream_can_write = R"doc(Always returns t
 
 static const char *__doc_mitsuba_MemoryStream_capacity = R"doc(Return the current capacity of the underlying memory buffer)doc";
 
-static const char *__doc_mitsuba_MemoryStream_class = R"doc()doc";
+static const char *__doc_mitsuba_MemoryStream_class_name = R"doc(//! @})doc";
 
 static const char *__doc_mitsuba_MemoryStream_close =
 R"doc(Closes the stream. No further read or write operations are permitted.
@@ -4680,8 +4740,6 @@ static const char *__doc_mitsuba_Mesh_5 = R"doc()doc";
 
 static const char *__doc_mitsuba_Mesh_6 = R"doc()doc";
 
-static const char *__doc_mitsuba_Mesh_7 = R"doc()doc";
-
 static const char *__doc_mitsuba_Mesh_Mesh =
 R"doc(Creates a zero-initialized mesh with the given vertex and face counts
 
@@ -4701,9 +4759,25 @@ static const char *__doc_mitsuba_Mesh_MeshAttributeType_Face = R"doc()doc";
 
 static const char *__doc_mitsuba_Mesh_MeshAttributeType_Vertex = R"doc()doc";
 
+static const char *__doc_mitsuba_Mesh_MeshAttribute_MeshAttribute = R"doc()doc";
+
+static const char *__doc_mitsuba_Mesh_MeshAttribute_MeshAttribute_2 = R"doc()doc";
+
 static const char *__doc_mitsuba_Mesh_MeshAttribute_buf = R"doc()doc";
 
+static const char *__doc_mitsuba_Mesh_MeshAttribute_fields = R"doc()doc";
+
+static const char *__doc_mitsuba_Mesh_MeshAttribute_fields_2 = R"doc()doc";
+
+static const char *__doc_mitsuba_Mesh_MeshAttribute_labels = R"doc()doc";
+
 static const char *__doc_mitsuba_Mesh_MeshAttribute_migrate = R"doc()doc";
+
+static const char *__doc_mitsuba_Mesh_MeshAttribute_name = R"doc()doc";
+
+static const char *__doc_mitsuba_Mesh_MeshAttribute_operator_assign = R"doc()doc";
+
+static const char *__doc_mitsuba_Mesh_MeshAttribute_operator_assign_2 = R"doc()doc";
 
 static const char *__doc_mitsuba_Mesh_MeshAttribute_size = R"doc()doc";
 
@@ -4722,15 +4796,15 @@ static const char *__doc_mitsuba_Mesh_bbox_2 = R"doc()doc";
 static const char *__doc_mitsuba_Mesh_bbox_3 = R"doc()doc";
 
 static const char *__doc_mitsuba_Mesh_build_directed_edges =
-R"doc(/brief Build directed edge data structure to efficiently access
-adjacent edges.
+R"doc(Build directed edge data structure to efficiently access adjacent
+edges.
 
 This is an implementation of the technique described in:
 ``https://www.graphics.rwth-aachen.de/media/papers/directed.pdf``.)doc";
 
 static const char *__doc_mitsuba_Mesh_build_indirect_silhouette_distribution =
-R"doc(/brief Precompute the set of edges that could contribute to the
-indirect discontinuous integral.
+R"doc(Precompute the set of edges that could contribute to the indirect
+discontinuous integral.
 
 This method filters out any concave edges or flat surfaces.
 
@@ -4751,7 +4825,7 @@ R"doc(Build internal tables for sampling uniformly wrt. area.
 Computes the surface area and sets up ``m_area_pmf`` Thread-safe,
 since it uses a mutex.)doc";
 
-static const char *__doc_mitsuba_Mesh_class = R"doc()doc";
+static const char *__doc_mitsuba_Mesh_class_name = R"doc()doc";
 
 static const char *__doc_mitsuba_Mesh_compute_surface_interaction = R"doc()doc";
 
@@ -4788,6 +4862,8 @@ static const char *__doc_mitsuba_Mesh_faces_buffer_2 = R"doc(Const variant of fa
 static const char *__doc_mitsuba_Mesh_has_attribute = R"doc()doc";
 
 static const char *__doc_mitsuba_Mesh_has_face_normals = R"doc(Does this mesh use face normals?)doc";
+
+static const char *__doc_mitsuba_Mesh_has_flipped_normals = R"doc(Does this shape have flipped normals?)doc";
 
 static const char *__doc_mitsuba_Mesh_has_mesh_attributes = R"doc(Does this mesh have additional mesh attributes?)doc";
 
@@ -4950,6 +5026,14 @@ static const char *__doc_mitsuba_Mesh_surface_area = R"doc()doc";
 static const char *__doc_mitsuba_Mesh_to_string = R"doc(Return a human-readable string representation of the shape contents.)doc";
 
 static const char *__doc_mitsuba_Mesh_traverse = R"doc(@})doc";
+
+static const char *__doc_mitsuba_Mesh_traverse_1_cb_fields = R"doc()doc";
+
+static const char *__doc_mitsuba_Mesh_traverse_1_cb_fields_2 = R"doc()doc";
+
+static const char *__doc_mitsuba_Mesh_traverse_1_cb_ro = R"doc()doc";
+
+static const char *__doc_mitsuba_Mesh_traverse_1_cb_rw = R"doc()doc";
 
 static const char *__doc_mitsuba_Mesh_vertex_count = R"doc(Return the total number of vertices)doc";
 
@@ -5190,27 +5274,17 @@ static const char *__doc_mitsuba_MonteCarloIntegrator_5 = R"doc()doc";
 
 static const char *__doc_mitsuba_MonteCarloIntegrator_6 = R"doc()doc";
 
-static const char *__doc_mitsuba_MonteCarloIntegrator_7 = R"doc()doc";
-
 static const char *__doc_mitsuba_MonteCarloIntegrator_MonteCarloIntegrator = R"doc(Create an integrator)doc";
 
-static const char *__doc_mitsuba_MonteCarloIntegrator_class = R"doc()doc";
+static const char *__doc_mitsuba_MonteCarloIntegrator_class_name = R"doc()doc";
 
 static const char *__doc_mitsuba_MonteCarloIntegrator_m_max_depth = R"doc()doc";
 
 static const char *__doc_mitsuba_MonteCarloIntegrator_m_rr_depth = R"doc()doc";
 
-static const char *__doc_mitsuba_NamedReference = R"doc(Wrapper object used to represent named references to Object instances)doc";
+static const char *__doc_mitsuba_MonteCarloIntegrator_traverse_1_cb_ro = R"doc()doc";
 
-static const char *__doc_mitsuba_NamedReference_NamedReference = R"doc()doc";
-
-static const char *__doc_mitsuba_NamedReference_m_value = R"doc()doc";
-
-static const char *__doc_mitsuba_NamedReference_operator_const_std_string = R"doc()doc";
-
-static const char *__doc_mitsuba_NamedReference_operator_eq = R"doc()doc";
-
-static const char *__doc_mitsuba_NamedReference_operator_ne = R"doc()doc";
+static const char *__doc_mitsuba_MonteCarloIntegrator_traverse_1_cb_rw = R"doc()doc";
 
 static const char *__doc_mitsuba_Normal = R"doc()doc";
 
@@ -5229,37 +5303,69 @@ R"doc(Object base class with builtin reference counting
 
 This class (in conjunction with the ``ref`` reference counter)
 constitutes the foundation of an efficient reference-counted object
-hierarchy. The implementation here is an alternative to standard
-mechanisms for reference counting such as ``std::shared_ptr`` from the
-STL.
+hierarchy.
 
-Why not simply use ``std::shared_ptr``? To be spec-compliant, such
-shared pointers must associate a special record with every instance,
-which stores at least two counters plus a deletion function.
-Allocating this record naturally incurs further overheads to maintain
-data structures within the memory allocator. In addition to this, the
-size of an individual ``shared_ptr`` references is at least two data
-words. All of this quickly adds up and leads to significant overheads
-for large collections of instances, hence the need for an alternative
-in Mitsuba.
+We use an intrusive reference counting approach to avoid various
+gnarly issues that arise in combined Python/C++ codebase, see the
+following page for details:
+https://nanobind.readthedocs.io/en/latest/ownership_adv.html
 
-In contrast, the ``Object`` class allows for a highly efficient
-implementation that only adds 64 bits to the base object (for the
-counter) and has no overhead for references. In addition, when using
-Mitsuba in Python, this counter is shared with Python such that the
-ownership and lifetime of any ``Object`` instance across C++ and
-Python is managed by it.)doc";
+The counter provided by ``drjit::TraversableBase`` establishes a
+unified reference count that is consistent across both C++ and Python.
+It is more efficient than ``std::shared_ptr<T>`` (as no external
+control block is needed) and works without Python actually being
+present.
 
-static const char *__doc_mitsuba_Object_Object = R"doc(Default constructor)doc";
+Object subclasses are *traversable*, that is, they expose methods that
+Dr.Jit can use to walk through object graphs, discover attributes, and
+potentially change them. This enables function freezing (@dr.freeze)
+that must detect and apply changes when executing frozen functions.)doc";
 
-static const char *__doc_mitsuba_Object_Object_2 = R"doc(Copy constructor)doc";
+static const char *__doc_mitsuba_ObjectType =
+R"doc(Available scene object types
 
-static const char *__doc_mitsuba_Object_class =
-R"doc(Return a Class instance containing run-time type information about
-this Object
+This enumeration lists high-level interfaces that can be implemented
+by Mitsuba scene objects. The scene loader uses these to ensure that a
+loaded object matches the expected interface.
 
-See also:
-    Class)doc";
+Note: This enum is forward-declared at the beginning of the file to
+allow its usage in macros that appear before the full definition.)doc";
+
+static const char *__doc_mitsuba_ObjectType_BSDF = R"doc(A bidirectional reflectance distribution function)doc";
+
+static const char *__doc_mitsuba_ObjectType_Emitter = R"doc(Emits radiance, subclasses Emitter)doc";
+
+static const char *__doc_mitsuba_ObjectType_Film = R"doc(Storage representation of the sensor)doc";
+
+static const char *__doc_mitsuba_ObjectType_Integrator = R"doc(A rendering algorithm aka. Integrator)doc";
+
+static const char *__doc_mitsuba_ObjectType_Medium = R"doc(A participating medium)doc";
+
+static const char *__doc_mitsuba_ObjectType_PhaseFunction = R"doc(A phase function characterizing scattering in volumes)doc";
+
+static const char *__doc_mitsuba_ObjectType_ReconstructionFilter = R"doc(A filter used to reconstruct/resample images)doc";
+
+static const char *__doc_mitsuba_ObjectType_Sampler = R"doc(Generates sample positions and directions, subclasses Sampler)doc";
+
+static const char *__doc_mitsuba_ObjectType_Scene = R"doc(The top-level scene object. No subclasses exist)doc";
+
+static const char *__doc_mitsuba_ObjectType_Sensor = R"doc(Carries out radiance measurements, subclasses Sensor)doc";
+
+static const char *__doc_mitsuba_ObjectType_Shape = R"doc(Denotes an arbitrary shape (including meshes))doc";
+
+static const char *__doc_mitsuba_ObjectType_Texture = R"doc(A 2D texture data source)doc";
+
+static const char *__doc_mitsuba_ObjectType_Unknown = R"doc(The default returned by Object subclasses)doc";
+
+static const char *__doc_mitsuba_ObjectType_Volume = R"doc(A 3D volume data source)doc";
+
+static const char *__doc_mitsuba_Object_Object = R"doc(Import default constructors)doc";
+
+static const char *__doc_mitsuba_Object_Object_2 = R"doc()doc";
+
+static const char *__doc_mitsuba_Object_Object_3 = R"doc()doc";
+
+static const char *__doc_mitsuba_Object_class_name = R"doc(Return the C++ class name of this object (e.g. "SmoothDiffuse"))doc";
 
 static const char *__doc_mitsuba_Object_expand =
 R"doc(Expand the object into a list of sub-objects and return them
@@ -5270,12 +5376,7 @@ combined sun & sky emitter instantiated via XML, which recursively
 expands into a separate sun & sky instance. This functionality is
 supported by any Mitsuba object, hence it is located this level.)doc";
 
-static const char *__doc_mitsuba_Object_variant_name = R"doc(Return the instance variant (or NULL, if this is not a variant object))doc";
-
-
-static const char *__doc_mitsuba_Object_id = R"doc(Return an identifier of the current instance (if available))doc";
-
-static const char *__doc_mitsuba_Object_class_name = R"doc(Return the C++ class name of this object (e.g. "Scene", "Integrator"))doc";
+static const char *__doc_mitsuba_Object_id = R"doc(Return an identifier of the current instance (or empty if none))doc";
 
 static const char *__doc_mitsuba_Object_parameters_changed =
 R"doc(Update internal state after applying changes to parameters
@@ -5298,7 +5399,7 @@ Remark:
 See also:
     TraversalCallback)doc";
 
-static const char *__doc_mitsuba_Object_set_id = R"doc(Set an identifier to the current instance (if applicable))doc";
+static const char *__doc_mitsuba_Object_set_id = R"doc(Set the identifier of the current instance (no-op if not supported))doc";
 
 static const char *__doc_mitsuba_Object_to_string =
 R"doc(Return a human-readable string representation of the object's
@@ -5322,6 +5423,14 @@ Remark:
 See also:
     TraversalCallback)doc";
 
+static const char *__doc_mitsuba_Object_traverse_1_cb_ro = R"doc()doc";
+
+static const char *__doc_mitsuba_Object_traverse_1_cb_rw = R"doc()doc";
+
+static const char *__doc_mitsuba_Object_type = R"doc(Return the object type. The default is ObjectType::Unknown.)doc";
+
+static const char *__doc_mitsuba_Object_variant_name = R"doc(Return the instance variant (empty if this is not a variant object))doc";
+
 static const char *__doc_mitsuba_OptixDenoiser =
 R"doc(Wrapper for the OptiX AI denoiser
 
@@ -5342,8 +5451,6 @@ static const char *__doc_mitsuba_OptixDenoiser_4 = R"doc()doc";
 static const char *__doc_mitsuba_OptixDenoiser_5 = R"doc()doc";
 
 static const char *__doc_mitsuba_OptixDenoiser_6 = R"doc()doc";
-
-static const char *__doc_mitsuba_OptixDenoiser_7 = R"doc()doc";
 
 static const char *__doc_mitsuba_OptixDenoiser_OptixDenoiser =
 R"doc(Constructs an OptiX denoiser
@@ -5373,7 +5480,7 @@ Returns:
 
 static const char *__doc_mitsuba_OptixDenoiser_OptixDenoiser_2 = R"doc()doc";
 
-static const char *__doc_mitsuba_OptixDenoiser_class = R"doc()doc";
+static const char *__doc_mitsuba_OptixDenoiser_class_name = R"doc()doc";
 
 static const char *__doc_mitsuba_OptixDenoiser_m_denoiser = R"doc()doc";
 
@@ -5423,7 +5530,7 @@ Parameter ``flow``:
     With temporal denoising, this parameter is the optical flow
     between the previous frame and the current one. It should capture
     the 2D motion of each individual pixel. When this parameter is
-    unknown, it can been set to a zero-initialized TensorXf of the
+    unknown, it can be set to a zero-initialized TensorXf of the
     correct size and still produce convincing results. This parameter
     is optional unless the OptixDenoiser was built with temporal
     denoising support. (tensor shape: (width, height, 2))
@@ -5469,7 +5576,7 @@ Parameter ``flow_ch``:
     the ``noisy`` parameter which contains the optical flow between
     the previous frame and the current one. It should capture the 2D
     motion of each individual pixel. When this parameter is unknown,
-    it can been set to a zero-initialized TensorXf of the correct size
+    it can be set to a zero-initialized TensorXf of the correct size
     and still produce convincing results. This parameter is optional
     unless the OptixDenoiser was built with temporal denoising
     support.
@@ -5521,13 +5628,11 @@ static const char *__doc_mitsuba_PCG32Sampler_5 = R"doc()doc";
 
 static const char *__doc_mitsuba_PCG32Sampler_6 = R"doc()doc";
 
-static const char *__doc_mitsuba_PCG32Sampler_7 = R"doc()doc";
-
 static const char *__doc_mitsuba_PCG32Sampler_PCG32Sampler = R"doc()doc";
 
 static const char *__doc_mitsuba_PCG32Sampler_PCG32Sampler_2 = R"doc(Copy state to a new PCG32Sampler object)doc";
 
-static const char *__doc_mitsuba_PCG32Sampler_class = R"doc()doc";
+static const char *__doc_mitsuba_PCG32Sampler_class_name = R"doc()doc";
 
 static const char *__doc_mitsuba_PCG32Sampler_m_rng = R"doc()doc";
 
@@ -5557,7 +5662,12 @@ static const char *__doc_mitsuba_ParamFlags_NonDifferentiable = R"doc(Tracking g
 
 static const char *__doc_mitsuba_ParamFlags_ReadOnly = R"doc(This parameter is read-only)doc";
 
-static const char *__doc_mitsuba_PhaseFunction = R"doc()doc";
+static const char *__doc_mitsuba_PhaseFunction =
+R"doc(Abstract phase function base-class.
+
+This class provides an abstract interface to all Phase function
+plugins in Mitsuba. It exposes functions for evaluating and sampling
+the model.)doc";
 
 static const char *__doc_mitsuba_PhaseFunction_2 = R"doc()doc";
 
@@ -5568,8 +5678,6 @@ static const char *__doc_mitsuba_PhaseFunction_4 = R"doc()doc";
 static const char *__doc_mitsuba_PhaseFunction_5 = R"doc()doc";
 
 static const char *__doc_mitsuba_PhaseFunction_6 = R"doc()doc";
-
-static const char *__doc_mitsuba_PhaseFunction_7 = R"doc()doc";
 
 static const char *__doc_mitsuba_PhaseFunctionContext = R"doc()doc";
 
@@ -5582,8 +5690,8 @@ static const char *__doc_mitsuba_PhaseFunctionContext_PhaseFunctionContext_3 = R
 static const char *__doc_mitsuba_PhaseFunctionContext_component = R"doc()doc";
 
 static const char *__doc_mitsuba_PhaseFunctionContext_is_enabled =
-R"doc(Checks whether a given phase function component type and phase
-function component index are enabled in this context.)doc";
+R"doc(Checks whether a given phase function component type and index are
+enabled in this context.)doc";
 
 static const char *__doc_mitsuba_PhaseFunctionContext_mode = R"doc(Transported mode (radiance or importance))doc";
 
@@ -5615,7 +5723,7 @@ static const char *__doc_mitsuba_PhaseFunctionFlags_Microflake = R"doc()doc";
 
 static const char *__doc_mitsuba_PhaseFunction_PhaseFunction = R"doc(//! @})doc";
 
-static const char *__doc_mitsuba_PhaseFunction_class = R"doc()doc";
+static const char *__doc_mitsuba_PhaseFunction_class_name = R"doc(//! @})doc";
 
 static const char *__doc_mitsuba_PhaseFunction_component_count = R"doc(Number of components this phase function is comprised of.)doc";
 
@@ -5647,13 +5755,9 @@ static const char *__doc_mitsuba_PhaseFunction_flags_2 = R"doc(Flags for a speci
 
 static const char *__doc_mitsuba_PhaseFunction_get_flags = R"doc(Return type of phase function)doc";
 
-static const char *__doc_mitsuba_PhaseFunction_id = R"doc(Return a string identifier)doc";
-
 static const char *__doc_mitsuba_PhaseFunction_m_components = R"doc(Flags for each component of this phase function.)doc";
 
 static const char *__doc_mitsuba_PhaseFunction_m_flags = R"doc(Type of phase function (e.g. anisotropic))doc";
-
-static const char *__doc_mitsuba_PhaseFunction_m_id = R"doc(Identifier (if available))doc";
 
 static const char *__doc_mitsuba_PhaseFunction_max_projected_area = R"doc(Return the maximum projected area of the microflake distribution)doc";
 
@@ -5699,87 +5803,93 @@ Returns:
 
 static const char *__doc_mitsuba_PhaseFunction_set_flags = R"doc(Set type of phase function)doc";
 
-static const char *__doc_mitsuba_PhaseFunction_set_id = R"doc(Set a string identifier)doc";
-
 static const char *__doc_mitsuba_PhaseFunction_to_string = R"doc(Return a human-readable representation of the phase function)doc";
 
-static const char *__doc_mitsuba_ObjectType = R"doc(Enumeration of plugin object types)doc";
+static const char *__doc_mitsuba_PhaseFunction_type = R"doc(//! @})doc";
 
-static const char *__doc_mitsuba_ObjectType_Unknown = R"doc(Unknown plugin type)doc";
-
-static const char *__doc_mitsuba_ObjectType_Scene = R"doc(Scene object)doc";
-
-static const char *__doc_mitsuba_ObjectType_Sensor = R"doc(Sensor object)doc";
-
-static const char *__doc_mitsuba_ObjectType_Film = R"doc(Film object)doc";
-
-static const char *__doc_mitsuba_ObjectType_Emitter = R"doc(Emitter object)doc";
-
-static const char *__doc_mitsuba_ObjectType_Sampler = R"doc(Sampler object)doc";
-
-static const char *__doc_mitsuba_ObjectType_Shape = R"doc(Shape object)doc";
-
-static const char *__doc_mitsuba_ObjectType_Texture = R"doc(Texture object)doc";
-
-static const char *__doc_mitsuba_ObjectType_Volume = R"doc(Volume object)doc";
-
-static const char *__doc_mitsuba_ObjectType_Medium = R"doc(Medium object)doc";
-
-static const char *__doc_mitsuba_ObjectType_BSDF = R"doc(BSDF object)doc";
-
-static const char *__doc_mitsuba_ObjectType_Integrator = R"doc(Integrator object)doc";
-
-static const char *__doc_mitsuba_ObjectType_PhaseFunction = R"doc(Phase function object)doc";
-
-static const char *__doc_mitsuba_ObjectType_ReconstructionFilter = R"doc(Reconstruction filter object)doc";
+static const char *__doc_mitsuba_PhaseFunction_variant_name = R"doc(//! @})doc";
 
 static const char *__doc_mitsuba_PluginManager =
-R"doc(The object factory is responsible for loading plugin modules and
-instantiating object instances.
+R"doc(Plugin manager
 
-Ordinarily, this class will be used by making repeated calls to the
-create_object() methods. The generated instances are then assembled
-into a final object graph, such as a scene. One such examples is the
-SceneHandler class, which parses an XML scene file by essentially
-translating the XML elements into calls to create_object().)doc";
+The plugin manager's main feature is the create_object() function that
+instantiates scene objects. To do its job, it loads external Mitsuba
+plugins as needed.
+
+When used from Python, it is also possible to register external
+plugins so that they can be instantiated analogously.)doc";
 
 static const char *__doc_mitsuba_PluginManager_PluginManager = R"doc()doc";
 
 static const char *__doc_mitsuba_PluginManager_PluginManagerPrivate = R"doc()doc";
 
-static const char *__doc_mitsuba_PluginManager_class = R"doc()doc";
+static const char *__doc_mitsuba_PluginManager_class_name = R"doc()doc";
 
 static const char *__doc_mitsuba_PluginManager_create_object =
-R"doc(Instantiate a plugin, verify its type, and return the newly created
-object instance.
+R"doc(Create a plugin object with the provided information
+
+This function potentially loads an external plugin module (if not
+already present), creates an instance, verifies its type, and finally
+returns the newly created object instance.
 
 Parameter ``props``:
     A Properties instance containing all information required to find
     and construct the plugin.
 
-Parameter ``class_type``:
-    Expected type of the instance. An exception will be thrown if it
-    turns out not to derive from this class.)doc";
+Parameter ``variant``:
+    The variant (e.g. 'scalar_rgb') of the plugin to instantiate
 
-static const char *__doc_mitsuba_PluginManager_create_object_2 = R"doc(Convenience template wrapper around create_object())doc";
+Parameter ``type``:
+    The expected interface of the instantiated plugin. Mismatches here
+    will produce an error message. Pass `ObjectType::Unknown` to
+    disable this check.)doc";
+
+static const char *__doc_mitsuba_PluginManager_create_object_2 =
+R"doc(Create a plugin object with the provided information
+
+This template function wraps the ordinary ``create_object()`` function
+defined above. It automatically infers variant and object type from
+the provided class 'T'.)doc";
 
 static const char *__doc_mitsuba_PluginManager_d = R"doc()doc";
 
-static const char *__doc_mitsuba_PluginManager_ensure_plugin_loaded = R"doc(Ensure that a plugin is loaded and ready)doc";
-
-static const char *__doc_mitsuba_PluginManager_get_plugin_class = R"doc(Return the class corresponding to a plugin for a specific variant)doc";
-
-static const char *__doc_mitsuba_PluginManager_get_plugin_type =
-R"doc(Return the plugin's shorthand from its class name (i.e "diffuse" from
-"SmoothDiffuse"))doc";
-
-static const char *__doc_mitsuba_PluginManager_plugin_type = R"doc(Get the ObjectType of a plugin by name)doc";
-
 static const char *__doc_mitsuba_PluginManager_instance = R"doc(Return the global plugin manager)doc";
 
-static const char *__doc_mitsuba_PluginManager_loaded_plugins = R"doc(Return the list of loaded plugins)doc";
+static const char *__doc_mitsuba_PluginManager_plugin_type =
+R"doc(Get the type of a plugin by name, or return Object::Unknown if
+unknown.)doc";
 
-static const char *__doc_mitsuba_PluginManager_register_python_plugin = R"doc(Register a Python plugin)doc";
+static const char *__doc_mitsuba_PluginManager_register_plugin =
+R"doc(Register a new plugin variant with the plugin manager
+
+Re-registering an already available (name, variant) pair is legal and
+will release the previously registered variant.
+
+Parameter ``name``:
+    The name of the plugin.
+
+Parameter ``variant``:
+    The plugin variant (e.g., ``"scalar_rgb"``). Separate plugin
+    variants must be registered independently.
+
+Parameter ``instantiate``:
+    A callback that creates an instance of the plugin.
+
+Parameter ``release``:
+    A callback that releases any (global) plugin state. Will, e.g., be
+    called by PluginManager::reset().
+
+Parameter ``payload``:
+    An opaque pointer parameter that will be forwarded to both
+    ``instantiate`` and ``release``.)doc";
+
+static const char *__doc_mitsuba_PluginManager_release_all =
+R"doc(Release registered plugins
+
+This calls the PluginInfo::release callback of all registered plugins,
+e.g., to enable garbage collection of classes in python. Note
+dynamically loaded shared libraries of native plugins aren't unloaded
+until the PluginManager class itself is destructed.)doc";
 
 static const char *__doc_mitsuba_Point = R"doc()doc";
 
@@ -5823,15 +5933,15 @@ static const char *__doc_mitsuba_PositionSample_delta =
 R"doc(Set if the sample was drawn from a degenerate (Dirac delta)
 distribution)doc";
 
-static const char *__doc_mitsuba_PositionSample_fields = R"doc()doc";
+static const char *__doc_mitsuba_PositionSample_fields = R"doc(//! @})doc";
 
-static const char *__doc_mitsuba_PositionSample_fields_2 = R"doc()doc";
+static const char *__doc_mitsuba_PositionSample_fields_2 = R"doc(//! @})doc";
 
-static const char *__doc_mitsuba_PositionSample_labels = R"doc()doc";
+static const char *__doc_mitsuba_PositionSample_labels = R"doc(//! @})doc";
 
 static const char *__doc_mitsuba_PositionSample_n = R"doc(Sampled surface normal (if applicable))doc";
 
-static const char *__doc_mitsuba_PositionSample_name = R"doc()doc";
+static const char *__doc_mitsuba_PositionSample_name = R"doc(//! @})doc";
 
 static const char *__doc_mitsuba_PositionSample_operator_assign = R"doc(//! @})doc";
 
@@ -5894,17 +6004,17 @@ Parameter ``ray_flags``:
 Returns:
     A data structure containing the detailed information)doc";
 
-static const char *__doc_mitsuba_PreliminaryIntersection_fields = R"doc()doc";
+static const char *__doc_mitsuba_PreliminaryIntersection_fields = R"doc(//! @})doc";
 
-static const char *__doc_mitsuba_PreliminaryIntersection_fields_2 = R"doc()doc";
+static const char *__doc_mitsuba_PreliminaryIntersection_fields_2 = R"doc(//! @})doc";
 
 static const char *__doc_mitsuba_PreliminaryIntersection_instance = R"doc(Stores a pointer to the parent instance (if applicable))doc";
 
 static const char *__doc_mitsuba_PreliminaryIntersection_is_valid = R"doc(Is the current interaction valid?)doc";
 
-static const char *__doc_mitsuba_PreliminaryIntersection_labels = R"doc()doc";
+static const char *__doc_mitsuba_PreliminaryIntersection_labels = R"doc(//! @})doc";
 
-static const char *__doc_mitsuba_PreliminaryIntersection_name = R"doc()doc";
+static const char *__doc_mitsuba_PreliminaryIntersection_name = R"doc(//! @})doc";
 
 static const char *__doc_mitsuba_PreliminaryIntersection_operator_assign = R"doc(//! @})doc";
 
@@ -6010,7 +6120,7 @@ Parameter ``ptr``:
     Custom pointer payload to be delivered as part of progress
     messages)doc";
 
-static const char *__doc_mitsuba_ProgressReporter_class = R"doc()doc";
+static const char *__doc_mitsuba_ProgressReporter_class_name = R"doc()doc";
 
 static const char *__doc_mitsuba_ProgressReporter_m_bar_size = R"doc()doc";
 
@@ -6056,11 +6166,9 @@ static const char *__doc_mitsuba_ProjectiveCamera_5 = R"doc()doc";
 
 static const char *__doc_mitsuba_ProjectiveCamera_6 = R"doc()doc";
 
-static const char *__doc_mitsuba_ProjectiveCamera_7 = R"doc()doc";
-
 static const char *__doc_mitsuba_ProjectiveCamera_ProjectiveCamera = R"doc()doc";
 
-static const char *__doc_mitsuba_ProjectiveCamera_class = R"doc()doc";
+static const char *__doc_mitsuba_ProjectiveCamera_class_name = R"doc()doc";
 
 static const char *__doc_mitsuba_ProjectiveCamera_far_clip = R"doc(Return the far clip plane distance)doc";
 
@@ -6076,44 +6184,72 @@ static const char *__doc_mitsuba_ProjectiveCamera_near_clip = R"doc(Return the n
 
 static const char *__doc_mitsuba_ProjectiveCamera_traverse = R"doc()doc";
 
-static const char *__doc_mitsuba_Properties =
-R"doc(Associative parameter map for constructing subclasses of Object.
+static const char *__doc_mitsuba_ProjectiveCamera_traverse_1_cb_ro = R"doc()doc";
 
-Note that the Python bindings for this class do not implement the
-various type-dependent getters and setters. Instead, they are accessed
-just like a normal Python map, e.g:
+static const char *__doc_mitsuba_ProjectiveCamera_traverse_1_cb_rw = R"doc()doc";
+
+static const char *__doc_mitsuba_Properties =
+R"doc(Map data structure for passing parameters to scene objects.
+
+The constructors of Mitsuba scene objects take a Properties object as
+input. It specifies named parameters of various types, such as
+filenames, colors, etc. It can also pass nested objects that have
+already been constructed.
+
+The C++ and Python APIs are slightly different. In C++, the type to be
+retrieved must be specified as a template parameter:
 
 ```
-myProps = mitsuba.core.Properties("plugin_name")
-myProps["stringProperty"] = "hello"
-myProps["spectrumProperty"] = mitsuba.core.Spectrum(1.0)
+Properties props("plugin_name")
+
+// Write to 'props':
+props.set("color_value", ScalarColor3f(0.1f, 0.2f, 0.3f));
+
+// Read from 'props':
+Color3f value = props.get<ScalarColor3f>("color_value");
+```
+
+In Python, the API behaves like a standard dictionary.
+
+```
+props = mi.Properties("plugin_name")
+
+// Write to 'props':
+props["color_value"] = mi.ScalarColor3f(0.1, 0.2, 0.3)
+
+// Read from 'props':
+value = props["color_value"]
 ```
 
 or using the ``get(key, default)`` method.)doc";
 
-static const char *__doc_mitsuba_PropertiesV = R"doc()doc";
+static const char *__doc_mitsuba_Properties_Properties = R"doc(Construct an empty and unnamed properties object)doc";
 
-static const char *__doc_mitsuba_PropertiesV_PropertiesV = R"doc()doc";
-
-static const char *__doc_mitsuba_PropertiesV_PropertiesV_2 = R"doc()doc";
-
-static const char *__doc_mitsuba_PropertiesV_PropertiesV_3 = R"doc()doc";
-
-static const char *__doc_mitsuba_PropertiesV_PropertiesV_4 = R"doc()doc";
-
-static const char *__doc_mitsuba_Properties_Properties = R"doc(Construct an empty property container)doc";
-
-static const char *__doc_mitsuba_Properties_Properties_2 = R"doc(Construct an empty property container with a specific plugin name)doc";
+static const char *__doc_mitsuba_Properties_Properties_2 = R"doc(Construct an empty properties object with a specific plugin name)doc";
 
 static const char *__doc_mitsuba_Properties_Properties_3 = R"doc(Copy constructor)doc";
 
+static const char *__doc_mitsuba_Properties_Properties_4 = R"doc(Move constructor)doc";
+
 static const char *__doc_mitsuba_Properties_PropertiesPrivate = R"doc()doc";
 
-static const char *__doc_mitsuba_Properties_Type = R"doc(Supported types of properties)doc";
+static const char *__doc_mitsuba_Properties_Reference =
+R"doc(Represents an indirect dependence on another object (referenced by
+name))doc";
 
-static const char *__doc_mitsuba_Properties_Type_AnimatedTransform = R"doc(An animated 4x4 transformation)doc";
+static const char *__doc_mitsuba_Properties_Reference_Reference = R"doc()doc";
 
-static const char *__doc_mitsuba_Properties_Type_Array3f = R"doc(3D array)doc";
+static const char *__doc_mitsuba_Properties_Reference_m_name = R"doc()doc";
+
+static const char *__doc_mitsuba_Properties_Reference_operator_const_std_string = R"doc()doc";
+
+static const char *__doc_mitsuba_Properties_Reference_operator_eq = R"doc()doc";
+
+static const char *__doc_mitsuba_Properties_Reference_operator_ne = R"doc()doc";
+
+static const char *__doc_mitsuba_Properties_Type = R"doc(Enumeration of representable property types)doc";
+
+static const char *__doc_mitsuba_Properties_Type_Any = R"doc(Generic type wrapper for arbitrary data exchange between plugins)doc";
 
 static const char *__doc_mitsuba_Properties_Type_Bool = R"doc(Boolean value (true/false))doc";
 
@@ -6121,21 +6257,17 @@ static const char *__doc_mitsuba_Properties_Type_Color = R"doc(Tristimulus color
 
 static const char *__doc_mitsuba_Properties_Type_Float = R"doc(Floating point value)doc";
 
-static const char *__doc_mitsuba_Properties_Type_Long = R"doc(64-bit signed integer)doc";
+static const char *__doc_mitsuba_Properties_Type_Integer = R"doc(64-bit signed integer)doc";
 
-static const char *__doc_mitsuba_Properties_Type_NamedReference = R"doc(Named reference to another named object)doc";
+static const char *__doc_mitsuba_Properties_Type_Object = R"doc(An arbitrary Mitsuba scene object)doc";
 
-static const char *__doc_mitsuba_Properties_Type_Object = R"doc(Arbitrary object)doc";
-
-static const char *__doc_mitsuba_Properties_Type_Pointer = R"doc(const void\* pointer (for internal communication between plugins))doc";
+static const char *__doc_mitsuba_Properties_Type_Reference = R"doc(Indirect dependence to another object (referenced by name))doc";
 
 static const char *__doc_mitsuba_Properties_Type_String = R"doc(String)doc";
 
-static const char *__doc_mitsuba_Properties_Type_Tensor = R"doc(A tensor of arbitrary shape)doc";
+static const char *__doc_mitsuba_Properties_Type_Transform = R"doc(3x3 or 4x4 homogeneous coordinate transform)doc";
 
-static const char *__doc_mitsuba_Properties_Type_Transform3f = R"doc(3x3 transform for homogeneous coordinates)doc";
-
-static const char *__doc_mitsuba_Properties_Type_Transform4f = R"doc(4x4 transform for homogeneous coordinates)doc";
+static const char *__doc_mitsuba_Properties_Type_Vector = R"doc(3D array)doc";
 
 static const char *__doc_mitsuba_Properties_as_string = R"doc(Return one of the parameters (converting it to a string if necessary))doc";
 
@@ -6143,29 +6275,95 @@ static const char *__doc_mitsuba_Properties_as_string_2 =
 R"doc(Return one of the parameters (converting it to a string if necessary,
 with default value))doc";
 
-static const char *__doc_mitsuba_Properties_copy_attribute =
-R"doc(Copy a single attribute from another Properties object and potentially
-rename it)doc";
-
 static const char *__doc_mitsuba_Properties_d = R"doc()doc";
 
-static const char *__doc_mitsuba_Properties_find_object =
-R"doc(Return a reference to an object for a specific name (return null ref
-if doesn't exist))doc";
-
 static const char *__doc_mitsuba_Properties_get =
-R"doc(Generic getter method to retrieve properties. (throw an error if type
-isn't supported))doc";
+R"doc(Retrieve a scalar parameter by name
+
+Look up the property ``name``. Raises an exception if the property
+cannot be found, or when it has an incompatible type. Accessing the
+parameter automatically marks it as queried (see was_queried).
+
+The template parameter ``T`` may refer to:
+
+- Strings (``std::string``)
+
+- Arithmetic types (``bool``, ``float``, ``double``, ``uint32_t``,
+``int32_t``, ``uint64_t``, ``int64_t``, ``size_t``).
+
+- Points/vectors (``ScalarPoint2f``, ``ScalarPoint3f``,
+`ScalarVector2f``, or ``ScalarVector3f``).
+
+- Tri-stimulus color values (``ScalarColor3f``).
+
+- Affine transformations (``ScalarTransform3f``,
+``ScalarTransform4f``)
+
+Both single/double precision versions of these are supported; the
+function will convert them as needed. The function cannot be used to
+obtain vectorized (e.g. JIT-compiled) arrays.)doc";
 
 static const char *__doc_mitsuba_Properties_get_2 =
-R"doc(Generic getter method to retrieve properties. (use default value if no
-entry exists))doc";
+R"doc(Retrieve a parameter (with default value)
 
-static const char *__doc_mitsuba_Properties_has_property = R"doc(Verify if a value with the specified name exists)doc";
+Please see the get() function above for details. The main difference
+of this overload is that it automatically substitutes a default value
+``def_val`` when the requested parameter cannot be found. It function
+raises an error if current parameter value has an incompatible type.)doc";
+
+static const char *__doc_mitsuba_Properties_get_any =
+R"doc(Retrieve an arbitrarily typed value for inter-plugin communication
+
+The function raises an exception if the parameter does not exist or
+cannot be cast. Accessing the parameter automatically marks it as
+queried.)doc";
+
+static const char *__doc_mitsuba_Properties_get_impl = R"doc(Implementation detail of get())doc";
+
+static const char *__doc_mitsuba_Properties_get_texture =
+R"doc(Retrieve a texture parameter
+
+This method retrieves a texture parameter, where ``T`` is a subclass
+of ``mitsuba::Texture<...>``.
+
+Scalar and color values are also accepted. In this case, the plugin
+manager will automatically construct a ``uniform`` or ``srgb`` texture
+instance.)doc";
+
+static const char *__doc_mitsuba_Properties_get_texture_2 =
+R"doc(Retrieve a texture parameter with float default
+
+When the texture parameter doesn't exist, creates a uniform texture
+with the specified floating point value.)doc";
+
+static const char *__doc_mitsuba_Properties_get_texture_d65 =
+R"doc(Retrieve a texture parameter with float default value
+
+When the texture parameter doesn't exist, creates a uniform D65
+whitepoint texture scaled by the specified floating point value.)doc";
+
+static const char *__doc_mitsuba_Properties_get_volume =
+R"doc(Retrieve a volume parameter
+
+This method retrieves a volume parameter, where ``T`` is a subclass of
+``mitsuba::Volume<...>``.
+
+Scalar and texture values are also accepted. In this case, the plugin
+manager will automatically construct a ``constvolume`` instance.)doc";
+
+static const char *__doc_mitsuba_Properties_get_volume_2 =
+R"doc(Retrieve a volume parameter with float default
+
+When the volume parameter doesn't exist, creates a constant volume
+with the specified floating point value.)doc";
+
+static const char *__doc_mitsuba_Properties_has_property = R"doc(Verify if a property with the specified name exists)doc";
 
 static const char *__doc_mitsuba_Properties_id =
 R"doc(Returns a unique identifier associated with this instance (or an empty
-string))doc";
+string)
+
+The ID is used to enable named references by other plugins)doc";
 
 static const char *__doc_mitsuba_Properties_mark_queried =
 R"doc(Manually mark a certain property as queried
@@ -6179,37 +6377,37 @@ R"doc(Merge another properties record into the current one.
 Existing properties will be overwritten with the values from ``props``
 if they have the same name.)doc";
 
-static const char *__doc_mitsuba_Properties_named_reference = R"doc(Retrieve a named reference value)doc";
-
-static const char *__doc_mitsuba_Properties_named_reference_2 =
-R"doc(Retrieve a named reference value (use default value if no entry
-exists))doc";
-
-static const char *__doc_mitsuba_Properties_references = R"doc(Return an array containing all named references and their destinations)doc";
-
-static const char *__doc_mitsuba_Properties_object = R"doc(Retrieve an arbitrary object)doc";
-
-static const char *__doc_mitsuba_Properties_object_2 = R"doc(Retrieve an arbitrary object (use default value if no entry exists))doc";
-
 static const char *__doc_mitsuba_Properties_objects =
-R"doc(Return an array containing names and references for all stored objects
+R"doc(Return an array containing directly nested scene objects and their
+associated names (in insertion order)
 
 Parameter ``mark_queried``:
     Whether all stored objects should be marked as queried)doc";
 
-static const char *__doc_mitsuba_Properties_operator_assign = R"doc(Assignment operator)doc";
+static const char *__doc_mitsuba_Properties_operator_assign = R"doc(Copy assignment operator)doc";
+
+static const char *__doc_mitsuba_Properties_operator_assign_2 = R"doc(Move assignment operator)doc";
 
 static const char *__doc_mitsuba_Properties_operator_eq = R"doc(Equality comparison operator)doc";
 
 static const char *__doc_mitsuba_Properties_operator_ne = R"doc(Inequality comparison operator)doc";
 
-static const char *__doc_mitsuba_Properties_plugin_name = R"doc(Get the associated plugin name)doc";
+static const char *__doc_mitsuba_Properties_plugin_name = R"doc(Get the plugin name)doc";
 
-static const char *__doc_mitsuba_Properties_pointer = R"doc(Retrieve an arbitrary pointer)doc";
+static const char *__doc_mitsuba_Properties_property_names =
+R"doc(Return an array containing the names of all stored properties (in
+insertion order))doc";
 
-static const char *__doc_mitsuba_Properties_pointer_2 = R"doc(Retrieve an arbitrary pointer (use default value if no entry exists))doc";
+static const char *__doc_mitsuba_Properties_raise_any_type_error = R"doc(Raise an exception when get_any() has incompatible type)doc";
 
-static const char *__doc_mitsuba_Properties_property_names = R"doc(Return an array containing the names of all stored properties)doc";
+static const char *__doc_mitsuba_Properties_raise_object_type_error = R"doc(Raise an exception when an object has incompatible type)doc";
+
+static const char *__doc_mitsuba_Properties_references =
+R"doc(Return an array containing indirect references to scene objects and
+their associated names (in insertion order)
+
+Parameter ``mark_queried``:
+    Whether all stored objects should be marked as queried)doc";
 
 static const char *__doc_mitsuba_Properties_remove_property =
 R"doc(Remove a property with the specified name
@@ -6217,81 +6415,44 @@ R"doc(Remove a property with the specified name
 Returns:
     ``True`` upon success)doc";
 
-static const char *__doc_mitsuba_Properties_set_array3f = R"doc(Store a 3D array in the Properties instance)doc";
+static const char *__doc_mitsuba_Properties_set =
+R"doc(Set a parameter value
 
-static const char *__doc_mitsuba_Properties_set_bool = R"doc(Store a boolean value in the Properties instance)doc";
+When a parameter with a matching names is already present, the method
+raises an exception if ``raise_if_exists`` is set to ``True`` (the
+default). Otherwise, it replaces the parameter.
 
-static const char *__doc_mitsuba_Properties_set_color = R"doc(Store a color in the Properties instance)doc";
+The parameter is initially marked as unqueried (see was_queried).)doc";
 
-static const char *__doc_mitsuba_Properties_set_float = R"doc(Store a floating point value in the Properties instance)doc";
+static const char *__doc_mitsuba_Properties_set_any =
+R"doc(Set an arbitrarily typed value for inter-plugin communication
+
+This method allows storing arbitrary data types that cannot be
+represented by the standard Properties types. The value is stored in a
+type-erased Any container and can be retrieved later using
+get_any<T>().)doc";
 
 static const char *__doc_mitsuba_Properties_set_id = R"doc(Set the unique identifier associated with this instance)doc";
 
-static const char *__doc_mitsuba_Properties_set_int = R"doc(Set an integer value in the Properties instance)doc";
+static const char *__doc_mitsuba_Properties_set_impl = R"doc(Implementation detail of set())doc";
 
-static const char *__doc_mitsuba_Properties_set_long = R"doc(Store a long value in the Properties instance)doc";
+static const char *__doc_mitsuba_Properties_set_impl_2 = R"doc()doc";
 
-static const char *__doc_mitsuba_Properties_set_named_reference = R"doc(Store a named reference in the Properties instance)doc";
-
-static const char *__doc_mitsuba_Properties_set_object = R"doc(Store an arbitrary object in the Properties instance)doc";
-
-static const char *__doc_mitsuba_Properties_set_plugin_name = R"doc(Set the associated plugin name)doc";
-
-static const char *__doc_mitsuba_Properties_set_pointer = R"doc(Store an arbitrary pointer in the Properties instance)doc";
-
-static const char *__doc_mitsuba_Properties_set_string = R"doc(Store a string in the Properties instance)doc";
-
-static const char *__doc_mitsuba_Properties_set_tensor_handle = R"doc(Store a tensor handle in the Properties instance)doc";
-
-static const char *__doc_mitsuba_Properties_set_transform =
-R"doc(Store a 4x4 homogeneous coordinate transformation in the Properties
-instance)doc";
-
-static const char *__doc_mitsuba_Properties_set_transform3f =
-R"doc(Store a 3x3 homogeneous coordinate transformation in the Properties
-instance)doc";
-
-static const char *__doc_mitsuba_Properties_share = R"doc(Share the internals. Used exclusively for Python bindings)doc";
-
-static const char *__doc_mitsuba_Properties_string = R"doc(Retrieve a string value)doc";
-
-static const char *__doc_mitsuba_Properties_string_2 = R"doc(Retrieve a string value (use default value if no entry exists))doc";
-
-static const char *__doc_mitsuba_Properties_tensor = R"doc(Retrieve a tensor)doc";
-
-static const char *__doc_mitsuba_Properties_texture =
-R"doc(Retrieve a texture (if the property is a float, create a uniform
-texture instead))doc";
-
-static const char *__doc_mitsuba_Properties_texture_2 = R"doc(Retrieve a texture (use the provided texture if no entry exists))doc";
-
-static const char *__doc_mitsuba_Properties_texture_3 = R"doc(Retrieve a texture (or create uniform texture with default value))doc";
-
-static const char *__doc_mitsuba_Properties_texture_d65 =
-R"doc(Retrieve a texture multiplied by D65 if necessary (if the property is
-a float, create a D65 texture instead))doc";
-
-static const char *__doc_mitsuba_Properties_texture_d65_2 =
-R"doc(Retrieve a texture multiplied by D65 if necessary (use the provided
-texture if no entry exists))doc";
-
-static const char *__doc_mitsuba_Properties_texture_d65_3 =
-R"doc(Retrieve a texture multiplied by D65 if necessary (or create D65
-texture with default value))doc";
+static const char *__doc_mitsuba_Properties_set_plugin_name = R"doc(Set the plugin name)doc";
 
 static const char *__doc_mitsuba_Properties_type =
-R"doc(Returns the type of an existing property. If no property exists under
-that name, an error is logged and type ``void`` is returned.)doc";
+R"doc(Returns the type of an existing property.
 
-static const char *__doc_mitsuba_Properties_unqueried = R"doc(Return the list of un-queried attributed)doc";
+Raises an exception if the property does not exist.)doc";
 
-static const char *__doc_mitsuba_Properties_volume = R"doc(Retrieve a 3D texture)doc";
+static const char *__doc_mitsuba_Properties_unqueried = R"doc(Return the list of unqueried attributed)doc";
 
-static const char *__doc_mitsuba_Properties_volume_2 = R"doc(Retrieve a 3D texture (use the provided texture if no entry exists))doc";
+static const char *__doc_mitsuba_Properties_was_queried =
+R"doc(Check if a certain property was queried
 
-static const char *__doc_mitsuba_Properties_volume_3 = R"doc()doc";
-
-static const char *__doc_mitsuba_Properties_was_queried = R"doc(Check if a certain property was queried)doc";
+Mitsuba assigns a queried bit with every parameter. Unqueried
+parameters are detected to issue warnings, since this is usually
+indicative of typos.)doc";
 
 static const char *__doc_mitsuba_RadicalInverse =
 R"doc(Efficient implementation of a radical inverse function with prime
@@ -6331,7 +6492,7 @@ static const char *__doc_mitsuba_RadicalInverse_bases =
 R"doc(Return the number of prime bases for which precomputed tables are
 available)doc";
 
-static const char *__doc_mitsuba_RadicalInverse_class = R"doc()doc";
+static const char *__doc_mitsuba_RadicalInverse_class_name = R"doc()doc";
 
 static const char *__doc_mitsuba_RadicalInverse_compute_faure_permutations =
 R"doc(Compute the Faure permutations using dynamic programming
@@ -6340,7 +6501,7 @@ For reference, see "Good permutations for extreme discrepancy" by
 Henri Faure, Journal of Number Theory, Vol. 42, 1, 1992.)doc";
 
 static const char *__doc_mitsuba_RadicalInverse_eval =
-R"doc(Calculate the radical inverse function
+R"doc(Calculate the value of the radical inverse function
 
 This function is used as a building block to construct Halton and
 Hammersley sequences. Roughly, it computes a b-ary representation of
@@ -6528,13 +6689,11 @@ static const char *__doc_mitsuba_ReconstructionFilter_5 = R"doc()doc";
 
 static const char *__doc_mitsuba_ReconstructionFilter_6 = R"doc()doc";
 
-static const char *__doc_mitsuba_ReconstructionFilter_7 = R"doc()doc";
-
 static const char *__doc_mitsuba_ReconstructionFilter_ReconstructionFilter = R"doc(Create a new reconstruction filter)doc";
 
 static const char *__doc_mitsuba_ReconstructionFilter_border_size = R"doc(Return the block border size required when rendering with this filter)doc";
 
-static const char *__doc_mitsuba_ReconstructionFilter_class = R"doc()doc";
+static const char *__doc_mitsuba_ReconstructionFilter_class_name = R"doc()doc";
 
 static const char *__doc_mitsuba_ReconstructionFilter_eval = R"doc(Evaluate the filter function)doc";
 
@@ -6556,6 +6715,10 @@ static const char *__doc_mitsuba_ReconstructionFilter_m_values = R"doc()doc";
 
 static const char *__doc_mitsuba_ReconstructionFilter_radius = R"doc(Return the filter's width)doc";
 
+static const char *__doc_mitsuba_ReconstructionFilter_type = R"doc()doc";
+
+static const char *__doc_mitsuba_ReconstructionFilter_variant_name = R"doc()doc";
+
 static const char *__doc_mitsuba_Resampler =
 R"doc(Utility class for efficiently resampling discrete datasets to
 different resolutions
@@ -6570,8 +6733,8 @@ resolutions
 
 This constructor precomputes all information needed to efficiently
 perform the desired resampling operation. For that reason, it is most
-efficient if it can be used over and over again (e.g. to resample the
-equal-sized rows of a bitmap)
+efficient if it can be used repeatedly (e.g. to resample the equal-
+sized rows of a bitmap)
 
 Parameter ``source_res``:
     Source resolution
@@ -6653,7 +6816,7 @@ vectors [[S_xx, S_yy, S_zz], [S_xy, S_xz, S_yz]])doc";
 
 static const char *__doc_mitsuba_SGGXPhaseFunctionParams_SGGXPhaseFunctionParams =
 R"doc(Construct from a pair of 3D vectors [S_xx, S_yy, S_zz] and [S_xy,
-S_xz, S_yz] that correspond to the entries of a symmetric positive
+S_xz, S_yz] that correspond to the entries of a symmetric positive-
 definite 3x3 matrix.)doc";
 
 static const char *__doc_mitsuba_SGGXPhaseFunctionParams_SGGXPhaseFunctionParams_2 = R"doc()doc";
@@ -6739,8 +6902,6 @@ static const char *__doc_mitsuba_Sampler_5 = R"doc()doc";
 
 static const char *__doc_mitsuba_Sampler_6 = R"doc()doc";
 
-static const char *__doc_mitsuba_Sampler_7 = R"doc()doc";
-
 static const char *__doc_mitsuba_Sampler_Sampler = R"doc()doc";
 
 static const char *__doc_mitsuba_Sampler_Sampler_2 = R"doc(Copy state to a new sampler object)doc";
@@ -6751,7 +6912,7 @@ R"doc(Advance to the next sample.
 A subsequent call to ``next_1d`` or ``next_2d`` will access the first
 1D or 2D components of this sample.)doc";
 
-static const char *__doc_mitsuba_Sampler_class = R"doc()doc";
+static const char *__doc_mitsuba_Sampler_class_name = R"doc()doc";
 
 static const char *__doc_mitsuba_Sampler_clone =
 R"doc(Create a clone of this sampler.
@@ -6813,9 +6974,13 @@ static const char *__doc_mitsuba_Sampler_set_samples_per_wavefront =
 R"doc(Set the number of samples per pixel per pass in wavefront modes
 (default is 1))doc";
 
-static const char *__doc_mitsuba_Sampler_traverse_1_cb_ro = R"doc(Traversal callback mechanism for symbolic loops)doc";
+static const char *__doc_mitsuba_Sampler_traverse_1_cb_ro = R"doc()doc";
 
-static const char *__doc_mitsuba_Sampler_traverse_1_cb_rw = R"doc(Traversal callback mechanism for symbolic loops)doc";
+static const char *__doc_mitsuba_Sampler_traverse_1_cb_rw = R"doc()doc";
+
+static const char *__doc_mitsuba_Sampler_type = R"doc()doc";
+
+static const char *__doc_mitsuba_Sampler_variant_name = R"doc()doc";
 
 static const char *__doc_mitsuba_Sampler_wavefront_size = R"doc(Return the size of the wavefront (or 0, if not seeded))doc";
 
@@ -6840,11 +7005,9 @@ static const char *__doc_mitsuba_SamplingIntegrator_5 = R"doc()doc";
 
 static const char *__doc_mitsuba_SamplingIntegrator_6 = R"doc()doc";
 
-static const char *__doc_mitsuba_SamplingIntegrator_7 = R"doc()doc";
-
 static const char *__doc_mitsuba_SamplingIntegrator_SamplingIntegrator = R"doc(//! @})doc";
 
-static const char *__doc_mitsuba_SamplingIntegrator_class = R"doc()doc";
+static const char *__doc_mitsuba_SamplingIntegrator_class_name = R"doc(//! @})doc";
 
 static const char *__doc_mitsuba_SamplingIntegrator_m_block_size = R"doc(Size of (square) image blocks to render in parallel (in scalar mode))doc";
 
@@ -6903,6 +7066,10 @@ Remark:
 (spec, mask, aov) = integrator.sample(scene, sampler, ray, medium, active)
 ```)doc";
 
+static const char *__doc_mitsuba_SamplingIntegrator_traverse_1_cb_ro = R"doc()doc";
+
+static const char *__doc_mitsuba_SamplingIntegrator_traverse_1_cb_rw = R"doc()doc";
+
 static const char *__doc_mitsuba_Scene =
 R"doc(Central scene data structure
 
@@ -6935,8 +7102,6 @@ static const char *__doc_mitsuba_Scene_5 = R"doc()doc";
 
 static const char *__doc_mitsuba_Scene_6 = R"doc()doc";
 
-static const char *__doc_mitsuba_Scene_7 = R"doc()doc";
-
 static const char *__doc_mitsuba_Scene_Scene = R"doc(Instantiate a scene from a Properties object)doc";
 
 static const char *__doc_mitsuba_Scene_accel_init_cpu = R"doc(Create the ray-intersection acceleration data structure)doc";
@@ -6953,7 +7118,7 @@ static const char *__doc_mitsuba_Scene_accel_release_gpu = R"doc()doc";
 
 static const char *__doc_mitsuba_Scene_bbox = R"doc(Return a bounding box surrounding the scene)doc";
 
-static const char *__doc_mitsuba_Scene_class = R"doc()doc";
+static const char *__doc_mitsuba_Scene_class_name = R"doc()doc";
 
 static const char *__doc_mitsuba_Scene_clear_shapes_dirty = R"doc(Unmarks all shapes as dirty)doc";
 
@@ -7087,7 +7252,7 @@ interactions following the usual conventions.
 This method is a convenience wrapper of the generalized version of
 ``ray_intersect``() below. It assumes that incoherent rays are being
 traced, that the user desires access to all fields of the
-SurfaceInteraction, and that no thread reodering is requested. In
+SurfaceInteraction, and that no thread reordering is requested. In
 other words, it simply invokes the general ``ray_intersect``()
 overload with ``coherent=false``, ``ray_flags`` equal to
 RayFlags::All, and ``reorder=false``.
@@ -7216,7 +7381,7 @@ essentially the same region of space). This flag is currently only
 used by the combination of ``llvm_*`` variants and the Embree ray
 tracing backend.
 
-The ``reoder`` flag is a trigger for the Shader Execution Reordering
+The ``reorder`` flag is a trigger for the Shader Execution Reordering
 (SER) feature on NVIDIA GPUs. It can improve performance in highly
 divergent workloads by shuffling threads into coherent warps. This
 shuffling operation uses the result of the intersection (the shape ID)
@@ -7251,7 +7416,7 @@ Parameter ``reorder_hint``:
 
 Parameter ``reorder_hint_bits``:
     Number of bits from the ``reorder_hint`` to use (starting from the
-    least signifcant bit). It is recommended to use as few as
+    least significant bit). It is recommended to use as few as
     possible. At most, 16 bits can be used. This flag has no effect in
     scalar or LLVM variants, or if the ``reorder`` parameter is
     ``False``.
@@ -7365,7 +7530,7 @@ essentially the same region of space). This flag is currently only
 used by the combination of ``llvm_*`` variants and the Embree ray
 intersector.
 
-The ``reoder`` flag is a trigger for the Shader Execution Reordering
+The ``reorder`` flag is a trigger for the Shader Execution Reordering
 (SER) feature on NVIDIA GPUs. It can improve performance in highly
 divergent workloads by shuffling threads into coherent warps. This
 shuffling operation uses the result of the intersection (the shape ID)
@@ -7396,7 +7561,7 @@ Parameter ``reorder_hint``:
 
 Parameter ``reorder_hint_bits``:
     Number of bits from the ``reorder_hint`` to use (starting from the
-    least signifcant bit). It is recommended to use as few as
+    least significant bit). It is recommended to use as few as
     possible. At most, 16 bits can be used. This flag has no effect in
     scalar or LLVM variants, or if the ``reorder`` parameter is
     ``False``.
@@ -7523,8 +7688,6 @@ provides further detail about the sampled emitter position (e.g. its
 surface normal, solid angle density, whether Dirac delta distributions
 were involved, etc.)
 
-*
-
 * ``spec`` is a Monte Carlo sampling weight specifying the ratio of
 the radiance incident from the emitter and the sample probability per
 unit solid angle.)doc";
@@ -7624,9 +7787,33 @@ static const char *__doc_mitsuba_Scene_to_string = R"doc(Return a human-readable
 
 static const char *__doc_mitsuba_Scene_traverse = R"doc(Traverse the scene graph and invoke the given callback for each object)doc";
 
+static const char *__doc_mitsuba_Scene_traverse_1_cb_fields = R"doc()doc";
+
+static const char *__doc_mitsuba_Scene_traverse_1_cb_fields_2 = R"doc()doc";
+
+static const char *__doc_mitsuba_Scene_traverse_1_cb_ro = R"doc()doc";
+
+static const char *__doc_mitsuba_Scene_traverse_1_cb_ro_cpu =
+R"doc(When the scene is defined on the CPU, traversal of the acceleration
+structure has to be handled separately. These functions are defined
+either for the Embree or native version of the scene, and handle its
+traversal.)doc";
+
+static const char *__doc_mitsuba_Scene_traverse_1_cb_rw = R"doc()doc";
+
+static const char *__doc_mitsuba_Scene_traverse_1_cb_rw_cpu =
+R"doc(When the scene is defined on the CPU, traversal of the acceleration
+structure has to be handled separately. These functions are defined
+either for the Embree or native version of the scene, and handle its
+traversal.)doc";
+
+static const char *__doc_mitsuba_Scene_type = R"doc()doc";
+
 static const char *__doc_mitsuba_Scene_update_emitter_sampling_distribution = R"doc(Updates the discrete distribution used to select an emitter)doc";
 
 static const char *__doc_mitsuba_Scene_update_silhouette_sampling_distribution = R"doc(Updates the discrete distribution used to select a shape's silhouette)doc";
+
+static const char *__doc_mitsuba_Scene_variant_name = R"doc()doc";
 
 static const char *__doc_mitsuba_ScopedPhase = R"doc()doc";
 
@@ -7635,20 +7822,6 @@ static const char *__doc_mitsuba_ScopedPhase_ScopedPhase = R"doc()doc";
 static const char *__doc_mitsuba_ScopedPhase_ScopedPhase_2 = R"doc()doc";
 
 static const char *__doc_mitsuba_ScopedPhase_operator_assign = R"doc()doc";
-
-static const char *__doc_mitsuba_ScopedSetThreadEnvironment =
-R"doc(RAII-style class to temporarily switch to another thread's logger/file
-resolver)doc";
-
-static const char *__doc_mitsuba_ScopedSetThreadEnvironment_ScopedSetThreadEnvironment = R"doc()doc";
-
-static const char *__doc_mitsuba_ScopedSetThreadEnvironment_ScopedSetThreadEnvironment_2 = R"doc()doc";
-
-static const char *__doc_mitsuba_ScopedSetThreadEnvironment_m_file_resolver = R"doc()doc";
-
-static const char *__doc_mitsuba_ScopedSetThreadEnvironment_m_logger = R"doc()doc";
-
-static const char *__doc_mitsuba_ScopedSetThreadEnvironment_operator_assign = R"doc()doc";
 
 static const char *__doc_mitsuba_Sensor = R"doc()doc";
 
@@ -7662,11 +7835,9 @@ static const char *__doc_mitsuba_Sensor_5 = R"doc()doc";
 
 static const char *__doc_mitsuba_Sensor_6 = R"doc()doc";
 
-static const char *__doc_mitsuba_Sensor_7 = R"doc()doc";
+static const char *__doc_mitsuba_Sensor_Sensor = R"doc(This is both a class and the base of various Mitsuba plugins)doc";
 
-static const char *__doc_mitsuba_Sensor_Sensor = R"doc()doc";
-
-static const char *__doc_mitsuba_Sensor_class = R"doc()doc";
+static const char *__doc_mitsuba_Sensor_class_name = R"doc(This is both a class and the base of various Mitsuba plugins)doc";
 
 static const char *__doc_mitsuba_Sensor_film = R"doc(Return the Film instance associated with this sensor)doc";
 
@@ -7700,7 +7871,7 @@ The sensor profile is a six-dimensional quantity that depends on time,
 wavelength, surface position, and direction. This function takes a
 given time value and five uniformly distributed samples on the
 interval [0, 1] and warps them so that the returned ray the profile.
-Any discrepancies between ideal and actual sampled profile are
+Any discrepancies between ideal and actual sampled profiles are
 absorbed into a spectral importance weight that is returned along with
 the ray.
 
@@ -7771,6 +7942,14 @@ static const char *__doc_mitsuba_Sensor_shutter_open_time = R"doc(Return the len
 
 static const char *__doc_mitsuba_Sensor_traverse = R"doc(//! @})doc";
 
+static const char *__doc_mitsuba_Sensor_traverse_1_cb_ro = R"doc()doc";
+
+static const char *__doc_mitsuba_Sensor_traverse_1_cb_rw = R"doc()doc";
+
+static const char *__doc_mitsuba_Sensor_type = R"doc(This is both a class and the base of various Mitsuba plugins)doc";
+
+static const char *__doc_mitsuba_Sensor_variant_name = R"doc(This is both a class and the base of various Mitsuba plugins)doc";
+
 static const char *__doc_mitsuba_Shape = R"doc(Forward declaration for `SilhouetteSample`)doc";
 
 static const char *__doc_mitsuba_Shape_2 = R"doc(Forward declaration for `SilhouetteSample`)doc";
@@ -7785,8 +7964,6 @@ static const char *__doc_mitsuba_Shape_6 = R"doc()doc";
 
 static const char *__doc_mitsuba_Shape_7 = R"doc()doc";
 
-static const char *__doc_mitsuba_Shape_8 = R"doc()doc";
-
 static const char *__doc_mitsuba_ShapeGroup = R"doc()doc";
 
 static const char *__doc_mitsuba_ShapeGroup_2 = R"doc()doc";
@@ -7799,13 +7976,11 @@ static const char *__doc_mitsuba_ShapeGroup_5 = R"doc()doc";
 
 static const char *__doc_mitsuba_ShapeGroup_6 = R"doc()doc";
 
-static const char *__doc_mitsuba_ShapeGroup_7 = R"doc()doc";
-
 static const char *__doc_mitsuba_ShapeGroup_ShapeGroup = R"doc()doc";
 
 static const char *__doc_mitsuba_ShapeGroup_bbox = R"doc()doc";
 
-static const char *__doc_mitsuba_ShapeGroup_class = R"doc()doc";
+static const char *__doc_mitsuba_ShapeGroup_class_name = R"doc()doc";
 
 static const char *__doc_mitsuba_ShapeGroup_compute_surface_interaction = R"doc()doc";
 
@@ -7814,6 +7989,8 @@ static const char *__doc_mitsuba_ShapeGroup_effective_primitive_count = R"doc()d
 static const char *__doc_mitsuba_ShapeGroup_embree_geometry = R"doc()doc";
 
 static const char *__doc_mitsuba_ShapeGroup_m_accel = R"doc()doc";
+
+static const char *__doc_mitsuba_ShapeGroup_m_accel_handles = R"doc()doc";
 
 static const char *__doc_mitsuba_ShapeGroup_m_bbox = R"doc()doc";
 
@@ -7853,6 +8030,14 @@ static const char *__doc_mitsuba_ShapeGroup_to_string = R"doc()doc";
 
 static const char *__doc_mitsuba_ShapeGroup_traverse = R"doc()doc";
 
+static const char *__doc_mitsuba_ShapeGroup_traverse_1_cb_fields = R"doc()doc";
+
+static const char *__doc_mitsuba_ShapeGroup_traverse_1_cb_fields_2 = R"doc()doc";
+
+static const char *__doc_mitsuba_ShapeGroup_traverse_1_cb_ro = R"doc()doc";
+
+static const char *__doc_mitsuba_ShapeGroup_traverse_1_cb_rw = R"doc()doc";
+
 static const char *__doc_mitsuba_ShapeKDTree = R"doc()doc";
 
 static const char *__doc_mitsuba_ShapeKDTree_2 = R"doc()doc";
@@ -7864,8 +8049,6 @@ static const char *__doc_mitsuba_ShapeKDTree_4 = R"doc()doc";
 static const char *__doc_mitsuba_ShapeKDTree_5 = R"doc()doc";
 
 static const char *__doc_mitsuba_ShapeKDTree_6 = R"doc()doc";
-
-static const char *__doc_mitsuba_ShapeKDTree_7 = R"doc()doc";
 
 static const char *__doc_mitsuba_ShapeKDTree_ShapeKDTree =
 R"doc(Create an empty kd-tree and take build-related parameters from
@@ -7879,7 +8062,7 @@ static const char *__doc_mitsuba_ShapeKDTree_bbox_2 = R"doc(Return the (clipped)
 
 static const char *__doc_mitsuba_ShapeKDTree_build = R"doc(Build the kd-tree)doc";
 
-static const char *__doc_mitsuba_ShapeKDTree_class = R"doc()doc";
+static const char *__doc_mitsuba_ShapeKDTree_class_name = R"doc()doc";
 
 static const char *__doc_mitsuba_ShapeKDTree_clear = R"doc(Clear the kd-tree (build-related parameters remain))doc";
 
@@ -7940,6 +8123,8 @@ static const char *__doc_mitsuba_ShapeType_Rectangle = R"doc(Rectangle: a partic
 
 static const char *__doc_mitsuba_ShapeType_SDFGrid = R"doc(SDF Grids (`sdfgrid`))doc";
 
+static const char *__doc_mitsuba_ShapeType_ShapeGroup = R"doc(ShapeGroup (`shapegroup`))doc";
+
 static const char *__doc_mitsuba_ShapeType_Sphere = R"doc(Spheres (`sphere`))doc";
 
 static const char *__doc_mitsuba_Shape_Shape = R"doc(//! @})doc";
@@ -7984,7 +8169,7 @@ static const char *__doc_mitsuba_Shape_bsdf = R"doc(Return the shape's BSDF)doc"
 
 static const char *__doc_mitsuba_Shape_bsdf_2 = R"doc(Return the shape's BSDF)doc";
 
-static const char *__doc_mitsuba_Shape_class = R"doc()doc";
+static const char *__doc_mitsuba_Shape_class_name = R"doc(//! @})doc";
 
 static const char *__doc_mitsuba_Shape_compute_surface_interaction =
 R"doc(Compute and return detailed information related to a surface
@@ -8054,9 +8239,6 @@ the scene by this shape
 Includes instanced geometry. The default implementation simply returns
 the same value as primitive_count().)doc";
 
-static const char *__doc_mitsuba_Shape_has_flipped_normals =
-R"doc(Does this shape have flipped normals?)doc";
-
 static const char *__doc_mitsuba_Shape_embree_geometry = R"doc(Return the Embree version of this shape)doc";
 
 static const char *__doc_mitsuba_Shape_emitter = R"doc(Return the area emitter associated with this shape (if any))doc";
@@ -8111,7 +8293,7 @@ Parameter ``si``:
     Surface interaction associated with the query
 
 Returns:
-    An trichromatic intensity or reflectance value)doc";
+    A trichromatic intensity or reflectance value)doc";
 
 static const char *__doc_mitsuba_Shape_eval_attribute_x =
 R"doc(Evaluate a dynamically sized shape attribute at the given surface
@@ -8124,7 +8306,7 @@ Parameter ``si``:
     Surface interaction associated with the query
 
 Returns:
-    An dynamic array of attribute values)doc";
+    A dynamic array of attribute values)doc";
 
 static const char *__doc_mitsuba_Shape_eval_parameterization =
 R"doc(Parameterize the mesh using UV values
@@ -8143,7 +8325,7 @@ R"doc(Returns whether this shape contains the specified attribute.
 Parameter ``name``:
     Name of the attribute)doc";
 
-static const char *__doc_mitsuba_Shape_id = R"doc(Return a string identifier)doc";
+static const char *__doc_mitsuba_Shape_has_flipped_normals = R"doc(Does this shape have flipped normals?)doc";
 
 static const char *__doc_mitsuba_Shape_initialize = R"doc()doc";
 
@@ -8176,7 +8358,7 @@ static const char *__doc_mitsuba_Shape_is_mesh = R"doc(Is this shape a triangle 
 
 static const char *__doc_mitsuba_Shape_is_sensor = R"doc(Is this shape also an area sensor?)doc";
 
-static const char *__doc_mitsuba_Shape_is_shapegroup = R"doc(Is this shape a shapegroup?)doc";
+static const char *__doc_mitsuba_Shape_is_shape_group = R"doc(Is this shape a shape group?)doc";
 
 static const char *__doc_mitsuba_Shape_m_bsdf = R"doc()doc";
 
@@ -8188,9 +8370,7 @@ static const char *__doc_mitsuba_Shape_m_emitter = R"doc()doc";
 
 static const char *__doc_mitsuba_Shape_m_exterior_medium = R"doc()doc";
 
-static const char *__doc_mitsuba_Shape_m_id = R"doc()doc";
-
-static const char *__doc_mitsuba_Shape_m_initialized = R"doc(True if the shape has called iniatlize() at least once)doc";
+static const char *__doc_mitsuba_Shape_m_initialized = R"doc(True if the shape has called initialize() at least once)doc";
 
 static const char *__doc_mitsuba_Shape_m_interior_medium = R"doc()doc";
 
@@ -8511,8 +8691,8 @@ Returns:
     A PositionSample instance describing the generated sample)doc";
 
 static const char *__doc_mitsuba_Shape_sample_precomputed_silhouette =
-R"doc(Samples a boundary segement on the shape's silhouette using
-precomputed information computed in precompute_silhouette.
+R"doc(Samples a boundary segment on the shape's silhouette using precomputed
+information computed in precompute_silhouette.
 
 This method is meant to be used for silhouettes that are shared
 between all threads, as is the case for primarily visible derivatives.
@@ -8557,8 +8737,6 @@ static const char *__doc_mitsuba_Shape_sensor_2 = R"doc(Return the area sensor a
 
 static const char *__doc_mitsuba_Shape_set_bsdf = R"doc(Set the shape's BSDF)doc";
 
-static const char *__doc_mitsuba_Shape_set_id = R"doc(Set a string identifier)doc";
-
 static const char *__doc_mitsuba_Shape_shape_type = R"doc(Returns the shape type ShapeType of this shape)doc";
 
 static const char *__doc_mitsuba_Shape_silhouette_discontinuity_types = R"doc(//! @{ \name Silhouette sampling routines and other utilities)doc";
@@ -8579,6 +8757,18 @@ static const char *__doc_mitsuba_Shape_texture_attribute_2 = R"doc(Return the te
 
 static const char *__doc_mitsuba_Shape_traverse = R"doc()doc";
 
+static const char *__doc_mitsuba_Shape_traverse_1_cb_fields = R"doc()doc";
+
+static const char *__doc_mitsuba_Shape_traverse_1_cb_fields_2 = R"doc()doc";
+
+static const char *__doc_mitsuba_Shape_traverse_1_cb_ro = R"doc()doc";
+
+static const char *__doc_mitsuba_Shape_traverse_1_cb_rw = R"doc()doc";
+
+static const char *__doc_mitsuba_Shape_type = R"doc(//! @})doc";
+
+static const char *__doc_mitsuba_Shape_variant_name = R"doc(//! @})doc";
+
 static const char *__doc_mitsuba_SilhouetteSample =
 R"doc(Data structure holding the result of visibility silhouette sampling
 operations on geometry.)doc";
@@ -8595,9 +8785,9 @@ static const char *__doc_mitsuba_SilhouetteSample_d = R"doc(Direction of the bou
 
 static const char *__doc_mitsuba_SilhouetteSample_discontinuity_type = R"doc(Type of discontinuity (DiscontinuityFlags))doc";
 
-static const char *__doc_mitsuba_SilhouetteSample_fields = R"doc()doc";
+static const char *__doc_mitsuba_SilhouetteSample_fields = R"doc(//! @})doc";
 
-static const char *__doc_mitsuba_SilhouetteSample_fields_2 = R"doc()doc";
+static const char *__doc_mitsuba_SilhouetteSample_fields_2 = R"doc(//! @})doc";
 
 static const char *__doc_mitsuba_SilhouetteSample_flags =
 R"doc(The set of ``DiscontinuityFlags`` that were used to generate this
@@ -8609,11 +8799,11 @@ R"doc(Local-form boundary foreshortening term.
 It stores `sin_phi_B` for perimeter silhouettes or the normal
 curvature for interior silhouettes.)doc";
 
-static const char *__doc_mitsuba_SilhouetteSample_is_valid = R"doc(Is the current boundary segment valid=)doc";
+static const char *__doc_mitsuba_SilhouetteSample_is_valid = R"doc(Is the current boundary segment valid?)doc";
 
-static const char *__doc_mitsuba_SilhouetteSample_labels = R"doc()doc";
+static const char *__doc_mitsuba_SilhouetteSample_labels = R"doc(//! @})doc";
 
-static const char *__doc_mitsuba_SilhouetteSample_name = R"doc()doc";
+static const char *__doc_mitsuba_SilhouetteSample_name = R"doc(//! @})doc";
 
 static const char *__doc_mitsuba_SilhouetteSample_offset =
 R"doc(Offset along the boundary segment direction (`d`) to avoid self-
@@ -8646,8 +8836,8 @@ static const char *__doc_mitsuba_SilhouetteSample_silhouette_d = R"doc(Direction
 static const char *__doc_mitsuba_SilhouetteSample_spawn_ray =
 R"doc(Spawn a ray on the silhouette point in the direction of d
 
-The ray origin is offset in the direction of the segment (d) aswell as
-in the in the direction of the silhouette normal (n). Without this
+The ray origin is offset in the direction of the segment (d) as well
+as in the direction of the silhouette normal (n). Without this
 offsetting, during a ray intersection, the ray could potentially find
 an intersection point at its origin due to numerical instabilities in
 the intersection routines.)doc";
@@ -8689,7 +8879,7 @@ frame, and block size)doc";
 
 static const char *__doc_mitsuba_Spiral_block_count = R"doc(Return the total number of blocks)doc";
 
-static const char *__doc_mitsuba_Spiral_class = R"doc()doc";
+static const char *__doc_mitsuba_Spiral_class_name = R"doc()doc";
 
 static const char *__doc_mitsuba_Spiral_direction = R"doc()doc";
 
@@ -8754,13 +8944,13 @@ static const char *__doc_mitsuba_StreamAppender_StreamAppender_2 = R"doc(Create 
 
 static const char *__doc_mitsuba_StreamAppender_append = R"doc(Append a line of text)doc";
 
-static const char *__doc_mitsuba_StreamAppender_class = R"doc()doc";
+static const char *__doc_mitsuba_StreamAppender_class_name = R"doc()doc";
 
 static const char *__doc_mitsuba_StreamAppender_log_progress = R"doc(Process a progress message)doc";
 
 static const char *__doc_mitsuba_StreamAppender_logs_to_file = R"doc(Does this appender log to a file)doc";
 
-static const char *__doc_mitsuba_StreamAppender_m_fileName = R"doc()doc";
+static const char *__doc_mitsuba_StreamAppender_m_fname = R"doc()doc";
 
 static const char *__doc_mitsuba_StreamAppender_m_is_file = R"doc()doc";
 
@@ -8794,7 +8984,7 @@ static const char *__doc_mitsuba_Stream_can_read = R"doc(Can we read from the st
 
 static const char *__doc_mitsuba_Stream_can_write = R"doc(Can we write to the stream?)doc";
 
-static const char *__doc_mitsuba_Stream_class = R"doc()doc";
+static const char *__doc_mitsuba_Stream_class_name = R"doc(@})doc";
 
 static const char *__doc_mitsuba_Stream_close =
 R"doc(Closes the stream.
@@ -8971,7 +9161,7 @@ static const char *__doc_mitsuba_StructConverter_Value_flags = R"doc()doc";
 
 static const char *__doc_mitsuba_StructConverter_Value_type = R"doc()doc";
 
-static const char *__doc_mitsuba_StructConverter_class = R"doc()doc";
+static const char *__doc_mitsuba_StructConverter_class_name = R"doc()doc";
 
 static const char *__doc_mitsuba_StructConverter_convert = R"doc(Convert ``count`` elements. Returns ``True`` upon success)doc";
 
@@ -9119,7 +9309,7 @@ static const char *__doc_mitsuba_Struct_begin_2 = R"doc(Return an iterator assoc
 
 static const char *__doc_mitsuba_Struct_byte_order = R"doc(Return the byte order of the ``Struct``)doc";
 
-static const char *__doc_mitsuba_Struct_class = R"doc()doc";
+static const char *__doc_mitsuba_Struct_class_name = R"doc()doc";
 
 static const char *__doc_mitsuba_Struct_end = R"doc(Return an iterator associated with the end of the data structure)doc";
 
@@ -9257,9 +9447,9 @@ static const char *__doc_mitsuba_SurfaceInteraction_emitter =
 R"doc(Return the emitter associated with the intersection (if any) \note
 Defined in scene.h)doc";
 
-static const char *__doc_mitsuba_SurfaceInteraction_fields = R"doc()doc";
+static const char *__doc_mitsuba_SurfaceInteraction_fields = R"doc(//! @})doc";
 
-static const char *__doc_mitsuba_SurfaceInteraction_fields_2 = R"doc()doc";
+static const char *__doc_mitsuba_SurfaceInteraction_fields_2 = R"doc(//! @})doc";
 
 static const char *__doc_mitsuba_SurfaceInteraction_finalize_surface_interaction =
 R"doc(Fills uninitialized fields after a call to
@@ -9287,9 +9477,9 @@ static const char *__doc_mitsuba_SurfaceInteraction_is_medium_transition = R"doc
 
 static const char *__doc_mitsuba_SurfaceInteraction_is_sensor = R"doc(Is the intersected shape also a sensor?)doc";
 
-static const char *__doc_mitsuba_SurfaceInteraction_labels = R"doc()doc";
+static const char *__doc_mitsuba_SurfaceInteraction_labels = R"doc(//! @})doc";
 
-static const char *__doc_mitsuba_SurfaceInteraction_name = R"doc()doc";
+static const char *__doc_mitsuba_SurfaceInteraction_name = R"doc(//! @})doc";
 
 static const char *__doc_mitsuba_SurfaceInteraction_operator_array = R"doc(Convenience operator for masking)doc";
 
@@ -9715,7 +9905,7 @@ static const char *__doc_mitsuba_TShapeKDTree_bbox = R"doc(Return the bounding b
 
 static const char *__doc_mitsuba_TShapeKDTree_build = R"doc()doc";
 
-static const char *__doc_mitsuba_TShapeKDTree_class = R"doc()doc";
+static const char *__doc_mitsuba_TShapeKDTree_class_name = R"doc()doc";
 
 static const char *__doc_mitsuba_TShapeKDTree_clip_primitives = R"doc(Return whether primitive clipping is used during tree construction)doc";
 
@@ -9819,7 +10009,7 @@ static const char *__doc_mitsuba_TensorFile_Field_shape = R"doc(Specifies both r
 
 static const char *__doc_mitsuba_TensorFile_TensorFile = R"doc(Map the specified file into memory)doc";
 
-static const char *__doc_mitsuba_TensorFile_class = R"doc()doc";
+static const char *__doc_mitsuba_TensorFile_class_name = R"doc()doc";
 
 static const char *__doc_mitsuba_TensorFile_field = R"doc(Return a data structure with information about the specified field)doc";
 
@@ -9852,8 +10042,6 @@ static const char *__doc_mitsuba_Texture_5 = R"doc()doc";
 
 static const char *__doc_mitsuba_Texture_6 = R"doc()doc";
 
-static const char *__doc_mitsuba_Texture_7 = R"doc()doc";
-
 static const char *__doc_mitsuba_Texture_D65 = R"doc(Convenience function returning the standard D65 illuminant)doc";
 
 static const char *__doc_mitsuba_Texture_D65_2 =
@@ -9862,7 +10050,7 @@ standard D65 illuminant)doc";
 
 static const char *__doc_mitsuba_Texture_Texture = R"doc()doc";
 
-static const char *__doc_mitsuba_Texture_class = R"doc()doc";
+static const char *__doc_mitsuba_Texture_class_name = R"doc()doc";
 
 static const char *__doc_mitsuba_Texture_eval =
 R"doc(Evaluate the texture at the given surface interaction
@@ -9914,11 +10102,7 @@ Parameter ``si``:
 Returns:
     An trichromatic intensity or reflectance value)doc";
 
-static const char *__doc_mitsuba_Texture_id = R"doc(Return a string identifier)doc";
-
 static const char *__doc_mitsuba_Texture_is_spatially_varying = R"doc(Does this texture evaluation depend on the UV coordinates)doc";
-
-static const char *__doc_mitsuba_Texture_m_id = R"doc()doc";
 
 static const char *__doc_mitsuba_Texture_max =
 R"doc(Return the maximum value of the spectrum
@@ -10000,13 +10184,19 @@ Returns:
 2. The Monte Carlo importance weight (Spectral power distribution
 value divided by the sampling density))doc";
 
-static const char *__doc_mitsuba_Texture_set_id = R"doc(Set a string identifier)doc";
-
 static const char *__doc_mitsuba_Texture_spectral_resolution =
 R"doc(Returns the resolution of the spectrum in nanometers (if discretized)
 
 Not every implementation necessarily provides this function. The
 default implementation throws an exception.)doc";
+
+static const char *__doc_mitsuba_Texture_traverse_1_cb_ro = R"doc()doc";
+
+static const char *__doc_mitsuba_Texture_traverse_1_cb_rw = R"doc()doc";
+
+static const char *__doc_mitsuba_Texture_type = R"doc()doc";
+
+static const char *__doc_mitsuba_Texture_variant_name = R"doc()doc";
 
 static const char *__doc_mitsuba_Texture_wavelength_range =
 R"doc(Returns the range of wavelengths covered by the spectrum
@@ -10014,157 +10204,35 @@ R"doc(Returns the range of wavelengths covered by the spectrum
 The default implementation returns ``(MI_CIE_MIN, MI_CIE_MAX)``)doc";
 
 static const char *__doc_mitsuba_Thread =
-R"doc(Cross-platform thread implementation
+R"doc(Dummy thread class for backward compatibility
 
-Mitsuba threads are internally implemented via the ``std::thread``
-class defined in C++11. This wrapper class is needed to attach
-additional state (Loggers, Path resolvers, etc.) that is inherited
-when a thread launches another thread.)doc";
+This class has been largely stripped down and only maintains essential
+methods for file resolver and logger access, plus static
+initialization. Use std::thread or the nanothread-based thread pool
+for actual threading needs.)doc";
 
-static const char *__doc_mitsuba_ThreadEnvironment =
-R"doc(Captures a thread environment (logger and file resolver). Used with
-ScopedSetThreadEnvironment)doc";
+static const char *__doc_mitsuba_Thread_Thread = R"doc(Create a dummy thread object (for compatibility))doc";
 
-static const char *__doc_mitsuba_ThreadEnvironment_ThreadEnvironment = R"doc()doc";
+static const char *__doc_mitsuba_Thread_class_name = R"doc()doc";
 
-static const char *__doc_mitsuba_ThreadEnvironment_ThreadEnvironment_2 = R"doc()doc";
+static const char *__doc_mitsuba_Thread_file_resolver = R"doc(Return the global file resolver)doc";
 
-static const char *__doc_mitsuba_ThreadEnvironment_m_file_resolver = R"doc()doc";
-
-static const char *__doc_mitsuba_ThreadEnvironment_m_logger = R"doc()doc";
-
-static const char *__doc_mitsuba_ThreadEnvironment_operator_assign = R"doc()doc";
-
-static const char *__doc_mitsuba_Thread_EPriority = R"doc(Possible priority values for Thread::set_priority())doc";
-
-static const char *__doc_mitsuba_Thread_EPriority_EHighPriority = R"doc()doc";
-
-static const char *__doc_mitsuba_Thread_EPriority_EHighestPriority = R"doc()doc";
-
-static const char *__doc_mitsuba_Thread_EPriority_EIdlePriority = R"doc()doc";
-
-static const char *__doc_mitsuba_Thread_EPriority_ELowPriority = R"doc()doc";
-
-static const char *__doc_mitsuba_Thread_EPriority_ELowestPriority = R"doc()doc";
-
-static const char *__doc_mitsuba_Thread_EPriority_ENormalPriority = R"doc()doc";
-
-static const char *__doc_mitsuba_Thread_EPriority_ERealtimePriority = R"doc()doc";
-
-static const char *__doc_mitsuba_Thread_Thread =
-R"doc(Create a new thread object
-
-Parameter ``name``:
-    An identifying name of this thread (will be shown in debug
-    messages))doc";
-
-static const char *__doc_mitsuba_Thread_ThreadPrivate = R"doc()doc";
-
-static const char *__doc_mitsuba_Thread_class = R"doc()doc";
-
-static const char *__doc_mitsuba_Thread_core_affinity = R"doc(Return the core affinity)doc";
-
-static const char *__doc_mitsuba_Thread_d = R"doc()doc";
-
-static const char *__doc_mitsuba_Thread_detach =
-R"doc(Detach the thread and release resources
-
-After a call to this function, join() cannot be used anymore. This
-releases resources, which would otherwise be held until a call to
-join().)doc";
-
-static const char *__doc_mitsuba_Thread_dispatch = R"doc(Initialize thread execution environment and then call run())doc";
-
-static const char *__doc_mitsuba_Thread_exit = R"doc(Exit the thread, should be called from inside the thread)doc";
-
-static const char *__doc_mitsuba_Thread_file_resolver = R"doc(Return the file resolver associated with the current thread)doc";
-
-static const char *__doc_mitsuba_Thread_file_resolver_2 = R"doc(Return the parent thread (const version))doc";
-
-static const char *__doc_mitsuba_Thread_get_main_thread = R"doc(Return the main thread)doc";
-
-static const char *__doc_mitsuba_Thread_has_initialized_thread = R"doc(Return whether the current thread data structure has been initialized.)doc";
-
-static const char *__doc_mitsuba_Thread_is_critical = R"doc(Return the value of the critical flag)doc";
-
-static const char *__doc_mitsuba_Thread_is_running = R"doc(Is this thread still running?)doc";
-
-static const char *__doc_mitsuba_Thread_join = R"doc(Wait until the thread finishes)doc";
-
-static const char *__doc_mitsuba_Thread_logger = R"doc(Return the thread's logger instance)doc";
-
-static const char *__doc_mitsuba_Thread_name = R"doc(Return the name of this thread)doc";
-
-static const char *__doc_mitsuba_Thread_parent = R"doc(Return the parent thread)doc";
-
-static const char *__doc_mitsuba_Thread_parent_2 = R"doc(Return the parent thread (const version))doc";
-
-static const char *__doc_mitsuba_Thread_priority = R"doc(Return the thread priority)doc";
-
-static const char *__doc_mitsuba_Thread_register_external_thread =
-R"doc(Register a new thread (e.g. Dr.Jit, Python) with Mitsuba thread
-system. Returns true upon success.)doc";
+static const char *__doc_mitsuba_Thread_logger = R"doc(Return the global logger instance)doc";
 
 static const char *__doc_mitsuba_Thread_register_task = R"doc(Register nanothread Task to prevent internal resources leakage)doc";
 
-static const char *__doc_mitsuba_Thread_run = R"doc(The thread's run method)doc";
+static const char *__doc_mitsuba_Thread_set_logger =
+R"doc(Set the global logger used by Mitsuba $.. deprecated::
 
-static const char *__doc_mitsuba_Thread_set_core_affinity =
-R"doc(Set the core affinity
-
-This function provides a hint to the operating system scheduler that
-the thread should preferably run on the specified processor core. By
-default, the parameter is set to -1, which means that there is no
-affinity.)doc";
-
-static const char *__doc_mitsuba_Thread_set_critical =
-R"doc(Specify whether or not this thread is critical
-
-When an thread marked critical crashes from an uncaught exception, the
-whole process is brought down. The default is ``False``.)doc";
-
-static const char *__doc_mitsuba_Thread_set_file_resolver = R"doc(Set the file resolver associated with the current thread)doc";
-
-static const char *__doc_mitsuba_Thread_set_logger = R"doc(Set the logger instance used to process log messages from this thread)doc";
-
-static const char *__doc_mitsuba_Thread_set_name = R"doc(Set the name of this thread)doc";
-
-static const char *__doc_mitsuba_Thread_set_priority =
-R"doc(Set the thread priority
-
-This does not always work -- for instance, Linux requires root
-privileges for this operation.
-
-Returns:
-    ``True`` upon success.)doc";
-
-static const char *__doc_mitsuba_Thread_set_thread_count =
-R"doc(Set the global thread count (e.g. spawn new threads in thread pool if
-> 1))doc";
-
-static const char *__doc_mitsuba_Thread_sleep = R"doc(Sleep for a certain amount of time (in milliseconds))doc";
-
-static const char *__doc_mitsuba_Thread_start = R"doc(Start the thread)doc";
+Use mitsuba::set_logger() directly)doc";
 
 static const char *__doc_mitsuba_Thread_static_initialization = R"doc(Initialize the threading system)doc";
 
 static const char *__doc_mitsuba_Thread_static_shutdown = R"doc(Shut down the threading system)doc";
 
-static const char *__doc_mitsuba_Thread_thread = R"doc(Return the current thread)doc";
-
-static const char *__doc_mitsuba_Thread_thread_count = R"doc(Return the global thread count)doc";
-
-static const char *__doc_mitsuba_Thread_thread_id = R"doc(Return a unique ID that is associated with this thread)doc";
-
-static const char *__doc_mitsuba_Thread_to_string = R"doc(Return a string representation)doc";
-
-static const char *__doc_mitsuba_Thread_unregister_external_thread =
-R"doc(Unregister a thread (e.g. Dr.Jit, Python) from Mitsuba's thread
-system.)doc";
+static const char *__doc_mitsuba_Thread_thread = R"doc(Return the current thread (dummy implementation))doc";
 
 static const char *__doc_mitsuba_Thread_wait_for_tasks = R"doc(Wait for previously registered nanothread tasks to complete)doc";
-
-static const char *__doc_mitsuba_Thread_yield = R"doc(Yield to another processor)doc";
 
 static const char *__doc_mitsuba_Timer = R"doc()doc";
 
@@ -10205,9 +10273,9 @@ static const char *__doc_mitsuba_Transform_Transform_6 = R"doc(//! @})doc";
 
 static const char *__doc_mitsuba_Transform_extract = R"doc(Extract a lower-dimensional submatrix)doc";
 
-static const char *__doc_mitsuba_Transform_fields = R"doc()doc";
+static const char *__doc_mitsuba_Transform_fields = R"doc(//! @})doc";
 
-static const char *__doc_mitsuba_Transform_fields_2 = R"doc()doc";
+static const char *__doc_mitsuba_Transform_fields_2 = R"doc(//! @})doc";
 
 static const char *__doc_mitsuba_Transform_from_frame =
 R"doc(Creates a transformation that converts from 'frame' to the standard
@@ -10224,7 +10292,7 @@ arithmetic))doc";
 
 static const char *__doc_mitsuba_Transform_inverse_transpose = R"doc()doc";
 
-static const char *__doc_mitsuba_Transform_labels = R"doc()doc";
+static const char *__doc_mitsuba_Transform_labels = R"doc(//! @})doc";
 
 static const char *__doc_mitsuba_Transform_look_at =
 R"doc(Create a look-at camera transformation
@@ -10240,7 +10308,7 @@ Parameter ``up``:
 
 static const char *__doc_mitsuba_Transform_matrix = R"doc(//! @{ \name Fields)doc";
 
-static const char *__doc_mitsuba_Transform_name = R"doc()doc";
+static const char *__doc_mitsuba_Transform_name = R"doc(//! @})doc";
 
 static const char *__doc_mitsuba_Transform_operator_assign = R"doc()doc";
 
@@ -10348,16 +10416,43 @@ R"doc(Abstract class providing an interface for traversing scene graphs
 
 This interface can be implemented either in C++ or in Python, to be
 used in conjunction with Object::traverse() to traverse a scene graph.
-Mitsuba currently uses this mechanism to determine a scene's
-differentiable parameters.)doc";
+Mitsuba uses this mechanism for two primary purposes:
+
+1. **Dynamic scene modification**: After a scene is loaded, the
+traversal mechanism allows programmatic access to modify scene
+parameters without rebuilding the entire scene. This enables workflows
+where parameters are adjusted and the scene is re-rendered with
+different settings.
+
+2. **Differentiable parameter discovery**: The traversal callback can
+discover all differentiable parameters in a scene (e.g., material
+properties, transformation matrices, emission values). These
+parameters can then be exposed to gradient-based optimizers for
+inverse rendering tasks, which in practice involves the
+``SceneParameters`` Python class.
+
+The callback receives information about each traversed object's
+parameters through the put() methods, which distinguish between
+regular parameters and references to other scene objects that are
+handled recursively.)doc";
+
+static const char *__doc_mitsuba_TraversalCallback_put = R"doc()doc";
+
+static const char *__doc_mitsuba_TraversalCallback_put_2 = R"doc()doc";
+
+static const char *__doc_mitsuba_TraversalCallback_put_3 = R"doc()doc";
+
+static const char *__doc_mitsuba_TraversalCallback_put_4 =
+R"doc(Forward declaration for field<...> values that simultaneously store
+host+device values)doc";
 
 static const char *__doc_mitsuba_TraversalCallback_put_object =
-R"doc(Inform the traversal callback that the instance references another
-Mitsuba object)doc";
+R"doc(Actual implementation for Object references [To be provided by
+subclass])doc";
 
-static const char *__doc_mitsuba_TraversalCallback_put_value = R"doc(Inform the traversal callback about an attribute of an instance)doc";
-
-static const char *__doc_mitsuba_TraversalCallback_put_value_impl = R"doc(Actual implementation of put_value(). [To be provided by subclass])doc";
+static const char *__doc_mitsuba_TraversalCallback_put_value =
+R"doc(Actual implementation for regular parameters [To be provided by
+subclass])doc";
 
 static const char *__doc_mitsuba_Vector = R"doc(//! @{ \name Elementary vector, point, and normal data types)doc";
 
@@ -10383,9 +10478,12 @@ static const char *__doc_mitsuba_Volume_5 = R"doc()doc";
 
 static const char *__doc_mitsuba_Volume_6 = R"doc()doc";
 
-static const char *__doc_mitsuba_Volume_7 = R"doc()doc";
+static const char *__doc_mitsuba_VolumeGrid =
+R"doc(Class to read and write 3D volume grids
 
-static const char *__doc_mitsuba_VolumeGrid = R"doc()doc";
+This class handles loading of volumes in the Mitsuba volume file
+format Please see the documentation of gridvolume (grid3d.cpp) for the
+file format specification.)doc";
 
 static const char *__doc_mitsuba_VolumeGrid_2 = R"doc()doc";
 
@@ -10396,8 +10494,6 @@ static const char *__doc_mitsuba_VolumeGrid_4 = R"doc()doc";
 static const char *__doc_mitsuba_VolumeGrid_5 = R"doc()doc";
 
 static const char *__doc_mitsuba_VolumeGrid_6 = R"doc()doc";
-
-static const char *__doc_mitsuba_VolumeGrid_7 = R"doc()doc";
 
 static const char *__doc_mitsuba_VolumeGrid_VolumeGrid =
 R"doc(Load a VolumeGrid from a given filename
@@ -10423,7 +10519,7 @@ static const char *__doc_mitsuba_VolumeGrid_bytes_per_voxel = R"doc(Return the n
 
 static const char *__doc_mitsuba_VolumeGrid_channel_count = R"doc(Return the number of channels)doc";
 
-static const char *__doc_mitsuba_VolumeGrid_class = R"doc()doc";
+static const char *__doc_mitsuba_VolumeGrid_class_name = R"doc()doc";
 
 static const char *__doc_mitsuba_VolumeGrid_data = R"doc(Return a pointer to the underlying volume storage)doc";
 
@@ -10461,6 +10557,10 @@ static const char *__doc_mitsuba_VolumeGrid_size = R"doc(Return the resolution o
 
 static const char *__doc_mitsuba_VolumeGrid_to_string = R"doc(Return a human-readable summary of this volume grid)doc";
 
+static const char *__doc_mitsuba_VolumeGrid_traverse_1_cb_ro = R"doc()doc";
+
+static const char *__doc_mitsuba_VolumeGrid_traverse_1_cb_rw = R"doc()doc";
+
 static const char *__doc_mitsuba_VolumeGrid_write =
 R"doc(Write an encoded form of the bitmap to a binary volume file
 
@@ -10483,7 +10583,7 @@ R"doc(Returns the number of channels stored in the volume
 When the channel count is zero, it indicates that the volume does not
 support per-channel queries.)doc";
 
-static const char *__doc_mitsuba_Volume_class = R"doc()doc";
+static const char *__doc_mitsuba_Volume_class_name = R"doc()doc";
 
 static const char *__doc_mitsuba_Volume_eval =
 R"doc(Evaluate the volume at the given surface interaction, with color
@@ -10533,7 +10633,15 @@ The default implementation returns ``(1, 1, 1)``)doc";
 
 static const char *__doc_mitsuba_Volume_to_string = R"doc(Returns a human-reable summary)doc";
 
+static const char *__doc_mitsuba_Volume_traverse_1_cb_ro = R"doc()doc";
+
+static const char *__doc_mitsuba_Volume_traverse_1_cb_rw = R"doc()doc";
+
+static const char *__doc_mitsuba_Volume_type = R"doc()doc";
+
 static const char *__doc_mitsuba_Volume_update_bbox = R"doc()doc";
+
+static const char *__doc_mitsuba_Volume_variant_name = R"doc()doc";
 
 static const char *__doc_mitsuba_ZStream =
 R"doc(Transparent compression/decompression stream based on ``zlib``.
@@ -10560,7 +10668,7 @@ static const char *__doc_mitsuba_ZStream_child_stream = R"doc(Returns the child 
 
 static const char *__doc_mitsuba_ZStream_child_stream_2 = R"doc(Returns the child stream of this compression stream)doc";
 
-static const char *__doc_mitsuba_ZStream_class = R"doc()doc";
+static const char *__doc_mitsuba_ZStream_class_name = R"doc(//! @})doc";
 
 static const char *__doc_mitsuba_ZStream_close =
 R"doc(Closes the stream, but not the underlying child stream. No further
@@ -10614,6 +10722,10 @@ Out-of-bounds regions are safely ignored. It is assumed that ``source
 
 The function supports `T` being a raw pointer or an arbitrary Dr.Jit
 array that can potentially live on the GPU and/or be differentiable.)doc";
+
+static const char *__doc_mitsuba_any_cast = R"doc()doc";
+
+static const char *__doc_mitsuba_any_cast_2 = R"doc()doc";
 
 static const char *__doc_mitsuba_bezier_interpolate =
 R"doc(Interpolates the dataset along a quintic bezier curve
@@ -10822,17 +10934,29 @@ static const char *__doc_mitsuba_detail_OrderedChunkAllocator_used = R"doc(Retur
 
 static const char *__doc_mitsuba_detail_Throw = R"doc()doc";
 
+static const char *__doc_mitsuba_detail_base_type = R"doc()doc";
+
+static const char *__doc_mitsuba_detail_base_type_2 = R"doc()doc";
+
+static const char *__doc_mitsuba_detail_compare_typeid = R"doc()doc";
+
 static const char *__doc_mitsuba_detail_get_color_space_tables = R"doc()doc";
 
-static const char *__doc_mitsuba_detail_get_construct_functor = R"doc()doc";
+static const char *__doc_mitsuba_detail_is_transform_3 = R"doc()doc";
 
-static const char *__doc_mitsuba_detail_get_construct_functor_2 = R"doc()doc";
+static const char *__doc_mitsuba_detail_prop_map = R"doc()doc";
 
-static const char *__doc_mitsuba_detail_get_unserialize_functor = R"doc()doc";
+static const char *__doc_mitsuba_detail_prop_map_2 = R"doc()doc";
 
-static const char *__doc_mitsuba_detail_get_unserialize_functor_2 = R"doc()doc";
+static const char *__doc_mitsuba_detail_prop_map_3 = R"doc()doc";
 
-static const char *__doc_mitsuba_detail_is_constructible = R"doc()doc";
+static const char *__doc_mitsuba_detail_prop_map_4 = R"doc()doc";
+
+static const char *__doc_mitsuba_detail_prop_map_5 = R"doc()doc";
+
+static const char *__doc_mitsuba_detail_prop_map_6 = R"doc()doc";
+
+static const char *__doc_mitsuba_detail_prop_map_7 = R"doc()doc";
 
 static const char *__doc_mitsuba_detail_serialization_helper =
 R"doc(The serialization_helper<T> implementations for new types should in
@@ -10876,12 +11000,6 @@ static const char *__doc_mitsuba_detail_spectrum_traits = R"doc(//! @{ \name Col
 
 static const char *__doc_mitsuba_detail_spectrum_traits_2 = R"doc()doc";
 
-static const char *__doc_mitsuba_detail_static_max =
-R"doc(Basic C++11 variant data structure
-
-Significantly redesigned version of the approach described at
-http://www.ojdip.net/2013/10/implementing-a-variant-type-in-cpp)doc";
-
 static const char *__doc_mitsuba_detail_struct_type = R"doc()doc";
 
 static const char *__doc_mitsuba_detail_struct_type_2 = R"doc()doc";
@@ -10918,19 +11036,19 @@ static const char *__doc_mitsuba_detail_underlying = R"doc(Type trait to strip a
 
 static const char *__doc_mitsuba_detail_underlying_2 = R"doc()doc";
 
-static const char *__doc_mitsuba_detail_variant_helper = R"doc()doc";
+static const char *__doc_mitsuba_detail_variant =
+R"doc(Helper partial template overload to determine the variant string
+associated with a given floating point and spectral type)doc";
 
-static const char *__doc_mitsuba_detail_variant_helper_2 = R"doc()doc";
+static const char *__doc_mitsuba_detail_variant_2 = R"doc()doc";
 
-static const char *__doc_mitsuba_detail_variant_helper_copy = R"doc()doc";
+static const char *__doc_mitsuba_detail_variant_3 = R"doc()doc";
 
-static const char *__doc_mitsuba_detail_variant_helper_destruct = R"doc()doc";
+static const char *__doc_mitsuba_detail_variant_4 = R"doc()doc";
 
-static const char *__doc_mitsuba_detail_variant_helper_equals = R"doc()doc";
+static const char *__doc_mitsuba_detail_variant_5 = R"doc()doc";
 
-static const char *__doc_mitsuba_detail_variant_helper_move = R"doc()doc";
-
-static const char *__doc_mitsuba_detail_variant_helper_visit = R"doc()doc";
+static const char *__doc_mitsuba_detail_variant_6 = R"doc()doc";
 
 static const char *__doc_mitsuba_dir_to_sph =
 R"doc(Converts a unit vector to its spherical coordinates parameterization
@@ -10971,6 +11089,10 @@ simultaneous access. Even if all code effectively runs on the host
 traversal of JIT compiler data structures, which was a severe
 bottleneck e.g. when Embree calls shape-specific intersection
 routines.)doc";
+
+static const char *__doc_mitsuba_file_resolver =
+R"doc(Return the global file resolver instance (this is a process-wide
+setting))doc";
 
 static const char *__doc_mitsuba_filesystem_absolute =
 R"doc(Returns an absolute path to the same location pointed by ``p``,
@@ -11069,12 +11191,17 @@ static const char *__doc_mitsuba_filesystem_path_path_2 = R"doc(Copy constructor
 static const char *__doc_mitsuba_filesystem_path_path_3 = R"doc(Move constructor.)doc";
 
 static const char *__doc_mitsuba_filesystem_path_path_4 =
-R"doc(Construct a path from a string with native type. On Windows, the path
-can use both '/' or '\\' as a delimiter.)doc";
+R"doc(Construct a path from a string view with native type. On Windows, the
+path can use both '/' or '\\' as a delimiter.)doc";
 
 static const char *__doc_mitsuba_filesystem_path_path_5 =
 R"doc(Construct a path from a string with native type. On Windows, the path
 can use both '/' or '\\' as a delimiter.)doc";
+
+static const char *__doc_mitsuba_filesystem_path_path_6 =
+R"doc(Construct a path from a native C-style string. On Windows, this
+accepts wide strings (wchar_t*). On other platforms, this accepts
+regular strings (char*).)doc";
 
 static const char *__doc_mitsuba_filesystem_path_replace_extension =
 R"doc(Replaces the substring starting at the rightmost '.' symbol by the
@@ -11267,6 +11394,43 @@ Parameter ``custom_half_aperture``:
 Returns:
     The ratio of the sun's area to the custom aperture's area)doc";
 
+static const char *__doc_mitsuba_get_texture =
+R"doc(Retrieve a texture parameter
+
+This method retrieves a texture parameter, where ``T`` is a subclass
+of ``mitsuba::Texture<...>``.
+
+Scalar and color values are also accepted. In this case, the plugin
+manager will automatically construct a ``uniform`` or ``srgb`` texture
+instance.)doc";
+
+static const char *__doc_mitsuba_get_texture_2 =
+R"doc(Retrieve a texture parameter with float default
+
+When the texture parameter doesn't exist, creates a uniform texture
+with the specified floating point value.)doc";
+
+static const char *__doc_mitsuba_get_texture_d65 =
+R"doc(Retrieve a texture parameter with float default value
+
+When the texture parameter doesn't exist, creates a uniform D65
+whitepoint texture scaled by the specified floating point value.)doc";
+
+static const char *__doc_mitsuba_get_volume =
+R"doc(Retrieve a volume parameter
+
+This method retrieves a volume parameter, where ``T`` is a subclass of
+``mitsuba::Volume<...>``.
+
+Scalar and texture values are also accepted. In this case, the plugin
+manager will automatically construct a ``constvolume`` instance.)doc";
+
+static const char *__doc_mitsuba_get_volume_2 =
+R"doc(Retrieve a volume parameter with float default
+
+When the volume parameter doesn't exist, creates a constant volume
+with the specified floating point value.)doc";
+
 static const char *__doc_mitsuba_has_flag = R"doc()doc";
 
 static const char *__doc_mitsuba_has_flag_2 = R"doc()doc";
@@ -11312,6 +11476,8 @@ library is loaded)doc";
 static const char *__doc_mitsuba_linear_rgb_rec =
 R"doc(Evaluate the ITU-R Rec. BT.709 linear RGB color matching functions
 given a wavelength in nanometers)doc";
+
+static const char *__doc_mitsuba_logger = R"doc(Return the logger instance (this is a process-wide setting))doc";
 
 static const char *__doc_mitsuba_lookup_ior = R"doc()doc";
 
@@ -11649,6 +11815,8 @@ Returns:
     The (implicitly defined) reference coordinate system basis for the
     Stokes vector traveling along forward.)doc";
 
+static const char *__doc_mitsuba_object_type_name = R"doc(Turn an ObjectType enumeration value into string form)doc";
+
 static const char *__doc_mitsuba_operator_add = R"doc()doc";
 
 static const char *__doc_mitsuba_operator_add_2 = R"doc()doc";
@@ -11831,6 +11999,14 @@ static const char *__doc_mitsuba_orthographic_projection =
 R"doc(Helper function to create a orthographic projection transformation
 matrix)doc";
 
+static const char *__doc_mitsuba_pair_eq = R"doc()doc";
+
+static const char *__doc_mitsuba_pair_eq_operator_call = R"doc()doc";
+
+static const char *__doc_mitsuba_pair_hasher = R"doc()doc";
+
+static const char *__doc_mitsuba_pair_hasher_operator_call = R"doc()doc";
+
 static const char *__doc_mitsuba_parse_fov = R"doc(Helper function to parse the field of view field of a camera)doc";
 
 static const char *__doc_mitsuba_path_to_dataset =
@@ -11903,9 +12079,13 @@ static const char *__doc_mitsuba_perspective_projection =
 R"doc(Helper function to create a perspective projection transformation
 matrix)doc";
 
+static const char *__doc_mitsuba_plugin_type_name = R"doc(Get the XML tag name for an ObjectType (e.g. "scene", "bsdf"))doc";
+
 static const char *__doc_mitsuba_prepare_ias =
 R"doc(Prepares and fills the OptixInstance array associated with a given
 list of shapes.)doc";
+
+static const char *__doc_mitsuba_property_type_name = R"doc(Turn a Properties::Type enumeration value into string form)doc";
 
 static const char *__doc_mitsuba_quad_chebyshev =
 R"doc(Computes the Chebyshev nodes, i.e. the roots of the Chebyshev
@@ -12130,6 +12310,10 @@ R"doc(RAII wrapper which sets the CUDA context associated to the OptiX
 context for the current scope.)doc";
 
 static const char *__doc_mitsuba_scoped_optix_context_scoped_optix_context = R"doc()doc";
+
+static const char *__doc_mitsuba_set_file_resolver = R"doc(Set the global file resolver instance (this is a process-wide setting))doc";
+
+static const char *__doc_mitsuba_set_logger = R"doc(Set the logger instance (this is a process-wide setting))doc";
 
 static const char *__doc_mitsuba_sggx_pdf =
 R"doc(Evaluates the probability of sampling a given normal using the SGGX
@@ -12924,42 +13108,6 @@ static const char *__doc_mitsuba_util_trap_debugger =
 R"doc(Generate a trap instruction if running in a debugger; otherwise,
 return.)doc";
 
-static const char *__doc_mitsuba_variant = R"doc()doc";
-
-static const char *__doc_mitsuba_variant_data = R"doc()doc";
-
-static const char *__doc_mitsuba_variant_empty = R"doc()doc";
-
-static const char *__doc_mitsuba_variant_is = R"doc()doc";
-
-static const char *__doc_mitsuba_variant_operator_assign = R"doc()doc";
-
-static const char *__doc_mitsuba_variant_operator_assign_2 = R"doc()doc";
-
-static const char *__doc_mitsuba_variant_operator_assign_3 = R"doc()doc";
-
-static const char *__doc_mitsuba_variant_operator_assign_4 = R"doc()doc";
-
-static const char *__doc_mitsuba_variant_operator_const_type_parameter_1_0 = R"doc()doc";
-
-static const char *__doc_mitsuba_variant_operator_eq = R"doc()doc";
-
-static const char *__doc_mitsuba_variant_operator_ne = R"doc()doc";
-
-static const char *__doc_mitsuba_variant_operator_type_parameter_1_0 = R"doc()doc";
-
-static const char *__doc_mitsuba_variant_type = R"doc()doc";
-
-static const char *__doc_mitsuba_variant_type_info = R"doc()doc";
-
-static const char *__doc_mitsuba_variant_variant = R"doc()doc";
-
-static const char *__doc_mitsuba_variant_variant_2 = R"doc()doc";
-
-static const char *__doc_mitsuba_variant_variant_3 = R"doc()doc";
-
-static const char *__doc_mitsuba_variant_visit = R"doc()doc";
-
 static const char *__doc_mitsuba_warp_beckmann_to_square = R"doc(Inverse of the mapping square_to_uniform_cone)doc";
 
 static const char *__doc_mitsuba_warp_bilinear_to_square = R"doc(Inverse of square_to_bilinear)doc";
@@ -13162,6 +13310,10 @@ Parameter ``parallel``:
 
 static const char *__doc_mitsuba_xml_load_string = R"doc(Load a Mitsuba scene from an XML string)doc";
 
+static const char *__doc_mitsuba_xml_tag_to_object_type =
+R"doc(Analyze an XML tag name (e.g. "shape") and map it to a known
+ObjectType enumeration value or ObjectType::Unknown.)doc";
+
 static const char *__doc_mitsuba_xyz_to_srgb = R"doc(Convert XYZ tristimulus values to ITU-R Rec. BT.709 linear RGB)doc";
 
 static const char *__doc_operator_lshift = R"doc(Turns a vector of elements into a human-readable representation)doc";
@@ -13169,3 +13321,4 @@ static const char *__doc_operator_lshift = R"doc(Turns a vector of elements into
 #if defined(__GNUG__)
 #pragma GCC diagnostic pop
 #endif
+

--- a/include/mitsuba/python/docstr.h
+++ b/include/mitsuba/python/docstr.h
@@ -543,7 +543,7 @@ static const char *__doc_mitsuba_AdjointIntegrator_6 = R"doc()doc";
 
 static const char *__doc_mitsuba_AdjointIntegrator_AdjointIntegrator = R"doc(Create an integrator)doc";
 
-static const char *__doc_mitsuba_AdjointIntegrator_class_name = R"doc(//! @})doc";
+static const char *__doc_mitsuba_AdjointIntegrator_class_name = R"doc()doc";
 
 static const char *__doc_mitsuba_AdjointIntegrator_m_max_depth =
 R"doc(Longest visualized path depth (\c -1 = infinite). A value of ``1``
@@ -915,13 +915,13 @@ static const char *__doc_mitsuba_BSDFSample3_BSDFSample3_4 = R"doc(//! @})doc";
 
 static const char *__doc_mitsuba_BSDFSample3_eta = R"doc(Relative index of refraction in the sampled direction)doc";
 
-static const char *__doc_mitsuba_BSDFSample3_fields = R"doc(//! @})doc";
+static const char *__doc_mitsuba_BSDFSample3_fields = R"doc()doc";
 
-static const char *__doc_mitsuba_BSDFSample3_fields_2 = R"doc(//! @})doc";
+static const char *__doc_mitsuba_BSDFSample3_fields_2 = R"doc()doc";
 
-static const char *__doc_mitsuba_BSDFSample3_labels = R"doc(//! @})doc";
+static const char *__doc_mitsuba_BSDFSample3_labels = R"doc()doc";
 
-static const char *__doc_mitsuba_BSDFSample3_name = R"doc(//! @})doc";
+static const char *__doc_mitsuba_BSDFSample3_name = R"doc()doc";
 
 static const char *__doc_mitsuba_BSDFSample3_operator_assign = R"doc(//! @})doc";
 
@@ -937,7 +937,7 @@ static const char *__doc_mitsuba_BSDFSample3_wo = R"doc(Normalized outgoing dire
 
 static const char *__doc_mitsuba_BSDF_BSDF = R"doc(//! @})doc";
 
-static const char *__doc_mitsuba_BSDF_class_name = R"doc(//! @})doc";
+static const char *__doc_mitsuba_BSDF_class_name = R"doc()doc";
 
 static const char *__doc_mitsuba_BSDF_component_count = R"doc(Number of components this BSDF is comprised of.)doc";
 
@@ -1209,9 +1209,9 @@ static const char *__doc_mitsuba_BSDF_traverse_1_cb_ro = R"doc()doc";
 
 static const char *__doc_mitsuba_BSDF_traverse_1_cb_rw = R"doc()doc";
 
-static const char *__doc_mitsuba_BSDF_type = R"doc(//! @})doc";
+static const char *__doc_mitsuba_BSDF_type = R"doc()doc";
 
-static const char *__doc_mitsuba_BSDF_variant_name = R"doc(//! @})doc";
+static const char *__doc_mitsuba_BSDF_variant_name = R"doc()doc";
 
 static const char *__doc_mitsuba_Bitmap =
 R"doc(General-purpose bitmap class with read and write support for several
@@ -2193,13 +2193,13 @@ choosing one of several objects (shapes, emitters, ..) on which the
 position lies. In that case, the ``object`` attribute stores a pointer
 to this object.)doc";
 
-static const char *__doc_mitsuba_DirectionSample_fields = R"doc(//! @})doc";
+static const char *__doc_mitsuba_DirectionSample_fields = R"doc()doc";
 
-static const char *__doc_mitsuba_DirectionSample_fields_2 = R"doc(//! @})doc";
+static const char *__doc_mitsuba_DirectionSample_fields_2 = R"doc()doc";
 
-static const char *__doc_mitsuba_DirectionSample_labels = R"doc(//! @})doc";
+static const char *__doc_mitsuba_DirectionSample_labels = R"doc()doc";
 
-static const char *__doc_mitsuba_DirectionSample_name = R"doc(//! @})doc";
+static const char *__doc_mitsuba_DirectionSample_name = R"doc()doc";
 
 static const char *__doc_mitsuba_DirectionSample_operator_array = R"doc(Convenience operator for masking)doc";
 
@@ -2479,7 +2479,7 @@ static const char *__doc_mitsuba_DummyStream_can_read = R"doc()doc";
 
 static const char *__doc_mitsuba_DummyStream_can_write = R"doc()doc";
 
-static const char *__doc_mitsuba_DummyStream_class_name = R"doc(//! @})doc";
+static const char *__doc_mitsuba_DummyStream_class_name = R"doc()doc";
 
 static const char *__doc_mitsuba_DummyStream_close =
 R"doc(Closes the stream. No further read or write operations are permitted.
@@ -2551,7 +2551,7 @@ static const char *__doc_mitsuba_EmitterFlags_Surface = R"doc(The emitter is att
 
 static const char *__doc_mitsuba_Emitter_Emitter = R"doc(This is both a class and the base of various Mitsuba plugins)doc";
 
-static const char *__doc_mitsuba_Emitter_class_name = R"doc(This is both a class and the base of various Mitsuba plugins)doc";
+static const char *__doc_mitsuba_Emitter_class_name = R"doc()doc";
 
 static const char *__doc_mitsuba_Emitter_dirty = R"doc(Return whether the emitter parameters have changed)doc";
 
@@ -2577,9 +2577,9 @@ static const char *__doc_mitsuba_Emitter_traverse_1_cb_ro = R"doc()doc";
 
 static const char *__doc_mitsuba_Emitter_traverse_1_cb_rw = R"doc()doc";
 
-static const char *__doc_mitsuba_Emitter_type = R"doc(This is both a class and the base of various Mitsuba plugins)doc";
+static const char *__doc_mitsuba_Emitter_type = R"doc()doc";
 
-static const char *__doc_mitsuba_Emitter_variant_name = R"doc(This is both a class and the base of various Mitsuba plugins)doc";
+static const char *__doc_mitsuba_Emitter_variant_name = R"doc()doc";
 
 static const char *__doc_mitsuba_Endpoint =
 R"doc(Abstract interface subsuming emitters and sensors in Mitsuba.
@@ -2972,7 +2972,7 @@ static const char *__doc_mitsuba_FileStream_can_read = R"doc(True except if the 
 
 static const char *__doc_mitsuba_FileStream_can_write = R"doc(Whether the field was open in write-mode (and was not closed))doc";
 
-static const char *__doc_mitsuba_FileStream_class_name = R"doc(//! @})doc";
+static const char *__doc_mitsuba_FileStream_class_name = R"doc()doc";
 
 static const char *__doc_mitsuba_FileStream_close =
 R"doc(Closes the stream and the underlying file. No further read or write
@@ -4010,17 +4010,17 @@ static const char *__doc_mitsuba_Interaction_Interaction_3 = R"doc(//! @})doc";
 
 static const char *__doc_mitsuba_Interaction_Interaction_4 = R"doc(//! @})doc";
 
-static const char *__doc_mitsuba_Interaction_fields = R"doc(//! @})doc";
+static const char *__doc_mitsuba_Interaction_fields = R"doc()doc";
 
-static const char *__doc_mitsuba_Interaction_fields_2 = R"doc(//! @})doc";
+static const char *__doc_mitsuba_Interaction_fields_2 = R"doc()doc";
 
 static const char *__doc_mitsuba_Interaction_is_valid = R"doc(Is the current interaction valid?)doc";
 
-static const char *__doc_mitsuba_Interaction_labels = R"doc(//! @})doc";
+static const char *__doc_mitsuba_Interaction_labels = R"doc()doc";
 
 static const char *__doc_mitsuba_Interaction_n = R"doc(Geometric normal (only valid for ``SurfaceInteraction``))doc";
 
-static const char *__doc_mitsuba_Interaction_name = R"doc(//! @})doc";
+static const char *__doc_mitsuba_Interaction_name = R"doc()doc";
 
 static const char *__doc_mitsuba_Interaction_offset_p =
 R"doc(Compute an offset position, used when spawning a ray from this
@@ -4467,17 +4467,17 @@ static const char *__doc_mitsuba_MediumInteraction_MediumInteraction_3 = R"doc(/
 
 static const char *__doc_mitsuba_MediumInteraction_combined_extinction = R"doc()doc";
 
-static const char *__doc_mitsuba_MediumInteraction_fields = R"doc(//! @})doc";
+static const char *__doc_mitsuba_MediumInteraction_fields = R"doc()doc";
 
-static const char *__doc_mitsuba_MediumInteraction_fields_2 = R"doc(//! @})doc";
+static const char *__doc_mitsuba_MediumInteraction_fields_2 = R"doc()doc";
 
-static const char *__doc_mitsuba_MediumInteraction_labels = R"doc(//! @})doc";
+static const char *__doc_mitsuba_MediumInteraction_labels = R"doc()doc";
 
 static const char *__doc_mitsuba_MediumInteraction_medium = R"doc(Pointer to the associated medium)doc";
 
 static const char *__doc_mitsuba_MediumInteraction_mint = R"doc(mint used when sampling the given distance ``t``)doc";
 
-static const char *__doc_mitsuba_MediumInteraction_name = R"doc(//! @})doc";
+static const char *__doc_mitsuba_MediumInteraction_name = R"doc()doc";
 
 static const char *__doc_mitsuba_MediumInteraction_operator_assign = R"doc(//! @})doc";
 
@@ -4665,7 +4665,7 @@ static const char *__doc_mitsuba_MemoryStream_can_write = R"doc(Always returns t
 
 static const char *__doc_mitsuba_MemoryStream_capacity = R"doc(Return the current capacity of the underlying memory buffer)doc";
 
-static const char *__doc_mitsuba_MemoryStream_class_name = R"doc(//! @})doc";
+static const char *__doc_mitsuba_MemoryStream_class_name = R"doc()doc";
 
 static const char *__doc_mitsuba_MemoryStream_close =
 R"doc(Closes the stream. No further read or write operations are permitted.
@@ -5723,7 +5723,7 @@ static const char *__doc_mitsuba_PhaseFunctionFlags_Microflake = R"doc()doc";
 
 static const char *__doc_mitsuba_PhaseFunction_PhaseFunction = R"doc(//! @})doc";
 
-static const char *__doc_mitsuba_PhaseFunction_class_name = R"doc(//! @})doc";
+static const char *__doc_mitsuba_PhaseFunction_class_name = R"doc()doc";
 
 static const char *__doc_mitsuba_PhaseFunction_component_count = R"doc(Number of components this phase function is comprised of.)doc";
 
@@ -5805,9 +5805,9 @@ static const char *__doc_mitsuba_PhaseFunction_set_flags = R"doc(Set type of pha
 
 static const char *__doc_mitsuba_PhaseFunction_to_string = R"doc(Return a human-readable representation of the phase function)doc";
 
-static const char *__doc_mitsuba_PhaseFunction_type = R"doc(//! @})doc";
+static const char *__doc_mitsuba_PhaseFunction_type = R"doc()doc";
 
-static const char *__doc_mitsuba_PhaseFunction_variant_name = R"doc(//! @})doc";
+static const char *__doc_mitsuba_PhaseFunction_variant_name = R"doc()doc";
 
 static const char *__doc_mitsuba_PluginManager =
 R"doc(Plugin manager
@@ -5933,15 +5933,15 @@ static const char *__doc_mitsuba_PositionSample_delta =
 R"doc(Set if the sample was drawn from a degenerate (Dirac delta)
 distribution)doc";
 
-static const char *__doc_mitsuba_PositionSample_fields = R"doc(//! @})doc";
+static const char *__doc_mitsuba_PositionSample_fields = R"doc()doc";
 
-static const char *__doc_mitsuba_PositionSample_fields_2 = R"doc(//! @})doc";
+static const char *__doc_mitsuba_PositionSample_fields_2 = R"doc()doc";
 
-static const char *__doc_mitsuba_PositionSample_labels = R"doc(//! @})doc";
+static const char *__doc_mitsuba_PositionSample_labels = R"doc()doc";
 
 static const char *__doc_mitsuba_PositionSample_n = R"doc(Sampled surface normal (if applicable))doc";
 
-static const char *__doc_mitsuba_PositionSample_name = R"doc(//! @})doc";
+static const char *__doc_mitsuba_PositionSample_name = R"doc()doc";
 
 static const char *__doc_mitsuba_PositionSample_operator_assign = R"doc(//! @})doc";
 
@@ -6004,17 +6004,17 @@ Parameter ``ray_flags``:
 Returns:
     A data structure containing the detailed information)doc";
 
-static const char *__doc_mitsuba_PreliminaryIntersection_fields = R"doc(//! @})doc";
+static const char *__doc_mitsuba_PreliminaryIntersection_fields = R"doc()doc";
 
-static const char *__doc_mitsuba_PreliminaryIntersection_fields_2 = R"doc(//! @})doc";
+static const char *__doc_mitsuba_PreliminaryIntersection_fields_2 = R"doc()doc";
 
 static const char *__doc_mitsuba_PreliminaryIntersection_instance = R"doc(Stores a pointer to the parent instance (if applicable))doc";
 
 static const char *__doc_mitsuba_PreliminaryIntersection_is_valid = R"doc(Is the current interaction valid?)doc";
 
-static const char *__doc_mitsuba_PreliminaryIntersection_labels = R"doc(//! @})doc";
+static const char *__doc_mitsuba_PreliminaryIntersection_labels = R"doc()doc";
 
-static const char *__doc_mitsuba_PreliminaryIntersection_name = R"doc(//! @})doc";
+static const char *__doc_mitsuba_PreliminaryIntersection_name = R"doc()doc";
 
 static const char *__doc_mitsuba_PreliminaryIntersection_operator_assign = R"doc(//! @})doc";
 
@@ -7007,7 +7007,7 @@ static const char *__doc_mitsuba_SamplingIntegrator_6 = R"doc()doc";
 
 static const char *__doc_mitsuba_SamplingIntegrator_SamplingIntegrator = R"doc(//! @})doc";
 
-static const char *__doc_mitsuba_SamplingIntegrator_class_name = R"doc(//! @})doc";
+static const char *__doc_mitsuba_SamplingIntegrator_class_name = R"doc()doc";
 
 static const char *__doc_mitsuba_SamplingIntegrator_m_block_size = R"doc(Size of (square) image blocks to render in parallel (in scalar mode))doc";
 
@@ -7837,7 +7837,7 @@ static const char *__doc_mitsuba_Sensor_6 = R"doc()doc";
 
 static const char *__doc_mitsuba_Sensor_Sensor = R"doc(This is both a class and the base of various Mitsuba plugins)doc";
 
-static const char *__doc_mitsuba_Sensor_class_name = R"doc(This is both a class and the base of various Mitsuba plugins)doc";
+static const char *__doc_mitsuba_Sensor_class_name = R"doc()doc";
 
 static const char *__doc_mitsuba_Sensor_film = R"doc(Return the Film instance associated with this sensor)doc";
 
@@ -7946,9 +7946,9 @@ static const char *__doc_mitsuba_Sensor_traverse_1_cb_ro = R"doc()doc";
 
 static const char *__doc_mitsuba_Sensor_traverse_1_cb_rw = R"doc()doc";
 
-static const char *__doc_mitsuba_Sensor_type = R"doc(This is both a class and the base of various Mitsuba plugins)doc";
+static const char *__doc_mitsuba_Sensor_type = R"doc()doc";
 
-static const char *__doc_mitsuba_Sensor_variant_name = R"doc(This is both a class and the base of various Mitsuba plugins)doc";
+static const char *__doc_mitsuba_Sensor_variant_name = R"doc()doc";
 
 static const char *__doc_mitsuba_Shape = R"doc(Forward declaration for `SilhouetteSample`)doc";
 
@@ -8169,7 +8169,7 @@ static const char *__doc_mitsuba_Shape_bsdf = R"doc(Return the shape's BSDF)doc"
 
 static const char *__doc_mitsuba_Shape_bsdf_2 = R"doc(Return the shape's BSDF)doc";
 
-static const char *__doc_mitsuba_Shape_class_name = R"doc(//! @})doc";
+static const char *__doc_mitsuba_Shape_class_name = R"doc()doc";
 
 static const char *__doc_mitsuba_Shape_compute_surface_interaction =
 R"doc(Compute and return detailed information related to a surface
@@ -8765,9 +8765,9 @@ static const char *__doc_mitsuba_Shape_traverse_1_cb_ro = R"doc()doc";
 
 static const char *__doc_mitsuba_Shape_traverse_1_cb_rw = R"doc()doc";
 
-static const char *__doc_mitsuba_Shape_type = R"doc(//! @})doc";
+static const char *__doc_mitsuba_Shape_type = R"doc()doc";
 
-static const char *__doc_mitsuba_Shape_variant_name = R"doc(//! @})doc";
+static const char *__doc_mitsuba_Shape_variant_name = R"doc()doc";
 
 static const char *__doc_mitsuba_SilhouetteSample =
 R"doc(Data structure holding the result of visibility silhouette sampling
@@ -8785,9 +8785,9 @@ static const char *__doc_mitsuba_SilhouetteSample_d = R"doc(Direction of the bou
 
 static const char *__doc_mitsuba_SilhouetteSample_discontinuity_type = R"doc(Type of discontinuity (DiscontinuityFlags))doc";
 
-static const char *__doc_mitsuba_SilhouetteSample_fields = R"doc(//! @})doc";
+static const char *__doc_mitsuba_SilhouetteSample_fields = R"doc()doc";
 
-static const char *__doc_mitsuba_SilhouetteSample_fields_2 = R"doc(//! @})doc";
+static const char *__doc_mitsuba_SilhouetteSample_fields_2 = R"doc()doc";
 
 static const char *__doc_mitsuba_SilhouetteSample_flags =
 R"doc(The set of ``DiscontinuityFlags`` that were used to generate this
@@ -8801,9 +8801,9 @@ curvature for interior silhouettes.)doc";
 
 static const char *__doc_mitsuba_SilhouetteSample_is_valid = R"doc(Is the current boundary segment valid?)doc";
 
-static const char *__doc_mitsuba_SilhouetteSample_labels = R"doc(//! @})doc";
+static const char *__doc_mitsuba_SilhouetteSample_labels = R"doc()doc";
 
-static const char *__doc_mitsuba_SilhouetteSample_name = R"doc(//! @})doc";
+static const char *__doc_mitsuba_SilhouetteSample_name = R"doc()doc";
 
 static const char *__doc_mitsuba_SilhouetteSample_offset =
 R"doc(Offset along the boundary segment direction (`d`) to avoid self-
@@ -8984,7 +8984,7 @@ static const char *__doc_mitsuba_Stream_can_read = R"doc(Can we read from the st
 
 static const char *__doc_mitsuba_Stream_can_write = R"doc(Can we write to the stream?)doc";
 
-static const char *__doc_mitsuba_Stream_class_name = R"doc(@})doc";
+static const char *__doc_mitsuba_Stream_class_name = R"doc()doc";
 
 static const char *__doc_mitsuba_Stream_close =
 R"doc(Closes the stream.
@@ -9447,9 +9447,9 @@ static const char *__doc_mitsuba_SurfaceInteraction_emitter =
 R"doc(Return the emitter associated with the intersection (if any) \note
 Defined in scene.h)doc";
 
-static const char *__doc_mitsuba_SurfaceInteraction_fields = R"doc(//! @})doc";
+static const char *__doc_mitsuba_SurfaceInteraction_fields = R"doc()doc";
 
-static const char *__doc_mitsuba_SurfaceInteraction_fields_2 = R"doc(//! @})doc";
+static const char *__doc_mitsuba_SurfaceInteraction_fields_2 = R"doc()doc";
 
 static const char *__doc_mitsuba_SurfaceInteraction_finalize_surface_interaction =
 R"doc(Fills uninitialized fields after a call to
@@ -9477,9 +9477,9 @@ static const char *__doc_mitsuba_SurfaceInteraction_is_medium_transition = R"doc
 
 static const char *__doc_mitsuba_SurfaceInteraction_is_sensor = R"doc(Is the intersected shape also a sensor?)doc";
 
-static const char *__doc_mitsuba_SurfaceInteraction_labels = R"doc(//! @})doc";
+static const char *__doc_mitsuba_SurfaceInteraction_labels = R"doc()doc";
 
-static const char *__doc_mitsuba_SurfaceInteraction_name = R"doc(//! @})doc";
+static const char *__doc_mitsuba_SurfaceInteraction_name = R"doc()doc";
 
 static const char *__doc_mitsuba_SurfaceInteraction_operator_array = R"doc(Convenience operator for masking)doc";
 
@@ -10273,9 +10273,9 @@ static const char *__doc_mitsuba_Transform_Transform_6 = R"doc(//! @})doc";
 
 static const char *__doc_mitsuba_Transform_extract = R"doc(Extract a lower-dimensional submatrix)doc";
 
-static const char *__doc_mitsuba_Transform_fields = R"doc(//! @})doc";
+static const char *__doc_mitsuba_Transform_fields = R"doc()doc";
 
-static const char *__doc_mitsuba_Transform_fields_2 = R"doc(//! @})doc";
+static const char *__doc_mitsuba_Transform_fields_2 = R"doc()doc";
 
 static const char *__doc_mitsuba_Transform_from_frame =
 R"doc(Creates a transformation that converts from 'frame' to the standard
@@ -10292,7 +10292,7 @@ arithmetic))doc";
 
 static const char *__doc_mitsuba_Transform_inverse_transpose = R"doc()doc";
 
-static const char *__doc_mitsuba_Transform_labels = R"doc(//! @})doc";
+static const char *__doc_mitsuba_Transform_labels = R"doc()doc";
 
 static const char *__doc_mitsuba_Transform_look_at =
 R"doc(Create a look-at camera transformation
@@ -10308,7 +10308,7 @@ Parameter ``up``:
 
 static const char *__doc_mitsuba_Transform_matrix = R"doc(//! @{ \name Fields)doc";
 
-static const char *__doc_mitsuba_Transform_name = R"doc(//! @})doc";
+static const char *__doc_mitsuba_Transform_name = R"doc()doc";
 
 static const char *__doc_mitsuba_Transform_operator_assign = R"doc()doc";
 
@@ -10668,7 +10668,7 @@ static const char *__doc_mitsuba_ZStream_child_stream = R"doc(Returns the child 
 
 static const char *__doc_mitsuba_ZStream_child_stream_2 = R"doc(Returns the child stream of this compression stream)doc";
 
-static const char *__doc_mitsuba_ZStream_class_name = R"doc(//! @})doc";
+static const char *__doc_mitsuba_ZStream_class_name = R"doc()doc";
 
 static const char *__doc_mitsuba_ZStream_close =
 R"doc(Closes the stream, but not the underlying child stream. No further

--- a/include/mitsuba/render/bsdf.h
+++ b/include/mitsuba/render/bsdf.h
@@ -124,7 +124,7 @@ MI_DECLARE_ENUM_OPERATORS(BSDFFlags)
  * BSDF models in Mitsuba can be queried and sampled using a variety of
  * different modes -- for instance, a rendering algorithm can indicate whether
  * radiance or importance is being transported, and it can also restrict
- * evaluation and sampling to a subset of lobes in a a multi-lobe BSDF model.
+ * evaluation and sampling to a subset of lobes in a multi-lobe BSDF model.
  *
  * The \ref BSDFContext data structure encodes these preferences and is
  * supplied to most \ref BSDF methods.
@@ -165,7 +165,7 @@ struct MI_EXPORT_LIB BSDFContext {
     }
 
     /**
-     * Checks whether a given BSDF component type and BSDF component index are
+     * Checks whether a given BSDF component type and index are
      * enabled in this context.
      */
     bool is_enabled(BSDFFlags type_, uint32_t component_ = 0) const {
@@ -324,7 +324,7 @@ public:
      *
      * Based on the information in the supplied query context \c ctx, this
      * method will either evaluate the entire BSDF or query individual
-     * components (e.g. the diffuse lobe). Only smooth (i.e. non Dirac-delta)
+     * components (e.g. the diffuse lobe). Only smooth (i.e. non-Dirac-delta)
      * components are supported: calling ``eval()`` on a perfectly specular
      * material will return zero.
      *
@@ -386,7 +386,7 @@ public:
      *
      * Based on the information in the supplied query context \c ctx, this
      * method will either evaluate the entire BSDF or query individual
-     * components (e.g. the diffuse lobe). Only smooth (i.e. non Dirac-delta)
+     * components (e.g. the diffuse lobe). Only smooth (i.e. non-Dirac-delta)
      * components are supported: calling ``eval()`` on a perfectly specular
      * material will return zero.
      *
@@ -423,7 +423,7 @@ public:
      * the BSDF model.
      *
      * This is simply a wrapper around two separate function calls to eval_pdf()
-     * and sample(). The function exists to perform a smaller number of virtual
+     * and sample(). This function exists to reduce the number of virtual
      * function calls, which has some performance benefits on highly vectorized
      * JIT variants of the renderer. (A ~20% performance improvement for the
      * basic path tracer on CUDA)

--- a/include/mitsuba/render/emitter.h
+++ b/include/mitsuba/render/emitter.h
@@ -90,7 +90,7 @@ protected:
     /// Sampling weight
     ScalarFloat m_sampling_weight;
 
-    /// True if the emitters's parameters have changed
+    /// True if the emitter's parameters have changed
     bool m_dirty = false;
 
     MI_TRAVERSE_CB(Base);

--- a/include/mitsuba/render/endpoint.h
+++ b/include/mitsuba/render/endpoint.h
@@ -342,10 +342,10 @@ public:
     //! @{ \name Miscellaneous
     // =============================================================
 
-    /// Return the shape, to which the emitter is currently attached
+    /// Return the shape to which the emitter is currently attached
     Shape *shape() { return m_shape; }
 
-    /// Return the shape, to which the emitter is currently attached (const version)
+    /// Return the shape to which the emitter is currently attached (const version)
     const Shape *shape() const { return m_shape; }
 
     /// Return a pointer to the medium that surrounds the emitter

--- a/include/mitsuba/render/film.h
+++ b/include/mitsuba/render/film.h
@@ -54,12 +54,12 @@ public:
     ~Film();
 
     /**
-     * Configure the film for rendering a specified set of extra channels (AOVS).
+     * Configure the film for rendering a specified set of extra channels (AOVs).
      * Returns the total number of channels that the film will store
      */
     virtual size_t prepare(const std::vector<std::string> &aovs) = 0;
 
-    /// Return the number of channels for the developed image (excluding AOVS)
+    /// Return the number of channels for the developed image (excluding AOVs)
     virtual size_t base_channels_count() const = 0;
 
     /// Merge an image block into the film. This methods should be thread-safe.

--- a/include/mitsuba/render/integrator.h
+++ b/include/mitsuba/render/integrator.h
@@ -118,7 +118,7 @@ public:
      * parameters, or the function will just return a zero-valued gradient image.
      * This is typically done by invoking ``dr.enable_grad()`` and
      * ``dr.set_grad()`` on elements of the ``SceneParameters`` data structure
-     * that can be obtained obtained via a call to ``mi.traverse()``.
+     * that can be obtained via a call to ``mi.traverse()``.
      *
      * Note the default implementation of this functionality relies on naive
      * automatic differentiation (AD), which records a computation graph of the
@@ -196,7 +196,7 @@ public:
      *
      * Reverse-mode differentiation transforms image-space gradients into scene
      * parameter gradients, enabling simultaneous optimization of scenes with
-     * millions of free parameters. The function is invoked with an input
+     * millions of differentiable parameters. The function is invoked with an input
      * *gradient image* (``grad_in``) and transforms and accumulates these into
      * the gradient arrays of scene parameters that previously had gradient
      * tracking enabled.
@@ -204,7 +204,7 @@ public:
      * Before calling this function, you must first enable gradient tracking for
      * one or more scene parameters, or the function will not do anything. This is
      * typically done by invoking ``dr.enable_grad()`` on elements of the
-     * ``SceneParameters`` data structure that can be obtained obtained via a call
+     * ``SceneParameters`` data structure that can be obtained via a call
      * to ``mi.traverse()``. Use ``dr.grad()`` to query the resulting gradients of
      * these parameters once ``render_backward()`` returns.
      *
@@ -386,7 +386,7 @@ public:
      * \return
      *    A pair containing a spectrum and a mask specifying whether a surface
      *    or medium interaction was sampled. False mask entries indicate that
-     *    the ray "escaped" the scene, in which case the the returned spectrum
+     *    the ray "escaped" the scene, in which case the returned spectrum
      *    contains the contribution of environment maps, if present. The mask
      *    can be used to estimate a suitable alpha channel of a rendered image.
      *

--- a/include/mitsuba/render/mesh.h
+++ b/include/mitsuba/render/mesh.h
@@ -216,7 +216,7 @@ public:
     void recompute_bbox();
 
     /**
-     * /brief Build directed edge data structure to efficiently access adjacent
+     * \brief Build directed edge data structure to efficiently access adjacent
      * edges.
      *
      * This is an implementation of the technique described in:
@@ -419,7 +419,7 @@ protected:
     void build_pmf();
 
     /**
-     * /brief Precompute the set of edges that could contribute to the indirect
+     * \brief Precompute the set of edges that could contribute to the indirect
      * discontinuous integral.
      *
      * This method filters out any concave edges or flat surfaces.

--- a/include/mitsuba/render/microflake.h
+++ b/include/mitsuba/render/microflake.h
@@ -17,8 +17,8 @@ struct SGGXPhaseFunctionParams {
 
     /**
      * \brief Construct from a pair of 3D vectors [S_xx, S_yy, S_zz] and 
-     * [S_xy, S_xz, S_yz] that correspond to the entries of a symmetric positive
-     * definite 3x3 matrix.
+     * [S_xy, S_xz, S_yz] that correspond to the entries of a symmetric positive-definite
+     * 3x3 matrix.
      */
     SGGXPhaseFunctionParams(const dr::Array<Float, 3>& diag, 
                             const dr::Array<Float, 3>& off_diag) :

--- a/include/mitsuba/render/optixdenoiser.h
+++ b/include/mitsuba/render/optixdenoiser.h
@@ -93,7 +93,7 @@ public:
      *      With temporal denoising, this parameter is the optical flow between
      *      the previous frame and the current one. It should capture the 2D
      *      motion of each individual pixel.
-     *      When this parameter is unknown, it can been set to a
+     *      When this parameter is unknown, it can be set to a
      *      zero-initialized TensorXf of the correct size and still produce
      *      convincing results.
      *      This parameter is optional unless the OptixDenoiser was built with
@@ -150,7 +150,7 @@ public:
      *      the \c noisy parameter which contains the optical flow between
      *      the previous frame and the current one. It should capture the 2D
      *      motion of each individual pixel.
-     *      When this parameter is unknown, it can been set to a
+     *      When this parameter is unknown, it can be set to a
      *      zero-initialized TensorXf of the correct size and still produce
      *      convincing results.
      *      This parameter is optional unless the OptixDenoiser was built with

--- a/include/mitsuba/render/phase.h
+++ b/include/mitsuba/render/phase.h
@@ -85,8 +85,8 @@ struct MI_EXPORT_LIB PhaseFunctionContext {
     void reverse() { mode = (TransportMode)(1 - (int) mode); }
 
     /**
-     * Checks whether a given phase function component type and phase function
-     * component index are enabled in this context.
+     * Checks whether a given phase function component type and index are
+     * enabled in this context.
      */
     bool is_enabled(PhaseFunctionFlags type_, uint32_t component_ = 0) const {
         uint32_t type = (uint32_t) type_;

--- a/include/mitsuba/render/records.h
+++ b/include/mitsuba/render/records.h
@@ -156,7 +156,7 @@ struct DirectionSample : public PositionSample<Float_, Spectrum_> {
      * the density of a surface position with respect to a given reference
      * position.
      *
-     * Direction `s` is set so that it points from the reference surface to
+     * Direction 's' is set so that it points from the reference surface to
      * the intersected surface, as required when using e.g. the \ref Endpoint
      * interface to compute PDF values.
      *

--- a/include/mitsuba/render/scene.h
+++ b/include/mitsuba/render/scene.h
@@ -61,7 +61,7 @@ public:
      * This method is a convenience wrapper of the generalized version of
      * \c ray_intersect() below. It assumes that incoherent rays are being traced,
      * that the user desires access to all fields of the
-     * \ref SurfaceInteraction, and that no thread reodering is requested. In
+     * \ref SurfaceInteraction, and that no thread reordering is requested. In
      * other words, it simply invokes the general \c ray_intersect() overload
      * with <tt>coherent=false</tt>, \c ray_flags equal to \ref RayFlags::All,
      * and <tt>reorder=false</tt>.
@@ -200,7 +200,7 @@ public:
      * of space). This flag is currently only used by the combination of
      * <tt>llvm_*</tt> variants and the Embree ray tracing backend.
      *
-     * The \c reoder flag is a trigger for the Shader Execution Reordering (SER)
+     * The \c reorder flag is a trigger for the Shader Execution Reordering (SER)
      * feature on NVIDIA GPUs. It can improve performance in highly divergent
      * workloads by shuffling threads into coherent warps. This shuffling
      * operation uses the result of the intersection (the shape ID) as a sorting
@@ -235,7 +235,7 @@ public:
      *
      * \param reorder_hint_bits
      *    Number of bits from the \c reorder_hint to use (starting from the
-     *    least signifcant bit). It is recommended to use as few as possible.
+     *    least significant bit). It is recommended to use as few as possible.
      *    At most, 16 bits can be used. This flag has no effect in scalar or
      *    LLVM variants, or if the \c reorder parameter is \c false.
      *
@@ -247,7 +247,7 @@ public:
                                        uint32_t ray_flags,
                                        Mask coherent,
                                        bool reorder,
-                                       UInt32 reoder_hint,
+                                       UInt32 reorder_hint,
                                        uint32_t reorder_hint_bits,
                                        Mask active = true) const;
 
@@ -408,7 +408,7 @@ public:
      * by the combination of <tt>llvm_*</tt> variants and the Embree ray
      * intersector.
      *
-     * The \c reoder flag is a trigger for the Shader Execution Reordering (SER)
+     * The \c reorder flag is a trigger for the Shader Execution Reordering (SER)
      * feature on NVIDIA GPUs. It can improve performance in highly divergent
      * workloads by shuffling threads into coherent warps. This shuffling
      * operation uses the result of the intersection (the shape ID) as a sorting
@@ -439,7 +439,7 @@ public:
      *
      * \param reorder_hint_bits
      *    Number of bits from the \c reorder_hint to use (starting from the
-     *    least signifcant bit). It is recommended to use as few as possible.
+     *    least significant bit). It is recommended to use as few as possible.
      *    At most, 16 bits can be used. This flag has no effect in scalar or
      *    LLVM variants, or if the \c reorder parameter is \c false.
      *
@@ -564,7 +564,6 @@ public:
      *          structure, which provides further detail about the sampled
      *          emitter position (e.g. its surface normal, solid angle density,
      *          whether Dirac delta distributions were involved, etc.)</li>
-     *      <li>
      *      <li>\c spec is a Monte Carlo sampling weight specifying the ratio
      *          of the radiance incident from the emitter and the sample
      *          probability per unit solid angle.</li>

--- a/include/mitsuba/render/sensor.h
+++ b/include/mitsuba/render/sensor.h
@@ -32,7 +32,7 @@ public:
      * wavelength, surface position, and direction. This function takes a given
      * time value and five uniformly distributed samples on the interval [0, 1]
      * and warps them so that the returned ray the profile. Any
-     * discrepancies between ideal and actual sampled profile are absorbed into
+     * discrepancies between ideal and actual sampled profiles are absorbed into
      * a spectral importance weight that is returned along with the ray.
      *
      * In contrast to \ref Endpoint::sample_ray(), this function returns

--- a/include/mitsuba/render/shape.h
+++ b/include/mitsuba/render/shape.h
@@ -203,7 +203,7 @@ struct SilhouetteSample : public PositionSample<Float_, Spectrum_> {
           d(0), silhouette_d(0), prim_index(0), scene_index(0), flags(0),
           projection_index(0), shape(nullptr), foreshortening(0), offset(0) {}
 
-    /// Is the current boundary segment valid=
+    /// Is the current boundary segment valid?
     Mask is_valid() const {
         return discontinuity_type != (uint32_t) DiscontinuityFlags::Empty;
     }
@@ -212,7 +212,7 @@ struct SilhouetteSample : public PositionSample<Float_, Spectrum_> {
      * \brief Spawn a ray on the silhouette point in the direction of \ref d
      *
      * The ray origin is offset in the direction of the segment (\ref d) as well
-     * as in the in the direction of the silhouette normal (\ref n). Without this
+     * as in the direction of the silhouette normal (\ref n). Without this
      * offsetting, during a ray intersection, the ray could potentially find
      * an intersection point at its origin due to numerical instabilities in
      * the intersection routines.

--- a/src/bsdfs/bumpmap.cpp
+++ b/src/bsdfs/bumpmap.cpp
@@ -50,7 +50,7 @@ Note that the magnitude of the height field variations influences the scale of t
 
 
 The following XML snippet describes a rough plastic material affected by a bump
-map. Note the we set the ``raw`` properties of the bump map ``bitmap`` object to
+map. Note that we set the ``raw`` properties of the bump map ``bitmap`` object to
 ``true`` in order to disable the transformation from sRGB to linear encoding:
 
 .. tabs::

--- a/src/bsdfs/dielectric.cpp
+++ b/src/bsdfs/dielectric.cpp
@@ -70,7 +70,7 @@ This snippet describes a simple air-to-water interface
                 <string name="int_ior" value="water"/>
                 <string name="ext_ior" value="air"/>
             </bsdf>
-        <shape>
+        </shape>
 
     .. code-tab:: python
 
@@ -103,7 +103,7 @@ An example of how one might describe a slightly absorbing piece of glass is show
                 <rgb name="sigma_t" value="1, 1, 0.5"/>
                 <rgb name="albedo" value="0.0, 0.0, 0.0"/>
             </medium>
-        <shape>
+        </shape>
 
     .. code-tab:: python
 

--- a/src/bsdfs/normalmap.cpp
+++ b/src/bsdfs/normalmap.cpp
@@ -46,7 +46,7 @@ normal map with a value of :math:`(0,0,1)` everywhere causes no changes to the s
 3D normal directions into (nonnegative) color values suitable for this plugin, the mapping
 :math:`x \mapsto (x+1)/2` must be applied to each component.
 
-The following XML snippet describes a smooth mirror material affected by a normal map. Note the we set the
+The following XML snippet describes a smooth mirror material affected by a normal map. Note that we set the
 ``raw`` properties of the normal map ``bitmap`` object to ``true`` in order to disable the
 transformation from sRGB to linear encoding:
 

--- a/src/bsdfs/pplastic.cpp
+++ b/src/bsdfs/pplastic.cpp
@@ -321,7 +321,7 @@ public:
             }
 
             if (has_diffuse) {
-                /* Diffuse scattering is modeled a a sequence of events:
+                /* Diffuse scattering is modeled as a sequence of events:
                    1) Specular refraction inside
                    2) Subsurface scattering
                    3) Specular refraction outside again
@@ -385,7 +385,7 @@ public:
 
             if (has_diffuse) {
                 UnpolarizedSpectrum diff = m_diffuse_reflectance->eval(si, active);
-                /* Diffuse scattering is modeled a a sequence of events:
+                /* Diffuse scattering is modeled as a sequence of events:
                    1) Specular refraction inside
                    2) Subsurface scattering
                    3) Specular refraction outside again

--- a/src/core/python/properties.cpp
+++ b/src/core/python/properties.cpp
@@ -199,14 +199,14 @@ MI_PY_EXPORT(Properties) {
 
     // Add Type enum as a nested attribute of Properties
     properties_class.attr("Type") = nb::enum_<Properties::Type>(properties_class, "Type")
-        .value("Bool", Properties::Type::Bool)
-        .value("Integer", Properties::Type::Integer)
-        .value("Float", Properties::Type::Float)
-        .value("Vector", Properties::Type::Vector)
-        .value("Transform", Properties::Type::Transform)
-        .value("Color", Properties::Type::Color)
-        .value("String", Properties::Type::String)
-        .value("Reference", Properties::Type::Reference)
-        .value("Object", Properties::Type::Object)
-        .value("Any", Properties::Type::Any);
+        .value("Bool", Properties::Type::Bool, D(Properties, Type, Bool))
+        .value("Integer", Properties::Type::Integer, D(Properties, Type, Integer))
+        .value("Float", Properties::Type::Float, D(Properties, Type, Float))
+        .value("Vector", Properties::Type::Vector, D(Properties, Type, Vector))
+        .value("Transform", Properties::Type::Transform, D(Properties, Type, Transform))
+        .value("Color", Properties::Type::Color, D(Properties, Type, Color))
+        .value("String", Properties::Type::String, D(Properties, Type, String))
+        .value("Reference", Properties::Type::Reference, D(Properties, Type, Reference))
+        .value("Object", Properties::Type::Object, D(Properties, Type, Object))
+        .value("Any", Properties::Type::Any, D(Properties, Type, Any));
 }

--- a/src/emitters/projector.cpp
+++ b/src/emitters/projector.cpp
@@ -20,7 +20,7 @@ Projection light source (:monosp:`projector`)
    - 2D texture specifying irradiance on the emitter's virtual image plane,
      which lies at a distance of :math:`z=1` from the pinhole. Note that this
      does not directly correspond to emitted radiance due to the presence of an
-     additional directionally varying scale factor equal to to the inverse
+     additional directionally varying scale factor equal to the inverse
      sensitivity profile (a.k.a. importance) of a perspective camera. This
      ensures that a projection of a constant texture onto a plane is truly
      constant.

--- a/src/emitters/sunsky.cpp
+++ b/src/emitters/sunsky.cpp
@@ -110,7 +110,7 @@ It uses the Hosek-Wilkie sun :cite:`HosekSun2013` and sky model
 the cost of path tracing the atmosphere.
 
 Internally, this emitter does not compute a bitmap of the sky-dome like an
-environment map, but evaluates the irradiance whenever it is needed.
+environment map, but evaluates the spectral radiance whenever it is needed.
 Consequently, sampling is done through a Truncated Gaussian Mixture Model
 pre-fitted to the given parameters :cite:`vitsas2021tgmm`.
 
@@ -123,7 +123,7 @@ losing information.
 
 Note that attaching a ``sunsky`` emitter to the scene introduces physical units
 into the rendering process of Mitsuba 3, which is ordinarily a unitless system.
-Specifically, the evaluated irradiance has units of power (:math:`W`) per
+Specifically, the evaluated spectral radiance has units of power (:math:`W`) per
 unit area (:math:`m^{-2}`) per steradian (:math:`sr^{-1}`) per unit wavelength
 (:math:`nm^{-1}`). As a consequence, your scene should be modeled in meters for
 this plugin to work properly.

--- a/src/films/hdrfilm.cpp
+++ b/src/films/hdrfilm.cpp
@@ -23,7 +23,7 @@ High dynamic range film (:monosp:`hdrfilm`)
 
  * - width, height
    - |int|
-   - Width and height of the camera sensor in pixels. Default: 768, 576)
+   - Width and height of the camera sensor in pixels. (Default: 768, 576)
 
  * - file_format
    - |string|
@@ -39,7 +39,7 @@ High dynamic range film (:monosp:`hdrfilm`)
 
  * - component_format
    - |string|
-   - Specifies the desired floating  point component format of output images (when saving to disk).
+   - Specifies the desired floating point component format of output images (when saving to disk).
      The options are :monosp:`float16`, :monosp:`float32`, or :monosp:`uint32`.
      (Default: :monosp:`float16`)
 

--- a/src/films/specfilm.cpp
+++ b/src/films/specfilm.cpp
@@ -25,11 +25,11 @@ Spectral film (:monosp:`specfilm`)
 
  * - width, height
    - |int|
-   - Width and height of the camera sensor in pixels Default: 768, 576)
+   - Width and height of the camera sensor in pixels. (Default: 768, 576)
 
  * - component_format
    - |string|
-   - Specifies the desired floating  point component format of output images. The options are
+   - Specifies the desired floating point component format of output images. The options are
      :monosp:`float16`, :monosp:`float32`, or :monosp:`uint32`. (Default: :monosp:`float16`)
 
  * - crop_offset_x, crop_offset_y, crop_width, crop_height

--- a/src/integrators/path.cpp
+++ b/src/integrators/path.cpp
@@ -27,7 +27,7 @@ Path tracer (:monosp:`path`)
    - |int|
    - Specifies the path depth, at which the implementation will begin to use
      the *russian roulette* path termination criterion. For example, if set to
-     1, then path generation many randomly cease after encountering directly
+     1, then path generation may randomly cease after encountering directly
      visible surfaces. (Default: 5)
 
  * - hide_emitters
@@ -121,7 +121,7 @@ public:
         BSDFContext   bsdf_ctx;
 
         /* Set up a Dr.Jit loop. This optimizes away to a normal loop in scalar
-           mode, and it generates either a a megakernel (default) or
+           mode, and it generates either a megakernel (default) or
            wavefront-style renderer in JIT variants. This can be controlled by
            passing the '-W' command line flag to the mitsuba binary or
            enabling/disabling the JitFlag.LoopRecord bit in Dr.Jit.
@@ -303,7 +303,7 @@ public:
             Mask rr_active = ls.depth >= m_rr_depth,
                  rr_continue = ls.sampler->next_1d() < rr_prob;
 
-            /* Differentiable variants of the renderer require the the russian
+            /* Differentiable variants of the renderer require the russian
                roulette sampling weight to be detached to avoid bias. This is a
                no-op in non-differentiable variants. */
             ls.throughput[rr_active] *= dr::rcp(dr::detach(rr_prob));

--- a/src/integrators/volpath.cpp
+++ b/src/integrators/volpath.cpp
@@ -190,7 +190,7 @@ public:
             // ----------------- Handle termination of paths ------------------
             // Russian roulette: try to keep path weights equal to one, while accounting for the
             // solid angle compression at refractive index boundaries. Stop with at least some
-            // probability to avoid  getting stuck (e.g. due to total internal reflection)
+            // probability to avoid getting stuck (e.g. due to total internal reflection)
             active &= dr::any(unpolarized_spectrum(throughput) != 0.f);
             Float q = dr::minimum(dr::max(unpolarized_spectrum(throughput)) * dr::square(eta), .95f);
             Mask perform_rr = (depth > (uint32_t) m_rr_depth);

--- a/src/integrators/volpathmis.cpp
+++ b/src/integrators/volpathmis.cpp
@@ -232,7 +232,7 @@ public:
 
             // Russian roulette: try to keep path weights equal to one, while accounting for the
             // solid angle compression at refractive index boundaries. Stop with at least some
-            // probability to avoid  getting stuck (e.g. due to total internal reflection)
+            // probability to avoid getting stuck (e.g. due to total internal reflection)
             Spectrum mis_throughput = mis_weight(p_over_f);
             Float q = dr::minimum(dr::max(unpolarized_spectrum(mis_throughput)) * dr::square(eta), .95f);
             Mask perform_rr = active && !last_event_was_null && (depth > (uint32_t) m_rr_depth);

--- a/src/shapes/ellipsoids.cpp
+++ b/src/shapes/ellipsoids.cpp
@@ -85,7 +85,7 @@ Ellipsoids (:monosp:`ellipsoids`)
      an opacity value for each ellipsoids, or a set of spherical harmonic coefficients
      as used in the :monosp:`volprim_rf_basic` integrator.
 
-This shape plugin defines a a point cloud of anisotropic ellipsoid primitives
+This shape plugin defines a point cloud of anisotropic ellipsoid primitives
 using specified centers, scales, and quaternions. It employs a closed-form
 ray-intersection formula with backface culling. Although it is slower than the
 :monosp:`ellipsoidsmesh` shape plugin, which uses tessellated ellipsoids for


### PR DESCRIPTION
This PR fixes many typos in Mitsuba documentation. It does not change any code behavior.  

- [x] Should we add `pybind11_mkdoc` to `docs/requirements.txt`?
- [x] Update `docstr.h` when it's done