### PR TITLE
Fix accidental change of dlopen flags when importing Mitsuba

### DIFF
--- a/src/python/alias.cpp
+++ b/src/python/alias.cpp
@@ -68,7 +68,7 @@ nb::object import_with_deepbind_if_necessary(const char* name) {
 
 #if defined(__clang__) && !defined(__APPLE__)
     if (!std::getenv("DRJIT_NO_RTLD_DEEPBIND"))
-        sys.attr("setdlopenflags")(sys.attr("getdlopenflags")());
+        sys.attr("setdlopenflags")(backupflags);
 #endif
 
     return out;


### PR DESCRIPTION
## Description

The previous flags were accidentally not restored after importing the library.

## Testing

Resolves an obscure crash in the initialization of Matplotlib's TkAgg backend. It turns out that `environ` can unexpectedly be `nullptr` when `RTLD_DEEPBIND` is enabled, see: https://gist.github.com/traversaro/2d12a7067f686472207c942043f8c7b7

Thanks @wjakob, @dvicini and @njroussel for helping with the investigation.

## Checklist

<!-- Please make sure to complete this checklist before requesting a review. -->

- [x] My code follows the [style guidelines](https://mitsuba.readthedocs.io/en/latest/src/developer_guide.html#coding-style) of this project
- [x] My changes generate no new warnings
- [x] My code also compiles for `cuda_*` and `llvm_*` variants. If you can't test this, please leave below
- [ ] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 3 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba/blob/master/LICENSE)