### PR TITLE
AD integrators: differentiating geometry

### DIFF
--- a/src/emitters/projector.cpp
+++ b/src/emitters/projector.cpp
@@ -280,7 +280,8 @@ public:
         it_query.wavelengths = it.wavelengths;
         it_query.uv = ds.uv;
         if constexpr (dr::is_diff_v<Float>) {
-            // Re-attach UV
+            // Re-compute attached UV when the shading point is moving and the
+            // input ds.uv has not been re-computed
             if (dr::grad_enabled(it_local) && !dr::grad_enabled(ds.uv)) {
                 Point2f uv_diff = dr::head<2>(m_sample_to_camera.inverse() * it_local);
                 it_query.uv = dr::replace_grad(it_query.uv, uv_diff);

--- a/src/integrators/tests/test_ad_integrators.py
+++ b/src/integrators/tests/test_ad_integrators.py
@@ -841,8 +841,7 @@ CONFIGS = []
 for integrator_name, handles_discontinuities in INTEGRATORS:
     todos = BASIC_CONFIGS_LIST + (DISCONTINUOUS_CONFIGS_LIST if handles_discontinuities else [])
     for config in todos:
-        if (('direct' in integrator_name or 'projective' in integrator_name) and
-            config in INDIRECT_ILLUMINATION_CONFIGS_LIST):
+        if (('direct' in integrator_name) and config in INDIRECT_ILLUMINATION_CONFIGS_LIST):
             continue
         CONFIGS.append((integrator_name, config))
 

--- a/src/integrators/tests/test_ad_integrators.py
+++ b/src/integrators/tests/test_ad_integrators.py
@@ -162,7 +162,7 @@ class ConfigBase:
             'to_world': mi.ScalarTransform4f.look_at(origin=[0, 0, 4], target=[0, 0, 0], up=[0, 1, 0]),
             'film': {
                 'type': 'hdrfilm',
-                'rfilter': { 'type': 'gaussian', 'stddev': 0.5 },
+                'rfilter': { 'type': 'box' },
                 'width': self.res,
                 'height': self.res,
                 'sample_border': True,
@@ -524,6 +524,7 @@ class ScaleSphereEmitterOnBlackConfig(ScaleShapeConfigBase):
                 },
             }
         }
+        self.res = 64
         self.ref_fd_epsilon = 1e-3
         self.error_mean_threshold = 0.08
         self.error_max_threshold = 0.5

--- a/src/integrators/tests/test_ad_integrators.py
+++ b/src/integrators/tests/test_ad_integrators.py
@@ -228,6 +228,11 @@ class DiffuseAlbedoConfig(ConfigBase):
             },
             'light': { 'type': 'constant' }
         }
+        self.error_mean_threshold = 0.015
+        self.error_max_threshold = 0.25
+        self.error_mean_threshold_bwd = 0.0005
+        self.ref_fd_epsilon = 1e-3
+
 
 # BSDF albedo of a off camera plane blending onto a directly visible gray plane
 class DiffuseAlbedoGIConfig(ConfigBase):
@@ -259,6 +264,11 @@ class DiffuseAlbedoGIConfig(ConfigBase):
         self.integrator_dict = {
             'max_depth': 3,
         }
+        self.error_mean_threshold = 0.04
+        self.error_max_threshold = 0.4
+        self.error_mean_threshold_bwd = 0.0005
+        self.ref_fd_epsilon = 1e-3
+
 
 # Off camera area light illuminating a gray plane
 class AreaLightRadianceConfig(ConfigBase):
@@ -287,6 +297,11 @@ class AreaLightRadianceConfig(ConfigBase):
                 }
             }
         }
+        self.error_mean_threshold = 0.02
+        self.error_max_threshold = 0.4
+        self.error_mean_threshold_bwd = 0.0005
+        self.ref_fd_epsilon = 1e-3
+
 
 # Directly visible area light illuminating a gray plane
 class DirectlyVisibleAreaLightRadianceConfig(ConfigBase):
@@ -304,6 +319,11 @@ class DirectlyVisibleAreaLightRadianceConfig(ConfigBase):
                 }
             }
         }
+        self.error_mean_threshold = 0.02
+        self.error_max_threshold = 0.2
+        self.error_mean_threshold_bwd = 0.02
+        self.ref_fd_epsilon = 1e-3
+
 
 # Off camera point light illuminating a gray plane
 class PointLightIntensityConfig(ConfigBase):
@@ -329,6 +349,11 @@ class PointLightIntensityConfig(ConfigBase):
                 'intensity': {'type': 'rgb', 'value': [5.0, 5.0, 5.0]}
             },
         }
+        self.error_mean_threshold = 0.02
+        self.error_max_threshold = 0.2
+        self.error_mean_threshold_bwd = 0.002
+        self.ref_fd_epsilon = 1e-3
+
 
 # Instensity of a constant emitter illuminating a gray rectangle
 class ConstantEmitterRadianceConfig(ConfigBase):
@@ -347,6 +372,11 @@ class ConstantEmitterRadianceConfig(ConfigBase):
             },
             'light': { 'type': 'constant' }
         }
+        self.error_mean_threshold = 0.02
+        self.error_max_threshold = 0.1
+        self.error_mean_threshold_bwd = 0.02
+        self.ref_fd_epsilon = 1e-3
+
 
 # Test crop offset and crop window on the film
 class CropWindowConfig(ConfigBase):
@@ -377,6 +407,53 @@ class CropWindowConfig(ConfigBase):
                 "crop_offset_y" : 20,
             }
         }
+        self.error_mean_threshold = 0.01
+        self.error_max_threshold = 0.2
+        self.error_mean_threshold_bwd = 0.002
+        self.ref_fd_epsilon = 1e-3
+
+
+# Rotate plane's shading normals (no discontinuities)
+class RotateShadingNormalsPlaneConfig(ConfigBase):
+    def __init__(self) -> None:
+        super().__init__()
+        self.key = 'plane.vertex_normals'
+        self.scene_dict = {
+            'type': 'scene',
+            'plane': {
+                'type': 'obj',
+                'filename': 'resources/data/common/meshes/rectangle.obj',
+                'bsdf': { 'type': 'diffuse' },
+            },
+            'light': {
+                'type': 'rectangle',
+                'to_world': T().translate([1.25, 0.0, 1.0]) @ T().rotate([0, 1, 0], -90),
+                'emitter': {
+                    'type': 'area',
+                    'radiance': {'type': 'rgb', 'value': [3.0, 3.0, 3.0]}
+                }
+            }
+        }
+        self.integrator_dict = {
+            'max_depth': 2,
+        }
+        self.error_mean_threshold = 0.02
+        self.error_max_threshold = 0.3
+        self.error_mean_threshold_bwd = 0.00002
+
+    def initialize(self):
+        super().initialize()
+        self.params.keep([self.key])
+        self.initial_state = mi.Float(self.params[self.key])
+
+    def update(self, theta):
+        self.params[self.key] = dr.ravel(
+            mi.Transform4f().rotate(angle=theta, axis=[0.0, 1.0, 0.0]) @
+            dr.unravel(mi.Normal3f, self.initial_state)
+        )
+        self.params.update()
+        dr.eval()
+
 
 # -------------------------------------------------------------------
 #            Test configs with discontinuities
@@ -413,6 +490,37 @@ class ScaleShapeConfigBase(ConfigBase):
         self.params[self.key] = dr.ravel(self.initial_state * (1.0 + theta))
         self.params.update()
         dr.eval()
+
+
+# Translate textured plane (this is actually a continuous problem)
+class TranslateTexturedPlaneConfig(TranslateShapeConfigBase):
+    def __init__(self) -> None:
+        super().__init__()
+        self.key = 'plane.vertex_positions'
+        self.scene_dict = {
+            'type': 'scene',
+            'plane': {
+                'type': 'obj',
+                'filename': 'resources/data/common/meshes/rectangle.obj',
+                'face_normals': True,
+                'bsdf': {
+                    'type': 'diffuse',
+                    'reflectance' : {
+                        'type': 'bitmap',
+                        # 'filename' : 'resources/data/common/textures/flower.bmp'
+                        'filename' : 'resources/data/common/textures/museum.exr',
+                        'format' : 'variant'
+                    }
+                },
+                'to_world': T().scale(2.0),
+            },
+            'light': { 'type': 'constant' }
+        }
+        self.res = 64
+        self.ref_fd_epsilon = 1e-3
+        self.error_mean_threshold = 0.1
+        self.error_max_threshold = 56.0
+
 
 # Translate diffuse sphere under constant illumination
 class TranslateDiffuseSphereConstantConfig(TranslateShapeConfigBase):
@@ -607,36 +715,6 @@ class TranslateShadowReceiverAreaLightConfig(TranslateShapeConfigBase):
         }
 
 
-# Translate textured plane
-class TranslateTexturedPlaneConfig(TranslateShapeConfigBase):
-    def __init__(self) -> None:
-        super().__init__()
-        self.key = 'plane.vertex_positions'
-        self.scene_dict = {
-            'type': 'scene',
-            'plane': {
-                'type': 'obj',
-                'filename': 'resources/data/common/meshes/rectangle.obj',
-                'face_normals': True,
-                'bsdf': {
-                    'type': 'diffuse',
-                    'reflectance' : {
-                        'type': 'bitmap',
-                        # 'filename' : 'resources/data/common/textures/flower.bmp'
-                        'filename' : 'resources/data/common/textures/museum.exr',
-                        'format' : 'variant'
-                    }
-                },
-                'to_world': mi.ScalarTransform4f.scale(2.0),
-            },
-            'light': { 'type': 'constant' }
-        }
-        self.res = 64
-        self.ref_fd_epsilon = 1e-3
-        self.error_mean_threshold = 0.23
-        self.error_max_threshold = 142.0
-
-
 # Translate occluder casting shadow on itself
 class TranslateSelfShadowAreaLightConfig(ConfigBase):
     def __init__(self) -> None:
@@ -751,47 +829,6 @@ class TranslateCameraConfig(ConfigBase):
         dr.eval()
 
 
-# Rotate plane's shading normals (no discontinuities)
-class RotateShadingNormalsPlaneConfig(ConfigBase):
-    def __init__(self) -> None:
-        super().__init__()
-        self.key = 'plane.vertex_normals'
-        self.scene_dict = {
-            'type': 'scene',
-            'plane': {
-                'type': 'obj',
-                'filename': 'resources/data/common/meshes/rectangle.obj',
-                'bsdf': { 'type': 'diffuse' },
-            },
-            'light': {
-                'type': 'rectangle',
-                'to_world': mi.ScalarTransform4f.translate([1.25, 0.0, 1.0]) @ mi.ScalarTransform4f.rotate([0, 1, 0], -90),
-                'emitter': {
-                    'type': 'area',
-                    'radiance': {'type': 'rgb', 'value': [3.0, 3.0, 3.0]}
-                }
-            }
-        }
-        self.integrator_dict = {
-            'max_depth': 2,
-        }
-        self.error_mean_threshold = 0.02
-        self.error_max_threshold = 0.38
-
-    def initialize(self):
-        super().initialize()
-        self.params.keep([self.key])
-        self.initial_state = mi.Float(self.params[self.key])
-
-    def update(self, theta):
-        self.params[self.key] = dr.ravel(
-            mi.Transform4f().rotate(angle=theta, axis=[0.0, 1.0, 0.0]) @
-            dr.unravel(mi.Normal3f, mi.Float(self.initial_state))
-        )
-        self.params.update()
-        dr.eval()
-
-
 # -------------------------------------------------------------------
 #                           List configs
 # -------------------------------------------------------------------
@@ -801,13 +838,11 @@ BASIC_CONFIGS_LIST = [
     DiffuseAlbedoGIConfig,
     AreaLightRadianceConfig,
     DirectlyVisibleAreaLightRadianceConfig,
-    TranslateTexturedPlaneConfig,
+    PointLightIntensityConfig,
+    ConstantEmitterRadianceConfig,
     CropWindowConfig,
     RotateShadingNormalsPlaneConfig,
-
-    # The next two configs have issues with Nvidia driver v545
-    # PointLightIntensityConfig,
-    # ConstantEmitterRadianceConfig,
+    TranslateTexturedPlaneConfig,
 ]
 
 DISCONTINUOUS_CONFIGS_LIST = [

--- a/src/python/python/ad/integrators/common.py
+++ b/src/python/python/ad/integrators/common.py
@@ -1346,3 +1346,35 @@ def mis_weight(pdf_a, pdf_b):
     b2 = dr.square(pdf_b)
     w = a2 / (a2 + b2)
     return dr.detach(dr.select(dr.isfinite(w), w, 0))
+
+
+def solid_angle_to_area_jacobian(o: mi.Point3f,
+                                 p: mi.Point3f,
+                                 n: mi.Normal3f,
+                                 active: mi.Bool = True):
+    """
+    Computes the Jacobian determinant of the change of variables from solid
+    angle (dω) to surface area (dA) when reparameterizing the integration over
+    a surface.
+
+    Parameter ``o`` (``mi.Point3f``)
+        Origin point (e.g., shading point).
+
+    Parameter ``p`` (``mi.Point3f``)
+        Sampled point on the surface.
+
+    Parameter ``n`` (``mi.Normal3f``)
+        Normal at the sampled point.
+
+    Output:
+        The Jacobian determinant |∂A/∂ω| = (|dot(n, wi)| / ||p - o||^2)
+    """
+    d = p - o
+    d_squared = dr.squared_norm(d)
+    wo = dr.normalize(d)
+
+    cos_theta = dr.abs_dot(n, wo)
+    J = cos_theta / d_squared
+    J = dr.select(active, J, 1)
+
+    return J

--- a/src/python/python/ad/integrators/direct_projective.py
+++ b/src/python/python/ad/integrators/direct_projective.py
@@ -205,7 +205,7 @@ class DirectProjectiveIntegrator(PSIntegrator):
         # Perform detached BSDF sampling
         sample_bsdf, weight_bsdf = bsdf.sample(bsdf_ctx, si, sampler.next_1d(active_next),
                                                sampler.next_2d(active_next), active_next)
-        active_bsdf = active_next & dr.any(weight_bsdf != 0.0, axis=None)
+        active_bsdf = active_next & dr.any(mi.unpolarized_spectrum(weight_bsdf) != 0.0)
         delta_bsdf = mi.has_flag(sample_bsdf.sampled_type, mi.BSDFFlags.Delta)
 
         # Construct the BSDF sampled ray

--- a/src/python/python/ad/integrators/direct_projective.py
+++ b/src/python/python/ad/integrators/direct_projective.py
@@ -216,12 +216,11 @@ class DirectProjectiveIntegrator(PSIntegrator):
             si_bsdf = scene.ray_intersect(
                 ray_bsdf, ray_flags=mi.RayFlags.All, coherent=False, active=active_bsdf)
 
-            if (not primal):
+            if dr.hint(not primal, mode='scalar'):
                 si_bsdf_detached = dr.detach(si_bsdf)
 
-            # Re-compute `weight_bsdf` with AD attached only in differentiable
-            # phase
-            if not primal:
+                # Re-compute `weight_bsdf` with AD attached only in
+                # differentiable phase
                 J = solid_angle_to_area_jacobian(
                     si.p, si_bsdf_detached.p, si_bsdf_detached.n, active_next & si_bsdf.is_valid()
                 )
@@ -240,8 +239,7 @@ class DirectProjectiveIntegrator(PSIntegrator):
                     (J / dr.detach(J))
                 )
 
-            # Re-attach si_bsdf.wi if si.p was moving
-            if (not primal):
+                # Re-attach si_bsdf.wi if si.p was moving
                 wi_global = dr.normalize(si.p - si_bsdf_detached.p)
                 si.wi = dr.replace_grad(si.wi, si_bsdf_detached.to_local(wi_global))
 

--- a/src/python/python/ad/integrators/prb.py
+++ b/src/python/python/ad/integrators/prb.py
@@ -224,9 +224,7 @@ class PRBIntegrator(RBIntegrator):
                     # Differentiable version of the reflected indirect
                     # radiance. Minor optional tweak: indicate that the primal
                     # value of the second term is always 1.
-                    tmp = inv_bsdf_val_det * bsdf_val
-                    tmp_replaced = dr.replace_grad(dr.ones(mi.Float, dr.width(tmp)), tmp) #FIXME
-                    Lr_ind = L * tmp_replaced
+                    Lr_ind = L * dr.replace_grad(1, inv_bsdf_val_det * bsdf_val)
 
                     # Differentiable Monte Carlo estimate of all contributions
                     Lo = Le + Lr_dir + Lr_ind

--- a/src/python/python/ad/integrators/prb_basic.py
+++ b/src/python/python/ad/integrators/prb_basic.py
@@ -3,7 +3,7 @@ from __future__ import annotations # Delayed parsing of type annotations
 import drjit as dr
 import mitsuba as mi
 
-from .common import RBIntegrator
+from .common import RBIntegrator, solid_angle_to_area_jacobian
 
 class BasicPRBIntegrator(RBIntegrator):
     r"""
@@ -72,13 +72,15 @@ class BasicPRBIntegrator(RBIntegrator):
         # --------------------- Configure loop state ----------------------
 
         # Copy input arguments to avoid mutating the caller's state
-        ray = mi.Ray3f(ray)
-        depth = mi.UInt32(0)                          # Depth of current vertex
-        L = mi.Spectrum(0 if primal else state_in)    # Radiance accumulator
-        δL = mi.Spectrum(δL if δL is not None else 0) # Differential/adjoint radiance
-        β = mi.Spectrum(1)                            # Path throughput weight
-        active = mi.Bool(active)                      # Active SIMD lanes
-        pi = scene.ray_intersect_preliminary(ray,
+        ray = mi.Ray3f(ray)                              # Current ray
+        ray_prev = mi.Ray3f(ray)                         # Ray for the previous bounce
+        depth = mi.UInt32(0)                             # Depth of current vertex
+        L = mi.Spectrum(0 if primal else state_in)       # Radiance accumulator
+        δL = mi.Spectrum(δL if δL is not None else 0)    # Differential/adjoint radiance
+        β = mi.Spectrum(1)                               # Path throughput weight
+        active = mi.Bool(active)                         # Active SIMD lanes
+        pi_prev = dr.zeros(mi.PreliminaryIntersection3f) # Interaction of the previous bounce
+        pi = scene.ray_intersect_preliminary(ray,        # Current interaction
                                              coherent=True,
                                              reorder=False,
                                              active=active)
@@ -94,10 +96,20 @@ class BasicPRBIntegrator(RBIntegrator):
             with dr.resume_grad(when=not primal):
                 si = pi.compute_surface_interaction(ray, ray_flags=mi.RayFlags.All)
 
+                # Recompute an attached si.wi to account for motion of the
+                # previous surface interaction
+                if (not primal) & mi.Bool(depth >= 1):
+                    si_prev = pi_prev.compute_surface_interaction(ray_prev, ray_flags=mi.RayFlags.All)
+                    # We should not account for the current interaction's motion
+                    si_detach = dr.detach(si)
+                    wi_global = dr.normalize(si_prev.p - si_detach.p)
+                    si_wi_diff = si_detach.to_local(wi_global)
+                    si.wi = dr.replace_grad(si.wi, si_wi_diff)
+
             # ---------------------- Direct emission ----------------------
 
             # Hide the environment emitter if necessary
-            if self.hide_emitters:
+            if dr.hint(self.hide_emitters, mode='scalar'):
                 active_next &= ~((depth == 0) & ~si.is_valid())
 
             # Differentiable evaluation of intersected emitter / envmap
@@ -120,16 +132,35 @@ class BasicPRBIntegrator(RBIntegrator):
             # ---- Update loop variables based on current interaction -----
 
             L = L + Le if primal else L - Le
-            ray = si.spawn_ray(si.to_world(bsdf_sample.wo))
             β *= bsdf_weight
 
             # Don't run another iteration if the throughput has reached zero
-            active_next &= dr.any(β != 0)
+            β_max = dr.max(mi.unpolarized_spectrum(β))
+            active_next &= (β_max != 0)
+
+            # ------------------ Find the next ineraction ------------------
+
+            ray_next = si.spawn_ray(si.to_world(bsdf_sample.wo))
+            pi_next = scene.ray_intersect_preliminary(ray_next,
+                                                      coherent=False,
+                                                      reorder=False,
+                                                      active=active_next)
 
             # ------------------ Differential phase only ------------------
 
-            if not primal:
+            if dr.hint(not primal, mode='scalar'):
+                si_next = pi_next.compute_surface_interaction(ray_next,
+                                                              ray_flags=mi.RayFlags.All,
+                                                              active=active_next)
+
                 with dr.resume_grad():
+                    # If the current interaction point is moving, we need
+                    # to differentiate the solid angle to surface area
+                    # reparameterization.
+                    J = solid_angle_to_area_jacobian(
+                        si.p, si_next.p, si_next.n, active_next & si_next.is_valid()
+                    )
+
                     # 'L' stores the reflected radiance at the current vertex
                     # but does not track parameter derivatives. The following
                     # addresses this by canceling the detached BSDF value and
@@ -137,37 +168,48 @@ class BasicPRBIntegrator(RBIntegrator):
                     # tracking enabled.
 
                     # Recompute 'wo' to propagate derivatives to cosine term
-                    wo = si.to_local(ray.d)
+                    wo_world_diff = dr.normalize(si_next.p - si.p)
+                    wo_world = dr.replace_grad(
+                        ray_next.d,
+                        dr.select(si_next.is_valid(), wo_world_diff, ray_next.d)
+                    )
+                    wo = si.to_local(wo_world)
 
                     # Re-evaluate BSDF * cos(theta) differentiably
                     bsdf_val = bsdf.eval(bsdf_ctx, si, wo, active_next)
 
-                    # Detached version of the above term and inverse
-                    bsdf_val_detach = bsdf_weight * bsdf_sample.pdf
-                    inv_bsdf_val_detach = dr.select(bsdf_val_detach != 0,
-                                                    dr.rcp(bsdf_val_detach), 0)
-
-                    # Differentiable version of the reflected radiance. Minor
-                    # optional tweak: indicate that the primal value of the
-                    # second term is 1.
-                    Lr = L * dr.replace_grad(1, inv_bsdf_val_detach * bsdf_val)
+                    # Differentiable version of the reflected radiance.
+                    Lr = L * dr.replace_grad(
+                        1,
+                        (bsdf_val / dr.detach(bsdf_val)) *
+                        (J / dr.detach(J))
+                    )
 
                     # Differentiable Monte Carlo estimate of all contributions
                     Lo = Le + Lr
 
                     # Propagate derivatives from/to 'Lo' based on 'mode'
-                    if mode == dr.ADMode.Backward:
+                    if dr.hint(mode == dr.ADMode.Backward, mode='scalar'):
                         dr.backward_from(δL * Lo)
                     else:
                         δL += dr.forward_to(Lo)
 
+            # ----------- Reorder threads for the next iteration --------
+
+            # hint layout: [shape ID (bits 1–31) | active flag (LSB)]
+            reorder_hint = dr.reinterpret_array(mi.UInt32, pi_next.shape)
+            reorder_hint = (reorder_hint << 1) | dr.select(active_next, 1, 0)
+            depth = dr.reorder_threads(reorder_hint, 16, depth)
+
+            # ------------------ Update loop variables ------------------
+
             depth[si.is_valid()] += 1
             active = active_next
 
-            pi = scene.ray_intersect_preliminary(ray,
-                                                 coherent=False,
-                                                 reorder=dr.flag(dr.JitFlag.LoopRecord),
-                                                 active=active)
+            pi_prev = pi
+            pi = pi_next
+            ray_prev = ray
+            ray = ray_next
 
         return (
             L if primal else δL, # Radiance/differential radiance

--- a/src/python/python/ad/integrators/prb_projective.py
+++ b/src/python/python/ad/integrators/prb_projective.py
@@ -353,9 +353,7 @@ class PathProjectiveIntegrator(PSIntegrator):
                     # Differentiable version of the reflected indirect
                     # radiance. Minor optional tweak: indicate that the primal
                     # value of the second term is always 1.
-                    tmp = inv_bsdf_val_det * bsdf_val
-                    tmp_replaced = dr.replace_grad(dr.ones(mi.Float, dr.width(tmp)), tmp) #FIXME
-                    Lr_ind = L * tmp_replaced
+                    Lr_ind = L * dr.replace_grad(1, inv_bsdf_val_det * bsdf_val)
 
                     # Differentiable Monte Carlo estimate of all contributions
                     Lo = Le + Lr_dir + Lr_ind

--- a/src/python/python/ad/integrators/prb_projective.py
+++ b/src/python/python/ad/integrators/prb_projective.py
@@ -252,24 +252,36 @@ class PathProjectiveIntegrator(PSIntegrator):
                 if dr.hint(not primal, mode='scalar'):
                     is_surface = mi.has_flag(ds.emitter.flags(), mi.EmitterFlags.Surface)
                     is_infinite = mi.has_flag(ds.emitter.flags(), mi.EmitterFlags.Infinite)
+                    is_spatially_varying = mi.has_flag(ds.emitter.flags(), mi.EmitterFlags.SpatiallyVarying)
+
+                    # For textured area lights, we need to track UV changes on
+                    # the emitter if it is moving
+                    textured_area_em = active_em & is_surface & is_spatially_varying
+                    ray_em = si.spawn_ray_to(ds.p)
+                    # Move ray origin closer, visibibliy is already accounted for
+                    ray_em.o = dr.fma(ray_em.d, ray_em.maxt, ray_em.o)
+                    ray_em.maxt = dr.largest(ray_em.maxt)
+                    si_em = scene.ray_intersect(ray_em, textured_area_em)
+
+                    # Re-attach gradients for the the `ds` struct
+                    ds_diff = mi.DirectionSample3f(scene, si_em, si)
+                    ds_diff = dr.select(textured_area_em, ds_diff, dr.zeros(mi.DirectionSample3f))
+                    ds_diff.d = dr.select(~is_infinite, ds_diff.d, ds.d)
+                    ds = dr.replace_grad(ds, ds_diff)
 
                     # If the current interaction point is moving, we need
                     # to differentiate the solid angle to surface area
                     # reparameterization.
-                    J = solid_angle_to_area_jacobian(si.p, ds.p, ds.n, active_em & is_surface)
+                    J = solid_angle_to_area_jacobian(
+                        si.p, dr.detach(ds.p), dr.detach(ds.n), active_em & is_surface
+                    )
 
                     # Given the detached emitter sample, *recompute* its
                     # contribution with AD to enable light source optimization
-                    ds_d_diff = dr.normalize(ds.p - si.p)
-                    ds_d_diff = dr.select(~is_infinite, ds_d_diff, ds.d)
-                    ds.d = dr.replace_grad(ds.d, ds_d_diff)
-                    em_val = scene.eval_emitter_direction(si, ds, active_em)
+                    em_val_diff = scene.eval_emitter_direction(si, ds, active_em)
+                    em_weight_diff = (em_val_diff / dr.detach(ds.pdf)) * (J / dr.detach(J))
+                    em_weight = dr.replace_grad(em_weight, em_weight_diff)
 
-                    em_weight = dr.replace_grad(em_weight, dr.select(
-                        (ds.pdf != 0),
-                        (em_val / ds.pdf) * (J / dr.detach(J)),
-                        0
-                    ))
 
                 # Evaluate BSDF * cos(theta) differentiably
                 wo = si.to_local(ds.d)

--- a/src/python/python/ad/integrators/prb_projective.py
+++ b/src/python/python/ad/integrators/prb_projective.py
@@ -3,7 +3,7 @@ from __future__ import annotations # Delayed parsing of type annotations
 import drjit as dr
 import mitsuba as mi
 
-from .common import PSIntegrator, mis_weight
+from .common import PSIntegrator, mis_weight, solid_angle_to_area_jacobian
 
 class PathProjectiveIntegrator(PSIntegrator):
     r"""
@@ -163,7 +163,7 @@ class PathProjectiveIntegrator(PSIntegrator):
         η = mi.Float(1)                               # Index of refraction
         active = mi.Bool(active)                      # Active SIMD lanes
         depth_init = mi.UInt32(depth)                 # Initial depth
-        pi = dr.zeros(mi.PreliminaryIntersection3f)
+        pi = dr.zeros(mi.PreliminaryIntersection3f)   # Current interaction
 
         if dr.hint(ignore_ray, mode='scalar'):
             si = si_shade
@@ -173,10 +173,12 @@ class PathProjectiveIntegrator(PSIntegrator):
                                                  reorder=False,
                                                  active=active)
 
-        # Variables caching information
-        prev_si         = dr.zeros(mi.SurfaceInteraction3f)
-        prev_bsdf_pdf   = mi.Float(1.0)
-        prev_bsdf_delta = mi.Bool(True)
+        # Variables caching information from the previous bounce
+        ray_prev        = mi.Ray3f(ray)
+        pi_prev         = dr.zeros(mi.PreliminaryIntersection3f)
+        si_prev         = dr.zeros(mi.SurfaceInteraction3f)
+        bsdf_pdf_prev   = mi.Float(1.0)
+        bsdf_delta_prev = mi.Bool(True)
 
         # Projective seed ray information
         cnt_seed = mi.UInt32(0)            # Number of valid seed rays encountered
@@ -196,6 +198,20 @@ class PathProjectiveIntegrator(PSIntegrator):
                 si = pi.compute_surface_interaction(ray,
                                                     ray_flags=mi.RayFlags.All,
                                                     active=active_next & ~use_si_shade)
+
+                # Recompute an attached si.wi to account for motion of the
+                # previous surface interaction
+                if (not primal) & mi.Bool(depth >= 1):
+                    si_prev_diff = pi_prev.compute_surface_interaction(
+                        ray_prev,
+                        ray_flags=mi.RayFlags.Minimal,
+                        active=active_next & ~use_si_shade
+                    )
+                    si_prev = dr.replace_grad(si_prev, si_prev_diff)
+                    si_detached = dr.detach(si) # Ignore motion of current point
+                    wi_global = dr.normalize(si_prev.p - si_detached.p)
+                    si.wi = dr.replace_grad(si.wi, si_detached.to_local(wi_global))
+
             if dr.hint(ignore_ray, mode='scalar'):
                 si[use_si_shade] = si_shade
 
@@ -209,11 +225,11 @@ class PathProjectiveIntegrator(PSIntegrator):
                 active_next &= ~((depth == 0) & ~si.is_valid())
 
             # Compute MIS weight for emitter sample from previous bounce
-            ds = mi.DirectionSample3f(scene, si=si, ref=prev_si)
+            ds = mi.DirectionSample3f(scene, si=si, ref=si_prev)
 
             mis = mis_weight(
-                prev_bsdf_pdf,
-                scene.pdf_emitter_direction(prev_si, ds, ~prev_bsdf_delta)
+                bsdf_pdf_prev,
+                scene.pdf_emitter_direction(si_prev, ds, ~bsdf_delta_prev)
             )
 
             with dr.resume_grad(when=not primal):
@@ -234,12 +250,26 @@ class PathProjectiveIntegrator(PSIntegrator):
 
             with dr.resume_grad(when=not primal):
                 if dr.hint(not primal, mode='scalar'):
+                    is_surface = mi.has_flag(ds.emitter.flags(), mi.EmitterFlags.Surface)
+                    is_infinite = mi.has_flag(ds.emitter.flags(), mi.EmitterFlags.Infinite)
+
+                    # If the current interaction point is moving, we need
+                    # to differentiate the solid angle to surface area
+                    # reparameterization.
+                    J = solid_angle_to_area_jacobian(si.p, ds.p, ds.n, active_em & is_surface)
+
                     # Given the detached emitter sample, *recompute* its
                     # contribution with AD to enable light source optimization
-                    ds.d = dr.replace_grad(ds.d, dr.normalize(ds.p - si.p))
+                    ds_d_diff = dr.normalize(ds.p - si.p)
+                    ds_d_diff = dr.select(~is_infinite, ds_d_diff, ds.d)
+                    ds.d = dr.replace_grad(ds.d, ds_d_diff)
                     em_val = scene.eval_emitter_direction(si, ds, active_em)
-                    em_weight = dr.replace_grad(em_weight, dr.select((ds.pdf != 0), em_val / ds.pdf, 0))
-                    dr.disable_grad(ds.d)
+
+                    em_weight = dr.replace_grad(em_weight, dr.select(
+                        (ds.pdf != 0),
+                        (em_val / ds.pdf) * (J / dr.detach(J)),
+                        0
+                    ))
 
                 # Evaluate BSDF * cos(theta) differentiably
                 wo = si.to_local(ds.d)
@@ -257,22 +287,22 @@ class PathProjectiveIntegrator(PSIntegrator):
             # ---- Update loop variables based on current interaction -----
 
             L = (L + Le + Lr_dir) if primal else (L - Le - Lr_dir)
-            ray = si.spawn_ray(si.to_world(bsdf_sample.wo))
+            ray_next = si.spawn_ray(si.to_world(bsdf_sample.wo))
             η *= bsdf_sample.eta
             β *= bsdf_weight
 
             # Information about the current vertex needed by the next iteration
 
-            prev_si = dr.detach(si, True)
-            prev_bsdf_pdf = bsdf_sample.pdf
-            prev_bsdf_delta = mi.has_flag(bsdf_sample.sampled_type, mi.BSDFFlags.Delta)
+            si_prev = dr.detach(si, True)
+            bsdf_pdf_prev = bsdf_sample.pdf
+            bsdf_delta_prev = mi.has_flag(bsdf_sample.sampled_type, mi.BSDFFlags.Delta)
 
             # ------------------------ Seed rays --------------------------
 
             # Note: even when the current vertex has a delta BSDF, which implies
             # that any perturbation of the direction will be invalid, we still
             # allow projection of such a ray segment. If this is not desired,
-            # mask ``active_seed_cand &= ~prev_bsdf_delta``.
+            # mask ``active_seed_cand &= ~bsdf_delta_prev``.
 
             if dr.hint(project, mode='scalar'):
                     # Given the detached emitter sample, *recompute* its
@@ -282,7 +312,7 @@ class PathProjectiveIntegrator(PSIntegrator):
                 # If so, pick a seed ray (if applicable)
                 if dr.hint(self.project_seed == "bsdf", mode='scalar'):
                     # We assume that `ray` intersects the scene
-                    ray_seed_cand = ray
+                    ray_seed_cand = ray_next
                 elif dr.hint(self.project_seed == "emitter", mode='scalar'):
                     ray_seed_cand = si.spawn_ray_to(ds.p)
                     ray_seed_cand.maxt = dr.largest(mi.Float)
@@ -292,7 +322,7 @@ class PathProjectiveIntegrator(PSIntegrator):
                                          mi.has_flag(bsdf.flags(), mi.BSDFFlags.Transmission)
                 elif dr.hint(self.project_seed == "both", mode='scalar'):
                     # By default we use the BSDF sample as the seed ray
-                    ray_seed_cand = ray
+                    ray_seed_cand = ray_next
 
                     # Flip a coin only when the emitter sample is valid
                     mask_replace = (dr.dot(si.n, ray_seed_cand.d) > 0) | \
@@ -326,34 +356,51 @@ class PathProjectiveIntegrator(PSIntegrator):
             rr_continue = sampler.next_1d() < rr_prob
             active_next &= ~rr_active | rr_continue
 
+            # ----------------- Find the next interaction -----------------
+
+            pi_next = scene.ray_intersect_preliminary(ray_next,
+                                                      coherent=False,
+                                                      reorder=False,
+                                                      active=active_next)
+
             # ------------------ Differential phase only ------------------
 
             if dr.hint(not primal, mode='scalar'):
+                si_next = pi_next.compute_surface_interaction(ray_next,
+                                                              ray_flags=mi.RayFlags.Minimal,
+                                                              active=active_next)
+
                 with dr.resume_grad():
-                    # 'L' stores the indirectly reflected radiance at the
-                    # current vertex but does not track parameter derivatives.
-                    # The following addresses this by canceling the detached
-                    # BSDF value and replacing it with an equivalent term that
-                    # has derivative tracking enabled. (nit picking: the
-                    # direct/indirect terminology isn't 100% accurate here,
-                    # since there may be a direct component that is weighted
-                    # via multiple importance sampling)
+                    # If the current interaction point is moving, we need
+                    # to differentiate the solid angle to surface area
+                    # reparameterization.
+                    J = solid_angle_to_area_jacobian(
+                        si.p, si_next.p, si_next.n, active_next & si_next.is_valid()
+                    )
+
+                    # 'L' stores the reflected radiance at the current vertex
+                    # but does not track parameter derivatives. The following
+                    # addresses this by canceling the detached BSDF value and
+                    # replacing it with an equivalent term that has derivative
+                    # tracking enabled.
 
                     # Recompute 'wo' to propagate derivatives to cosine term
-                    wo = si.to_local(ray.d)
+                    wo_world_diff = dr.normalize(si_next.p - si.p)
+                    wo_world = dr.replace_grad(
+                        ray_next.d,
+                        dr.select(si_next.is_valid(), wo_world_diff, ray_next.d)
+                    )
+                    wo = si.to_local(wo_world)
 
                     # Re-evaluate BSDF * cos(theta) differentiably
                     bsdf_val = bsdf.eval(bsdf_ctx, si, wo, active_next)
 
-                    # Detached version of the above term and inverse
-                    bsdf_val_det = bsdf_weight * bsdf_sample.pdf
-                    inv_bsdf_val_det = dr.select(bsdf_val_det != 0,
-                                                 dr.rcp(bsdf_val_det), 0)
-
-                    # Differentiable version of the reflected indirect
-                    # radiance. Minor optional tweak: indicate that the primal
-                    # value of the second term is always 1.
-                    Lr_ind = L * dr.replace_grad(1, inv_bsdf_val_det * bsdf_val)
+                    # Differentiable version of the reflected radiance.
+                    Lr_ind = L * dr.replace_grad(
+                        1,
+                        (bsdf_val / dr.detach(bsdf_val)) *
+                        (J / dr.detach(J))
+                    )
 
                     # Differentiable Monte Carlo estimate of all contributions
                     Lo = Le + Lr_dir + Lr_ind
@@ -376,13 +423,22 @@ class PathProjectiveIntegrator(PSIntegrator):
                     else:
                         δL += dr.forward_to(Lo)
 
+            # ----------- Reorder threads for the next iteration --------
+
+            # hint layout: [shape ID (bits 1–31) | active flag (LSB)]
+            reorder_hint = dr.reinterpret_array(mi.UInt32, pi_next.shape)
+            reorder_hint = (reorder_hint << 1) | dr.select(active_next, 1, 0)
+            depth = dr.reorder_threads(reorder_hint, 16, depth)
+
+            # ------------------ Update loop variables ------------------
+
             depth[si.is_valid()] += 1
             active = active_next
 
-            pi = scene.ray_intersect_preliminary(ray,
-                                                 coherent=False,
-                                                 reorder=dr.flag(dr.JitFlag.LoopRecord),
-                                                 active=active)
+            pi_prev = pi
+            pi = pi_next
+            ray_prev = ray
+            ray = ray_next
 
         return (
             L if primal else δL, # Radiance/differential radiance


### PR DESCRIPTION
## Description

This PR updates all AD integrators to correctly handle missing _continuous_ derivative terms arising from moving geometry. 

Mitsuba's integrators follow the methods described in [RB](https://rgl.epfl.ch/publications/NimierDavid2020Radiative) and [PRB](https://rgl.epfl.ch/publications/Vicini2021PathReplay), which focus on differentiating scenes with _static_ geometry. 
This assumption is to exclude [boundary derivatives](https://rgl.epfl.ch/publications/Zhang2023Projective), which are a separate concern and handled independently.
However, moving geometry introduces non-boundary derivative terms that were previously unaccounted for in Mitsuba 3's AD integrators.
This PR re-attaches these missing terms.

See #1506 and [this paper](https://diglib.eg.org/handle/10.2312/sr20251198) for more context. We thank the authors for spotting and investigating the issue.

Although `prb` and `prb_basic` were updated, they still do not compute the boundary integral and are therefore still typically ill-suited for geometry optimization tasks. 

## Performance

**When the scene's geometry is static, the updated integrators bare no additional runtime cost.** Dr.Jit can prune the new terms as they will not be attached (AD) for static geometry.

The new integrators required some extra changes to fully benefit from SER. Unexpectedly, the **new integrators reduce the average runtime by ~30% when compared to the older ones** (primal evaluation). Both versions shuffle threads based on the shape ID of the current surface interaction. However, the old version also used some encoding of the XYZ coordinates of the hitpoint. I believe that this extra information effectively scheduled all warps to be shuffled in the hope of improving data access coherence. On the other hand, by exclusively using the shape ID, the new integrators might have warps that will skip the SER process entirely if the warp is coherent. (This is just a hypothesis.)

Here's a summary of the speedups I've benchmarked with `prb` on some standard scenes:
| scene name     | speedup   |
|:---------------|:----------|
| staircase      | 1.42x     |
| living-room    | 1.25x     |
| bathroom | 1.31x     |
| spaceship      | 1.23x     |

We should maybe apply this change to the non-AD integrators of Mitsuba too.

Fixes #1506

## Testing

Five new configurations were added to `test_ad_integrators.py`, all of which almost exclusively produce gradients from the missing terms. I've also spent some time to tighten the thresholds on all configurations. Some configurations are particularly expensive, I might update their resolution/spp if I see a noticeable impact on the CI.

:warning: The `resources/data` submodule changed should be merged to `mitsuba-data:master` before this PR is merged.