### PR TITLE
Fixes to the `blendbsdf` and `blendphase` plugin

### DIFF
--- a/src/bsdfs/blendbsdf.cpp
+++ b/src/bsdfs/blendbsdf.cpp
@@ -134,6 +134,8 @@ public:
         if (dr::any_or<true>(m0)) {
             auto [bs0, result0] = m_nested_bsdf[0]->sample(
                 ctx, si, (sample1 - weight) / (1 - weight), sample2, m0);
+            Float pdf1 = m_nested_bsdf[1]->pdf(ctx, si, bs0.wo, m0);
+            bs0.pdf = weight * pdf1 + (1.f - weight) * bs0.pdf;
             dr::masked(bs, m0) = bs0;
             dr::masked(result, m0) = result0;
         }
@@ -141,9 +143,12 @@ public:
         if (dr::any_or<true>(m1)) {
             auto [bs1, result1] = m_nested_bsdf[1]->sample(
                 ctx, si, sample1 / weight, sample2, m1);
+            Float pdf0 = m_nested_bsdf[0]->pdf(ctx, si, bs1.wo, m1);
+            bs1.pdf = weight * bs1.pdf + (1.f - weight) * pdf0;
             dr::masked(bs, m1) = bs1;
             dr::masked(result, m1) = result1;
         }
+
 
         return { bs, result };
     }

--- a/src/bsdfs/blendbsdf.cpp
+++ b/src/bsdfs/blendbsdf.cpp
@@ -226,6 +226,16 @@ public:
                m_nested_bsdf[1]->eval_diffuse_reflectance(si, active) * weight;
     }
 
+    Spectrum eval_null_transmission(const SurfaceInteraction3f &si,
+                                    Mask active) const override {
+        if (likely(!has_flag(m_flags, BSDFFlags::Null)))
+            return 0.f;
+        // Evaluate the null transmission of the nested BSDFs
+        Float weight = eval_weight(si, active);
+        return m_nested_bsdf[0]->eval_null_transmission(si, active) * (1 - weight) +
+               m_nested_bsdf[1]->eval_null_transmission(si, active) * weight;
+    }
+
     std::string to_string() const override {
         std::ostringstream oss;
         oss << "BlendBSDF[" << std::endl

--- a/src/bsdfs/tests/test_blendbsdf.py
+++ b/src/bsdfs/tests/test_blendbsdf.py
@@ -32,16 +32,19 @@ def test01_create(variant_scalar_rgb):
 def test02_eval_all(variant_scalar_rgb):
     weight = 0.2
 
+    bsdf_0 = mi.load_dict({
+        'type': 'conductor'
+    })
+
+    bsdf_1 = mi.load_dict({
+        'type': 'diffuse',
+        'reflectance': {'type': 'rgb', 'value': 1.0}
+    })
+
     bsdf = mi.load_dict({
         'type': 'blendbsdf',
-        'nested1': {
-            'type': 'diffuse',
-            'reflectance': {'type': 'rgb', 'value': 0.0}
-        },
-        'nested2': {
-            'type': 'diffuse',
-            'reflectance': {'type': 'rgb', 'value': 1.0}
-        },
+        'nested1': bsdf_0,
+        'nested2': bsdf_1,
         'weight': weight,
     })
 
@@ -56,7 +59,8 @@ def test02_eval_all(variant_scalar_rgb):
     ctx = mi.BSDFContext()
 
     # Evaluate the blend of both components
-    expected = (1 - weight) * 0.0 * dr.inv_pi + weight * 1.0 * dr.inv_pi
+    expected = (1 - weight) * bsdf_0.eval(ctx, si, wo) + \
+                weight * bsdf_1.eval(ctx, si, wo)
     value    = bsdf.eval(ctx, si, wo)
     assert dr.allclose(value, expected)
 
@@ -64,16 +68,19 @@ def test02_eval_all(variant_scalar_rgb):
 def test03_eval_components(variant_scalar_rgb):
     weight = 0.2
 
+    bsdf_0 = mi.load_dict({
+        'type': 'conductor'
+    })
+
+    bsdf_1 = mi.load_dict({
+        'type': 'diffuse',
+        'reflectance': {'type': 'rgb', 'value': 1.0}
+    })
+
     bsdf = mi.load_dict({
         'type': 'blendbsdf',
-        'nested1': {
-            'type': 'diffuse',
-            'reflectance': {'type': 'rgb', 'value': 0.0}
-        },
-        'nested2': {
-            'type': 'diffuse',
-            'reflectance': {'type': 'rgb', 'value': 1.0}
-        },
+        'nested1': bsdf_0,
+        'nested2': bsdf_1,
         'weight': weight,
     })
 
@@ -86,17 +93,18 @@ def test03_eval_components(variant_scalar_rgb):
 
     wo = [0, 0, 1]
     ctx = mi.BSDFContext()
+    blend_ctx = mi.BSDFContext()
 
     # Evaluate the two components separately
 
-    ctx.component = 0
-    value0 = bsdf.eval(ctx, si, wo)
-    expected0 = (1-weight) * 0.0*dr.inv_pi
+    blend_ctx.component = 0
+    value0 = bsdf.eval(blend_ctx, si, wo)
+    expected0 = (1.0-weight) * bsdf_0.eval(ctx, si, wo)
     assert dr.allclose(value0, expected0)
 
-    ctx.component = 1
-    value1 = bsdf.eval(ctx, si, wo)
-    expected1 = weight * 1.0*dr.inv_pi
+    blend_ctx.component = 1
+    value1 = bsdf.eval(blend_ctx, si, wo)
+    expected1 = weight * bsdf_1.eval(ctx, si, wo)
     assert dr.allclose(value1, expected1)
 
 
@@ -106,8 +114,7 @@ def test04_sample_all(variant_scalar_rgb):
     bsdf = mi.load_dict({
         'type': 'blendbsdf',
         'nested1': {
-            'type': 'diffuse',
-            'reflectance': {'type': 'rgb', 'value': 0.0}
+            'type': 'plastic'
         },
         'nested2': {
             'type': 'diffuse',
@@ -128,28 +135,33 @@ def test04_sample_all(variant_scalar_rgb):
     # Sample using two different values of 'sample1' and make sure correct
     # components are chosen.
 
-    expected_a = 1.0    # InvPi & weight will cancel out with sampling pdf
-    bs_a, weight_a = bsdf.sample(ctx, si, 0.1, [0.5, 0.5])
+    bs_a, weight_a = bsdf.sample(ctx, si, 0.1, [0.2, 0.9])
+    eval_a, pdf_a = bsdf.eval_pdf(ctx, si, wo=bs_a.wo)
+    expected_a = eval_a / pdf_a
     assert dr.allclose(weight_a, expected_a)
 
-    expected_b = 0.0    # InvPi & weight will cancel out with sampling pdf
-    bs_b, weight_b = bsdf.sample(ctx, si, 0.3, [0.5, 0.5])
+    bs_b, weight_b = bsdf.sample(ctx, si, 0.3, [0.4, 0.6])
+    eval_b, pdf_b = bsdf.eval_pdf(ctx, si, wo=bs_b.wo)
+    expected_b = eval_b / pdf_b
     assert dr.allclose(weight_b, expected_b)
 
 
 def test05_sample_components(variant_scalar_rgb):
     weight = 0.2
 
+    bsdf_0 = mi.load_dict({
+        'type': 'conductor'
+    })
+
+    bsdf_1 = mi.load_dict({
+        'type': 'diffuse',
+        'reflectance': {'type': 'rgb', 'value': 1.0}
+    })
+
     bsdf = mi.load_dict({
         'type': 'blendbsdf',
-        'nested1': {
-            'type': 'diffuse',
-            'reflectance': {'type': 'rgb', 'value': 0.0}
-        },
-        'nested2': {
-            'type': 'diffuse',
-            'reflectance': {'type': 'rgb', 'value': 1.0}
-        },
+        'nested1': bsdf_0,
+        'nested2': bsdf_1,
         'weight': weight,
     })
 
@@ -161,26 +173,92 @@ def test05_sample_components(variant_scalar_rgb):
     si.wi = [0, 0, 1]
 
     ctx = mi.BSDFContext()
+    blend_ctx = mi.BSDFContext()
 
     # Sample specific components separately using two different values of 'sample1'
     # and make sure the desired component is chosen always.
 
-    ctx.component = 0
+    blend_ctx.component = 0
 
-    expected_a = (1-weight)*0.0    # InvPi will cancel out with sampling pdf, but still need to apply weight
-    bs_a, weight_a = bsdf.sample(ctx, si, 0.1, [0.5, 0.5])
-    assert dr.allclose(weight_a, expected_a)
+    expected_bs_a, expected_a = bsdf_0.sample(ctx, si, 0.1, [0.5, 0.5])
+    bs_a, weight_a = bsdf.sample(blend_ctx, si, 0.1, [0.5, 0.5])
+    assert dr.allclose(weight_a, (1.0-weight) * expected_a)
+    assert dr.allclose(bs_a.wo, expected_bs_a.wo)
+    assert dr.allclose(bs_a.pdf, expected_bs_a.pdf)
 
-    expected_b = (1-weight)*0.0    # InvPi will cancel out with sampling pdf, but still need to apply weight
-    bs_b, weight_b = bsdf.sample(ctx, si, 0.3, [0.5, 0.5])
-    assert dr.allclose(weight_b, expected_b)
+    expected_bs_b, expected_b = bsdf_0.sample(ctx, si, 0.3, [0.2, 0.7])
+    bs_b, weight_b = bsdf.sample(blend_ctx, si, 0.3, [0.2, 0.7])
+    assert dr.allclose(weight_b, (1.0-weight) * expected_b)
+    assert dr.allclose(bs_b.wo, expected_bs_b.wo)
+    assert dr.allclose(bs_b.pdf, expected_bs_b.pdf)
 
-    ctx.component = 1
+    blend_ctx.component = 1
 
-    expected_a = weight*1.0    # InvPi will cancel out with sampling pdf, but still need to apply weight
-    bs_a, weight_a = bsdf.sample(ctx, si, 0.1, [0.5, 0.5])
-    assert dr.allclose(weight_a, expected_a)
+    expected_bs_a, expected_a = bsdf_1.sample(ctx, si, 0.1, [0.5, 0.5])
+    bs_a, weight_a = bsdf.sample(blend_ctx, si, 0.1, [0.5, 0.5])
+    assert dr.allclose(weight_a, weight * expected_a)
+    assert dr.allclose(bs_a.wo, expected_bs_a.wo)
+    assert dr.allclose(bs_a.pdf, expected_bs_a.pdf)
 
-    expected_b = weight*1.0    # InvPi will cancel out with sampling pdf, but still need to apply weight
-    bs_b, weight_b = bsdf.sample(ctx, si, 0.3, [0.5, 0.5])
-    assert dr.allclose(weight_b, expected_b)
+    expected_bs_b, expected_b = bsdf_1.sample(ctx, si, 0.3, [0.2, 0.7])
+    bs_b, weight_b = bsdf.sample(blend_ctx, si, 0.3, [0.2, 0.7])
+    assert dr.allclose(weight_b, weight * expected_b)
+    assert dr.allclose(bs_b.wo, expected_bs_b.wo)
+    assert dr.allclose(bs_b.pdf, expected_bs_b.pdf)
+
+def test06_chi2_diffuse(variants_vec_backends_once_rgb):
+    from mitsuba.chi2 import BSDFAdapter, ChiSquareTest, SphericalDomain
+
+    sample_func, pdf_func = BSDFAdapter("blendbsdf", {
+        'type': 'blendbsdf',
+        'nested1': { 'type' : 'diffuse' },
+        'nested2': { 'type' : 'diffuse' },
+        'weight': 0.2,
+    })
+
+    chi2 = ChiSquareTest(
+        domain=SphericalDomain(),
+        sample_func=sample_func,
+        pdf_func=pdf_func,
+        sample_dim=3
+    )
+
+    assert chi2.run()
+
+def test07_chi2_diffuse_roughdielectric(variants_vec_backends_once_rgb):
+    from mitsuba.chi2 import BSDFAdapter, ChiSquareTest, SphericalDomain
+
+    sample_func, pdf_func = BSDFAdapter("blendbsdf", {
+        'type': 'blendbsdf',
+        'nested1': { 'type' : 'diffuse' },
+        'nested2': { 'type' : 'roughdielectric', 'alpha': 0.5 },
+        'weight': 0.2,
+    })
+
+    chi2 = ChiSquareTest(
+        domain=SphericalDomain(),
+        sample_func=sample_func,
+        pdf_func=pdf_func,
+        sample_dim=3
+    )
+
+    assert chi2.run()
+
+def test08_chi2_roughconductor_roughdielectric(variants_vec_backends_once_rgb):
+    from mitsuba.chi2 import BSDFAdapter, ChiSquareTest, SphericalDomain
+
+    sample_func, pdf_func = BSDFAdapter("blendbsdf", {
+        'type': 'blendbsdf',
+        'nested1': { 'type' : 'roughconductor', 'alpha': 0.5 },
+        'nested2': { 'type' : 'roughdielectric', 'alpha': 0.5 },
+        'weight': 0.2,
+    })
+
+    chi2 = ChiSquareTest(
+        domain=SphericalDomain(),
+        sample_func=sample_func,
+        pdf_func=pdf_func,
+        sample_dim=3
+    )
+
+    assert chi2.run()

--- a/src/phase/tests/test_blendphase.py
+++ b/src/phase/tests/test_blendphase.py
@@ -35,11 +35,14 @@ def test02_eval_all(variant_scalar_rgb):
     weight = 0.2
     g = 0.2
 
+    phase_0 = mi.load_dict({"type": "isotropic"})
+    phase_1 = mi.load_dict({"type": "hg", "g": g})
+
     phase = mi.load_dict(
         {
             "type": "blendphase",
-            "phase1": {"type": "isotropic"},
-            "phase2": {"type": "hg", "g": g},
+            "phase1": phase_0,
+            "phase2": phase_1,
             "weight": weight,
         }
     )
@@ -53,23 +56,29 @@ def test02_eval_all(variant_scalar_rgb):
     wo = [0, 0, 1]
     ctx = mi.PhaseFunctionContext()
 
+    eval0, pdf0 = phase_0.eval_pdf(ctx, mei, wo)
+    eval1, pdf1 = phase_1.eval_pdf(ctx, mei, wo)
+    expected_eval = (1 - weight) * eval0 + weight * eval1
+    expected_pdf = (1 - weight) * pdf0 + weight * pdf1
+
     # Evaluate the blend of both components
-    expected = (1.0 - weight) * dr.inv_four_pi + weight * dr.inv_four_pi * (1.0 - g) / (
-        1.0 + g
-    ) ** 2
-    value = phase.eval_pdf(ctx, mei, wo)[0]
-    assert dr.allclose(value, expected)
+    eval, pdf = phase.eval_pdf(ctx, mei, wo)
+    assert dr.allclose(eval, expected_eval)
+    assert dr.allclose(pdf, expected_pdf)
 
 
 def test03_sample_all(variants_all_rgb):
     weight = 0.2
     g = 0.2
 
+    phase_0 = mi.load_dict({"type": "isotropic"})
+    phase_1 = mi.load_dict({"type": "hg", "g": g})
+
     phase = mi.load_dict(
         {
             "type": "blendphase",
-            "phase1": {"type": "isotropic"},
-            "phase2": {"type": "hg", "g": g},
+            "phase1": phase_0,
+            "phase2": phase_1,
             "weight": weight,
         }
     )
@@ -86,25 +95,32 @@ def test03_sample_all(variants_all_rgb):
     # components are chosen.
 
     # -- Sample above weight: first component (isotropic) is selected
-    expected_a = dr.inv_four_pi
     wo_a, w_a, pdf_a = phase.sample(ctx, mei, 0.3, [0.5, 0.5])
-    assert dr.allclose(pdf_a, expected_a)
+    expected_eval_a, expected_pdf_a = phase.eval_pdf(ctx, mei, wo_a)
+    expected_w_a = expected_eval_a / expected_pdf_a
+    assert dr.allclose(pdf_a, expected_pdf_a)
+    assert dr.allclose(w_a, expected_w_a)
 
     # -- Sample below weight: second component (HG) is selected
-    expected_b = dr.inv_four_pi * (1 - g) / (1 + g) ** 2
     wo_b, w_b, pdf_b = phase.sample(ctx, mei, 0.1, [0, 0])
-    assert dr.allclose(pdf_b, expected_b)
+    expected_eval_b, expected_pdf_b = phase.eval_pdf(ctx, mei, wo_b)
+    expected_w_b = expected_eval_b / expected_pdf_b
+    assert dr.allclose(pdf_b, expected_pdf_b)
+    assert dr.allclose(w_b, expected_w_b)
 
 
 def test04_eval_components(variant_scalar_rgb):
     weight = 0.2
     g = 0.2
 
+    phase_0 = mi.load_dict({"type": "isotropic"})
+    phase_1 = mi.load_dict({"type": "hg", "g": g})
+
     phase = mi.load_dict(
         {
             "type": "blendphase",
-            "phase1": {"type": "isotropic"},
-            "phase2": {"type": "hg", "g": g},
+            "phase1": phase_0,
+            "phase2": phase_1,
             "weight": weight,
         }
     )
@@ -117,31 +133,35 @@ def test04_eval_components(variant_scalar_rgb):
 
     wo = [0, 0, 1]
     ctx = mi.PhaseFunctionContext()
+    blend_ctx = mi.PhaseFunctionContext()
 
     # Evaluate the two components separately
 
-    ctx.component = 0
-    value0, pdf0 = phase.eval_pdf(ctx, mei, wo)
-    expected0 = (1 - weight) * dr.inv_four_pi
-    assert dr.allclose(value0, expected0)
-    assert dr.allclose(value0, pdf0)
+    blend_ctx.component = 0
+    value0, pdf0 = phase.eval_pdf(blend_ctx, mei, wo)
+    expected_value0, expected_pdf0 = phase_0.eval_pdf(ctx, mei, wo)
+    assert dr.allclose(value0, (1.0-weight) * expected_value0)
+    assert dr.allclose(pdf0, (1.0-weight) * expected_pdf0)
 
-    ctx.component = 1
-    value1, pdf1 = phase.eval_pdf(ctx, mei, wo)
-    expected1 = weight * dr.inv_four_pi * (1.0 - g) / (1.0 + g) ** 2
-    assert dr.allclose(value1, expected1)
-    assert dr.allclose(value1, pdf1)
+    blend_ctx.component = 1
+    value1, pdf1 = phase.eval_pdf(blend_ctx, mei, wo)
+    expected_value1, expected_pdf1 = phase_1.eval_pdf(ctx, mei, wo)
+    assert dr.allclose(value1, weight * expected_value1)
+    assert dr.allclose(pdf1, weight * expected_pdf1)
 
 
 def test05_sample_components(variant_scalar_rgb):
     weight = 0.2
     g = 0.2
 
+    phase_0 = mi.load_dict({"type": "isotropic"})
+    phase_1 = mi.load_dict({"type": "hg", "g": g})
+
     phase = mi.load_dict(
         {
             "type": "blendphase",
-            "phase1": {"type": "isotropic"},
-            "phase2": {"type": "hg", "g": g},
+            "phase1": phase_0,
+            "phase2": phase_1,
             "weight": weight,
         }
     )
@@ -153,28 +173,71 @@ def test05_sample_components(variant_scalar_rgb):
     mei.wi = [0, 0, 1]
 
     ctx = mi.PhaseFunctionContext()
+    blend_ctx = mi.PhaseFunctionContext()
 
     # Sample using two different values of 'sample1' and make sure correct
     # components are chosen.
 
     # -- Select component 0: first component is always sampled
-    ctx.component = 0
+    blend_ctx.component = 0
 
-    expected_a = (1 - weight) *  dr.inv_four_pi
-    wo_a, w_a, pdf_a = phase.sample(ctx, mei, 0.3, [0.5, 0.5])
-    assert dr.allclose(pdf_a, expected_a)
+    wo_a, w_a, pdf_a = phase.sample(blend_ctx, mei, 0.3, [0.5, 0.5])
+    expected_eval_a, expected_pdf_a = phase_0.eval_pdf(ctx, mei, wo_a)
+    assert dr.allclose(pdf_a, (1.0-weight) * expected_pdf_a)
+    assert dr.allclose(w_a, (1.0-weight) * expected_eval_a / expected_pdf_a)
 
-    expected_b = (1 - weight) *  dr.inv_four_pi
-    wo_b, w_b, pdf_b = phase.sample(ctx, mei, 0.1, [0.5, 0.5])
-    assert dr.allclose(pdf_b, expected_b)
+    wo_b, w_b, pdf_b = phase.sample(blend_ctx, mei, 0.1, [0.5, 0.5])
+    expected_eval_b, expected_pdf_b = phase_0.eval_pdf(ctx, mei, wo_b)
+    assert dr.allclose(pdf_b, (1.0-weight)*expected_pdf_b)
+    assert dr.allclose(w_b, (1.0-weight)*expected_eval_b / expected_pdf_b)
 
     # -- Select component 1: second component is always sampled
-    ctx.component = 1
+    blend_ctx.component = 1
 
-    expected_a = weight *  dr.inv_four_pi * (1 - g) / (1 + g) ** 2
-    wo_a, w_a, pdf_a = phase.sample(ctx, mei, 0.3, [0.0, 0.0])
-    assert dr.allclose(pdf_a, expected_a)
+    wo_a, w_a, pdf_a = phase.sample(blend_ctx, mei, 0.3, [0.0, 0.0])
+    expected_eval_a, expected_pdf_a = phase_1.eval_pdf(ctx, mei, wo_a)
+    assert dr.allclose(pdf_a, weight * expected_pdf_a)
+    assert dr.allclose(w_a, weight * expected_eval_a / expected_pdf_a)
 
-    expected_b = weight * dr.inv_four_pi * (1 - g) / (1 + g) ** 2
-    wo_b, w_b, pdf_b = phase.sample(ctx, mei, 0.1, [0.0, 0.0])
-    assert dr.allclose(pdf_b, expected_b)
+    wo_b, w_b, pdf_b = phase.sample(blend_ctx, mei, 0.1, [0.0, 0.0])
+    expected_eval_b, expected_pdf_b = phase_1.eval_pdf(ctx, mei, wo_b)
+    assert dr.allclose(pdf_b, weight * expected_pdf_b)
+    assert dr.allclose(w_b, weight * expected_eval_b / expected_pdf_b)
+
+def test06_chi2_isotropic_hg(variants_vec_backends_once_rgb):
+    from mitsuba.chi2 import PhaseFunctionAdapter, ChiSquareTest, SphericalDomain
+
+    sample_func, pdf_func = PhaseFunctionAdapter("blendphase", {
+        "type": "blendphase",
+        "phase1": {"type": "isotropic"},
+        "phase2": {"type": "hg", "g": 0.2},
+        "weight": 0.2
+    })
+
+    chi2 = ChiSquareTest(
+        domain=SphericalDomain(),
+        sample_func=sample_func,
+        pdf_func=pdf_func,
+        sample_dim=3
+    )
+
+    assert chi2.run()
+
+def test07_chi2_hg_rayleigh(variants_vec_backends_once_rgb):
+    from mitsuba.chi2 import PhaseFunctionAdapter, ChiSquareTest, SphericalDomain
+
+    sample_func, pdf_func = PhaseFunctionAdapter("blendphase", {
+        "type": "blendphase",
+        "phase1": {"type": "hg", "g": 0.2},
+        "phase2": {"type": "rayleigh"},
+        "weight": 0.4
+    })
+
+    chi2 = ChiSquareTest(
+        domain=SphericalDomain(),
+        sample_func=sample_func,
+        pdf_func=pdf_func,
+        sample_dim=3
+    )
+
+    assert chi2.run()


### PR DESCRIPTION
The `blendbsdf` plugin can produce biased renderings under certain conditions:
- When sampling, we don't compute the correct pdf, which results in incorrect MIS weights
- If one of the nested BSDFs has a null component, the `volpath` plugin will miss some energy as the BSDF does not implement a `eval_null_transmission` method.

The tests run on this plugin seem to only use the same (opaque) BSDF twice, which may explain why we did not notice this before.

Below is some test scene containing 2 spheres and 2 planes:
- top sphere: `blendbsdf` mixing a `null` and `diffuse` BSDF
- bottom sphere: `mask` BSDF equivalent to the top one
- top plane: `blendbsdf` mixing 2 `diffuse` BSDFs
- bottom: `blendbsdf` mixing a `diffuse` and a `null` BSDF

Rendering with `volpath` on `master`:
<img width="1920" height="1080" alt="pr_before" src="https://github.com/user-attachments/assets/06b7befd-5f3e-4363-8c13-a6ad1ac0464d" />

Rendering with `volpath` on this branch:
<img width="1920" height="1080" alt="pr_after" src="https://github.com/user-attachments/assets/67554837-4859-4ae0-a526-8e9a407615a1" />

Rendering the same scene in Cycles:
<img width="1920" height="1080" alt="pr_blender" src="https://github.com/user-attachments/assets/ae560fff-87cf-4211-8b39-5ed38d023803" />

I also tested the MIS issue in a simpler scene where the expected pixel value can be determined analytically.