### PR TITLE
Sensor-related Jacobian determinant uses AD & support orthographic cameras

### DIFF
--- a/include/mitsuba/render/sensor.h
+++ b/include/mitsuba/render/sensor.h
@@ -199,6 +199,10 @@ public:
     /// Return the distance to the focal plane
     Float focus_distance() const { return m_focus_distance; }
 
+    /// Return the projection matrix of this sensor (camera space to sample
+    /// space transformation)
+    virtual ProjectiveTransform4f projection_transform() const = 0;
+
     void traverse(TraversalCallback *cb) override {
         cb->put("near_clip",      m_near_clip,      ParamFlags::NonDifferentiable);
         cb->put("far_clip",       m_far_clip,       ParamFlags::NonDifferentiable);

--- a/include/mitsuba/render/sensor.h
+++ b/include/mitsuba/render/sensor.h
@@ -203,6 +203,10 @@ public:
     /// space transformation)
     virtual ProjectiveTransform4f projection_transform() const = 0;
 
+    /// Return the sample-to-camera transformation matrix (inverse of
+    /// projection_transform)
+    virtual ProjectiveTransform4f sample_to_camera() const = 0;
+
     void traverse(TraversalCallback *cb) override {
         cb->put("near_clip",      m_near_clip,      ParamFlags::NonDifferentiable);
         cb->put("far_clip",       m_far_clip,       ParamFlags::NonDifferentiable);

--- a/sppp_test.py
+++ b/sppp_test.py
@@ -1,0 +1,98 @@
+import mitsuba as mi
+import drjit as dr
+import os
+
+mi.set_variant('cuda_ad_rgb')
+
+T = mi.ScalarTransform4f
+
+reso = 99
+folder = 'output'
+if not os.path.exists(folder):
+    os.makedirs(folder)
+
+scene_dict = {
+    'type': 'scene',
+    'shape': {
+        'type': 'rectangle',
+        'to_world': T().translate([0, 0, 0]),
+        'emitter': {
+            'type': 'area',
+            'radiance': {
+                'type': 'rgb',
+                'value': 2.0
+            }
+        }
+    },
+    'light': {
+        'type': 'constant',
+        'radiance': {
+            'type': 'rgb',
+            'value': 1.0,
+        }
+    },
+    'integrator': {
+        'type': 'direct_projective',
+        'max_depth': 1,
+        'sppc': 0,
+        'sppi': 0,
+    },
+    'sensor': {
+        'type': 'perspective',
+        'to_world': T().look_at(origin=[0, 0, 2], target=[0, 0, 0], up=[0, 1, 0]),
+        'fov': 90,
+        'film': {
+            'type': 'hdrfilm',
+            'rfilter': {'type': 'box'},
+            'width': reso,
+            'height': reso,
+            'sample_border': True,
+            'pixel_format': 'rgb',
+            'component_format': 'float32',
+        }
+    }
+}
+
+scene = mi.load_dict(scene_dict)
+params = mi.traverse(scene)
+key = 'shape.to_world'
+value_init = mi.Transform4f(params[key])
+
+def update_scene(theta):
+    params[key] = mi.Transform4f().translate([theta, 0, 0]) @ value_init
+    params.update()
+
+eps = 1e-3
+
+# Render FD
+repeat_fd = 8
+spp_fd = 8192 * 16
+image_fd = dr.zeros(mi.TensorXf, (reso, reso, 3))
+for i in range(repeat_fd):
+    update_scene(eps)
+    img1 = mi.render(scene, params=params, spp= spp_fd, seed=i)
+    update_scene(-eps)
+    img2 = mi.render(scene, params=params, spp= spp_fd, seed=i)
+
+    image_fd += img1 - img2
+    dr.eval(image_fd)
+image_fd /= (2 * eps * repeat_fd)
+mi.Bitmap(image_fd).write(f'{folder}/image_fd.exr')
+
+# Render AD
+repeat_ad = 1
+spp_ad = 8192 * 16
+image_ad = dr.zeros(mi.TensorXf, (reso, reso, 3))
+for i in range(repeat_ad):
+
+    theta = mi.Float(0.0)
+    dr.enable_grad(theta)
+    update_scene(theta)
+    dr.forward(theta, dr.ADFlag.ClearEdges)
+
+    image = mi.render(scene, seed=i, spp=spp_ad, params=params)
+    dr.forward_to(image)
+    image_ad += dr.grad(image)
+    dr.eval(image_ad)
+image_ad /= repeat_ad
+mi.Bitmap(image_ad).write(f'{folder}/image_ad.exr')

--- a/src/python/python/ad/projective.py
+++ b/src/python/python/ad/projective.py
@@ -117,19 +117,8 @@ class ProjectiveDetail():
         near_clip = sensor.near_clip()
         sensor_center = to_world @ mi.Point3f(0)
         sensor_lookat_dir = to_world @ mi.Vector3f(0, 0, 1)
-        x_fov = mi.traverse(sensor)["x_fov"][0]
-        film = sensor.film()
 
-        camera_to_sample = mi.perspective_projection(
-            film.size(),
-            film.crop_size(),
-            film.crop_offset(),
-            x_fov,
-            near_clip,
-            sensor.far_clip()
-        )
-
-        sample_to_camera = camera_to_sample.inverse()
+        sample_to_camera = sensor.sample_to_camera()
         p_min = sample_to_camera @ mi.Point3f(0, 0, 0)
         multiplier = dr.square(near_clip) / dr.abs(p_min[0] * p_min[1] * 4.0)
 

--- a/src/render/python/sensor_v.cpp
+++ b/src/render/python/sensor_v.cpp
@@ -193,7 +193,9 @@ MI_PY_EXPORT(Sensor) {
     MI_PY_CLASS(ProjectiveCamera, Sensor)
         .def_method(ProjectiveCamera, near_clip)
         .def_method(ProjectiveCamera, far_clip)
-        .def_method(ProjectiveCamera, focus_distance);
+        .def_method(ProjectiveCamera, focus_distance)
+        .def("projection_transform", &ProjectiveCamera::projection_transform,
+             "Return the projection matrix of this sensor (camera space to sample space transformation)");
 
     m.def("perspective_projection", &perspective_projection<Float>,
           "film_size"_a, "crop_size"_a, "crop_offset"_a, "fov_x"_a, "near_clip"_a, "far_clip"_a,

--- a/src/render/python/sensor_v.cpp
+++ b/src/render/python/sensor_v.cpp
@@ -194,8 +194,8 @@ MI_PY_EXPORT(Sensor) {
         .def_method(ProjectiveCamera, near_clip)
         .def_method(ProjectiveCamera, far_clip)
         .def_method(ProjectiveCamera, focus_distance)
-        .def("projection_transform", &ProjectiveCamera::projection_transform,
-             "Return the projection matrix of this sensor (camera space to sample space transformation)");
+        .def("projection_transform", &ProjectiveCamera::projection_transform)
+        .def("sample_to_camera", &ProjectiveCamera::sample_to_camera);
 
     m.def("perspective_projection", &perspective_projection<Float>,
           "film_size"_a, "crop_size"_a, "crop_offset"_a, "fov_x"_a, "near_clip"_a, "far_clip"_a,

--- a/src/sensors/orthographic.cpp
+++ b/src/sensors/orthographic.cpp
@@ -168,6 +168,12 @@ public:
         return { ray, wav_weight };
     }
 
+    ProjectiveTransform4f projection_transform() const override {
+        // Convert AffineTransform4f to ProjectiveTransform4f and invert
+        auto camera_to_sample = m_sample_to_camera.inverse();
+        return ProjectiveTransform4f(camera_to_sample.matrix);
+    }
+
     ScalarBoundingBox3f bbox() const override {
         ScalarPoint3f p = m_to_world.scalar() * ScalarPoint3f(0.f);
         return ScalarBoundingBox3f(p, p);

--- a/src/sensors/orthographic.cpp
+++ b/src/sensors/orthographic.cpp
@@ -169,9 +169,12 @@ public:
     }
 
     ProjectiveTransform4f projection_transform() const override {
-        // Convert AffineTransform4f to ProjectiveTransform4f and invert
         auto camera_to_sample = m_sample_to_camera.inverse();
         return ProjectiveTransform4f(camera_to_sample.matrix);
+    }
+
+    ProjectiveTransform4f sample_to_camera() const override {
+        return ProjectiveTransform4f(m_sample_to_camera.matrix);
     }
 
     ScalarBoundingBox3f bbox() const override {

--- a/src/sensors/perspective.cpp
+++ b/src/sensors/perspective.cpp
@@ -282,6 +282,10 @@ public:
         return m_sample_to_camera.inverse();
     }
 
+    ProjectiveTransform4f sample_to_camera() const override {
+        return m_sample_to_camera;
+    }
+
     std::pair<DirectionSample3f, Spectrum>
     sample_direction(const Interaction3f &it, const Point2f & /*sample*/,
                      Mask active) const override {

--- a/src/sensors/perspective.cpp
+++ b/src/sensors/perspective.cpp
@@ -278,6 +278,10 @@ public:
         return { ray, wav_weight };
     }
 
+    ProjectiveTransform4f projection_transform() const override {
+        return m_sample_to_camera.inverse();
+    }
+
     std::pair<DirectionSample3f, Spectrum>
     sample_direction(const Interaction3f &it, const Point2f & /*sample*/,
                      Mask active) const override {

--- a/src/sensors/tests/test_projection_matrix.py
+++ b/src/sensors/tests/test_projection_matrix.py
@@ -1,0 +1,79 @@
+import pytest
+import drjit as dr
+import mitsuba as mi
+
+
+def create_perspective_camera(fov=45):
+    camera_dict = {
+        "type": "perspective",
+        "near_clip": 0.1,
+        "far_clip": 100.0,
+        "fov": fov,
+        "to_world": mi.ScalarTransform4f().look_at(
+            origin=[0, 0, 0],
+            target=[0, 0, 1],
+            up=[0, 1, 0]
+        ),
+        "film": {
+            "type": "hdrfilm",
+            "width": 640,
+            "height": 480,
+        }
+    }
+    return mi.load_dict(camera_dict)
+
+
+def create_orthographic_camera():
+    camera_dict = {
+        "type": "orthographic",
+        "near_clip": 0.1,
+        "far_clip": 100.0,
+        "to_world": mi.ScalarTransform4f().look_at(
+            origin=[0, 0, 0],
+            target=[0, 0, 1],
+            up=[0, 1, 0]
+        ),
+        "film": {
+            "type": "hdrfilm",
+            "width": 640,
+            "height": 480,
+        }
+    }
+    return mi.load_dict(camera_dict)
+
+
+def test_perspective_matches_manual_calculation(variant_scalar_rgb):
+    """Test that perspective camera projection matrix matches mi.perspective_projection()"""
+    sensor = create_perspective_camera(fov=45)
+
+    # Get projection matrix from the sensor
+    proj_matrix = sensor.projection_transform()
+
+    # Calculate manually using mi.perspective_projection
+    film = sensor.film()
+    x_fov = mi.traverse(sensor)['x_fov']
+    manual_proj = mi.perspective_projection(
+        film.size(), film.crop_size(), film.crop_offset(),
+        x_fov, sensor.near_clip(), sensor.far_clip()
+    )
+
+    # They should be identical
+    assert dr.allclose(proj_matrix.matrix, manual_proj.matrix)
+
+
+def test_orthographic_matches_manual_calculation(variant_scalar_rgb):
+    """Test that orthographic camera projection matrix matches mi.orthographic_projection()"""
+    sensor = create_orthographic_camera()
+
+    # Get projection matrix from the sensor
+    proj_matrix = sensor.projection_transform()
+
+    # Calculate manually using mi.orthographic_projection
+    film = sensor.film()
+    manual_proj = mi.orthographic_projection(
+        film.size(), film.crop_size(), film.crop_offset(),
+        sensor.near_clip(), sensor.far_clip()
+    )
+
+    # They should be identical
+    assert dr.allclose(proj_matrix.matrix, manual_proj.matrix)

--- a/src/sensors/tests/test_projection_matrix.py
+++ b/src/sensors/tests/test_projection_matrix.py
@@ -83,18 +83,18 @@ def test_sample_to_camera_is_inverse_of_projection_transform(variant_scalar_rgb)
     """Test that sample_to_camera() returns the inverse of projection_transform()"""
     # Test with perspective camera
     sensor = create_perspective_camera(fov=45)
-    
+
     proj_matrix = sensor.projection_transform()
     sample_to_cam = sensor.sample_to_camera()
-    
+
     # sample_to_camera should be the inverse of projection_transform
     assert dr.allclose(sample_to_cam.matrix, proj_matrix.inverse().matrix)
-    
+
     # Test with orthographic camera
     sensor = create_orthographic_camera()
-    
+
     proj_matrix = sensor.projection_transform()
     sample_to_cam = sensor.sample_to_camera()
-    
+
     # sample_to_camera should be the inverse of projection_transform
     assert dr.allclose(sample_to_cam.matrix, proj_matrix.inverse().matrix)

--- a/src/sensors/tests/test_projection_matrix.py
+++ b/src/sensors/tests/test_projection_matrix.py
@@ -77,3 +77,24 @@ def test_orthographic_matches_manual_calculation(variant_scalar_rgb):
 
     # They should be identical
     assert dr.allclose(proj_matrix.matrix, manual_proj.matrix)
+
+
+def test_sample_to_camera_is_inverse_of_projection_transform(variant_scalar_rgb):
+    """Test that sample_to_camera() returns the inverse of projection_transform()"""
+    # Test with perspective camera
+    sensor = create_perspective_camera(fov=45)
+    
+    proj_matrix = sensor.projection_transform()
+    sample_to_cam = sensor.sample_to_camera()
+    
+    # sample_to_camera should be the inverse of projection_transform
+    assert dr.allclose(sample_to_cam.matrix, proj_matrix.inverse().matrix)
+    
+    # Test with orthographic camera
+    sensor = create_orthographic_camera()
+    
+    proj_matrix = sensor.projection_transform()
+    sample_to_cam = sensor.sample_to_camera()
+    
+    # sample_to_camera should be the inverse of projection_transform
+    assert dr.allclose(sample_to_cam.matrix, proj_matrix.inverse().matrix)

--- a/src/sensors/thinlens.cpp
+++ b/src/sensors/thinlens.cpp
@@ -212,6 +212,10 @@ public:
                         m_x_fov, m_image_rect, m_normalization);
     }
 
+    ProjectiveTransform4f projection_transform() const override {
+        return m_sample_to_camera.inverse();
+    }
+
     std::pair<Ray3f, Spectrum> sample_ray(Float time, Float wavelength_sample,
                                           const Point2f &position_sample,
                                           const Point2f &aperture_sample,

--- a/src/sensors/thinlens.cpp
+++ b/src/sensors/thinlens.cpp
@@ -216,6 +216,10 @@ public:
         return m_sample_to_camera.inverse();
     }
 
+    ProjectiveTransform4f sample_to_camera() const override {
+        return m_sample_to_camera;
+    }
+
     std::pair<Ray3f, Spectrum> sample_ray(Float time, Float wavelength_sample,
                                           const Point2f &position_sample,
                                           const Point2f &aperture_sample,


### PR DESCRIPTION
This PR replaces a manually derived expression with AD and extends support for orthographic cameras when handling a specific type of discontinuity.

## Description
To compute __primarily visible discontinuous derivatives__ (enabled via `sppp` parameter in `*_projective` integrators), we implemented the edge sampling algorithm [[Li et al. 2018]](https://cseweb.ucsd.edu/~tzli/diffrt/). This requires evaluating two Jacobian determinants: (1) To convert the silhouette curve length from scene space to sample space for sampling PDF, and (2) to transform scene-space normal motion $\partial p/\partial \pi$ into motion on the film plane as the pixel integral is defined there. 
The original paper targets triangle meshes and computes differentials after projecting both endpoints of a silhouette triangle edge onto the film. This is not directly applicable in Mitsuba, which supports a wider range of shape primitives---including smooth ones.
Previously, the overall Jacobian determinant was computed using a manually derived expression. This had two major issues:
- It is hardcoded for perspective cameras.
- The code was difficult to read, understand, and maintain.

This PR replaces it with Autodiff.