### PR TITLE
[FIX] Fix  `Scene::sample_emitter_ray` missing emitter assignment.

### DIFF
--- a/src/render/scene.cpp
+++ b/src/render/scene.cpp
@@ -310,6 +310,7 @@ Scene<Float, Spectrum>::sample_emitter_ray(Float time, Float sample1,
     } else if (emitter_count == 1) {
         std::tie(ray, weight) =
             m_emitters[0]->sample_ray(time, sample1, sample2, sample3, active);
+        emitter = m_emitters[0].get();
     } else {
         ray = dr::zeros<Ray3f>();
         weight = dr::zeros<Spectrum>();


### PR DESCRIPTION
## Description

Hello, This PR aims to fix an issue I found whereby calling `sample_emitter_ray` does not return a valid emitter. This edge case happens when the scene has only one emitter in scalar mode. Here is a minimal reproducer:

```
import mitsuba as mi
mi.set_variant("scalar_rgb")

scene = mi.load_dict({
    "type":"scene",
    "light": {
        "type": "point",
    },
})

time = 0.
sample1 = 0.5
sample2 = mi.Point2f(0.1,0.2)
sample3 = mi.Point2f(0.3,0.3)
active = True
ray, weight, emitter = scene.sample_emitter_ray(time, sample1, sample2, sample3, active)
print(emitter)
```
This PR adds an assignment of the emitter pointer to the returned `EmitterPtr`.

It's a fairly minimal change, let me know if leaving this out was intentional or if this needs additional tests or comments.
Many thanks!

## Testing

- Run the reproducer with the fix, which returns a valid emitter. 
- Run the full test suite. **I could not however test it in CUDA.**

## Checklist

<!-- Please make sure to complete this checklist before requesting a review. -->

- [X] My code follows the [style guidelines](https://mitsuba.readthedocs.io/en/latest/src/developer_guide.html#coding-style) of this project
- [X] My changes generate no new warnings
- [ ] My code also compiles for `cuda_*` and `llvm_*` variants. If you can't test this, please leave below
- [ ] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I cleaned the commit history and removed any "Merge" commits
- [X] I give permission that the Mitsuba 3 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba/blob/master/LICENSE)