### PR TITLE
Improved ``TensorFile`` API

### DIFF
--- a/src/core/python/drjit_v.cpp
+++ b/src/core/python/drjit_v.cpp
@@ -128,6 +128,7 @@ MI_PY_EXPORT(DrJit) {
     constexpr SuffixMapping float_mappings[] = {
         { "f",   is_double_precision ? "f64" : "f" },
         { "f32", "f" },
+        { "f16", "f16" },
         { "f64", "f64" },
         { "d",   "f64" }
     };
@@ -149,8 +150,15 @@ MI_PY_EXPORT(DrJit) {
             std::string name = prefix + map.mitsuba_suffix;
             std::string dr_name = prefix + map.drjit_suffix;
 
-            m.attr(name.c_str()) = drjit_variant.attr(dr_name.c_str());
-            m.attr(("Scalar" + name).c_str()) = drjit_scalar.attr(dr_name.c_str());
+            nb::object value = nb::getattr(drjit_variant, dr_name.c_str(), nb::handle());
+
+            if (value.is_valid())
+                m.attr(name.c_str()) = value;
+
+            value = nb::getattr(drjit_scalar, dr_name.c_str(), nb::handle());
+
+            if (value.is_valid())
+                m.attr(("Scalar" + name).c_str()) = value;
         }
     };
 

--- a/src/core/python/mmap.cpp
+++ b/src/core/python/mmap.cpp
@@ -1,18 +1,24 @@
 #include <nanobind/nanobind.h> // Needs to be first, to get `ref<T>` caster
 #include <mitsuba/core/mmap.h>
 #include <mitsuba/core/filesystem.h>
+#include <mitsuba/core/tensor.h>
 #include <mitsuba/python/python.h>
 
 #include <nanobind/ndarray.h>
+#include <nanobind/stl/string_view.h>
+#include <nanobind/stl/string.h>
+
+#include <drjit/tensor.h>
+#include <drjit/python.h>
 
 MI_PY_EXPORT(MemoryMappedFile) {
     MI_PY_CLASS(MemoryMappedFile, Object)
-        .def(nb::init<const mitsuba::filesystem::path &, size_t>(),
+        .def(nb::init<const fs::path &, size_t>(),
             D(MemoryMappedFile, MemoryMappedFile), "filename"_a, "size"_a)
-        .def(nb::init<const mitsuba::filesystem::path &, bool>(),
+        .def(nb::init<const fs::path &, bool>(),
             D(MemoryMappedFile, MemoryMappedFile, 2), "filename"_a, "write"_a = false)
-        .def("__init__", [](MemoryMappedFile* t, 
-            const mitsuba::filesystem::path &p, 
+        .def("__init__", [](MemoryMappedFile* t,
+            const fs::path &p,
             nb::ndarray<nb::device::cpu> array) {
             size_t size = array.size() * array.itemsize();
             auto m = new (t) MemoryMappedFile(p, size);
@@ -27,4 +33,54 @@ MI_PY_EXPORT(MemoryMappedFile) {
         .def("__array__", [](MemoryMappedFile &m) {
             return nb::ndarray<nb::numpy, uint8_t>((uint8_t*) m.data(), { m.size() }, nb::handle());
         }, nb::rv_policy::reference_internal);
+
+    auto tf = MI_PY_CLASS(TensorFile, MemoryMappedFile)
+        .def(nb::init<fs::path>())
+        .def("__contains__", &TensorFile::has_field)
+        .def("__getitem__", &TensorFile::field, nb::rv_policy::reference_internal);
+
+    nb::class_<TensorFile::Field>(tf, "Field")
+        .def_ro("dtype", &TensorFile::Field::dtype)
+        .def_ro("offset", &TensorFile::Field::offset)
+        .def_ro("shape", &TensorFile::Field::shape)
+        .def("__repr__", &TensorFile::Field::to_string)
+        .def("to", [](TensorFile::Field &f, nb::type_object_t<dr::ArrayBase> tp) -> nb::object {
+            const auto &s = nb::type_supplement<dr::ArraySupplement>(tp);
+            if (!s.is_tensor)
+                nb::raise_type_error("to(): 'dtype' must be a Dr.Jit tensor type!");
+
+            nb::object tensor = nb::inst_alloc_zero(tp);
+            nb::object array = nb::steal(s.tensor_array(tensor.ptr()));
+            dr::vector<size_t> &shape = s.tensor_shape(nb::inst_ptr<dr::ArrayBase>(tensor));
+
+            using Type = Struct::Type;
+            VarType vt;
+            switch (f.dtype) {
+                case Type::UInt32: vt = VarType::UInt32; break;
+                case Type::Int32: vt = VarType::Int32; break;
+                case Type::UInt64: vt = VarType::UInt64; break;
+                case Type::Int64: vt = VarType::Int64; break;
+                case Type::Float16: vt = VarType::Float16; break;
+                case Type::Float32: vt = VarType::Float32; break;
+                case Type::Float64: vt = VarType::Float64; break;
+                default: vt = VarType::Void;
+            }
+
+            if (vt != (VarType) s.type)
+                nb::raise_type_error("to(): incompatible dtype (got %s, field has type %s)",
+                                     jit_type_name((VarType) s.type),
+                                     jit_type_name(vt));
+
+            size_t size = 1;
+            shape.reserve(f.shape.size());
+            for (size_t s : f.shape) {
+                size *= s;
+                shape.push_back(s);
+            }
+
+            const auto &s2 = nb::type_supplement<dr::ArraySupplement>(s.array);
+            s2.init_data(size, f.data, nb::inst_ptr<dr::ArrayBase>(array));
+
+            return tensor;
+        }, "dtype"_a);
 }

--- a/src/python/python/__init__.py
+++ b/src/python/python/__init__.py
@@ -3,3 +3,4 @@ from . import chi2
 from . import ad
 from . import math_py
 from . import testing
+from . import tensor_io

--- a/src/python/python/tensor_io.py
+++ b/src/python/python/tensor_io.py
@@ -1,0 +1,142 @@
+import numpy as np
+import struct
+import os
+
+
+def size_fmt(num, suffix='B'):
+    for unit in ['', 'Ki', 'Mi', 'Gi', 'Ti', 'Pi']:
+        if abs(num) < 1024.0:
+            return "%3.1f %s%s" % (num, unit, suffix)
+        num /= 1024.0
+    return "%.1f %s%s" % (num, 'Yi', suffix)
+
+
+def read(filename):
+    with open(filename, 'rb') as f:
+        def unpack(fmt):
+            result = struct.unpack(fmt, f.read(struct.calcsize(fmt)))
+            return result if len(result) > 1 else result[0]
+
+        if f.read(12) != 'tensor_file\0'.encode('utf8'):
+            raise Exception('Invalid tensor file (header not recognized)')
+
+        if unpack('<BB') != (1, 0):
+            raise Exception('Invalid tensor file (unrecognized '
+                            'file format version)')
+
+        field_count = unpack('<I')
+        size = os.stat(filename).st_size
+        print('Loading tensor data from \"%s\" .. (%s, %i field%s)'
+            % (filename, size_fmt(size),
+               field_count, 's' if field_count > 1 else ''))
+
+        # Maps from Struct.EType field in Mitsuba
+        dtype_map = {
+            1: np.uint8,
+            2: np.int8,
+            3: np.uint16,
+            4: np.int16,
+            5: np.uint32,
+            6: np.int32,
+            7: np.uint64,
+            8: np.int64,
+            9: np.float16,
+            10: np.float32,
+            11: np.float64
+        }
+
+        fields = {}
+        for i in range(field_count):
+            field_name = f.read(unpack('<H')).decode('utf8')
+            field_ndim = unpack('<H')
+            field_dtype = dtype_map[unpack('<B')]
+            field_offset = unpack('<Q')
+            field_shape = unpack('<' + 'Q' * field_ndim)
+            fields[field_name] = (field_offset, field_dtype, field_shape)
+
+        result = {}
+        for k, v in fields.items():
+            f.seek(v[0])
+            result[k] = np.fromfile(f, dtype=v[1],
+                                    count=np.prod(v[2])).reshape(v[2])
+    return result
+
+
+def write(filename, align=8, **kwargs):
+    with open(filename, 'wb') as f:
+        # Identifier
+        f.write('tensor_file\0'.encode('utf8'))
+
+        # Version number
+        f.write(struct.pack('<BB', 1, 0))
+
+        # Number of fields
+        f.write(struct.pack('<I', len(kwargs)))
+
+        # Maps to Struct.EType field in Mitsuba
+        dtype_map = {
+            np.uint8: 1,
+            np.int8: 2,
+            np.uint16: 3,
+            np.int16: 4,
+            np.uint32: 5,
+            np.int32: 6,
+            np.uint64: 7,
+            np.int64: 8,
+            np.float16: 9,
+            np.float32: 10,
+            np.float64: 11
+        }
+
+        offsets = {}
+        fields = dict(kwargs)
+
+        # Write all fields
+        for k, v in fields.items():
+            if type(v) is str:
+                v = np.frombuffer(v.encode('utf8'), dtype=np.uint8)
+            else:
+                v = np.ascontiguousarray(v)
+            fields[k] = v
+
+            # Field identifier
+            label = k.encode('utf8')
+            f.write(struct.pack('<H', len(label)))
+            f.write(label)
+
+            # Field dimension
+            f.write(struct.pack('<H', v.ndim))
+
+            found = False
+            for dt in dtype_map.keys():
+                if dt == v.dtype:
+                    found = True
+                    f.write(struct.pack('B', dtype_map[dt]))
+                    break
+            if not found:
+                raise Exception("Unsupported dtype: %s" % str(v.dtype))
+
+            # Field offset (unknown for now)
+            offsets[k] = f.tell()
+            f.write(struct.pack('<Q', 0))
+
+            # Field sizes
+            f.write(struct.pack('<' + ('Q' * v.ndim), *v.shape))
+
+        for k, v in fields.items():
+            # Set field offset
+            pos = f.tell()
+
+            # Pad to requested alignment
+            pos = (pos + align - 1) // align * align
+
+            f.seek(offsets[k])
+            f.write(struct.pack('<Q', pos))
+            f.seek(pos)
+
+            # Field data
+            v.tofile(f)
+
+        print('Wrote \"%s\" (%s)' % (filename, size_fmt(f.tell())))
+
+


### PR DESCRIPTION
Mitsuba ships with a memory-mapped ``TensorFile`` class that provides a lightweight and convenient way to get tensors from some other tool (e.g. NumPy) into Mitsuba.

This commit makes it easer to work with such tensor files.

1. *Creation*: the ``tensor_io`` module now provides an API to write an arbitrary number of names tensors to a ``TensorFile``-compatible representation:

   ```python
   mi.tensor_io.write("my_tensor.data", tensor_1=.., tensor_2=..)
   ```

2. *Reading*: similarly, ``tensor_io`` can turn ``TensorFile`` contents back into NumPy arrays:

   ```python
   data = mi.tensor_io.read("my_tensor.data")
   tensor_1 = data['tensor_1'] # ...
   ```
   
3. In C++, use
    ```cpp
    tensor_file.field("field_name").as<TensorXf>()
    ```

    to obtain a device tensor handle to the data.
