### PR TITLE
Fix weights in `sample_wavelengths` when using SRF.

### DIFF
--- a/src/films/specfilm.cpp
+++ b/src/films/specfilm.cpp
@@ -301,17 +301,12 @@ public:
         SurfaceInteraction3f si = dr::zeros<SurfaceInteraction3f>();
         si.wavelengths = wavelengths;
 
-        // The SRF is not necessarily normalized, cancel out multiplicative factors
-        UnpolarizedSpectrum inv_spec = m_srf->eval(si);
-        inv_spec = dr::select(inv_spec != 0.f, dr::rcp(inv_spec), 1.f);
-        UnpolarizedSpectrum values = spec * inv_spec;
-
         for (size_t j = 0; j < m_srfs.size(); ++j) {
             UnpolarizedSpectrum weights = m_srfs[j]->eval(si);
             aovs[j] = dr::zeros<Float>();
 
             for (size_t i = 0; i<Spectrum::Size; ++i)
-                aovs[j] = dr::fmadd(weights[i], values[i], aovs[j]);
+                aovs[j] = dr::fmadd(weights[i], spec[i], aovs[j]);
 
             aovs[j] *= 1.f / Spectrum::Size;
         }


### PR DESCRIPTION
## Description

This PR fixes the weight (inverse PDF) calculation in `Sensor::sample_wavelengths()` when sampling through a user-defined SRF (`m_srf`), making its behavior consistent with the default path (`sample_rgb_spectrum()`).

Previously, the implementation directly returned `m_srf->sample_spectrum()`, which maps to `RegularSpectrum::sample_spectrum()` or `IrregularSpectrum::sample_spectrum()`. The second return value from that function was `m_distr.integral()`, which is not the inverse PDF.

With this change, I removed the redundant weight multiplication in `SpecFilm::prepare_sample()`, simplifying the code.

Furthermore, rendering with a user-defined SRF in the sensor now produces the correct RGB image. I tested using the following code:

```python
import mitsuba as mi

# mi.set_variant("scalar_spectral")
mi.set_variant("llvm_ad_spectral")

scene_dict = {
    "type": "scene",
    "integrator": {"type": "path"},
    "emitter": {"type": "sunsky"},
    "sphere": {
        "type": "sphere",
        "bsdf": {"type": "diffuse", "reflectance": {"type": "rgb", "value": [0.7, 0.1, 0.1]}},
    },
    "floor": {
        "type": "rectangle",
        "to_world": mi.ScalarTransform4f().translate([0, 0, -1]).scale(40),
        "bsdf": {
            "type": "diffuse",
            "reflectance": {"type": "checkerboard", "color0": 0.1, "color1": 0.8, "to_uv": mi.ScalarTransform4f().scale(8.0)},
        },
    },
    "sensor": {
        "type": "perspective",
        "to_world": mi.ScalarTransform4f().look_at(origin=[3, 4, 1.5], target=[0.5, 0.5, 0], up=[0, 0, 1]),
        "fov": 45,
        "film": {"type": "hdrfilm", "width": 400, "height": 400},
        "srf": {
            "type": "regular",
            "wavelength_min": mi.MI_CIE_MIN,
            "wavelength_max": mi.MI_CIE_MAX,
            "values": "1.0, 0.1, 1.0",
        },  # User-defined (extreme) SRF
    },
}

scene = mi.load_dict(scene_dict)
result = mi.render(scene, spp=64)
mi.Bitmap(result).write("output.exr")
```

| Previous (default) | Previous (with user-defined SRF) | Fixed (with user-defined SRF) |
| :-: | :-: | :-: |
| ![hdrfilm_default_prev](https://github.com/user-attachments/assets/0694790e-6962-400a-b390-1b257a6b5974) | ![hdrfilm_srf_prev](https://github.com/user-attachments/assets/7e4e902f-dbd2-4034-8c94-b907c4b8e4cf) | ![hdrfilm_srf_new](https://github.com/user-attachments/assets/8606534a-adfc-40d0-8dc5-bbb33094043d) |

While providing a custom SRF is an uncommon scenario, this fix ensures correctness for those cases.

## Checklist

- [x] My code follows the [style guidelines](https://mitsuba.readthedocs.io/en/latest/src/developer_guide.html#coding-style) of this project
- [x] My changes generate no new warnings
- [ ] My code also compiles for `cuda_*` and `llvm_*` variants. If you can't test this, please leave below
- [ ] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 3 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba/blob/master/LICENSE)