### PR TITLE
Fix minor parser issues

### DIFF
--- a/src/core/parser.cpp
+++ b/src/core/parser.cpp
@@ -409,9 +409,11 @@ static ScalarVector3d parse_vector_from_string(const ParserState &state,
  */
 std::string file_location(const ParserState &state, const SceneNode &node) {
     // First check if we have a path from dictionary parsing
-    size_t node_idx = &node - &state.nodes[0];  // Get index of this node
-    if (node_idx < state.node_paths.size() && !state.node_paths[node_idx].empty())
-        return tfm::format("dictionary node \"%s\"", state.node_paths[node_idx]);
+    if (!state.nodes.empty()) {
+        size_t node_idx = &node - &state.nodes[0];  // Get index of this node
+        if (node_idx < state.node_paths.size() && !state.node_paths[node_idx].empty())
+            return tfm::format("dictionary node \"%s\"", state.node_paths[node_idx]);
+    }
 
     // Fall back to XML file location logic
     if (node.file_index >= state.files.size()) {

--- a/src/core/tests/test_parser.py
+++ b/src/core/tests/test_parser.py
@@ -621,11 +621,14 @@ def test28_parameter_substitution_warnings(variant_scalar_rgb):
     # Test multiple unused parameters - check exact error message format
     config = mi.parser.ParserConfig('scalar_rgb')
     config.unused_parameters = mi.LogLevel.Error
+
+    # Parameter keys are sorted by size. By using keys of different lengths,
+    # we can assert that the error message is always formatted in the same way.
     with pytest.raises(RuntimeError) as excinfo:
-        mi.parser.parse_string(config, xml, param1="value1", param2="value2", param3="value3")
+        mi.parser.parse_string(config, xml, param001="value1", param02="value2", param3="value3")
 
     # Check exact error message format
-    expected = "Found unused parameters:\n  - $param1=value1\n  - $param2=value2\n  - $param3=value3"
+    expected = "Found unused parameters:\n  - $param001=value1\n  - $param02=value2\n  - $param3=value3"
     assert error_string(excinfo.value) == expected
 
     # With config.unused_parameters=Debug, the operation should succeed


### PR DESCRIPTION
This PR fixes two issues I found in the new parser:

1) The test `test28_parameter_substitution_warnings` relied on the ordering of the `kwargs` being passed to a Python function. This ordering is not guaranteed and the test failed if a different order was obtained at runtime. I modified the test to use parameter keys of different lengths. The parser internally sorts by length, so this makes the test stable under arbitrary kwarg ordering

2) The `file_location` function should check if `state.nodes` is empty before trying to access. I was getting an invalid index issue otherwise.