### PR TITLE
Add eval_3 to uniform texture plugin

### DIFF
--- a/src/spectra/uniform.cpp
+++ b/src/spectra/uniform.cpp
@@ -79,6 +79,11 @@ public:
         return m_value;
     }
 
+    Color3f eval_3(const SurfaceInteraction3f & /*it*/, Mask active) const override {
+        MI_MASKED_FUNCTION(ProfilerPhase::TextureEvaluate, active);
+        return Color3f(m_value);
+    }
+
     Vector2f eval_1_grad(const SurfaceInteraction3f & /*it*/, Mask active) const override {
         MI_MASKED_FUNCTION(ProfilerPhase::TextureEvaluate, active);
         return 0.0;


### PR DESCRIPTION
This patch implements ` UniformSpectrum::eval_3()` which was missing.