### PR TITLE
Bugfix Sunsky

### DIFF
--- a/src/emitters/tests/test_timed_sunsky.py
+++ b/src/emitters/tests/test_timed_sunsky.py
@@ -193,6 +193,7 @@ def test04_sun_and_sky_sampling(variants_vec_backends_once, turb, start_day):
         "start_day": start_day,
         # Increase the sun aperture to avoid errors with chi2's resolution
         "sun_aperture": 30.0,
+        "window_start_time": 9,
         "albedo": 0.5
     })
 


### PR DESCRIPTION
This PR addresses an issue where the decision whether the sun was hit was made twice for the same ray and yielding different results due to numerical errors. This caused fireflies that were most visible using the `ptracer` integrator, and can be seen on the garage door, the tower's roof and the balcony rail of the following scene:

### Before changes:
![scene_before](https://github.com/user-attachments/assets/806905b2-9723-4c3b-a9e3-3e826a04257e)

### After changes:
![scene_after](https://github.com/user-attachments/assets/4493939b-be05-478b-8b9c-e643c074359c)
