### PR TITLE
Extra check when updating `UniformSpectrum`

### DIFF
--- a/src/spectra/uniform.cpp
+++ b/src/spectra/uniform.cpp
@@ -61,6 +61,9 @@ public:
     }
 
     void parameters_changed(const std::vector<std::string> &/*keys*/ = {}) override {
+        if constexpr (dr::is_jit_v<Float>)
+            if (unlikely(m_value.size() != 1))
+                Throw("Updated the uniform spectrum with a float of size %d", m_value.size());
         dr::make_opaque(m_value);
     }
 


### PR DESCRIPTION
Currently, updating a `UniformSpectrum` with a `mi.ScalarColor3f` is valid and caused it to have a buffer of size 3 in `m_value`. This provokes a silent broadcast to a wavefront of 3 colors when calling `eval3`. 

A check is thus added to warn the user instead of causing an invalid size operation in JIT compilation.