### PR TITLE
Add support for vcalls of Texture

### DIFF
--- a/include/mitsuba/render/fwd.h
+++ b/include/mitsuba/render/fwd.h
@@ -104,6 +104,7 @@ template <typename Float_, typename Spectrum_> struct RenderAliases {
     using MeshPtr                = dr::replace_scalar_t<Float, const Mesh *>;
     using SensorPtr              = dr::replace_scalar_t<Float, const Sensor *>;
     using EmitterPtr             = dr::replace_scalar_t<Float, const Emitter *>;
+    using TexturePtr             = dr::replace_scalar_t<Float, const Texture *>;
 };
 
 /**

--- a/include/mitsuba/render/texture.h
+++ b/include/mitsuba/render/texture.h
@@ -230,3 +230,22 @@ protected:
 
 MI_EXTERN_CLASS(Texture)
 NAMESPACE_END(mitsuba)
+
+// -----------------------------------------------------------------------
+//! @{ \name Enables vectorized method calls on Dr.Jit arrays of Textures
+// -----------------------------------------------------------------------
+
+DRJIT_CALL_TEMPLATE_BEGIN(mitsuba::Texture)
+    DRJIT_CALL_METHOD(eval)
+    DRJIT_CALL_METHOD(sample_spectrum)
+    DRJIT_CALL_METHOD(pdf_spectrum)
+    DRJIT_CALL_METHOD(sample_position)
+    DRJIT_CALL_METHOD(pdf_position)
+    DRJIT_CALL_METHOD(eval_1)
+    DRJIT_CALL_METHOD(eval_1_grad)
+    DRJIT_CALL_METHOD(eval_3)
+    DRJIT_CALL_METHOD(mean)
+
+    DRJIT_CALL_GETTER(max)
+    DRJIT_CALL_GETTER(is_spatially_varying)
+DRJIT_CALL_END()

--- a/src/render/tests/test_texture.py
+++ b/src/render/tests/test_texture.py
@@ -1,0 +1,61 @@
+import pytest
+import drjit as dr
+import mitsuba as mi
+import numpy as np
+
+def test01_vcalls(variants_vec_backends_once_rgb):
+    # Create a set of textures to test
+    tex1 = mi.load_dict({
+        'type' : 'uniform',
+        'value' : 5.0
+    })
+    tex2 = mi.load_dict({
+        'type' : 'uniform',
+        'value' : 28
+    })
+    tex3 = mi.load_dict({
+        'type' : 'uniform',
+        'value' : 133
+    })
+
+    # Initialize pointer variable
+    textures = dr.zeros(mi.TexturePtr, 6)
+    dr.scatter(textures, tex1, mi.UInt32(0,2))
+    dr.scatter(textures, tex2, mi.UInt32(1,3))
+    dr.scatter(textures, tex3, mi.UInt32(4,5))
+
+    # Evaluate the vcall
+    si = dr.zeros(mi.SurfaceInteraction3f)
+    result = textures.eval(si, True)
+
+    assert dr.allclose(result, mi.Float(5.0, 28.0, 5.0, 28.0, 133.0, 133.0))
+
+def test02_trampoline(variants_vec_backends_once_rgb):
+    class DummyTexture(mi.Texture):
+        def __init__(self, props):
+            mi.Texture.__init__(self, props)
+            self.value = props.get('value')
+
+        def eval(self, si, active):
+            return self.value
+
+        def resolution(self):
+            return 123
+
+        def to_string(self):
+            return f"DummyTexture"
+
+    mi.register_texture('dummy_texture', DummyTexture)
+    texture = mi.load_dict({
+        'type': 'dummy_texture',
+        'value' : 96.0
+    })
+
+    assert texture.resolution() == 123
+    assert str(texture) == "DummyTexture"
+
+    si = dr.zeros(mi.SurfaceInteraction3f)
+    assert dr.allclose(texture.eval(si, True), 96.0)
+    ptr = dr.zeros(mi.TexturePtr, 4)
+    dr.scatter(ptr, texture, mi.UInt32(0,1,2,3))
+    assert dr.allclose(ptr.eval(si, True), 96.0)


### PR DESCRIPTION
<!-- Please add the labels (e.g. bug fix, feature, ..) corresponding to this PR -->

## Description

This PR adds support for allowing vectorized vcalls of Mitsuba's texture plugins.

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

The modifications covered by this PR include defining the macros for vcall support, declaration of the `TexturePtr`, and modification of the python bindings to account for both standard texture and pointers.

## Testing

Added tests that cover vcall execution and trampoline class definition.

## Checklist

<!-- Please make sure to complete this checklist before requesting a review. -->

- [x] My code follows the [style guidelines](https://mitsuba.readthedocs.io/en/latest/src/developer_guide.html#coding-style) of this project
- [x] My changes generate no new warnings
- [x] My code also compiles for `cuda_*` and `llvm_*` variants. If you can't test this, please leave below
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 3 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba/blob/master/LICENSE)