### PR TITLE
Mesh: `opposite_dedge`: special case for uninitialized data structure

### DIFF
--- a/include/mitsuba/render/mesh.h
+++ b/include/mitsuba/render/mesh.h
@@ -164,11 +164,21 @@ public:
         return dr::normalize(dr::cross(v[1] - v[0], v[2] - v[0]));
     }
 
-    /// Returns the opposite edge index associated with directed edge \c index
+    /**
+     * Returns the opposite edge index associated with directed edge \c index
+     *
+     * If the directed edge data structure is not initialized or outdated,
+     * the return value is undefined. Ensure that \ref build_directed_edges()
+     * is called before this method.
+     */
     template <typename Index>
     MI_INLINE auto opposite_dedge(Index index,
                                  dr::mask_t<Index> active = true) const {
         using Result = dr::uint32_array_t<Index>;
+
+        if (dr::width(m_E2E) == 0)
+            return Result((uint32_t) -1);
+
         return dr::gather<Result>(m_E2E, index, active);
     }
 

--- a/src/render/tests/test_mesh.py
+++ b/src/render/tests/test_mesh.py
@@ -1383,3 +1383,30 @@ def test35_mesh_vcalls(variants_vec_rgb):
                       == sh.face_normal(idx_i))
         assert dr.all(dr.gather(type(opposite), opposite, i)
                       == sh.opposite_dedge(idx_i))
+
+
+@fresolver_append_path
+def test36_mesh_vcalls_with_directed_edges(variants_vec_rgb):
+    """
+    Test a special case where some meshes have their E2E data structure
+    initialized and others don't. Virtual function calls involving only
+    the initialized meshes should work.
+    """
+    scene = mi.load_dict({
+        "type": "scene",
+        "mesh1": {
+            "type": "ply",
+            "filename": "resources/data/tests/ply/cbox_smallbox.ply",
+        },
+        "mesh2": {
+            "type": "ply",
+            "filename": "resources/data/tests/ply/cbox_smallbox.ply",
+        },
+    })
+
+    # Second mesh will *not* have a valid E2E data structure.
+    mesh_ptr = dr.gather(mi.MeshPtr, scene.shapes_dr(), dr.zeros(mi.UInt32, 3))
+    mesh_ptr[0].build_directed_edges()
+
+    result = mesh_ptr.opposite_dedge(mi.UInt32([2, 3, 2]))
+    assert dr.all(result == mi.UInt32([3, 2, 3]))


### PR DESCRIPTION
## Description

Fix for a special case where some meshes have their E2E data structure initialized and others don't. Virtual function calls to `Mesh::opposite_dedge` involving only the initialized meshes should work, but they didn't because all meshes in the registry were traced, leading to:

```
RuntimeError: jit_var_gather(): attempted to gather from an empty array!
```

## Testing

Added a unit test.

## Checklist

<!-- Please make sure to complete this checklist before requesting a review. -->

- [x] My code follows the [style guidelines](https://mitsuba.readthedocs.io/en/latest/src/developer_guide.html#coding-style) of this project
- [x] My changes generate no new warnings
- [x] My code also compiles for `cuda_*` and `llvm_*` variants. If you can't test this, please leave below
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 3 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba/blob/master/LICENSE)