### PR TITLE
Python plugins for Blender shader nodes

### DIFF
--- a/src/python/python/__init__.py
+++ b/src/python/python/__init__.py
@@ -2,5 +2,6 @@ from .util import traverse, SceneParameters, render, cornell_box, variant_contex
 from . import chi2
 from . import ad
 from . import math_py
+from . import plugins
 from . import testing
 from . import tensor_io

--- a/src/python/python/plugins/__init__.py
+++ b/src/python/python/plugins/__init__.py
@@ -1,0 +1,1 @@
+from .textures import *

--- a/src/python/python/plugins/textures/__init__.py
+++ b/src/python/python/plugins/textures/__init__.py
@@ -1,0 +1,43 @@
+# Import/re-import all files in this folder to register Python plugins
+import mitsuba as mi
+import sys
+
+if mi.variant() is not None and not mi.variant().startswith('scalar'):
+    # List of submodules to import
+    submodules = [
+        'brightness_contrast',
+        'clamp',
+        'combine_color',
+        'curves',
+        'hue_saturation',
+        'invert_color',
+        'map_range',
+        'math',
+        'mesh_attribute_adapter',
+        'noise',
+        'normalmap',
+        'rgb_to_bw',
+        'separate_rgb',
+        'texture_coordinate',
+        'udim',
+        'uv_wrapper',
+        'vector_math'
+    ]
+
+    # Are we importing the submodules for the first time or reloading them?
+    reload = submodules[0] in globals()
+
+    import importlib
+    module, name = None, None
+
+    for name in submodules:
+        module = importlib.import_module(f'.{name}', package=__name__)
+        if reload:
+            importlib.reload(module)
+
+        # Make the submodule available at package level
+        globals()[name] = module
+
+    del importlib, name, submodules, module, reload
+
+del mi, sys

--- a/src/python/python/plugins/textures/brightness_contrast.py
+++ b/src/python/python/plugins/textures/brightness_contrast.py
@@ -1,0 +1,47 @@
+from __future__ import annotations # Delayed parsing of type annotations
+
+import drjit as dr
+import mitsuba as mi
+
+class BrightnessContrast(mi.Texture):
+    '''
+    Brightness Contrast Blender shader node texture.
+    '''
+    def __init__(self, props):
+        mi.Texture.__init__(self, props)
+        self.color      = props.get_texture('color')
+        self.brightness = props.get_texture('brightness', 0.0)
+        self.contrast   = props.get_texture('contrast', 0.0)
+
+    def traverse(self, cb):
+        cb.put('color',      self.color,      +mi.ParamFlags.Differentiable)
+        cb.put('brightness', self.brightness, +mi.ParamFlags.Differentiable)
+        cb.put('contrast',   self.contrast,   +mi.ParamFlags.Differentiable)
+
+    def eval(self, si, active):
+        return mi.UnpolarizedSpectrum(self.process(self.color.eval(si, active), si, active))
+
+    def eval_1(self, si, active):
+        return mi.Float(self.process(self.color.eval_1(si, active), si, active))
+
+    def eval_3(self, si, active):
+        return mi.Color3f(self.process(self.color.eval_3(si, active), si, active))
+
+    def process(self, color, si, active):
+        brightness = self.brightness.eval_1(si, active)
+        contrast   = self.contrast.eval_1(si, active)
+        return dr.maximum((1.0 + contrast) * color + (brightness - contrast * 0.5), 0.0)
+
+    def mean(self):
+        return self.color.mean() # TODO best effort
+
+    def resolution(self):
+        return mi.ScalarVector2i(1, 1)
+
+    def is_spatially_varying(self):
+        return any([t.is_spatially_varying() for t in [self.color, self.brightness, self.contrast]])
+
+    def to_string(self):
+        return f'BrightnessContrast[color={self.color}, brightness={self.brightness}, contrast={self.contrast}]'
+
+mi.register_texture('brightness_contrast', lambda props: BrightnessContrast(props))

--- a/src/python/python/plugins/textures/clamp.py
+++ b/src/python/python/plugins/textures/clamp.py
@@ -1,0 +1,56 @@
+from __future__ import annotations # Delayed parsing of type annotations
+
+import drjit as dr
+import mitsuba as mi
+
+class Clamp(mi.Texture):
+    '''
+    Clamp Blender shader node texture.
+    '''
+    def __init__(self, props):
+        mi.Texture.__init__(self, props)
+        self.input = props.get_texture('input', 1.0)
+        self.min = props.get_texture('min', 0.0)
+        self.max = props.get_texture('max', 1.0)
+        self.clamp_type = props.get('clamp_type', 'RANGE')
+
+    def traverse(self, cb):
+        cb.put('input', self.input, +mi.ParamFlags.Differentiable)
+        cb.put('min', self.min, +mi.ParamFlags.Differentiable)
+        cb.put('max', self.max, +mi.ParamFlags.Differentiable)
+
+    def parameters_changed(self, keys):
+        pass
+
+    def eval(self, si, active):
+        return mi.UnpolarizedSpectrum(self.process(self.input.eval(si, active), si, active))
+
+    def eval_1(self, si, active):
+        return mi.Float(self.process(self.input.eval_1(si, active), si, active))
+
+    def eval_3(self, si, active):
+        return mi.Color3f(self.process(self.input.eval_3(si, active), si, active))
+
+    def process(self, value, si, active):
+        min_value = self.min.eval_1(si, active)
+        max_value = self.max.eval_1(si, active)
+
+        if self.clamp_type == 'RANGE':
+            min_value, max_value = dr.minimum(min_value, max_value), dr.maximum(min_value, max_value)
+            return dr.clip(value, min_value, max_value)
+        else:
+            return dr.minimum(dr.maximum(value, min_value), max_value)
+
+    def mean(self):
+        return self.input.mean() # TODO best effort
+
+    def resolution(self):
+        return self.input.resolution()
+
+    def is_spatially_varying(self):
+        return any([t.is_spatially_varying() for t in [self.input, self.min, self.max]])
+
+    def to_string(self):
+        return f'Clamp[input={self.input}]'
+
+mi.register_texture('clamp', lambda props: Clamp(props))

--- a/src/python/python/plugins/textures/combine_color.py
+++ b/src/python/python/plugins/textures/combine_color.py
@@ -1,0 +1,48 @@
+from __future__ import annotations # Delayed parsing of type annotations
+
+import drjit as dr
+import mitsuba as mi
+
+class CombineColor(mi.Texture):
+    '''
+    RGB to BW Blender shader node texture.
+    '''
+    def __init__(self, props):
+        mi.Texture.__init__(self, props)
+        self.mode = props.get('mode', 'RGB')
+        assert self.mode == 'RGB', self.mode
+        self.R = props.get_texture('red', 0.0)
+        self.G = props.get_texture('green', 0.0)
+        self.B = props.get_texture('blue', 0.0)
+
+    def traverse(self, cb):
+        cb.put('R', self.R, +mi.ParamFlags.Differentiable)
+        cb.put('G', self.G, +mi.ParamFlags.Differentiable)
+        cb.put('B', self.B, +mi.ParamFlags.Differentiable)
+
+    def parameters_changed(self, keys):
+        pass
+
+    def eval(self, si, active):
+        return mi.UnpolarizedSpectrum(self.eval_3(si, active))
+
+    def eval_3(self, si, active):
+        return mi.Color3f(
+            self.R.eval_1(si, active),
+            self.G.eval_1(si, active),
+            self.B.eval_1(si, active)
+        )
+
+    def mean(self):
+        return self.color.mean() # TODO best effort
+
+    def resolution(self):
+        return self.color.resolution()
+
+    def is_spatially_varying(self):
+        return any([t.is_spatially_varying() for t in [self.R, self.G, self.B]])
+
+    def to_string(self):
+        return f'CombineColor[mode={self.mode}, R={self.R}, G={self.G}, B={self.B}]'
+
+mi.register_texture('combine_color', lambda props: CombineColor(props))

--- a/src/python/python/plugins/textures/curves.py
+++ b/src/python/python/plugins/textures/curves.py
@@ -1,0 +1,119 @@
+from __future__ import annotations # Delayed parsing of type annotations
+
+import drjit as dr
+import mitsuba as mi
+import numpy as np
+
+def eval_curve(points, value):
+    p0 = mi.Vector2f(0)
+    p1 = mi.Vector2f(1)
+
+    for i in range(len(points)-1):
+        found = (points[i][0] < value) & (points[i+1][0] >= value)
+        p0[found] = mi.Vector2f(points[i][:2])
+        p1[found] = mi.Vector2f(points[i+1][:2])
+
+    t = (value - p0.x) / dr.maximum(p1.x - p0.x, 1e-6)
+
+    res = dr.lerp(p0.y, p1.y, t)
+
+    res[value < points[0][0]]  = 0.0
+    res[value > points[-1][0]] = 1.0
+
+    return res
+
+class FloatCurve(mi.Texture):
+    '''
+    Float curve Blender shader node texture.
+    '''
+    def __init__(self, props):
+        mi.Texture.__init__(self, props)
+        self.factor = props.get_texture('factor', 1.0)
+        self.value  = props.get_texture('value')
+        self.points = np.array(props.get('points')).tolist()
+
+        # TODO handle bezier handles (e.g. points[i][2] == 1)
+
+    def traverse(self, cb):
+        cb.put('factor', self.factor, +mi.ParamFlags.Differentiable)
+        cb.put('value',  self.value,  +mi.ParamFlags.Differentiable)
+
+    def eval(self, si, active):
+        return mi.UnpolarizedSpectrum(self.process(si, active))
+
+    def eval_1(self, si, active):
+        return mi.Float(self.process(si, active))
+
+    def eval_3(self, si, active):
+        return mi.Color3f(self.process(si, active))
+
+    def process(self, si, active):
+        factor = self.factor.eval_1(si, active)
+        value  = self.value.eval_1(si, active)
+        return dr.lerp(value, eval_curve(self.points, value), factor)
+
+    def mean(self):
+        return self.value.mean() # TODO best effort
+
+    def resolution(self):
+        return self.value.resolution()
+
+    def is_spatially_varying(self):
+        return any([t.is_spatially_varying() for t in [self.factor, self.value]])
+
+    def to_string(self):
+        return f'FloatCurve[factor={self.factor}, value={self.value}]'
+
+mi.register_texture('float_curve', lambda props: FloatCurve(props))
+
+
+class RGBCurve(mi.Texture):
+    '''
+    RGB curve Blender shader node texture.
+    '''
+    def __init__(self, props):
+        mi.Texture.__init__(self, props)
+        self.factor = props.get_texture('factor', 1.0)
+        self.color  = props.get_texture('color')
+        self.points_c = np.array(props.get('points_c')).tolist()
+        self.points_r = np.array(props.get('points_r')).tolist()
+        self.points_g = np.array(props.get('points_g')).tolist()
+        self.points_b = np.array(props.get('points_b')).tolist()
+
+    def traverse(self, cb):
+        cb.put('factor', self.factor, +mi.ParamFlags.Differentiable)
+        cb.put('color',  self.color,  +mi.ParamFlags.Differentiable)
+
+    def eval(self, si, active):
+        return mi.UnpolarizedSpectrum(self.process(self.color.eval(si, active), si, active))
+
+    def eval_1(self, si, active):
+        return mi.luminance(self.process(mi.Color3f(self.color.eval_1(si, active)), si, active))
+
+    def eval_3(self, si, active):
+        return mi.Color3f(self.process(mi.Color3f(self.color.eval_3(si, active)), si, active))
+
+    def process(self, color, si, active):
+        factor = self.factor.eval_1(si, active)
+
+        color2 = mi.Color3f(
+            eval_curve(self.points_r, eval_curve(self.points_c, color.x)),
+            eval_curve(self.points_g, eval_curve(self.points_c, color.y)),
+            eval_curve(self.points_b, eval_curve(self.points_c, color.z)),
+        )
+
+        return dr.lerp(color, color2, factor)
+
+    def mean(self):
+        return self.color.mean() # TODO best effort
+
+    def resolution(self):
+        return self.color.resolution()
+
+    def is_spatially_varying(self):
+        return any([t.is_spatially_varying() for t in [self.factor, self.color]])
+
+    def to_string(self):
+        return f'RGBCurve[factor={self.factor}, color={self.color}]'
+
+mi.register_texture('rgb_curve', lambda props: RGBCurve(props))

--- a/src/python/python/plugins/textures/hue_saturation.py
+++ b/src/python/python/plugins/textures/hue_saturation.py
@@ -1,0 +1,123 @@
+from __future__ import annotations # Delayed parsing of type annotations
+
+import drjit as dr
+import mitsuba as mi
+
+def modulo(a, b):
+    return (a - mi.Int32(a)) + mi.Int32(a) % b
+
+def rgb2hsv(rgb):
+    """
+    Convert RGB colors to HSV.
+    """
+    # Calculate maximum and minimum RGB values
+    max_rgb = dr.max(rgb)
+    min_rgb = dr.min(rgb)
+
+    # Calculate delta RGB
+    delta = max_rgb - min_rgb
+
+    # Initialize HSV array
+    hsv = mi.Color3f(0, 0, max_rgb)
+
+    R, G, B = rgb.x, rgb.y, rgb.z
+
+    # Calculate Hue
+    hsv.x[delta == 0] = 0.0
+    hsv.x[(R >= G) & (G >= B)] = 60 * (G - B) / delta
+    hsv.x[(G >= R) & (R >= B)] = 60 * (2.0 - (R - B) / delta)
+    hsv.x[(G >= B) & (B >= R)] = 60 * (2.0 + (B - R) / delta)
+    hsv.x[(B >= G) & (G >= R)] = 60 * (4.0 - (G - R) / delta)
+    hsv.x[(B >= R) & (R >= G)] = 60 * (4.0 + (R - G) / delta)
+    hsv.x[(R >= B) & (B >= G)] = 60 * (6.0 - (B - G) / delta)
+
+    # Calculate Saturation
+    hsv.y = dr.select(max_rgb == 0, 0, delta / max_rgb)
+
+    return hsv
+
+def hsv2rgb(hsv):
+    """
+    Convert HSV colors to RGB.
+    """
+    # Make sure we got a valid hue value
+    hsv.x = modulo(dr.abs(hsv.x), 360)
+
+    # Calculate chroma
+    chroma = hsv.z * hsv.y
+
+    # Calculate intermediate values
+    x = chroma * (1.0 - dr.abs(modulo(hsv.x / 60.0, 2) - 1.0))
+
+    # Calculate RGB components based on hue
+    rgb = mi.Color3f(0.0)
+    rgb[(0.0 <= hsv.x) & (hsv.x < 60.0)]    = mi.Color3f(chroma, x, 0)
+    rgb[(60.0 <= hsv.x) & (hsv.x < 120.0)]  = mi.Color3f(x, chroma, 0)
+    rgb[(120.0 <= hsv.x) & (hsv.x < 180.0)] = mi.Color3f(0, chroma, x)
+    rgb[(180.0 <= hsv.x) & (hsv.x < 240.0)] = mi.Color3f(0, x, chroma)
+    rgb[(240.0 <= hsv.x) & (hsv.x < 300.0)] = mi.Color3f(x, 0, chroma)
+    rgb[(300.0 <= hsv.x) & (hsv.x < 360.0)] = mi.Color3f(chroma, 0, x)
+
+    # Add lightness to RGB components
+    rgb += (hsv.z - chroma)
+
+    return rgb
+
+class HueSaturationValue(mi.Texture):
+    '''
+    Hue-Saturation-Value Blender shader node texture.
+    '''
+    def __init__(self, props):
+        mi.Texture.__init__(self, props)
+        self.hue        = props.get_texture('hue', 0.5)
+        self.saturation = props.get_texture('saturation', 1.0)
+        self.value      = props.get_texture('value', 1.0)
+        self.mix        = props.get_texture('mix', 1.0)
+        self.input      = props.get_texture('input', 1.0)
+
+    def traverse(self, cb):
+        cb.put('hue',        self.hue,        +mi.ParamFlags.Differentiable)
+        cb.put('saturation', self.saturation, +mi.ParamFlags.Differentiable)
+        cb.put('value',      self.value,      +mi.ParamFlags.Differentiable)
+        cb.put('mix',        self.mix,        +mi.ParamFlags.Differentiable)
+        cb.put('input',      self.input,      +mi.ParamFlags.Differentiable)
+
+    def parameters_changed(self, keys):
+        pass
+
+    def eval(self, si, active):
+        return mi.UnpolarizedSpectrum(self.eval_3(si, active))
+
+    def eval_1(self, si, active):
+        return mi.Float(self.input.eval_1(si, active) * self.value.eval_1(si, active))
+
+    def eval_3(self, si, active):
+        hue        = self.hue.eval_1(si, active)
+        saturation = self.saturation.eval_1(si, active)
+        value      = self.value.eval_1(si, active)
+        mix        = self.mix.eval_1(si, active)
+        color      = self.input.eval_3(si, active)
+
+        hsv = rgb2hsv(color)
+
+        hsv.x = hsv.x + 360.0 * (hue - 0.5)
+        hsv.y = dr.clip(hsv.y * saturation, 0.0, 1.0)
+        hsv.z *= value
+
+        return mi.Color3f(dr.lerp(color, hsv2rgb(hsv), mix))
+
+    def mean(self):
+        return self.input.mean() # TODO best effort
+
+    def resolution(self):
+        return self.input.resolution()
+
+    def is_spatially_varying(self):
+        return any([t.is_spatially_varying() for t in [
+            self.hue, self.saturation, self.value, self.mix, self.input
+        ]])
+
+    def to_string(self):
+        return f'HueSaturationValue[hue={self.hue}, saturation={self.saturation}, value={self.value}, mix={self.mix}, color={self.color}]'
+
+mi.register_texture('hue_saturation_value', lambda props: HueSaturationValue(props))

--- a/src/python/python/plugins/textures/invert_color.py
+++ b/src/python/python/plugins/textures/invert_color.py
@@ -1,0 +1,44 @@
+from __future__ import annotations # Delayed parsing of type annotations
+
+import drjit as dr
+import mitsuba as mi
+
+class InvertColor(mi.Texture):
+    '''
+    Invert Color Blender shader node texture.
+    '''
+    def __init__(self, props):
+        mi.Texture.__init__(self, props)
+        self.factor = props.get_texture('factor', 1.0)
+        self.color  = props.get_texture('color')
+
+    def traverse(self, cb):
+        cb.put('factor', self.factor, +mi.ParamFlags.Differentiable)
+        cb.put('color',  self.color,  +mi.ParamFlags.Differentiable)
+
+    def eval(self, si, active):
+        return mi.UnpolarizedSpectrum(self.process(self.color.eval(si, active), si, active))
+
+    def eval_1(self, si, active):
+        return mi.Float(self.process(self.color.eval_1(si, active), si, active))
+
+    def eval_3(self, si, active):
+        return mi.Color3f(self.process(self.color.eval_3(si, active), si, active))
+
+    def process(self, color, si, active):
+        factor = self.factor.eval_1(si, active)
+        return color * (1.0 - factor) + factor * (1.0 - color)
+
+    def mean(self):
+        return self.color.mean() # TODO best effort
+
+    def resolution(self):
+        return self.color.resolution()
+
+    def is_spatially_varying(self):
+        return any([t.is_spatially_varying() for t in [self.color, self.factor]])
+
+    def to_string(self):
+        return f'InvertColor[factor={self.factor}, color={self.color}]'
+
+mi.register_texture('invert_color', lambda props: InvertColor(props))

--- a/src/python/python/plugins/textures/map_range.py
+++ b/src/python/python/plugins/textures/map_range.py
@@ -1,0 +1,91 @@
+from __future__ import annotations # Delayed parsing of type annotations
+
+import drjit as dr
+import mitsuba as mi
+
+class MapRange(mi.Texture):
+    '''
+    Map Range Blender shader node texture.
+    '''
+    def __init__(self, props):
+        mi.Texture.__init__(self, props)
+        self.clamp = props.get('clamp', True)
+        self.vector = props.get('vector', True) # Whether to interpret the inputs as vectors or floats
+        self.steps    = props.get_texture('steps', 4.0)
+        self.input    = props.get_texture('input', 1.0)
+        self.from_min = props.get_texture('from_min', 0.0)
+        self.from_max = props.get_texture('from_max', 1.0)
+        self.to_min   = props.get_texture('to_min', 0.0)
+        self.to_max   = props.get_texture('to_max', 1.0)
+        self.interpolation_type = props.get('interpolation_type', 'LINEAR')
+
+    def traverse(self, cb):
+        cb.put('input',    self.input,    +mi.ParamFlags.Differentiable)
+        cb.put('from_min', self.from_min, +mi.ParamFlags.Differentiable)
+        cb.put('from_max', self.from_max, +mi.ParamFlags.Differentiable)
+        cb.put('to_min',   self.to_min,   +mi.ParamFlags.Differentiable)
+        cb.put('to_max',   self.to_max,   +mi.ParamFlags.Differentiable)
+
+    def parameters_changed(self, keys):
+        pass
+
+    def eval(self, si, active):
+        return mi.UnpolarizedSpectrum(self.eval_3(si, active))
+
+    def eval_1(self, si, active):
+        return mi.Float(self.process(si, active))
+
+    def eval_3(self, si, active):
+        return mi.Color3f(self.process(si, active))
+
+    def process(self, si, active):
+        if self.vector:
+            v        = self.input.eval_3(si, active)
+            from_min = self.from_min.eval_3(si, active)
+            from_max = self.from_max.eval_3(si, active)
+            to_min   = self.to_min.eval_3(si, active)
+            to_max   = self.to_max.eval_3(si, active)
+            steps    = self.steps.eval_3(si, active)
+        else:
+            v        = self.input.eval_1(si, active)
+            from_min = self.from_min.eval_1(si, active)
+            from_max = self.from_max.eval_1(si, active)
+            to_min   = self.to_min.eval_1(si, active)
+            to_max   = self.to_max.eval_1(si, active)
+            steps    = self.steps.eval_1(si, active)
+
+        if self.interpolation_type == 'LINEAR':
+            v = (dr.clip(v, from_min, from_max) - from_min) / (from_max - from_min) * (to_max - to_min) + to_min
+        elif self.interpolation_type == 'STEPPED':
+            steps = self.steps.eval_1(si, active)
+            v = (dr.clip(v, from_min, from_max) - from_min) / (from_max - from_min)
+            v = dr.floor(v * (steps + 1)) / (steps + 1)
+            v = v * (to_max - to_min) + to_min
+        else:
+            v = (dr.clip(v, from_min, from_max) - from_min) / (from_max - from_min)
+            if self.interpolation_type == 'SMOOTHSTEP':
+                v = v * v * (3.0 - 2.0 * v)
+            else:
+                v = v * v * v * (v * (6.0 * v - 15.0) + 10.0)
+            v = v * (to_max - to_min) + to_min
+
+        if self.clamp:
+            v = dr.clip(v, dr.minimum(to_min, to_max), dr.maximum(to_min, to_max))
+
+        return v
+
+    def mean(self):
+        return self.input.mean() # TODO best effort
+
+    def resolution(self):
+        return self.input.resolution()
+
+    def is_spatially_varying(self):
+        return any([t.is_spatially_varying() for t in [
+            self.from_min, self.from_max, self.to_min, self.to_max, self.input
+        ]])
+
+    def to_string(self):
+        return f'MapRange[input={self.input}]'
+
+mi.register_texture('map_range', lambda props: MapRange(props))

--- a/src/python/python/plugins/textures/math.py
+++ b/src/python/python/plugins/textures/math.py
@@ -1,0 +1,130 @@
+from __future__ import annotations # Delayed parsing of type annotations
+
+import drjit as dr
+import mitsuba as mi
+
+def smooth_min(a, b, c):
+    h = dr.maximum(c - dr.abs(a - b), 0.0) / c
+    out = dr.minimum(a, b) - h * h * h * c * (1.0 / 6.0)
+    out[c == 0.0] = dr.minimum(a, b)
+    return out
+
+def fract(x):
+    return x - dr.floor(x)
+
+def safe_divide(a, b):
+    return dr.select(b != 0.0, a / b, 0.0)
+
+def wrap(a, b, c):
+    r = b - c
+    s = dr.select(a != b, dr.floor((a - c) / r), 1.0)
+    return dr.select(r != 0.0, a - r * s, c)
+
+# Supported math operators
+# See blender implementation: https://github.com/blender/blender/blob/594f47ecd2d5367ca936cf6fc6ec8168c2b360d0/source/blender/gpu/shaders/material/gpu_shader_material_math.glsl#L203
+OPERATORS = {
+    'ADD':            (lambda a, b, c: a + b),
+    'SUBTRACT':       (lambda a, b, c: a - b),
+    'MULTIPLY':       (lambda a, b, c: a * b),
+    'DIVIDE':         (lambda a, b, c: a / b),
+    'MULTIPLY_ADD':   (lambda a, b, c: a * b + c),
+    'POWER':          (lambda a, b, c: dr.power(a, b)),
+    'LOGARITHM':      (lambda a, b, c: dr.log(a)/ dr.log(b)),
+    'SQRT':           (lambda a, b, c: dr.sqrt(a)),
+    'INVERSE_SQRT':   (lambda a, b, c: dr.rcp(dr.sqrt(a))),
+    'ABSOLUTE':       (lambda a, b, c: dr.abs(a)),
+    'EXPONENT':       (lambda a, b, c: dr.exp(a)),
+    'MINIMUM':        (lambda a, b, c: dr.minimum(a, b)),
+    'MAXIMUM':        (lambda a, b, c: dr.maximum(a, b)),
+    'LESS_THAN':      (lambda a, b, c: dr.select(a < b, 1.0, 0.0)),
+    'GREATER_THAN':   (lambda a, b, c: dr.select(a > b, 1.0, 0.0)),
+    'SIGN':           (lambda a, b, c: dr.select(a >= 0.0, 1.0, 0.0)),
+    'COMPARE':        (lambda a, b, c: dr.select(dr.abs(a - b) <= dr.maximum(c, 1e-5), 1.0, 0.0)),
+    'SMOOTH_MIN':     (lambda a, b, c: smooth_min(a, b, c)),
+    'SMOOTH_MAX':     (lambda a, b, c: -smooth_min(-a, -b, c)),
+    'ROUND':          (lambda a, b, c: dr.round(a)),
+    'FLOOR':          (lambda a, b, c: dr.floor(a)),
+    'CEIL':           (lambda a, b, c: dr.ceil(a)),
+    'TRUNC':          (lambda a, b, c: dr.trunc(a)),
+    'FRACTION':       (lambda a, b, c: fract(a)),
+    'MODULO':         (lambda a, b, c: dr.select(b != 0.0, a - dr.trunc(a / b) * b, 0.0)),
+    'FLOORED_MODULO': (lambda a, b, c: dr.select(b != 0.0, a - dr.floor(a / b) * b, 0.0)),
+    'WRAP':           (lambda a, b, c: wrap(a, b, c)),
+    'SNAP':           (lambda a, b, c: dr.floor(safe_divide(a, b)) * b),
+    'PINGPONG':       (lambda a, b, c: dr.select(b != 0.0, dr.abs(fract((a - b) / (b * 2.0)) * b * 2.0 - b), 0.0)),
+    'SINE':           (lambda a, b, c: dr.sin(a)),
+    'COSINE':         (lambda a, b, c: dr.cos(a)),
+    'TANGENT':        (lambda a, b, c: dr.tan(a)),
+    'ARCSINE':        (lambda a, b, c: dr.select(a <= 1.0 & a >= -1.0, dr.asin(a), 0.0)),
+    'ARCCOSINE':      (lambda a, b, c: dr.select(a <= 1.0 & a >= -1.0, dr.acos(a), 0.0)),
+    'ARCTANGENT':     (lambda a, b, c: dr.atan(a)),
+    'ARCTAN2':        (lambda a, b, c: dr.atan2(a, b)),
+    'SINH':           (lambda a, b, c: dr.sinh(a)),
+    'COSH':           (lambda a, b, c: dr.cosh(a)),
+    'TANH':           (lambda a, b, c: dr.tanh(a)),
+    'RADIANS':        (lambda a, b, c: dr.deg2rad(a)),
+    'DEGREES':        (lambda a, b, c: dr.rad2deg(a))
+}
+
+class Math(mi.Texture):
+    '''
+    Math Blender shader node texture.
+    '''
+    def __init__(self, props):
+        mi.Texture.__init__(self, props)
+        self.input_0 = props.get_texture('input_0')
+        self.input_1 = props.get_texture('input_1', 0.0)
+        self.input_2 = props.get_texture('input_2', 0.0)
+        self.mode = str(props.get('mode'))
+        self.clamp = props.get('clamp', False)
+
+        if not self.mode in OPERATORS.keys():
+            mi.Log(mi.LogLevel.Error, f'Unknown math operator: {self.mode}')
+
+    def traverse(self, cb):
+        cb.put('input_0', self.input_0, +mi.ParamFlags.Differentiable)
+        cb.put('input_1', self.input_1, +mi.ParamFlags.Differentiable)
+        cb.put('input_2', self.input_1, +mi.ParamFlags.Differentiable)
+
+    def eval(self, si, active):
+        return mi.UnpolarizedSpectrum(self.process(
+            self.input_0.eval(si, active),
+            self.input_1.eval(si, active),
+            self.input_2.eval(si, active)
+        ))
+
+    def eval_1(self, si, active):
+        return mi.Float(self.process(
+            self.input_0.eval_1(si, active),
+            self.input_1.eval_1(si, active),
+            self.input_2.eval_1(si, active)
+        ))
+
+    def eval_3(self, si, active):
+        return mi.Color3f(self.process(
+            self.input_0.eval_3(si, active),
+            self.input_1.eval_3(si, active),
+            self.input_2.eval_3(si, active)
+        ))
+
+    def process(self, a, b, c):
+        out = OPERATORS[self.mode](a, b, c)
+
+        if self.clamp:
+            out = dr.clip(out, 0.0, 1.0)
+
+        return out
+
+    def mean(self):
+        return self.input_0.mean() # TODO best effort
+
+    def resolution(self):
+        return self.input_0.resolution()
+
+    def is_spatially_varying(self):
+        return any([t.is_spatially_varying() for t in [self.input_0, self.input_1, self.input_2]])
+
+    def to_string(self):
+        return f'Math[input_0={self.input_0}, input_1={self.input_1}, input_2={self.input_2}, mode={self.mode}, clamp={self.clamp}]'
+
+mi.register_texture('math', lambda props: Math(props))

--- a/src/python/python/plugins/textures/mesh_attribute_adapter.py
+++ b/src/python/python/plugins/textures/mesh_attribute_adapter.py
@@ -1,0 +1,34 @@
+from __future__ import annotations # Delayed parsing of type annotations
+
+import mitsuba as mi
+
+class MeshAttributeAdapter(mi.Texture):
+    '''
+    Ensure we always query the mesh attributes using eval instead of eval_1 and eval_3
+    '''
+    def __init__(self, props):
+        mi.Texture.__init__(self, props)
+        self.attribute = props.get_texture('attribute')
+
+    def traverse(self, cb):
+        cb.put('attribute', self.attribute, +mi.ParamFlags.Differentiable)
+
+    def parameters_changed(self, keys):
+        pass
+
+    def eval(self, si, active):
+        return mi.UnpolarizedSpectrum(self.attribute.eval(si, active))
+
+    def eval_1(self, si, active):
+        return mi.Float(mi.luminance(self.attribute.eval(si, active)))
+
+    def eval_3(self, si, active):
+        return mi.Color3f(self.attribute.eval(si, active))
+
+    def mean(self):
+        return mi.luminance(self.attribute.mean())
+
+    def to_string(self):
+        return f'MeshAttributeAdapter[{self.attribute}]'
+
+mi.register_texture('mesh_attribute_adapter', lambda props: MeshAttributeAdapter(props))

--- a/src/python/python/plugins/textures/noise.py
+++ b/src/python/python/plugins/textures/noise.py
@@ -1,0 +1,130 @@
+from __future__ import annotations # Delayed parsing of type annotations
+
+import drjit as dr
+import mitsuba as mi
+import numpy as np
+
+def perlin_noise(res, scale, octave, normalize, seed):
+    '''
+    Generate a perlin noise image of size res x res
+    '''
+    def perlin_octave(x, y, seed):
+        def lerp(a, b, x):
+            "linear interpolation"
+            return a + x * (b - a)
+
+        def fade(t):
+            "6t^5 - 15t^4 + 10t^3"
+            return 6 * t**5 - 15 * t**4 + 10 * t**3
+
+        def gradient(h, x, y):
+            "grad converts h to the right gradient vector and return the dot product with (x,y)"
+            vectors = np.array([[0, 1], [0, -1], [1, 0], [-1, 0]])
+            g = vectors[h % 4]
+            return g[:, :, 0] * x + g[:, :, 1] * y
+
+        # permutation table
+        np.random.seed(seed)
+        p = np.arange(res, dtype=int)
+        np.random.shuffle(p)
+        p = np.stack([p, p]).flatten()
+    # coordinates of the top-left
+        xi, yi = x.astype(int), y.astype(int)
+        # internal coordinates
+        xf, yf = x - xi, y - yi
+        # fade factors
+        u, v = fade(xf), fade(yf)
+
+        xi, yi = xi % res, yi % res
+
+        # noise components
+        n00 = gradient(p[p[xi] + yi], xf, yf)
+        n01 = gradient(p[p[xi] + yi + 1], xf, yf - 1)
+        n11 = gradient(p[p[xi + 1] + yi + 1], xf - 1, yf - 1)
+        n10 = gradient(p[p[xi + 1] + yi], xf - 1, yf)
+        # combine noises
+        x1 = lerp(n00, n10, u)
+        x2 = lerp(n01, n11, u)  # FIX1: I was using n10 instead of n01
+        return lerp(x1, x2, v)  # FIX2: I also had to reverse x1 and x2 here
+
+    p = np.zeros((res, res))
+    for i in range(octave):
+        freq = 2**i
+        lin = np.linspace(0, freq, res, endpoint=False)
+        x, y = np.meshgrid(lin, lin)  # FIX3: I thought I had to invert x and y here but it was a mistake
+        p += perlin_octave(x * scale, y * scale, seed) / freq
+
+    min_value = np.min(p)
+    max_value = np.max(p)
+
+    # Normalize between [0, 1]
+    p = (p - min_value) / (max_value - min_value)
+
+    if not normalize:
+        p = (p - 0.5) * octave
+
+    return p[:, :, None]
+
+class NoiseTexture(mi.Texture):
+    '''
+    Noise Texture generating a perlin-noise signal.
+    '''
+    def __init__(self, props):
+        mi.Texture.__init__(self, props)
+        self.noise_type = props.get('noise_type', 'FBM')
+        assert self.noise_type == 'FBM', self.noise_type
+        self.dimensions = props.get('dimensions', '3D')
+        assert self.dimensions == '3D', self.dimensions
+
+        self.normalize = props.get('normalize', True) # TODO use this!
+
+        self.scale      = props.get('scale', 0.0)
+        self.detail     = props.get('detail', 0.0)
+        self.roughness  = props.get('roughness', 0.0)
+        self.lacunarity = props.get('lacunarity', 0.0)
+        self.distortion = props.get('distortion', 0.0)
+
+        assert isinstance(self.scale, float), '\'scale\' parameter should be a scalar value!'
+        assert isinstance(self.detail, float), '\'detail\' parameter should be a scalar value!'
+        assert isinstance(self.roughness, float), '\'roughness\' parameter should be a scalar value!'
+        assert isinstance(self.lacunarity, float), '\'lacunarity\' parameter should be a scalar value!'
+        assert isinstance(self.distortion, float), '\'distortion\' parameter should be a scalar value!'
+
+        self.resolution = props.get('resolution', 128)
+
+        self.texture_r = mi.Texture2f(perlin_noise(self.resolution, scale=self.scale, octave=int(self.detail) + 1, seed=0, normalize=self.normalize))
+        self.texture_g = mi.Texture2f(perlin_noise(self.resolution, scale=self.scale, octave=int(self.detail) + 1, seed=1, normalize=self.normalize))
+        self.texture_b = mi.Texture2f(perlin_noise(self.resolution, scale=self.scale, octave=int(self.detail) + 1, seed=2, normalize=self.normalize))
+
+    def traverse(self, cb):
+        pass
+
+    def parameters_changed(self, keys):
+        pass
+
+    def eval(self, si, active):
+        return mi.UnpolarizedSpectrum(self.eval_3(si, active))
+
+    def eval_1(self, si, active):
+        return mi.Float(self.texture_r.eval(si.uv, active)[0])
+
+    def eval_3(self, si, active):
+        return mi.Color3f(
+            self.texture_r.eval(si.uv, active)[0],
+            self.texture_g.eval(si.uv, active)[0],
+            self.texture_b.eval(si.uv, active)[0],
+        )
+
+    def mean(self):
+        return mi.Float(0.5) # TODO best effort
+
+    def resolution(self):
+        return mi.ScalarVector2i(1, 1)
+
+    def is_spatially_varying(self):
+        return True
+
+    def to_string(self):
+        return f'NoiseTexture[]'
+
+mi.register_texture('noise', lambda props: NoiseTexture(props))

--- a/src/python/python/plugins/textures/normalmap.py
+++ b/src/python/python/plugins/textures/normalmap.py
@@ -1,0 +1,45 @@
+from __future__ import annotations # Delayed parsing of type annotations
+from typing import Tuple
+
+import drjit as dr
+import mitsuba as mi
+
+class NormalMap(mi.Texture):
+    '''
+    Normal map Blender shader node texture.
+    '''
+    def __init__(self, props):
+        mi.Texture.__init__(self, props)
+        self.color    = props.get_texture('color')
+        self.strength = props.get_texture('strength')
+        self.space    = props.get('space')
+        if not self.space in ['TANGENT', 'OBJECT', 'WORLD']:
+            raise Exception(f'NormalMap: Invalid space {self.space}!')
+
+    def eval(self, si, active):
+        return self.eval_3(si, active)
+
+    def eval_1(self, si, active):
+        raise ValueError(f"NormalMap: eval_1 not supported!")
+
+    def eval_3(self, si, active):
+        normal = mi.Normal3f(self.color.eval_3(si, active))
+        strength = self.strength.eval_1(si, active)
+
+        if self.space == 'TANGENT':
+            pass
+        elif self.space == 'OBJECT':
+            pass # TODO understand the difference between tangent space and object space
+        elif self.space == 'WORLD':
+            normal = si.to_local(normal)
+
+        normal = normal * 2.0 - 1.0 # [0, 1] -> [-1, 1]
+        normal = mi.Normal3f(normal.x, -normal.y, normal.z) # Match Blender convention
+        normal = dr.normalize(dr.lerp(mi.Normal3f(0, 0, 1), normal, strength))
+        normal = (normal + 1.0) * 0.5 # [-1, 1] -> [0, 1]
+        return normal
+
+    def to_string(self):
+        return f'Texture NormalMap[{self.color}]'
+
+mi.register_texture('normal_map', lambda props: NormalMap(props))

--- a/src/python/python/plugins/textures/rgb_to_bw.py
+++ b/src/python/python/plugins/textures/rgb_to_bw.py
@@ -1,0 +1,41 @@
+from __future__ import annotations # Delayed parsing of type annotations
+
+import drjit as dr
+import mitsuba as mi
+
+class RGB2BW(mi.Texture):
+    '''
+    RGB to BW Blender shader node texture.
+    '''
+    def __init__(self, props):
+        mi.Texture.__init__(self, props)
+        self.color = props.get_texture('color', 0.5)
+
+    def traverse(self, cb):
+        cb.put('color', self.color, +mi.ParamFlags.Differentiable)
+
+    def parameters_changed(self, keys):
+        pass
+
+    def eval(self, si, active):
+        return mi.UnpolarizedSpectrum(self.eval_3(si, active))
+
+    def eval_1(self, si, active):
+        return mi.Float(mi.luminance(self.color.eval_3(si, active)))
+
+    def eval_3(self, si, active):
+        return mi.Color3f(mi.luminance(self.color.eval_3(si, active)))
+
+    def mean(self):
+        return mi.luminance(self.color.mean()) # TODO best effort
+
+    def resolution(self):
+        return self.color.resolution()
+
+    def is_spatially_varying(self):
+        return self.color.is_spatially_varying()
+
+    def to_string(self):
+        return f'RGB2BW[color={self.color}]'
+
+mi.register_texture('rgb_to_bw', lambda props: RGB2BW(props))

--- a/src/python/python/plugins/textures/separate_rgb.py
+++ b/src/python/python/plugins/textures/separate_rgb.py
@@ -1,0 +1,49 @@
+from __future__ import annotations # Delayed parsing of type annotations
+from typing import Tuple
+
+import drjit as dr
+import mitsuba as mi
+
+class SeparateRGB(mi.Texture):
+    '''
+    Separate RGB Blender shader node texture.
+    '''
+    def __init__(self, props):
+        mi.Texture.__init__(self, props)
+        self.texture = props.get('input')
+        self.channel = props.get('channel', 'r')
+        if self.channel not in ['r', 'g', 'b']:
+            raise ValueError(f"SeparateRGB: Invalid channel {self.channel}")
+
+    def traverse(self, cb):
+        cb.put('input', self.texture, mi.ParamFlags.Differentiable)
+
+    def parameters_changed(self, keys):
+        self.texture.parameters_changed(keys)
+
+    def _eval_channel(self, si, active):
+        color = self.texture.eval_3(si, active)
+        return color[{ 'r': 0, 'g': 1, 'b': 2 }[self.channel]]
+
+    def eval(self, si, active):
+        return mi.UnpolarizedSpectrum(self._eval_channel(si, active))
+
+    def eval_1(self, si, active):
+        return mi.Float(self._eval_channel(si, active))
+
+    def eval_3(self, si, active):
+        return mi.Color3f(self._eval_channel(si, active))
+
+    def mean(self):
+        return self.texture.mean()
+
+    def resolution(self):
+        return self.texture.resolution()
+
+    def is_spatially_varying(self):
+        return self.texture.is_spatially_varying()
+
+    def to_string(self):
+        return f'Separate RGB[input={self.texture}, channel={self.channel}]'
+
+mi.register_texture('separate_rgb', lambda props: SeparateRGB(props))

--- a/src/python/python/plugins/textures/texture_coordinate.py
+++ b/src/python/python/plugins/textures/texture_coordinate.py
@@ -1,0 +1,35 @@
+from __future__ import annotations # Delayed parsing of type annotations
+from typing import Tuple
+
+import drjit as dr
+import mitsuba as mi
+
+class TextureCoordinate(mi.Texture):
+    '''
+    Texture coordinates Blender shader node texture.
+    '''
+    def __init__(self, props):
+        mi.Texture.__init__(self, props)
+        self.channel = props.get('channel', 'UV')
+        if self.channel not in ['UV']:
+            raise ValueError(f"TextureCoordinate: Invalid channel {self.channel}")
+
+    def _eval_channel(self, si, active):
+        return mi.Vector3f(si.uv.x, 1.0-si.uv.y, 0.0) # Follow Blender's convention
+
+    def eval(self, si, active):
+        raise ValueError(f"TextureCoordinate: eval not supported!")
+
+    def eval_1(self, si, active):
+        raise ValueError(f"TextureCoordinate: eval_1 not supported!")
+
+    def eval_3(self, si, active):
+        return mi.Color3f(self._eval_channel(si, active))
+
+    def mean(self):
+        return mi.Float(0.5)
+
+    def to_string(self):
+        return f'Texture Coordinate[{self.channel}]'
+
+mi.register_texture('texture_coordinate', lambda props: TextureCoordinate(props))

--- a/src/python/python/plugins/textures/udim.py
+++ b/src/python/python/plugins/textures/udim.py
@@ -1,0 +1,73 @@
+from __future__ import annotations # Delayed parsing of type annotations
+
+import drjit as dr
+import mitsuba as mi
+
+class UDIMTexture(mi.Texture):
+    '''
+    UDIM Blender shader node texture.
+    '''
+    def __init__(self, props):
+        mi.Texture.__init__(self, props)
+
+        self.textures = []
+        for name in props.unqueried():
+            obj = props.get(name)
+            if issubclass(type(obj), mi.Texture):
+                self.textures.append(obj)
+            else:
+                raise Exception('Invalid nested texture: ', name, obj)
+
+    def traverse(self, cb):
+        for i, texture in enumerate(self.textures):
+            cb.put(f'texture_{i:02d}', texture, +mi.ParamFlags.Differentiable)
+
+    def parameters_changed(self, keys):
+        pass
+
+    def eval(self, si, active):
+        si = mi.SurfaceInteraction3f(si)
+        idx = mi.UInt32(si.uv.x)
+        si.uv.x -= idx
+
+        value = mi.UnpolarizedSpectrum(0)
+        for i, texture in enumerate(self.textures):
+            value[idx == i] = mi.UnpolarizedSpectrum(texture.eval(si, active))
+
+        return value
+
+    def eval_1(self, si, active):
+        si = mi.SurfaceInteraction3f(si)
+        idx = mi.UInt32(si.uv.x)
+        si.uv.x -= idx
+
+        value = mi.Float(0)
+        for i, texture in enumerate(self.textures):
+            value[idx == i] = texture.eval_1(si, active)
+
+        return value
+
+    def eval_3(self, si, active):
+        si = mi.SurfaceInteraction3f(si)
+        idx = mi.UInt32(si.uv.x)
+        si.uv.x -= idx
+
+        value = mi.Color3f(0)
+        for i, texture in enumerate(self.textures):
+            value[idx == i] = texture.eval_3(si, active)
+
+        return value
+
+    def mean(self):
+        return mi.Float(0.5) # TODO best effort
+
+    def resolution(self):
+        return mi.ScalarVector2i(1, 1)
+
+    def is_spatially_varying(self):
+        return True
+
+    def to_string(self):
+        return f'UDIMTexture[]'
+
+mi.register_texture('udim_texture', lambda props: UDIMTexture(props))

--- a/src/python/python/plugins/textures/uv_wrapper.py
+++ b/src/python/python/plugins/textures/uv_wrapper.py
@@ -1,0 +1,39 @@
+from __future__ import annotations # Delayed parsing of type annotations
+from typing import Tuple
+
+import drjit as dr
+import mitsuba as mi
+
+class UVWrapper(mi.Texture):
+    '''
+    Wrapper texture to evaluate input texture with a different set of UVs.
+
+    This plugin in used in the Blender-Mitsuba add-on.
+    '''
+    def __init__(self, props):
+        mi.Texture.__init__(self, props)
+        self.uv = props.get('uv')
+        self.input = props.get('input')
+
+    def eval_si(self, si, active):
+        si = mi.SurfaceInteraction3f(si)
+        si.uv = self.uv.eval_3(si, active).xy
+        si.uv = mi.Vector2f(si.uv.x, 1.0-si.uv.y) # Blender convention
+        return si
+
+    def eval(self, si, active):
+        return self.input.eval(self.eval_si(si, active), active)
+
+    def eval_1(self, si, active):
+        return self.input.eval_1(self.eval_si(si, active), active)
+
+    def eval_3(self, si, active):
+        return self.input.eval_3(self.eval_si(si, active), active)
+
+    def mean(self):
+        return self.input.mean()
+
+    def to_string(self):
+        return f'UVWrapper[uv={self.uv}, input={self.input}]'
+
+mi.register_texture('uv_wrapper', lambda props: UVWrapper(props))

--- a/src/python/python/plugins/textures/vector_math.py
+++ b/src/python/python/plugins/textures/vector_math.py
@@ -1,0 +1,104 @@
+from __future__ import annotations # Delayed parsing of type annotations
+
+import drjit as dr
+import mitsuba as mi
+
+def fract(x):
+    return x - dr.floor(x)
+
+def safe_divide(a, b):
+    return dr.select(b != 0.0, a / b, 0.0)
+
+def wrap(a, b, c):
+    r = b - c
+    s = dr.select(a != b, dr.floor((a - c) / r), 1.0)
+    return dr.select(r != 0.0, a - r * s, c)
+
+def refract(incident, normal, eta):
+    normal = dr.normalize(normal)
+    dot_ni = dr.dot(normal, incident)
+    k = 1.0 - eta * eta * (1.0 - dot_ni * dot_ni)
+    return dr.select(k < 0.0, 0.0, eta * incident - (eta * dot_ni + dr.sqrt(k)) * normal)
+
+# Supported math operators
+# See blender implementation: https://github.com/blender/blender/blob/594f47ecd2d5367ca936cf6fc6ec8168c2b360d0/source/blender/gpu/shaders/material/gpu_shader_material_math.glsl#L203
+OPERATORS = {
+    'ADD':            (lambda a, b, c: a + b),
+    'SUBSTRACT':      (lambda a, b, c: a - b),
+    'MULTIPLY':       (lambda a, b, c: a * b),
+    'DIVIDE':         (lambda a, b, c: a / b),
+    'MULTIPLY_ADD':   (lambda a, b, c: a * b + c),
+
+    'CROSS_PRODUCT':  (lambda a, b, c: dr.cross(b, a)),
+    'PROJECT':        (lambda a, b, c: b * (dr.dot(a, b) / dr.dot(b, b))),
+    'REFLECT':        (lambda a, b, c: mi.reflect(a, dr.normalize(b))),
+    'REFRACT':        (lambda a, b, c: refract(a, b, c.x)),
+    'FACEFORWARD':    (lambda a, b, c: dr.select(dr.dot(b, c) < 0.0, a, -a)),
+    'DOT_PRODUCT':    (lambda a, b, c: dr.dot(a, b)),
+    'DISTANCE':       (lambda a, b, c: dr.norm(a - b)),
+    'LENGTH':         (lambda a, b, c: dr.norm(a)),
+    'SCALE':          (lambda a, b, c: a * b),
+    'NORMALIZE':      (lambda a, b, c: dr.normalize(a)),
+
+    'WRAP':           (lambda a, b, c: wrap(a, b, c)),
+    'SNAP':           (lambda a, b, c: dr.floor(safe_divide(a, b)) * b),
+    'FLOOR':          (lambda a, b, c: dr.floor(a)),
+    'CEIL':           (lambda a, b, c: dr.ceil(a)),
+    'ABSOLUTE':       (lambda a, b, c: dr.abs(a)),
+    'FRACTION':       (lambda a, b, c: fract(a)),
+    'MODULO':         (lambda a, b, c: dr.select(b != 0.0, a - dr.trunc(a / b) * b, 0.0)),
+    'MINIMUM':        (lambda a, b, c: dr.minimum(a, b)),
+    'MAXIMUM':        (lambda a, b, c: dr.maximum(a, b)),
+    'SINE':           (lambda a, b, c: dr.sin(a)),
+    'COSINE':         (lambda a, b, c: dr.cos(a)),
+    'TANGENT':        (lambda a, b, c: dr.tan(a)),
+}
+
+class VectorMath(mi.Texture):
+    '''
+    Vector math Blender shader node texture.
+    '''
+    def __init__(self, props):
+        mi.Texture.__init__(self, props)
+        self.input_0 = props.get_texture('input_0')
+        self.input_1 = props.get_texture('input_1', 0.0)
+        self.input_2 = props.get_texture('input_2', 0.0)
+        self.mode = str(props.get('mode'))
+
+        if not self.mode in OPERATORS.keys():
+            mi.Log(mi.LogLevel.Error, f'Unknown vector math operator: {self.mode}')
+
+    def traverse(self, cb):
+        cb.put('input_0', self.input_0, +mi.ParamFlags.Differentiable)
+        cb.put('input_1', self.input_1, +mi.ParamFlags.Differentiable)
+        cb.put('input_2', self.input_1, +mi.ParamFlags.Differentiable)
+
+    def eval(self, si, active):
+        return mi.UnpolarizedSpectrum(self.eval_3(si, active))
+
+    def eval_1(self, si, active):
+        return mi.Float(self.eval_3(si, active).x)
+
+    def eval_3(self, si, active):
+        return mi.Color3f(self.process(
+            self.input_0.eval_3(si, active),
+            self.input_1.eval_3(si, active),
+            self.input_2.eval_3(si, active)
+        ))
+
+    def process(self, a, b, c):
+        return OPERATORS[self.mode](a, b, c)
+
+    def mean(self):
+        return self.input_0.mean() # TODO best effort
+
+    def resolution(self):
+        return self.input_0.resolution()
+
+    def is_spatially_varying(self):
+        return any([t.is_spatially_varying() for t in [self.input_0, self.input_1, self.input_2]])
+
+    def to_string(self):
+        return f'VectorMath[input_0={self.input_0}, input_1={self.input_1}, input_2={self.input_2}, mode={self.mode}]'
+
+mi.register_texture('vector_math', lambda props: VectorMath(props))


### PR DESCRIPTION
This PR provides Python texture plugins that should cover most of the Blender shader graph nodes.

Remaining TODOs:

- [ ] Proper testing
- [ ] Add-on code to instanciate those plugins when traversing the shader graph.