### PR TITLE
Prevent NaN values for normals of triangles with zero area

### DIFF
--- a/src/render/mesh.cpp
+++ b/src/render/mesh.cpp
@@ -411,7 +411,10 @@ MI_VARIANT void Mesh<Float, Spectrum>::recompute_vertex_normals() {
 
         // --------------------- Kernel 2 starts here ---------------------
 
-        normals = dr::normalize(normals);
+        // Normalize and fall back to dummy value in case of zero-length vector.
+        Float final_length_sqr = dr::squared_norm(normals);
+        normals = dr::select(final_length_sqr > 0, normals * dr::rsqrt(final_length_sqr),
+                             Vector3f(1.f, 0.f, 0.f));
 
         // Convert to 32-bit precision
         using JitInputNormal3f = Normal<dr::replace_scalar_t<Float, InputFloat>, 3>;

--- a/src/render/mesh.cpp
+++ b/src/render/mesh.cpp
@@ -392,7 +392,10 @@ MI_VARIANT void Mesh<Float, Spectrum>::recompute_vertex_normals() {
                           vertex_position(fi[1]),
                           vertex_position(fi[2]) };
 
-        Vector3f n = dr::normalize(dr::cross(v[1] - v[0], v[2] - v[0]));
+        Vector3f n = dr::cross(v[1] - v[0], v[2] - v[0]);
+        Float length_sqr = dr::squared_norm(n);
+        Mask valid = length_sqr > 0;
+        n *= dr::rsqrt(length_sqr);
 
         Vector3f normals = dr::zeros<Vector3f>(m_vertex_count);
         for (int i = 0; i < 3; ++i) {
@@ -403,7 +406,7 @@ MI_VARIANT void Mesh<Float, Spectrum>::recompute_vertex_normals() {
             Vector3f nn = n * face_angle;
 
             for (int j = 0; j < 3; ++j)
-                dr::scatter_reduce(ReduceOp::Add, normals[j], nn[j], fi[i]);
+                dr::scatter_reduce(ReduceOp::Add, normals[j], nn[j], fi[i], valid);
         }
 
         // --------------------- Kernel 2 starts here ---------------------


### PR DESCRIPTION
The vertex normal computation in JIT mode should check for zero-area triangles. Such triangles might happen accidentally during an optimization and we do not want triangles with zero areas to lead to NaN normals for all adjacent vertices. 

This PR adds a simple check to prevent this. This actually mirrors the scalar code, which seems to already have this special case check (in that case, likely to work with imperfect existing assets)