### PR TITLE
Fix bug with unintentional reordering of unnamed EXR channels

### DIFF
--- a/src/core/bitmap.cpp
+++ b/src/core/bitmap.cpp
@@ -8,7 +8,10 @@
 #include <mitsuba/core/fstream.h>
 #include <mitsuba/core/profiler.h>
 #include <unordered_map>
+#include <algorithm>
 #include <atomic>
+#include <cmath>
+#include <string>
 #include <thread>
 
 #include <nanothread/nanothread.h>
@@ -175,8 +178,12 @@ void Bitmap::rebuild_struct(size_t channel_count, const std::vector<std::string>
         case PixelFormat::XYZA:  channels = { "X", "Y", "Z", "A"};      break;
         case PixelFormat::MultiChannel:
             if (channel_names.size() == 0) {
+                // Compute number of digits required for channel count - 1 to prepend zeros and ensure
+                // alphanumerical ordering of channel names
+                int num_digits = std::floor(std::log10(std::max<size_t>(1, channel_count - 1))) + 1;
+                std::string channel_format = tfm::format("ch%%0%dd", num_digits);
                 for (size_t i = 0; i < channel_count; ++i)
-                    channels.push_back(tfm::format("ch%i", i));
+                    channels.push_back(tfm::format(channel_format.c_str(), i));
             } else {
                 if (channel_names.size() != channel_count)
                     Throw("Bitmap::rebuild_struct(): expected %u channel "

--- a/src/core/tests/test_bitmap.py
+++ b/src/core/tests/test_bitmap.py
@@ -63,6 +63,21 @@ def test_read_write_complex_exr(variant_scalar_rgb, tmpdir):
     assert str(b3) != str(b1)
 
 
+@pytest.mark.parametrize('num_channels', [1, 3, 4, 9, 10, 11])
+def test_read_write_unnamed_multichannel_exr(variant_scalar_rgb, tmpdir, num_channels):
+    # Tests reading and writing of images with unnamed channels to/from exr
+    ref = np.zeros((16, 16, num_channels), dtype=np.float32)
+    for i in range(num_channels):
+        ref[..., i] = i
+
+    tmp_file = os.path.join(str(tmpdir), f"out_{num_channels}.exr")
+    b = mi.Bitmap(ref)
+    b.write(tmp_file)
+    b = mi.Bitmap(tmp_file)
+    os.remove(tmp_file)
+    assert np.allclose(np.array(b), ref)
+
+
 def test_convert_rgb_y(variant_scalar_rgb, tmpdir):
     # Tests RGBA(float64) -> Y (float32) conversion
     b1 = mi.Bitmap(mi.Bitmap.PixelFormat.RGBA, mi.Struct.Type.Float64, [3, 1])


### PR DESCRIPTION
## Description

Reordering of multi-channel bitmaps with more than 10 channels is buggy when serializing/deserializing without providing explicit channel names. 

Since channels are automatically named `ch{i}` if not provided, and `read_exr()` in Mitsuba orders the layers in alphanumerical order, bitmaps with more than 10 channels are mistakingly reorder to e.g.: `ch0, ch1, ch10, ch2, ch3, ..., ch9`.

In order to fix this, channels should have padded zeros such that the alphanumerical ordering is consistent with the channel ordering. This code adds padded zeros (e.g. `ch00, ch01, ch02, ch03, ..., ch09, ch10`) to the name depending on how many are needed in total.


## Testing

The following is a minimal example to reproduce this behavior:

```python
tmp_file = '/tmp/test.exr'

for num_channels in (1, 3, 4, 9, 10, 11):
    print('num_channels', num_channels)
    ref = np.zeros((16, 16, num_channels), dtype=np.float32)
    for i in range(num_channels):
        ref[..., i] = i

    b = mi.Bitmap(ref)
    b.write(tmp_file)
    b = mi.Bitmap(tmp_file)

    assert np.allclose(np.array(b), ref)
```

The test `test_read_write_unnamed_multichannel_exr` in `test_bitmap.py` was added to test for this.

## Checklist

- [x] My code follows the [style guidelines](https://mitsuba.readthedocs.io/en/latest/src/developer_guide.html#coding-style) of this project
- [x] My changes generate no new warnings
- [x] My code also compiles for `cuda_*` and `llvm_*` variants. If you can't test this, please leave below
- [x] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 3 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba/blob/master/LICENSE)

