### PR TITLE
Fix `to_string` for Python-created meshes

### DIFF
--- a/include/mitsuba/render/mesh.h
+++ b/include/mitsuba/render/mesh.h
@@ -47,6 +47,9 @@ public:
          ScalarSize face_count, const Properties &props = Properties(),
          bool has_vertex_normals = false, bool has_vertex_texcoords = false);
 
+    // Creates an empty mesh.
+    Mesh(const Properties &props);
+
     /// Destructor
     ~Mesh();
 
@@ -417,7 +420,6 @@ public:
     size_t face_data_bytes() const;
 
 protected:
-    Mesh(const Properties &);
     inline Mesh() {}
 
     /**

--- a/src/render/tests/test_mesh.py
+++ b/src/render/tests/test_mesh.py
@@ -1410,3 +1410,16 @@ def test36_mesh_vcalls_with_directed_edges(variants_vec_rgb):
 
     result = mesh_ptr.opposite_dedge(mi.UInt32([2, 3, 2]))
     assert dr.all(result == mi.UInt32([3, 2, 3]))
+
+
+def test37_create_mesh_with_properties(variant_scalar_rgb):
+    m = mi.Mesh(mi.Properties())
+    assert str(m) == """Mesh[
+  name = "",
+  bbox = BoundingBox3f[invalid],
+  vertex_count = 0,
+  vertices = [0 B of vertex data],
+  face_count = 0,
+  faces = [0 B of face data],
+  face_normals = 0
+]"""


### PR DESCRIPTION
The `to_string` method of meshes was not working for meshes that are created in Python using the properties only constructor. The reason for this appears to be that the C++ constructor that is referred to in the bindings was protected. Making it public makes it work. I added a simple unit test that fails before the fix and now passes.

This is a bug that confused quite a few new users, in particular when using mitsuba in colab/jupyter notebooks, where objects at the end of cells get printed by default.