### PR TITLE
Add assertion on align parameter of `tensor_io.write()`

### DIFF
--- a/src/python/python/tensor_io.py
+++ b/src/python/python/tensor_io.py
@@ -65,6 +65,7 @@ def read(filename):
 
 def write(filename, align=8, **kwargs):
     import numpy as np
+    assert isinstance(align, int), "Alignment must be an integer, make sure to unpack the tensor dictionary using **"
 
     with open(filename, 'wb') as f:
         # Identifier


### PR DESCRIPTION
This PR adds an assertion on the `align` parameter of the `tensor_io.write` function.
Previously, a user had no warning if he mistakenly passed a dictionary of tensors as the `align` parameter and the written file would just be empty. 