### PR TITLE
JIT-compatible implementation of `Mesh::build_directed_edges()`

### DIFF
--- a/include/mitsuba/render/mesh.h
+++ b/include/mitsuba/render/mesh.h
@@ -583,9 +583,6 @@ protected:
     mutable DynamicBuffer<UInt32> m_E2E;
     bool m_E2E_outdated = true;
 
-
-    constexpr static ScalarIndex m_invalid_dedge = (ScalarIndex) -1;
-
     /// Sampling density of silhouette (\ref build_indirect_silhouette_distribution)
     DiscreteDistribution<Float> m_sil_dedge_pmf;
 


### PR DESCRIPTION
## Description

This PR adds a JIT-enabled version of `Mesh::build_directed_edges()`.

The `Mesh::build_directed_edges()` method had a scalar implementation of the technique described in [this paper](https://www.graphics.rwth-aachen.de/media/papers/directed.pdf). Although the build is only triggered on topology changes, it still can be a significant cost during a surface reconstruction task. The new JIT-enabled implementation that this PR added is approximately 30x faster (speedups are practically linear w.r.t. to the size of the mesh). The new implementation relies on the[ recent addition of `scatter_cas` to Dr.Jit](https://github.com/mitsuba-renderer/drjit/pull/450).


## Testing

No new tests were added - there already are tests that check the data structure build. I've also manually tested a handful of various meshes against the scalar implementation.
