### PR TITLE
Fix `Properties::get<ScalarAffineTransform3f>`

### DIFF
--- a/include/mitsuba/core/properties.h
+++ b/include/mitsuba/core/properties.h
@@ -890,7 +890,7 @@ template <typename T> T Properties::get(size_t index) const {
     } else {
         // Handle Transform4f -> Transform3f conversion
         if constexpr (detail::is_transform_3<T>::value)
-            return static_cast<T>(value.extract());
+            return T(value.matrix, value.inverse_transpose);
         else
             return static_cast<T>(value);
     }

--- a/src/core/tests/test_properties.py
+++ b/src/core/tests/test_properties.py
@@ -207,7 +207,8 @@ def test10_transforms3(variant_scalar_rgb):
     p = mi.Properties()
     p["transform"] = mi.ScalarTransform3d().translate([2,4])
 
-    assert type(p["transform"] is mi.ScalarTransform3d)
+    # In Python, transforms are always returned as 4x4
+    assert type(p["transform"]) is mi.ScalarTransform4d
 
 
 def test11_tensor(variant_scalar_rgb):

--- a/src/textures/tests/test_bitmap.py
+++ b/src/textures/tests/test_bitmap.py
@@ -269,3 +269,17 @@ def test07_sample_position_consistency(variants_vec_backends_once, filter_type, 
     pdf = bitmap.pdf_position(mi.Point2f(out[0]))
 
     assert dr.allclose(out[1], pdf)
+
+
+@fresolver_append_path
+def test08_to_uv(variant_scalar_rgb):
+    transform = mi.ScalarTransform3f().translate([2,4]).scale([3, 9]).rotate(45)
+
+    bitmap = mi.load_dict({
+        "type" : "bitmap",
+        "filename" : "resources/data/common/textures/noise_8x8.png",
+        "to_uv" : transform
+    })
+
+    params = mi.traverse(bitmap)
+    assert params["to_uv"] == transform


### PR DESCRIPTION
## Description

This PR fixes #1759: `Properties` would incorrectly return their `Transform3f` values in C++.

When storing a `Transform3f` in a `Properties` object, it would naively add an extra row & column to store it as a `Transform4f` object. However, when accessed, the `Properties` object would call `Transform4f::extract()` which copies the last column (translation) of the `Transform4f` to the last column of the `Transform3f`. The final result would therefore have lost the original translation values.
 
A couple of notes on the current parser/properties interfaces, that feel awkward:
* In Python, `Properties` will **always** return `Transform4` objects through `__getitem__`.
* XML scene descriptions have no way of explicitly specifying that a 3x3 transform.

## Testing

Fixed and extended an existing test for `Transform3` objects in `Properties`.