### PR TITLE
Add missing UV partials computation for duv_dy AOV type

### DIFF
--- a/src/integrators/aov.cpp
+++ b/src/integrators/aov.cpp
@@ -318,6 +318,7 @@ public:
                     break;
 
                 case AOVType::dUVdy:
+                    si.compute_uv_partials(ray);
                     *aovs++ = si.duv_dy.x();
                     *aovs++ = si.duv_dy.y();
                     break;


### PR DESCRIPTION
## Description

The UV partials were computed for `AOVType::dUVdx`, but missing in the `AOVType::dUVdy` case in aov.cpp. This PR adds the missing `si.compute_uv_partials(ray)` statement also for the duv_dy case.

## Checklist

- [x] My code follows the [style guidelines](https://mitsuba.readthedocs.io/en/latest/src/developer_guide.html#coding-style) of this project
- [x] My changes generate no new warnings
- [x] My code also compiles for `cuda_*` and `llvm_*` variants. If you can't test this, please leave below
- [x] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 3 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba/blob/master/LICENSE)