### PR TITLE
[Bug fix] ray_intersect_triangle in python returned None

### DIFF
--- a/src/render/python/shape_v.cpp
+++ b/src/render/python/shape_v.cpp
@@ -288,7 +288,7 @@ template <typename Ptr, typename Cls> void bind_mesh_generic(Cls &cls) {
 
        .def("ray_intersect_triangle", [](const Ptr ptr, const UInt32 &index,
                                          const Ray3f &ray, Mask active) {
-                ptr->ray_intersect_triangle(index, ray, active);
+                return ptr->ray_intersect_triangle(index, ray, active);
             },
             "index"_a, "ray"_a, "active"_a = true,
             D(Mesh, ray_intersect_triangle));

--- a/src/render/tests/test_mesh.py
+++ b/src/render/tests/test_mesh.py
@@ -1423,3 +1423,20 @@ def test37_create_mesh_with_properties(variant_scalar_rgb):
   faces = [0 B of face data],
   face_normals = 0
 ]"""
+
+def test38_ray_intersect_triangle(variants_all_rgb):
+    mesh = mi.Mesh(name='', vertex_count=3, face_count=1)
+    params = mi.traverse(mesh)
+    params['vertex_positions'] = [
+        0.0, 0.0, 0.0, 
+        1.0, 0.0, 0.0,
+        0.5, 1.0, 0.0,
+    ]
+    params['faces'] = [0, 1, 2]
+    params.update()
+
+    ray = mi.Ray3f([0.5, 0.5, 1.0], [0.0, 0.0, -1.0])
+
+    pi = mesh.ray_intersect_triangle(mi.UInt32(0), ray)
+    assert dr.all(dr.abs(pi.t - 1) <= 1e-12)
+    assert dr.all(pi.prim_index == 0)


### PR DESCRIPTION
<!-- Please add the labels (e.g. bug fix, feature, ..) corresponding to this PR -->

## Description

Fixed bug where a return statement was missing in `src/render/python/shape_v.cpp`. Also added a test to cover the function.

## Testing

Added a simple unit test to ensure that a single ray traced towards a single triangle intersects it as expected.

## Checklist

- [x] My code follows the [style guidelines](https://mitsuba.readthedocs.io/en/latest/src/developer_guide.html#coding-style) of this project
- [x] My changes generate no new warnings
- [x] My code also compiles for `cuda_*` and `llvm_*` variants. If you can't test this, please leave below
- [ ] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 3 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba/blob/master/LICENSE)