### PR TITLE
Skip unavailable tests instead of removing them

### DIFF
--- a/src/conftest.py
+++ b/src/conftest.py
@@ -306,10 +306,6 @@ def pytest_collection_modifyitems(config, items):
 
     variant_items = []
     for item in items:
-        # Skip tests with empty variant groups
-        if 'NOTSET' in item.name:
-            continue
-
         # Try to extract variant from test name
         match = pattern.search(item.name)
         if match:
@@ -323,16 +319,11 @@ def pytest_collection_modifyitems(config, items):
                     break
 
         # Skip unavailable variants
-        if variant != "z" and variant not in v:
-            continue
-
+        if (variant != "z" and variant not in v) or 'NOTSET' in item.name:
+            skip_marker = pytest.mark.skip(
+                reason='Skipping test due to unavailable variant.')
+            item.add_marker(skip_marker)
         variant_items.append((variant, item.location, item))
 
     variant_items.sort()
-
-    if len(items) != len(variant_items):
-        print(
-            f"\033[93m-- Filtered tests with unavailable variants ({len(items)} →  {len(variant_items)})\033[0m"
-        )
-
     items[:] = [item[2] for item in variant_items]


### PR DESCRIPTION
The latest `conftest.py` removes tests with unavailable variants, as explained in #1659. This makes sense, as the code previously used a somewhat inefficient way to skip tests with missing variants.

However, this seems to cause a minor issue with the latest pytest versions (>= 8.4.1). With these, test files without any valid tests now produce a non-zero exit code (exit code `5` indicating _No tests were collected_). This can for example happen when running `test_optixdenoiser` in a setting without a GPU, or `test_polarizer` when no polarization variant has been built.

This PR modifies the logic in `conftest.py` to mark tests for skipping, using the same (fast) logic as originally added in #1659. On my system, both with and without PR the test suite (LLVM only, `-m "not slow"`) takes around 50s. I do not observe a significant performance issue from having pytest report the skipped tests instead of removing them entirely.

It's a somewhat minor change, but makes it such that tests that do not fail consistently return exit code 0 :) Maybe worth double checking performance on other systems, if there are known challenges (e.g., on certain OS?)