### PR TITLE
GitHub: add ubuntu-24.04-arm to wheels pipeline

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -11,7 +11,7 @@ jobs:
   build_wheels:
     strategy:
       matrix:
-        os: [ubuntu-24.04, windows-latest, macos-13, macos-14]
+        os: [ubuntu-24.04, ubuntu-24.04-arm, windows-latest, macos-13, macos-14]
         python: [cp39, cp310, cp311, cp312, cp312_stable, cp313]
       fail-fast: false
 


### PR DESCRIPTION
Building Linux aarch64 Mitsuba wheels will require the corresponding DrJit wheels to be published first (https://github.com/mitsuba-renderer/drjit/pull/461).