### PR TITLE
Include child properties in Mesh::to_string() output

### DIFF
--- a/include/mitsuba/render/mesh.h
+++ b/include/mitsuba/render/mesh.h
@@ -20,7 +20,8 @@ public:
     MI_IMPORT_TYPES(BSDF)
     MI_IMPORT_BASE(Shape, m_to_world, mark_dirty, m_emitter, m_sensor, m_bsdf,
                    m_interior_medium, m_exterior_medium, m_is_instance,
-                   m_discontinuity_types, m_shape_type, m_initialized)
+                   m_discontinuity_types, m_shape_type, m_initialized,
+                   get_children_string)
 
     // Mesh is always stored in single precision
     using InputFloat = float;

--- a/src/render/mesh.cpp
+++ b/src/render/mesh.cpp
@@ -1913,10 +1913,11 @@ MI_VARIANT std::string Mesh<Float, Spectrum>::to_string() const {
             oss << "    " << name << ": " << attribute.size
                 << (attribute.size == 1 ? " float" : " floats")
                 << (++i == m_mesh_attributes.size() ? "" : ",") << std::endl;
-        oss << "  ]" << std::endl;
-    } else {
-        oss << std::endl;
+        oss << "  ]";
     }
+
+    oss << "," << std::endl;
+    oss << "  " << string::indent(get_children_string()) << std::endl;
 
     oss << "]";
     return oss.str();

--- a/src/render/tests/test_mesh.py
+++ b/src/render/tests/test_mesh.py
@@ -45,7 +45,10 @@ def test01_create_mesh(variant_scalar_rgb):
   face_count = 2,
   faces = [24 B of face data],
   surface_area = 0.96,
-  face_normals = 0
+  face_normals = 0,
+  bsdf = SmoothDiffuse[
+    reflectance = UniformSpectrum[value=0.500000]
+  ]
 ]"""
 
 
@@ -219,6 +222,9 @@ def test07_ply_stored_attribute(variant_scalar_rgb):
   face_normals = 0,
   mesh attributes = [
     face_color: 3 floats
+  ],
+  bsdf = SmoothDiffuse[
+    reflectance = UniformSpectrum[value=0.500000]
   ]
 ]"""
 
@@ -246,6 +252,9 @@ def test08_mesh_manage_attributes(variant_scalar_rgb):
   face_normals = 0,
   mesh attributes = [
     vertex_color: 3 floats
+  ],
+  bsdf = SmoothDiffuse[
+    reflectance = UniformSpectrum[value=0.500000]
   ]
 ]"""
 
@@ -1421,7 +1430,10 @@ def test37_create_mesh_with_properties(variant_scalar_rgb):
   vertices = [0 B of vertex data],
   face_count = 0,
   faces = [0 B of face data],
-  face_normals = 0
+  face_normals = 0,
+  bsdf = SmoothDiffuse[
+    reflectance = UniformSpectrum[value=0.500000]
+  ]
 ]"""
 
 def test38_ray_intersect_triangle(variants_all_rgb):


### PR DESCRIPTION
<!-- Please add the labels (e.g. bug fix, feature, ..) corresponding to this PR -->

## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->
This PR enhances the `Mesh::to_string()` method to include a string representation of the mesh's children properties, such as the BSDF. This provide more comprehensive information when inspecting mesh objects.

Shapes like `mi.Disk` and `mi.Rectangle` include information about their children (e.g. BSDF) in their string representation by calling `get_children_string()`. However, `mi.Mesh` and by extension its subclasses like `mi.OBJMesh` and `mi.Cube` didn't include this information in their `to_string()` output.

## Testing

<!-- Please describe the tests that you added to verify your changes. -->
The existing Python tests in `src/render/tests/test_mesh.py` have been updated to account for the modified output of the `to_string()` method. These tests now validate that the child properties are correctly included in the string representation of the mesh.

## Checklist

<!-- Please make sure to complete this checklist before requesting a review. -->

- [x] My code follows the [style guidelines](https://mitsuba.readthedocs.io/en/latest/src/developer_guide.html#coding-style) of this project
- [x] My changes generate no new warnings
- [ ] My code also compiles for `cuda_*` and `llvm_*` variants. If you can't test this, please leave below
- [ ] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 3 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba/blob/master/LICENSE)