### PR TITLE
Fix 3D Gaussian ray tracing tests

### DIFF
--- a/src/conftest.py
+++ b/src/conftest.py
@@ -108,6 +108,7 @@ variant_groups = {
     "all": v,
     "all_scalar": v.all("scalar"),
     "all_rgb": v.all("rgb"),
+    "all_rgb_unpolarized": v.all("rgb").exclude("polarized"),
     "all_spectral": v.all("spectral"),
     "all_backends_once": v.all("scalar").one()
     + v.all("llvm").one()
@@ -119,6 +120,7 @@ variant_groups = {
     "vec_rgb": v.all("rgb").exclude("scalar"),
     "vec_spectral": v.all("spectral").exclude("scalar"),
     "all_ad_rgb": v.all("ad", "rgb"),
+    "all_ad_rgb_unpolarized": v.all("ad", "rgb").exclude("polarized"),
     "all_ad_spectral": v.all("ad", "spectral"),
 }
 

--- a/src/integrators/tests/test_volprim_rf_basic.py
+++ b/src/integrators/tests/test_volprim_rf_basic.py
@@ -40,7 +40,7 @@ class EllipsoidsFactory:
 
 
 @pytest.mark.parametrize("shape_type", ['ellipsoids', 'ellipsoidsmesh'])
-def test01_render_span(variants_all_ad_rgb, regression_test_options, shape_type):
+def test01_render_span(variants_all_ad_rgb_unpolarized, regression_test_options, shape_type):
     if 'double' in mi.variant():
         pytest.skip("Test needs to be adapted for double precision variants")
 
@@ -102,7 +102,7 @@ def test01_render_span(variants_all_ad_rgb, regression_test_options, shape_type)
 
 
 @pytest.mark.parametrize("srgb_primitives", [True, False])
-def test02_render_stack(variants_all_ad_rgb, regression_test_options, srgb_primitives):
+def test02_render_stack(variants_all_ad_rgb_unpolarized, regression_test_options, srgb_primitives):
     if 'double' in mi.variant():
         pytest.skip("Test needs to be adapted for double precision variants")
 
@@ -167,7 +167,7 @@ def test02_render_stack(variants_all_ad_rgb, regression_test_options, srgb_primi
 
 
 @pytest.mark.parametrize("shape_type", ['ellipsoids', 'ellipsoidsmesh'])
-def test03_render_depth(variants_all_rgb, regression_test_options, shape_type):
+def test03_render_depth(variants_all_rgb_unpolarized, regression_test_options, shape_type):
     if 'double' in mi.variant():
         pytest.skip("Test needs to be adapted for double precision variants")
 


### PR DESCRIPTION
The 3D Gaussian ray tracing tests are not compatible with *_rgb_polarized variants being enabled. This PR adds test fixtures to explicitly run only unpolarized RGB variants.