### PR TITLE
Fix repeated checks in `load_dict()` when loading instances

### DIFF
--- a/include/mitsuba/render/shapegroup.h
+++ b/include/mitsuba/render/shapegroup.h
@@ -100,6 +100,10 @@ private:
 
     std::vector<UInt64> m_accel_handles;
 
+    // Cache for parameters_grad_enabled() to avoid repeated iteration
+    mutable bool m_parameters_grad_enabled_cache = false;
+    mutable bool m_parameters_grad_enabled_dirty = true;
+
 #if defined(MI_ENABLE_LLVM) || defined(MI_ENABLE_CUDA)
     MI_DECLARE_TRAVERSE_CB(m_shapes, m_shapes_registry_ids, m_accel_handles)
 #else


### PR DESCRIPTION
## Description

This PR fixes two issues leading to significant overhead when parsing scenes with instances.

* The first commit, suggested by @wjakob, implements a tracking mechanism to avoid checking scene graph nodes for cycles multiple times.
* The second commit adds to the `ShapeGroup` class two boolean attributes to cache the `parameters_grad_enabled()` method output and avoid recomputing it repeatedly.

This significantly improves scene loading performance (see #1828).

Fixes #1828.

## Testing

I did not add unit tests to check this; the MWE shown in #1828 was used to check for performance.

## Checklist

- [x] My code follows the [style guidelines](https://mitsuba.readthedocs.io/en/latest/src/developer_guide.html#coding-style) of this project
- [x] My changes generate no new warnings
- [x] My code also compiles for `cuda_*` and `llvm_*` variants. If you can't test this, please leave below
- [x] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 3 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba/blob/master/LICENSE)