### PR TITLE
Spatially varying roughness and IOR for polarized plastics.

### DIFF
--- a/src/bsdfs/pplastic.cpp
+++ b/src/bsdfs/pplastic.cpp
@@ -156,7 +156,7 @@ public:
             m_specular_reflectance = props.get_texture<Texture>("specular_reflectance", 1.f);
 
         if (props.has_property("eta")) {
-            m_eta = props.get_texture<Texture>("eta", 0.f);
+            m_eta = props.get_unbounded_texture<Texture>("eta", 0.f);
             if (props.has_property("int_ior") || props.has_property("ext_iot"))
                 Throw("Should specify either eta or int_ior and ext_ior, not both.");
         }
@@ -195,10 +195,10 @@ public:
             if (props.has_property("alpha"))
                 Throw("Microfacet model: please specify"
                       "either 'alpha' or 'alpha_u'/'alpha_v'.");
-            m_alpha_u = props.get_texture<Texture>("alpha_u", 0.1f);
-            m_alpha_v = props.get_texture<Texture>("alpha_v", 0.1f);
+            m_alpha_u = props.get_unbounded_texture<Texture>("alpha_u", 0.1f);
+            m_alpha_v = props.get_unbounded_texture<Texture>("alpha_v", 0.1f);
         } else {
-            m_alpha_u = m_alpha_v = props.get_texture<Texture>("alpha", 0.1f);
+            m_alpha_u = m_alpha_v = props.get_unbounded_texture<Texture>("alpha", 0.1f);
         }
 
         m_flags = BSDFFlags::GlossyReflection | BSDFFlags::DiffuseReflection;


### PR DESCRIPTION
## Description

This PR adds functionality to the polarized plastic BRDF to allow using textures for roughness and index of refraction, which were previously limited to scalar values. 

## Testing

Matpreview scene with a checkerboard texture modulating the roughness (Stokes 0, 1 and 2):

<img width="256" height="" alt="alpha_s0" src="https://github.com/user-attachments/assets/ef301fab-3188-4d18-bd9d-765ccdb01919" /><img width="256" height="" alt="alpha_s1" src="https://github.com/user-attachments/assets/ffb9f1c2-cac5-480f-b6d0-8ee2bb5ad5d9" /><img width="256" height="" alt="alpha_s2" src="https://github.com/user-attachments/assets/9a771fab-66b9-4af5-bb62-bf2152d4c4ca" />


Matpreview scene with a checkerboard texture modulating the relative index of refraction (Stokes 0, 1 and 2):

<img width="256" height="" alt="eta_s0" src="https://github.com/user-attachments/assets/3bd3d5ac-e78e-4279-aeb1-fe31659d2a58" /><img width="256" height="" alt="eta_s1" src="https://github.com/user-attachments/assets/9b1e5f1a-27fd-49a5-851e-aa3130f8a82c" /><img width="256" height="" alt="eta_s2" src="https://github.com/user-attachments/assets/23659c81-8bef-4539-8414-aafd3b0a89d9" />



## Checklist

- [x] My code follows the [style guidelines](https://mitsuba.readthedocs.io/en/latest/src/developer_guide.html#coding-style) of this project
- [x] My changes generate no new warnings
- [x] My code also compiles for `cuda_*` and `llvm_*` variants. If you can't test this, please leave below
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 3 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba/blob/master/LICENSE)