### PR TITLE
removing from documentation deprecated python3-distutils

### DIFF
--- a/docs/src/developer_guide/compiling.rst
+++ b/docs/src/developer_guide/compiling.rst
@@ -138,7 +138,14 @@ To fetch all dependencies and Clang, enter the following commands on Ubuntu:
     sudo apt install libpng-dev libjpeg-dev
 
     # Install required Python packages
-    sudo apt install libpython3-dev python3-distutils
+    sudo apt install libpython3-dev python3-setuptools
+
+.. note::
+
+    Since Ubuntu 24.04 with python 3.12 python3-distutils has been deprecated,
+    see `PEP632 <https://peps.python.org/pep-0632/>`_ for details.
+    `setuptools`, as described in the `documentation <https://docs.python.org/3.10/library/distutils.html>`_ 
+    is an alternative even if the script itself only imports `distutils`.
 
 Additional packages are required to run the included test suite or to generate
 HTML documentation (see :ref:`Developer guide <sec-writing-documentation>`). If those are


### PR DESCRIPTION
## Description

Removing deprecated for python3.12 (ubuntu 24.04) `python3-distutils` from the compiling documentation.
Substituted with `python3-setuptools` as described in the documentation [1-2].

Added a note to explain the presence of setuptools instead of distutils.

[1] [https://docs.python.org/3.10/library/distutils.html](https://docs.python.org/3.10/library/distutils.html)
[2] [https://peps.python.org/pep-0632/](https://peps.python.org/pep-0632/)

Fixes # (issue)

No corresponding issue

## Testing

No tests executed

## Checklist

- [ ] My code follows the [style guidelines](https://mitsuba.readthedocs.io/en/latest/src/developer_guide.html#coding-style) of this project
- [ ] My changes generate no new warnings
- [ ] My code also compiles for `cuda_*` and `llvm_*` variants. If you can't test this, please leave below
- [ ] I have commented my code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I cleaned the commit history and removed any "Merge" commits
- [ ] I give permission that the Mitsuba 3 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba/blob/master/LICENSE)