### PR TITLE
Propose a solution about fixing connection of delta emitters to senso…

### DIFF
--- a/src/integrators/tests/test_ptracer.py
+++ b/src/integrators/tests/test_ptracer.py
@@ -234,3 +234,37 @@ def test07_adjoint_integrator_trampoline(variants_all_ad_rgb):
     mi.load_dict({
         'type': 'myptracer'
     })
+
+
+def test08_delta_light_irradiancemeter(variants_all_ad_rgb):
+    scene_dict = {
+        'type': 'scene',
+        'integrator': {
+            'type': 'ptracer',
+            'max_depth': 2,
+        },
+        'sensor': {
+            'type': 'sphere',
+            'center': [0, 0, 0],
+            'radius': 1.0,
+            'sensor': {
+                'type': 'irradiancemeter',
+                'film': {
+                    'type': 'hdrfilm',
+                    'width': 1,
+                    'height': 1,
+                    'rfilter': {'type': 'box'},
+                }
+            }
+        },
+        'emitter': {
+            'type': 'point',
+            'position': [2, 0, 0]
+        }
+    }
+
+    scene = mi.load_dict(scene_dict)
+    sensor = scene.sensors()[0]
+    image = mi.render(scene, seed=0, sensor=sensor)
+
+    assert image[0][0][0].numpy() > 0.1

--- a/src/sensors/irradiancemeter.cpp
+++ b/src/sensors/irradiancemeter.cpp
@@ -101,7 +101,9 @@ public:
 
     std::pair<DirectionSample3f, Spectrum>
     sample_direction(const Interaction3f &it, const Point2f &sample, Mask active) const override {
-        return { m_shape->sample_direction(it, sample, active), dr::Pi<ScalarFloat> };
+        DirectionSample3f ds = m_shape->sample_direction(it, sample, active);
+        return { ds, dr::select(ds.pdf > 0.f,
+                                dr::rcp(ds.pdf) / m_shape->surface_area(), 0.f) };
     }
 
     Float pdf_direction(const Interaction3f &it, const DirectionSample3f &ds,


### PR DESCRIPTION
<!-- Please add the labels (e.g. bug fix, feature, ..) corresponding to this PR -->

## Description

Address the limitations of the default ptracer integrator when simulating a system with delta emitters (e.g. Spot/Point Lights) and spatially extended sensors (e.g. Irradiancemeter)

1. Connectivity for delta emitters:
  * Under `ptracer` implementation, point light produces negligible signal (on the order of `10^-6`)
  <img width="640" height="480" alt="newplot (21)" src="https://github.com/user-attachments/assets/c1f1c41d-d02f-4f2e-8a2a-63405589ecbf" />

  * `ptracer` seems originally be designed for a pinhole camera, since the probability of a ray from a delta emitter to a delta sensor is zero, the integrator explicitly prevents connections between these. [ref](https://github.com/mitsuba-renderer/mitsuba3/blob/03c06ce9c2a3991960a430bd68cdb5b384031adf/src/integrators/ptracer.cpp#L113)

2. Constant Monte Carlo weighting (Distance Independence)
  * The rendered irradiance value of an `irradiancemeter` from an area light (which is not delta light) remains nearly constant regardless of the distance between the emitter and the sensor, it should probably follow the inverse-square law.
   <img width="640" height="480" alt="newplot (17)" src="https://github.com/user-attachments/assets/4cc8e190-8870-49a7-a46b-591872fe4b3a" />

  *  `irradiancemeter::sample_direction` returned a fixed weight of `dr::Pi`.  [ref](https://github.com/mitsuba-renderer/mitsuba3/blob/03c06ce9c2a3991960a430bd68cdb5b384031adf/src/sensors/irradiancemeter.cpp#L103)

## Suggest fix
### ptracer
* Enabling Connection for Delta emitter: If the sensor needs an aperture sample (e.g. irradiancemeter) we allow delta lights to connect to it.
* Add a `has_frame` check to verify a valid normal exists before performing coordinate transformations or back-face checks. (Since a delta light wound't have a normal `si.n`)

### irradiancemeter
* Change Monte Carlo weighting: Updated the return value to use the standard Monte Carlo weight: `(1 / (PDF * surface_area))`.

## Testing
To validate the modifications made to the `ptracer` integrator and the `irradiancemeter` sensor, a numerical verification test was performed by comparing simulation results against an analytical solution for a fundamental optical setup.

The test considers a disk of radius R centered at the origin (0,0,0) in the xy-plane, illuminated by a point light source with radiant intensity I (Watt/Steradian) located at height h on the z-axis.

Analytical solution
```python
# Formula for Flux of point source over a disk:
# Flux = 2 * pi * I * (1 - h / sqrt(R^2 + h^2))
term = h_height / np.sqrt(R_radius**2 + h_height**2)
total_flux_analytical = 2 * np.pi * I_intensity * (1 - term)
avg_irradiance_analytical = total_flux_analytical / disk_area
```


Scene setting
```python
mi.set_variant('llvm_ad_spectral')
 
scene_dict: dict[str, Any] = {
    'type': 'scene',
    'integrator': {
        'type': integrator_type,
        'max_depth': 2,
    },
    'sensor_disk': {
        'type': 'disk',
        'to_world': mi.ScalarTransform4f(),
        'sensor': {
            'type': 'irradiancemeter',
            'srf': {
                'type': 'regular',
                'wavelength_min': 360.0, # MI_CIE_MIN
                'wavelength_max': 830.0, # MI_CIE_MAX defined in spectrum.h
                'values': '1.0, 1.0'
            },
            'film': {
                'type': 'hdrfilm',
                'width': 1,
                'height': 1,
                'pixel_format': 'luminance',      
                'rfilter': {
                    'type': 'box'
                }
            },
        },
    },
    'emitter': {
        'type': 'point',
        'position': [0, 0, z_value],
        'intensity': {
            'type': 'spectrum',
            'value': 1.0,
        },
    }, 
}

```

Test Results:
<img width="900" height="600" alt="newplot (22)" src="https://github.com/user-attachments/assets/a38c30be-a58c-43bd-acbf-e3b60834e20b" />

<img width="1100" height="650" alt="newplot (23)" src="https://github.com/user-attachments/assets/3970eac0-6e20-493d-b031-d5709eddcead" />

1. **Signal Detection**:  The `ptracer` now successfully captures signals from a point light source, resolving the connectivity issue.
2. **Physical Accuracy**: The trends of mi Irradiance and Analytical Irradiance are almost the same.

Additionally, unit tests were implemented for the `test_incoming_flux_integrator` function. During these tests, the measured value of `mi.TensorXf(img)` was approximately 3.8, which is consistent with the theoretical expectation of `radiance * dr.pi`

## Checklist

<!-- Please make sure to complete this checklist before requesting a review. -->

- [x] My code follows the [style guidelines](https://mitsuba.readthedocs.io/en/latest/src/developer_guide.html#coding-style) of this project
- [x] My changes generate no new warnings
- [ ] My code also compiles for `cuda_*` and `llvm_*` variants. If you can't test this, please leave below
- [ ] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 3 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba/blob/master/LICENSE)