### PR TITLE
`measured` BSDF: Fix missing default for isotropic materials

### DIFF
--- a/src/bsdfs/measured.cpp
+++ b/src/bsdfs/measured.cpp
@@ -169,6 +169,8 @@ public:
             ScalarFloat *phi_i_data = (ScalarFloat *) phi_i.data;
             m_reduction = (int) std::rint((2 * dr::Pi<ScalarFloat>) /
                 (phi_i_data[phi_i.shape[0] - 1] - phi_i_data[0]));
+        } else {
+            m_reduction = 0;
         }
 
         // Construct NDF interpolant data structure


### PR DESCRIPTION
## Description

In the `measured` BSDF plugin, the `m_reduction` remains unset for isotropic materials. This causes unpredictable flips of the x and y components of the sampled directions. I observed this behaviour as I was instantiating two slightly different versions of this plugin to check for consistency: they had different values for `m_reduction`.

I put 0 (meaning that isotropic materials will not enter the symmetry reduction branches of the code), but to be honest, I'm not entirely sure if this is correct because isotropic materials do have symmetries.

## Testing

I checked for consistency, but I cannot say for sure that overall the results are correct (this plugin doesn't have unit tests).

## Checklist

- [x] My code follows the [style guidelines](https://mitsuba.readthedocs.io/en/latest/src/developer_guide.html#coding-style) of this project
- [x] My changes generate no new warnings
- [ ] My code also compiles for `cuda_*` and `llvm_*` variants. If you can't test this, please leave below
- [ ] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 3 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba/blob/master/LICENSE)