### PR TITLE
Fix delta emitter sample weights in the direct integrator

### DIFF
--- a/src/integrators/direct.cpp
+++ b/src/integrators/direct.cpp
@@ -178,8 +178,8 @@ public:
                 bsdf_val = si.to_world_mueller(bsdf_val, -wo, si.wi);
 
                 Float mis = dr::select(ds.delta, Float(1.f), mis_weight(
-                    ds.pdf * m_frac_lum, bsdf_pdf * m_frac_bsdf) * m_weight_lum);
-                result[active_e] += mis * bsdf_val * emitter_val;
+                    ds.pdf * m_frac_lum, bsdf_pdf * m_frac_bsdf));
+                result[active_e] += mis * bsdf_val * emitter_val * m_weight_lum;
             }
         }
 

--- a/src/integrators/tests/test_direct.py
+++ b/src/integrators/tests/test_direct.py
@@ -1,0 +1,62 @@
+import pytest
+import drjit as dr
+import mitsuba as mi
+
+def test01_delta_emitter_samples_weighted(variants_all_rgb):
+    scene = mi.load_dict({
+        'type': 'scene',
+        'sensor': {
+            'type': 'perspective',
+            'to_world': mi.ScalarTransform4f().look_at(
+                origin=(0, 0, 5),
+                target=(0, 0, 0),
+                up=(0, 1, 0),
+            ),
+            'sampler': {
+                'type': 'independent',
+                'sample_count': 1
+            },
+            'film': {
+                'type': 'hdrfilm',
+                'width': 128, 'height': 128,
+                'crop_offset_x': 64,
+                'crop_offset_y': 64,
+                'crop_width': 1,
+                'crop_height': 1
+            },
+        },
+        'emitter' : {
+            'type': 'point',
+            'position': [0.0, 0.0, 2.0],
+            'intensity': {
+                'type': 'rgb',
+                'value': 1.0,
+            }
+        },
+        'sphere' : {
+            'type': 'sphere',
+            'center': [0.0, 0.0, 0.0],
+            'radius': 1,
+            'bsdf': {
+                'type': 'diffuse'
+            }
+        }
+    })
+
+    integrator = mi.load_dict({
+        'type': 'direct',
+        'emitter_samples': 1,
+        'bsdf_samples': 0,
+    })
+    single_sample_img = mi.render(scene, integrator=integrator)
+
+    integrator = mi.load_dict({
+        'type': 'direct',
+        'emitter_samples': 10,
+        'bsdf_samples': 0,
+    })
+    multi_sample_img = mi.render(scene, integrator=integrator)
+    # The number of emitter samples should not affect a scene with a single
+    # point light source.
+    diff = single_sample_img.array - multi_sample_img.array
+    assert dr.allclose(diff, 0)


### PR DESCRIPTION
<!-- Please add the labels (e.g. bug fix, feature, ..) corresponding to this PR -->

## Description

Fixes #1861

The direct illumination integrator computes the (MIS) weight of emitter samples as 
```cc
Float mis = dr::select(ds.delta, Float(1.f), mis_weight(
                    ds.pdf * m_frac_lum, bsdf_pdf * m_frac_bsdf) * m_weight_lum);
result[active_e] += mis * bsdf_val * emitter_val;
```

where
- `m_frac_lum = emitter_samples / (emitter_samples + bsdf_samples)`
- `m_frac_bsdf = bsdf_samples / (emitter_samples + bsdf_samples)`
- `m_weight_lum = 1 / emitter_samples`

The weight of delta emitters is simply set to 1 so we are adding `1 * bsdf * Li` to the output for each sample. The more samples you take the brighter the output will be. 
My fix consists of moving the multiplication by `m_weight_lum` down one line so that it is also applied for delta emitter samples.

This bug is only present in the direct illumination integrator as far as I can tell.


## Testing

I added a test that constructs a scene with

- A sphere with radius 1 at (0,0,0)
- A point light at (0,0,2)
- A camera at (0,0,5), looking down the z-axis

The scene is rendered with the direct integrator with `emitter_samples=1` and `emitter_samples=10`. The test asserts that the color of the center pixel is the same in both renders.

## Checklist

- [x] My code follows the [style guidelines](https://mitsuba.readthedocs.io/en/latest/src/developer_guide.html#coding-style) of this project
- [x] My changes generate no new warnings
- [x] My code also compiles for `cuda_*` and `llvm_*` variants. If you can't test this, please leave below
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation (N/A)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 3 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba/blob/master/LICENSE)