### PR TITLE
Improve surface point offsetting to prevent self-intersection

### DIFF
--- a/include/mitsuba/render/interaction.h
+++ b/include/mitsuba/render/interaction.h
@@ -163,9 +163,37 @@ private:
      * position is offset along the surface normal to prevent self intersection.
      */
     Point3f offset_p(const Vector3f &d) const {
-        Float mag = (1.f + dr::max(dr::abs(p))) * math::RayEpsilon<Float>;
-        mag = dr::detach(dr::mulsign(mag, dr::dot(n, d)));
-        return dr::fmadd(mag, dr::detach(n), p);
+        using UInt32 = dr::uint32_array_t<Float>;
+        using Int32  = dr::int32_array_t<Float>;
+
+        Float dot_nd = dr::dot(n, d);
+        Vector3f n_signed = dr::select(dot_nd >= 0.f, n, -n);
+
+        auto offset_coord = [](const Float &p_c, const Float &n_c) {
+            UInt32 p_u = dr::reinterpret_array<UInt32>(p_c);
+            Int32 of_i = dr::floor2int<Int32>(256.f * n_c);
+
+            UInt32 p_i_u = dr::select(p_c >= 0.f,
+                                      dr::reinterpret_array<UInt32>(
+                                          dr::reinterpret_array<Int32>(p_u) + of_i),
+                                      dr::reinterpret_array<UInt32>(
+                                          dr::reinterpret_array<Int32>(p_u) - of_i));
+            Float p_i = dr::reinterpret_array<Float>(p_i_u);
+
+            Float origin = 1.f / 32.f;
+            Float float_scale = 1.f / 65536.f;
+
+            return dr::select(dr::abs(p_c) < origin,
+                              p_c + float_scale * n_c,
+                              p_i);
+        };
+
+        Point3f p_offset;
+        p_offset.x() = offset_coord(p.x(), n_signed.x());
+        p_offset.y() = offset_coord(p.y(), n_signed.y());
+        p_offset.z() = offset_coord(p.z(), n_signed.z());
+
+        return dr::detach(p_offset);
     }
 };
 


### PR DESCRIPTION
<!-- Please add the labels (e.g. bug fix, feature, ..) corresponding to this PR -->

## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->
This PR propose a robust, scale-invariant offsetting technique based on [Ray Tracing Gems ("A Fast and Robust Method for Avoiding Self-Intersection")](https://www.realtimerendering.com/raytracinggems/unofficial_RayTracingGems_v1.6.pdf) in Chapter 6.  (6.2.2.4) to the current ray offset mechanism.

### The Problem: Static `RayEpsilon`

Currently, Mitsuba's ray offset calculation uses a fairly generous static RayEpsilon to modify the origins of spawned rays. This constant approach frequently runs into issues in high-precision use cases where important intersections of nearby surfaces may be "missed."
A concrete example is rendering a realistic human eye: the distance between the inner eye structures and the cornea is often smaller than the default RayEpsilon, causing the renderer to skip critical intersections and produce noticeable rendering artifacts. Other renderers (e.g., Blender Cycles) seem to handle this case more robustly

### Visual Comparison
To demonstrate the precision of the adaptive offsetting, I use two spheres at the origin:
* Red Sphere: Radius = 1.0
* Dielectric Sphere: Radius = 1.0 + 4e-5 (which is smaller than `mi.math.RayEpsilon`)

In the current version, it fails to find the intersection of the inside sphere due to the generous epsilon, leading to the light leaking. With adaptive offsetting, we could have the two sphere been rendered.


```python
scene_dict = {
    "type": "scene",
    "integrator": {"type": "path"},
    "red_sphere": {
        "type": "sphere",
        "radius": 1.0,
        "center": [0, 0, 0],
        "bsdf": {
            "type": "diffuse",
            "reflectance": {
                "type": "rgb",
                "value": [1.0, 0.1, 0.1]
            }
        }
    },
    "outer_sphere": {
        "type": "sphere",
        "radius": 1.0 + 4e-5, # Distance is 4e-5, smaller than RayEpsilon (approx 8.9e-05 mi.math.RayEpsilon)
        "center": [0, 0, 0],
        "bsdf": {
            "type": "dielectric",
        }
    },
    "sensor": {
        'type': 'perspective',
        'to_world': mi.ScalarTransform4f().look_at(origin=(0.0, 4.0, 4.0), target=(0.0, 0.0, 0.0), up=(0, 0, 1)),
        'film': {'type': 'hdrfilm', 'width': 300, 'height': 300},   
    },
    "emitter": {'type': 'constant', 'radiance': 0.1},
    "light": {'type': 'cube', 'to_world': mi.ScalarTransform4f.translate([0, 0, 5]), 'emitter': {'type': 'area'}},
}

scene = mi.load_dict(scene_dict)

image = mi.render(scene=scene, spp=512)
mi.Bitmap(image).convert(mi.Bitmap.PixelFormat.RGB, mi.Struct.Type.UInt8, True)
```

|Current version|Adaptive offsetting|
|---|---|
|<img width="300" height="300" alt="image" src="https://github.com/user-attachments/assets/24afe0b2-8d6b-4b3c-ad9c-0b5bad71e199" />|<img width="300" height="300" alt="image" src="https://github.com/user-attachments/assets/1fd81943-f615-4660-b5bf-c68e66b33ba9" />|




## Testing

<!-- Please describe the tests that you added to verify your changes. -->


Existing tests have been executed. I observed some failures during the process; however, these appear to be strictly related to the CUDA environment/drivers on the test machine rather than the core logic of this implementation.

## Checklist

<!-- Please make sure to complete this checklist before requesting a review. -->

- [x] My code follows the [style guidelines](https://mitsuba.readthedocs.io/en/latest/src/developer_guide.html#coding-style) of this project
- [x] My changes generate no new warnings
- [ ] My code also compiles for `cuda_*` and `llvm_*` variants. If you can't test this, please leave below
- [ ] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 3 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba/blob/master/LICENSE)