### PR TITLE
MergeShape: improve mesh merge

### DIFF
--- a/include/mitsuba/python/docstr.h
+++ b/include/mitsuba/python/docstr.h
@@ -5710,6 +5710,8 @@ static const char *__doc_mitsuba_Mesh_m_vertex_texcoords = R"doc()doc";
 
 static const char *__doc_mitsuba_Mesh_merge = R"doc(Merge two meshes into one)doc";
 
+static const char *__doc_mitsuba_Mesh_merge_2 = R"doc(Merge a batch of compatible meshes into a single mesh)doc";
+
 static const char *__doc_mitsuba_Mesh_moeller_trumbore =
 R"doc(Moeller and Trumbore algorithm for computing ray-triangle intersection
 

--- a/include/mitsuba/render/mesh.h
+++ b/include/mitsuba/render/mesh.h
@@ -9,6 +9,7 @@
 #include <mitsuba/core/properties.h>
 #include <unordered_map>
 #include <mutex>
+#include <vector>
 #include <drjit/dynamic.h>
 #include <drjit/array_traverse.h>
 
@@ -222,6 +223,9 @@ public:
 
     /// Merge two meshes into one
     ref<Mesh> merge(const Mesh *other) const;
+
+    /// Merge a batch of compatible meshes into a single mesh
+    static ref<Mesh> merge(const std::vector<ref<Mesh>> &meshes);
 
     /// Compute smooth vertex normals and replace the current normal values
     void recompute_vertex_normals();

--- a/src/render/mesh.cpp
+++ b/src/render/mesh.cpp
@@ -9,6 +9,7 @@
 #include <mitsuba/render/mesh.h>
 #include <mitsuba/render/records.h>
 #include <mitsuba/render/scene.h>
+#include <algorithm>
 
 #if defined(MI_ENABLE_EMBREE)
     #include <embree3/rtcore.h>
@@ -732,68 +733,136 @@ Mesh<Float, Spectrum>::build_indirect_silhouette_distribution() {
 MI_VARIANT
 ref<Mesh<Float, Spectrum>>
 Mesh<Float, Spectrum>::merge(const Mesh *other) const {
-    if (other->emitter() != m_emitter || other->sensor() != m_sensor ||
-        other->bsdf() != m_bsdf ||
-        other->interior_medium() != m_interior_medium ||
-        other->exterior_medium() != m_exterior_medium ||
-        other->has_vertex_normals() != has_vertex_normals() ||
-        other->has_vertex_texcoords() != has_vertex_texcoords() ||
-        other->has_face_normals() != has_face_normals() ||
-        other->has_flipped_normals() != has_flipped_normals() ||
-        other->has_mesh_attributes() || has_mesh_attributes())
-        Throw("Mesh::merge(): the two meshes are incompatible (%s and %s)!",
-              to_string(), other->to_string());
+    return merge({ ref<Mesh>(const_cast<Mesh *>(this)),
+                   ref<Mesh>(const_cast<Mesh *>(other)) });
+}
 
+MI_VARIANT
+ref<Mesh<Float, Spectrum>>
+Mesh<Float, Spectrum>::merge(const std::vector<ref<Mesh>> &meshes) {
+    const size_t n = meshes.size();
+    if (n == 0)
+        Throw("Mesh::merge(): called with an empty mesh list!");
+    if (n == 1)
+        return meshes[0];
+
+    /* The first mesh is the reference: its attribute layout and attached
+       objects (BSDF, emitter, ...) are inherited by the result, and every
+       other input must match them exactly. */
+    const Mesh *first  = meshes[0].get();
+    const bool  has_vn = first->has_vertex_normals();
+    const bool  has_vt = first->has_vertex_texcoords();
+    if (first->has_mesh_attributes())
+        Throw("Mesh::merge(): mesh attributes are not supported (%s)!",
+              first->to_string());
+
+    /* Single pass over the inputs: compatibility check, prefix offsets,
+       totals, merged bounding box and merged name. */
+    std::vector<ScalarIndex> vertex_offsets(n), face_offsets(n);
+    ScalarBoundingBox3f bbox = first->m_bbox;
+    std::string name = first->m_name;
+    size_t total_vertices = first->vertex_count(),
+           total_faces    = first->face_count();
+    vertex_offsets[0] = 0;
+    face_offsets[0]   = 0;
+
+    for (size_t i = 1; i < n; ++i) {
+        const Mesh *m = meshes[i].get();
+
+        bool compatible =
+            m->emitter()              == first->m_emitter                   &&
+            m->sensor()               == first->m_sensor                    &&
+            m->bsdf()                 == first->m_bsdf                      &&
+            m->interior_medium()      == first->m_interior_medium           &&
+            m->exterior_medium()      == first->m_exterior_medium           &&
+            m->has_vertex_normals()   == has_vn                             &&
+            m->has_vertex_texcoords() == has_vt                             &&
+            m->has_face_normals()     == first->has_face_normals()          &&
+            m->has_flipped_normals()  == first->has_flipped_normals()       &&
+            !m->has_mesh_attributes();
+
+        if (!compatible)
+            Throw("Mesh::merge(): incompatible meshes (%s and %s)!",
+                  first->to_string(), m->to_string());
+
+        vertex_offsets[i] = (ScalarIndex) total_vertices;
+        face_offsets[i]   = (ScalarIndex) total_faces;
+        total_vertices   += m->vertex_count();
+        total_faces      += m->face_count();
+        bbox.expand(m->m_bbox);
+        name += " + ";
+        name += m->m_name;
+    }
+
+    /* Use the bare `Mesh(Properties)` overload and allocate buffers with
+       `dr::empty` — the sized overload would zero-fill before we overwrite. */
     Properties props;
-    if (m_bsdf)
-        props.set("bsdf", (Object *) m_bsdf.get());
-    if (m_interior_medium)
-        props.set("interior", (Object *) m_interior_medium.get());
-    if (m_exterior_medium)
-        props.set("exterior", (Object *) m_exterior_medium.get());
-    if (m_sensor)
-        props.set("sensor", (Object *) m_sensor.get());
-    if (m_emitter)
-        props.set("emitter", (Object *) m_emitter.get());
-    props.set("face_normals", m_face_normals);
-    props.set("flip_normals", m_flip_normals);
+    if (first->m_bsdf)
+        props.set("bsdf",     (Object *) first->m_bsdf.get());
+    if (first->m_interior_medium)
+        props.set("interior", (Object *) first->m_interior_medium.get());
+    if (first->m_exterior_medium)
+        props.set("exterior", (Object *) first->m_exterior_medium.get());
+    if (first->m_sensor)
+        props.set("sensor",   (Object *) first->m_sensor.get());
+    if (first->m_emitter)
+        props.set("emitter",  (Object *) first->m_emitter.get());
+    props.set("face_normals", first->m_face_normals);
+    props.set("flip_normals", first->m_flip_normals);
 
-    ref<Mesh> result = new Mesh(
-        m_name + " + " + other->m_name, m_vertex_count + other->vertex_count(),
-        m_face_count + other->face_count(), props, has_vertex_normals(),
-        has_vertex_texcoords());
+    ref<Mesh> result = new Mesh(props);
+    result->m_name         = std::move(name);
+    result->m_vertex_count = (ScalarSize) total_vertices;
+    result->m_face_count   = (ScalarSize) total_faces;
+    result->m_bbox         = bbox;
+    result->m_vertex_positions = dr::empty<FloatStorage>(total_vertices * 3);
+    if (has_vn)
+        result->m_vertex_normals = dr::empty<FloatStorage>(total_vertices * 3);
+    if (has_vt)
+        result->m_vertex_texcoords = dr::empty<FloatStorage>(total_vertices * 2);
+    result->m_faces = dr::empty<DynamicBuffer<UInt32>>(total_faces * 3);
 
-    result->m_vertex_positions =
-        dr::concat(m_vertex_positions, other->m_vertex_positions);
+    for (size_t i = 0; i < n; ++i) {
+        const Mesh  *m     = meshes[i].get();
+        ScalarSize   vc    = m->vertex_count(),
+                     fc    = m->face_count();
+        ScalarIndex  v_off = vertex_offsets[i],
+                     f_off = face_offsets[i];
 
-    if (has_vertex_normals())
-        result->m_vertex_normals =
-            dr::concat(m_vertex_normals, other->m_vertex_normals);
+        if constexpr (!dr::is_jit_v<Float>) {
+            std::copy_n(m->m_vertex_positions.data(), vc * 3,
+                        result->m_vertex_positions.data() + v_off * 3);
+            if (has_vn)
+                std::copy_n(m->m_vertex_normals.data(), vc * 3,
+                            result->m_vertex_normals.data() + v_off * 3);
+            if (has_vt)
+                std::copy_n(m->m_vertex_texcoords.data(), vc * 2,
+                            result->m_vertex_texcoords.data() + v_off * 2);
 
-    if (has_vertex_texcoords())
-        result->m_vertex_texcoords =
-            dr::concat(m_vertex_texcoords, other->m_vertex_texcoords);
+            const ScalarIndex *src = m->m_faces.data();
+            ScalarIndex       *dst = result->m_faces.data() + f_off * 3;
+            for (ScalarSize k = 0; k < fc * 3; ++k)
+                dst[k] = src[k] + v_off;
+        } else {
+            UInt32 v_idx = dr::arange<UInt32>(vc * 3) + v_off * 3;
+            dr::scatter(result->m_vertex_positions, m->m_vertex_positions,
+                        v_idx);
+            if (has_vn)
+                dr::scatter(result->m_vertex_normals, m->m_vertex_normals,
+                            v_idx);
+            if (has_vt) {
+                UInt32 uv_idx = dr::arange<UInt32>(vc * 2) + v_off * 2;
+                dr::scatter(result->m_vertex_texcoords,
+                            m->m_vertex_texcoords, uv_idx);
+            }
+            UInt32 f_idx = dr::arange<UInt32>(fc * 3) + f_off * 3;
+            dr::scatter(result->m_faces, m->m_faces + v_off, f_idx);
+        }
+    }
 
-    result->m_faces = dr::concat(m_faces, other->m_faces);
-    result->m_bbox = m_bbox;
-    result->m_bbox.expand(other->m_bbox);
-
-    if constexpr (dr::is_jit_v<Float>) {
-        UInt32 threshold = dr::opaque<UInt32>(face_count() * 3),
-               offset    = dr::opaque<UInt32>(vertex_count()),
-               index     = dr::arange<UInt32>(result->face_count() * 3);
-
-        result->m_faces = dr::select(index < threshold, result->m_faces,
-                                     result->m_faces + offset);
-
+    if constexpr (dr::is_jit_v<Float>)
         dr::eval(result->m_faces, result->m_vertex_positions,
                  result->m_vertex_normals, result->m_vertex_texcoords);
-    } else {
-        uint32_t  offset = vertex_count(),
-                 *ptr    = result->m_faces.data() + face_count() * 3;
-        for (size_t i = 0; i < other->face_count() * 3; ++i)
-            *ptr++ += offset;
-    }
 
     result->initialize();
 

--- a/src/render/python/shape_v.cpp
+++ b/src/render/python/shape_v.cpp
@@ -366,8 +366,12 @@ MI_PY_EXPORT(Shape) {
         .def("write_ply",
              nb::overload_cast<Stream *>(&Mesh::write_ply, nb::const_),
              "stream"_a, D(Mesh, write_ply, 2))
-        .def("merge", &Mesh::merge, "other"_a,
-             D(Mesh, merge))
+        .def("merge",
+             nb::overload_cast<const Mesh *>(&Mesh::merge, nb::const_),
+             "other"_a, D(Mesh, merge))
+        .def_static("merge_many",
+             nb::overload_cast<const std::vector<ref<Mesh>> &>(&Mesh::merge),
+             "meshes"_a, D(Mesh, merge, 2))
 
         .def("vertex_positions_buffer", nb::overload_cast<>(&Mesh::vertex_positions_buffer))
         .def("vertex_normals_buffer", nb::overload_cast<>(&Mesh::vertex_normals_buffer))

--- a/src/render/python/shape_v.cpp
+++ b/src/render/python/shape_v.cpp
@@ -367,10 +367,18 @@ MI_PY_EXPORT(Shape) {
              nb::overload_cast<Stream *>(&Mesh::write_ply, nb::const_),
              "stream"_a, D(Mesh, write_ply, 2))
         .def("merge",
-             nb::overload_cast<const Mesh *>(&Mesh::merge, nb::const_),
+             [](const Mesh *self, const Mesh *other) {
+                 return nb::cast(self->merge(other).get());
+             },
              "other"_a, D(Mesh, merge))
         .def_static("merge_many",
-             nb::overload_cast<const std::vector<ref<Mesh>> &>(&Mesh::merge),
+             [](const std::vector<Mesh *> &meshes) {
+                 std::vector<ref<Mesh>> refs;
+                 refs.reserve(meshes.size());
+                 for (Mesh *m : meshes)
+                     refs.emplace_back(m);
+                 return nb::cast(Mesh::merge(refs).get());
+             },
              "meshes"_a, D(Mesh, merge, 2))
 
         .def("vertex_positions_buffer", nb::overload_cast<>(&Mesh::vertex_positions_buffer))

--- a/src/shapes/merge.cpp
+++ b/src/shapes/merge.cpp
@@ -13,7 +13,9 @@ public:
     MergeShape(const Properties &props) {
         // Note: we are *not* calling the `Shape` constructor as we do not
         // want to accept various properties such as `to_world`.
-        std::unordered_map<Key, ref<Mesh>, key_hasher> tbl;
+        // Group meshes by merge key, then merge each group with a
+        // tree-balanced reduction (O(M log N) per group.
+        std::unordered_map<Key, std::vector<ref<Mesh>>, key_hasher> groups;
         size_t visited = 0, ignored = 0;
         Timer timer;
 
@@ -37,22 +39,35 @@ public:
             key.has_texcoords = mesh->has_vertex_texcoords();
             key.has_face_normals = mesh->has_face_normals();
 
-            auto [it, success] = tbl.try_emplace(key, mesh);
-            if (!success)
-                it->second = it->second->merge(mesh);
-
+            groups[key].push_back(ref<Mesh>(mesh));
             visited++;
         }
 
-        for (auto &kv : tbl) {
-            if (tbl.size() == 1 && !props.id().empty())
-                kv.second->set_id(props.id());
+        for (auto &kv : groups) {
+            ref<Mesh> merged = tree_merge(kv.second);
 
-            m_objects.push_back((ref<Object>) kv.second);
+            if (groups.size() == 1 && !props.id().empty())
+                merged->set_id(props.id());
+
+            m_objects.push_back((ref<Object>) merged);
         }
 
         Log(Info, "Collapsed %zu into %zu meshes. (took %s, %zu objects ignored)",
-            visited, tbl.size(), util::time_string((float) timer.value()), ignored);
+            visited, groups.size(), util::time_string((float) timer.value()),
+            ignored);
+    }
+
+    static ref<Mesh> tree_merge(std::vector<ref<Mesh>> meshes) {
+        while (meshes.size() > 1) {
+            std::vector<ref<Mesh>> next;
+            next.reserve((meshes.size() + 1) / 2);
+            for (size_t i = 0; i + 1 < meshes.size(); i += 2)
+                next.push_back(meshes[i]->merge(meshes[i + 1].get()));
+            if (meshes.size() % 2 == 1)
+                next.push_back(meshes.back());
+            meshes = std::move(next);
+        }
+        return meshes[0];
     }
 
     std::vector<ref<Object>> expand() const override {

--- a/src/shapes/merge.cpp
+++ b/src/shapes/merge.cpp
@@ -13,8 +13,8 @@ public:
     MergeShape(const Properties &props) {
         // Note: we are *not* calling the `Shape` constructor as we do not
         // want to accept various properties such as `to_world`.
-        // Group meshes by merge key, then merge each group with a
-        // tree-balanced reduction (O(M log N) per group.
+        // Group meshes by merge key, then collapse each group in a single
+        // batched call to `Mesh::merge`.
         std::unordered_map<Key, std::vector<ref<Mesh>>, key_hasher> groups;
         size_t visited = 0, ignored = 0;
         Timer timer;
@@ -44,7 +44,7 @@ public:
         }
 
         for (auto &kv : groups) {
-            ref<Mesh> merged = tree_merge(kv.second);
+            ref<Mesh> merged = Mesh::merge(kv.second);
 
             if (groups.size() == 1 && !props.id().empty())
                 merged->set_id(props.id());
@@ -55,19 +55,6 @@ public:
         Log(Info, "Collapsed %zu into %zu meshes. (took %s, %zu objects ignored)",
             visited, groups.size(), util::time_string((float) timer.value()),
             ignored);
-    }
-
-    static ref<Mesh> tree_merge(std::vector<ref<Mesh>> meshes) {
-        while (meshes.size() > 1) {
-            std::vector<ref<Mesh>> next;
-            next.reserve((meshes.size() + 1) / 2);
-            for (size_t i = 0; i + 1 < meshes.size(); i += 2)
-                next.push_back(meshes[i]->merge(meshes[i + 1].get()));
-            if (meshes.size() % 2 == 1)
-                next.push_back(meshes.back());
-            meshes = std::move(next);
-        }
-        return meshes[0];
     }
 
     std::vector<ref<Object>> expand() const override {

--- a/src/shapes/tests/test_merge.py
+++ b/src/shapes/tests/test_merge.py
@@ -1,3 +1,5 @@
+import pytest
+
 import mitsuba as mi
 
 from mitsuba.scalar_rgb.test.util import fresolver_append_path
@@ -10,6 +12,14 @@ def example_mesh(**kwargs):
         "face_normals" : True,
         **kwargs
     }
+
+
+def example_mesh_obj(bsdf=None):
+    """Load an example mesh as a Python object, optionally sharing a BSDF."""
+    d = example_mesh()
+    if bsdf is not None:
+        d["bsdf"] = bsdf
+    return mi.load_dict(d)
 
 
 @fresolver_append_path
@@ -103,3 +113,129 @@ def test02_two_shapes(variants_all_rgb):
     })
     assert len(m.shapes()) == 2
     assert set([m.shapes()[0].id(), m.shapes()[1].id()]) == {"parent", "child2"}
+
+
+@fresolver_append_path
+def test03_merge_many_pair(variants_all_backends_once):
+    """`Mesh.merge_many([m1, m2])` returns a merged mesh whose vertex/face
+    counts are the sum of the inputs."""
+    bsdf = mi.load_dict({"type": "diffuse"})
+    m1 = example_mesh_obj(bsdf)
+    m2 = example_mesh_obj(bsdf)
+
+    merged = mi.Mesh.merge_many([m1, m2])
+    assert isinstance(merged, mi.Mesh)
+    assert merged.vertex_count() == m1.vertex_count() + m2.vertex_count()
+    assert merged.face_count()   == m1.face_count()   + m2.face_count()
+
+
+@fresolver_append_path
+def test04_merge_many_n(variants_all_backends_once):
+    """Same, but with five inputs."""
+    bsdf = mi.load_dict({"type": "diffuse"})
+    meshes = [example_mesh_obj(bsdf) for _ in range(5)]
+    merged = mi.Mesh.merge_many(meshes)
+    assert merged.vertex_count() == sum(m.vertex_count() for m in meshes)
+    assert merged.face_count()   == sum(m.face_count()   for m in meshes)
+
+
+@fresolver_append_path
+def test05_merge_many_singleton(variants_all_backends_once):
+    """A 1-element input is returned unchanged (no merge work)."""
+    m = example_mesh_obj()
+    assert mi.Mesh.merge_many([m]) is m
+
+
+def test06_merge_many_empty(variants_all_backends_once):
+    """Calling on an empty list raises an exception."""
+    with pytest.raises(RuntimeError):
+        mi.Mesh.merge_many([])
+
+
+@fresolver_append_path
+def test07_merge_many_incompatible(variants_all_backends_once):
+    """Meshes with different attached BSDFs cannot be merged."""
+    # Each `mi.load_dict` here creates its own default BSDF, so the two
+    # meshes don't share the bsdf pointer that the compatibility check uses.
+    m1 = example_mesh_obj()
+    m2 = example_mesh_obj()
+    with pytest.raises(RuntimeError):
+        mi.Mesh.merge_many([m1, m2])
+
+
+@fresolver_append_path
+def test08_merge_many_face_indices(variants_all_backends_once):
+    """After a merge, the second input's face indices must be rewritten to
+    point into the second half of the merged vertex buffer. We verify the
+    weaker, robust property that every face index is in bounds."""
+    import drjit as dr
+    bsdf = mi.load_dict({"type": "diffuse"})
+    m1 = example_mesh_obj(bsdf)
+    m2 = example_mesh_obj(bsdf)
+
+    merged = mi.Mesh.merge_many([m1, m2])
+    faces = merged.faces_buffer()
+    assert dr.all(faces < merged.vertex_count())
+
+
+@fresolver_append_path
+def test09_pairwise_merge(variants_all_backends_once):
+    """The instance pairwise `m.merge(other)` still works and produces the
+    same counts as the batched 2-input call."""
+    bsdf = mi.load_dict({"type": "diffuse"})
+    m1 = example_mesh_obj(bsdf)
+    m2 = example_mesh_obj(bsdf)
+
+    merged_pair  = m1.merge(m2)
+    merged_batch = mi.Mesh.merge_many([m1, m2])
+    assert merged_pair.vertex_count()  == merged_batch.vertex_count()
+    assert merged_pair.face_count()    == merged_batch.face_count()
+
+
+@fresolver_append_path
+def test10_merge_many_vertex_positions(variants_all_backends_once):
+    """The merged `vertex_positions` buffer is the concatenation of the
+    inputs' position buffers."""
+    bsdf = mi.load_dict({"type": "diffuse"})
+    m1 = example_mesh_obj(bsdf)
+    m2 = example_mesh_obj(bsdf)
+
+    merged = mi.Mesh.merge_many([m1, m2])
+    p1 = list(m1.vertex_positions_buffer())
+    p2 = list(m2.vertex_positions_buffer())
+    assert list(merged.vertex_positions_buffer()) == p1 + p2
+
+
+@fresolver_append_path
+def test11_merge_many_faces_offset(variants_all_backends_once):
+    """The merged `faces` buffer is the concatenation of the inputs' face
+    buffers, with the second input's indices shifted by `m1.vertex_count()`
+    so they reference the second half of the merged vertex buffer."""
+    bsdf = mi.load_dict({"type": "diffuse"})
+    m1 = example_mesh_obj(bsdf)
+    m2 = example_mesh_obj(bsdf)
+
+    merged = mi.Mesh.merge_many([m1, m2])
+    f1 = list(m1.faces_buffer())
+    f2 = list(m2.faces_buffer())
+    vc1 = m1.vertex_count()
+    assert list(merged.faces_buffer()) == f1 + [i + vc1 for i in f2]
+
+
+@fresolver_append_path
+def test12_merge_many_vertex_normals(variants_all_backends_once):
+    """The merged `vertex_normals` buffer is the concatenation of the
+    inputs' normal buffers when both inputs carry per-vertex normals."""
+    bsdf = mi.load_dict({"type": "diffuse"})
+    # `face_normals=False` makes the PLY loader generate per-vertex normals.
+    d = example_mesh()
+    d["face_normals"] = False
+    d["bsdf"] = bsdf
+    m1 = mi.load_dict(d)
+    m2 = mi.load_dict(d)
+    assert m1.has_vertex_normals() and m2.has_vertex_normals()
+
+    merged = mi.Mesh.merge_many([m1, m2])
+    n1 = list(m1.vertex_normals_buffer())
+    n2 = list(m2.vertex_normals_buffer())
+    assert list(merged.vertex_normals_buffer()) == n1 + n2


### PR DESCRIPTION
The merge plugin previously reduced N input meshes per group via N successive acc.merge(next) calls. Each Mesh::merge runs dr::concat over the full accumulated buffers, giving O(M·N) total work per group, where M is the combined mesh size. This shows up clearly when many small meshes share few BSDFs.

Replace the linear fold with a tree-balanced pairwise reduction: O(M·log N) per group. 
On a 27k-mesh / 65-BSDF test case: load time ~1670 s → ~16 s.
We might want to implement a batched version of mesh merge ?