### PR TITLE
`ImageBlock`: Use packet scatter for per-pixel accumulation and remove kahan summation

### DIFF
--- a/include/mitsuba/render/imageblock.h
+++ b/include/mitsuba/render/imageblock.h
@@ -105,14 +105,6 @@ public:
      *   are random and will in any case be subject to thread divergence (e.g.
      *   in a particle tracer that makes random connections to the sensor).
      *
-     * \param compensate
-     *   If set to \c true, the implementation internally switches to
-     *   Kahan-style error-compensated floating point accumulation. This is
-     *   useful when accumulating many samples into a single precision image
-     *   block. Note that this is currently only supported in JIT modes, and
-     *   that it can make the accumulation quite a bit more expensive. The
-     *   default is \c false.
-     *
      * \param warn_negative
      *    If set to \c true, \ref put() will warn when writing samples with
      *    negative components. This test is only enabled in scalar variants by
@@ -132,7 +124,6 @@ public:
                bool border = std::is_scalar_v<Float>,
                bool normalize = false,
                bool coalesce = dr::is_jit_v<Float>,
-               bool compensate = false,
                bool warn_negative = std::is_scalar_v<Float>,
                bool warn_invalid = std::is_scalar_v<Float>);
 
@@ -154,7 +145,6 @@ public:
                bool border = std::is_scalar_v<Float>,
                bool normalize = false,
                bool coalesce = dr::is_jit_v<Float>,
-               bool compensate = false,
                bool warn_negative = std::is_scalar_v<Float>,
                bool warn_invalid = std::is_scalar_v<Float>);
 
@@ -298,12 +288,6 @@ public:
     /// Try to coalesce reads/writes in JIT modes?
     bool coalesce() const { return m_coalesce; }
 
-    /// Use Kahan-style error-compensated floating point accumulation?
-    void set_compensate(bool value) { m_compensate = value; }
-
-    /// Use Kahan-style error-compensated floating point accumulation?
-    bool compensate() const { return m_compensate; }
-
     /// Return the number of channels stored by the image block
     uint32_t channel_count() const { return m_channel_count; }
 
@@ -347,15 +331,13 @@ protected:
     uint32_t m_channel_count;
     uint32_t m_border_size;
     TensorXf m_tensor;
-    mutable TensorXf m_tensor_compensation;
     ref<const ReconstructionFilter> m_rfilter;
     bool m_normalize;
     bool m_coalesce;
-    bool m_compensate;
     bool m_warn_negative;
     bool m_warn_invalid;
 
-    MI_TRAVERSE_CB(Object, m_tensor, m_tensor_compensation)
+    MI_TRAVERSE_CB(Object, m_tensor)
 };
 
 MI_EXTERN_CLASS(ImageBlock)

--- a/include/mitsuba/render/imageblock.h
+++ b/include/mitsuba/render/imageblock.h
@@ -333,6 +333,14 @@ protected:
     // Implementation detail to atomically accumulate a value into the image block
     void accum(Float value, UInt32 index, Bool active);
 
+    // Packet variant of \ref accum: atomically accumulates m_channel_count
+    // consecutive values starting at index * m_channel_count
+    void accum_packet(const Float *values, UInt32 index, Bool active);
+
+    // Weighted variant of \ref accum_packet (each value multiplied by \c weight)
+    void accum_packet(const Float *values, const Float &weight,
+                      UInt32 index, Bool active);
+
 protected:
     ScalarPoint2i m_offset;
     ScalarVector2u m_size;

--- a/src/films/hdrfilm.cpp
+++ b/src/films/hdrfilm.cpp
@@ -55,15 +55,6 @@ High dynamic range film (:monosp:`hdrfilm`)
      improve the image quality at the edges, especially when using very large reconstruction
      filters. In general, this is not needed though. (Default: |false|, i.e. disabled)
 
- * - compensate
-   - |bool|
-   - If set to |true|, sample accumulation will be performed using Kahan-style
-     error-compensated accumulation. This can be useful to avoid roundoff error
-     when accumulating very many samples to compute reference solutions using
-     single precision variants of Mitsuba. This feature is currently only supported
-     in JIT variants and can make sample accumulation quite a bit more expensive.
-     (Default: |false|, i.e. disabled)
-
  * - (Nested plugin)
    - :paramtype:`rfilter`
    - Reconstruction filter that should be used by the film. (Default: :monosp:`gaussian`, a windowed
@@ -224,9 +215,14 @@ public:
             }
         }
 
-        m_compensate = props.get<bool>("compensate", false);
-
         props.mark_queried("banner"); // no banner in Mitsuba 3
+
+        if (props.has_property("compensate")) {
+            props.mark_queried("compensate");
+            Log(Warn, "The \"compensate\" (Kahan-style error-compensated "
+                      "accumulation) parameter has been removed and is now "
+                      "ignored.");
+        }
     }
 
     size_t base_channels_count() const override {
@@ -287,7 +283,6 @@ public:
                               border /* border */,
                               normalize /* normalize */,
                               dr::is_jit_v<Float> /* coalesce */,
-                              m_compensate /* compensate */,
                               warn /* warn_negative */,
                               warn /* warn_invalid */);
     }
@@ -597,7 +592,6 @@ public:
             << "  crop_size = " << m_crop_size << "," << std::endl
             << "  crop_offset = " << m_crop_offset << "," << std::endl
             << "  sample_border = " << m_sample_border << "," << std::endl
-            << "  compensate = " << m_compensate << "," << std::endl
             << "  filter = " << m_filter << "," << std::endl
             << "  file_format = " << m_file_format << "," << std::endl
             << "  pixel_format = " << m_pixel_format << "," << std::endl
@@ -611,7 +605,6 @@ protected:
     Bitmap::FileFormat m_file_format;
     Bitmap::PixelFormat m_pixel_format;
     sj::Type m_component_format;
-    bool m_compensate;
     ref<ImageBlock> m_storage;
     mutable std::mutex m_mutex;
     std::vector<std::string> m_channels;

--- a/src/films/specfilm.cpp
+++ b/src/films/specfilm.cpp
@@ -44,15 +44,6 @@ Spectral film (:monosp:`specfilm`)
      improve the image quality at the edges, especially when using very large reconstruction
      filters. In general, this is not needed though. (Default: |false|, i.e. disabled)
 
- * - compensate
-   - |bool|
-   - If set to |true|, sample accumulation will be performed using Kahan-style
-     error-compensated accumulation. This can be useful to avoid roundoff error
-     when accumulating very many samples to compute reference solutions using
-     single precision variants of Mitsuba. This feature is currently only supported
-     in JIT variants and can make sample accumulation quite a bit more expensive.
-     (Default: |false|, i.e. disabled)
-
  * - (Nested plugin)
    - :paramtype:`rfilter`
    - Reconstruction filter that should be used by the film. (Default: :monosp:`gaussian`, a windowed
@@ -186,9 +177,14 @@ public:
                   "equal to \"float16\", \"float32\", or \"uint32\"."
                   " Found %s instead.", component_format);
 
-        m_compensate = props.get<bool>("compensate", false);
-
         m_flags = FilmFlags::Spectral | FilmFlags::Special;
+
+        if (props.has_property("compensate")) {
+            props.mark_queried("compensate");
+            Log(Warn, "The \"compensate\" (Kahan-style error-compensated "
+                      "accumulation) parameter has been removed and is now "
+                      "ignored.");
+        }
 
         compute_srf_sampling();
     }
@@ -289,7 +285,6 @@ public:
                               border /* border */,
                               normalize /* normalize */,
                               dr::is_jit_v<Float> /* coalesce */,
-                              m_compensate /* compensate */,
                               false /* warn_negative */,
                               false /* warn_invalid */);
     }
@@ -471,7 +466,6 @@ public:
             << "  crop_size = " << m_crop_size << "," << std::endl
             << "  crop_offset = " << m_crop_offset << "," << std::endl
             << "  sample_border = " << m_sample_border << "," << std::endl
-            << "  compensate = " << m_compensate << "," << std::endl
             << "  filter = " << m_filter << "," << std::endl
             << "  file_format = " << m_file_format << "," << std::endl
             << "  pixel_format = " << m_pixel_format << "," << std::endl
@@ -489,7 +483,6 @@ protected:
     Bitmap::FileFormat m_file_format;
     Bitmap::PixelFormat m_pixel_format;
     sj::Type m_component_format;
-    bool m_compensate;
     ref<ImageBlock> m_storage;
     mutable std::mutex m_mutex;
     std::vector<std::string> m_channels;

--- a/src/render/imageblock.cpp
+++ b/src/render/imageblock.cpp
@@ -2,6 +2,7 @@
 #include <mitsuba/core/bitmap.h>
 #include <mitsuba/core/profiler.h>
 #include <drjit/while_loop.h>
+#include <drjit/util.h>
 
 NAMESPACE_BEGIN(mitsuba)
 
@@ -132,6 +133,51 @@ MI_VARIANT void ImageBlock<Float, Spectrum>::accum(Float value, UInt32 index, Bo
     }
 }
 
+MI_VARIANT void ImageBlock<Float, Spectrum>::accum_packet(const Float *values,
+                                                          UInt32 index,
+                                                          Bool active) {
+    if constexpr (dr::is_jit_v<Float>) {
+        if (!m_compensate) {
+            dr::scatter_reduce_packet_dynamic(
+                ReduceOp::Add, m_channel_count, m_tensor.array(),
+                values, index, active);
+            return;
+        }
+
+        // Kahan compensation has no packet variant; fall back to per-channel
+        UInt32 base = index * m_channel_count;
+        for (uint32_t k = 0; k < m_channel_count; ++k)
+            accum(values[k], base + k, active);
+    } else {
+        DRJIT_MARK_USED(values);
+        DRJIT_MARK_USED(index);
+        DRJIT_MARK_USED(active);
+    }
+}
+
+MI_VARIANT void ImageBlock<Float, Spectrum>::accum_packet(const Float *values,
+                                                          const Float &weight,
+                                                          UInt32 index,
+                                                          Bool active) {
+    if constexpr (dr::is_jit_v<Float>) {
+        // Multiply each channel by `weight` into a temporary buffer, then
+        // forward to the unweighted overload.
+        Float *weighted = (Float *) alloca(sizeof(Float) * m_channel_count);
+        for (uint32_t k = 0; k < m_channel_count; ++k)
+            new (weighted + k) Float(values[k] * weight);
+
+        accum_packet(weighted, index, active);
+
+        for (uint32_t k = 0; k < m_channel_count; ++k)
+            weighted[k].~Float();
+    } else {
+        DRJIT_MARK_USED(values);
+        DRJIT_MARK_USED(weight);
+        DRJIT_MARK_USED(index);
+        DRJIT_MARK_USED(active);
+    }
+}
+
 MI_VARIANT void ImageBlock<Float, Spectrum>::put_block(const ImageBlock *block) {
     ScopedPhase sp(ProfilerPhase::ImageBlockPut);
 
@@ -211,7 +257,7 @@ MI_VARIANT void ImageBlock<Float, Spectrum>::put(const Point2f &pos,
         Point2u p = Point2u(dr::floor2int<Point2i>(pos) - m_offset);
 
         // Switch over to unsigned integers, compute pixel index
-        UInt32 index = dr::fmadd(p.y(), m_size.x(), p.x()) * m_channel_count;
+        UInt32 index = dr::fmadd(p.y(), m_size.x(), p.x());
 
         // The sample could be out of bounds
         active &= dr::all(p < m_size);
@@ -221,12 +267,12 @@ MI_VARIANT void ImageBlock<Float, Spectrum>::put(const Point2f &pos,
             if (unlikely(!active))
                 return;
 
-            ScalarFloat *ptr = m_tensor.array().data() + index;
+            ScalarFloat *ptr = m_tensor.array().data() +
+                               (size_t) index * m_channel_count;
             for (uint32_t k = 0; k < m_channel_count; ++k)
                 *ptr++ += values[k];
         } else {
-            for (uint32_t k = 0; k < m_channel_count; ++k)
-                accum(values[k], index++, active);
+            accum_packet(values, index, active);
         }
 
         return;
@@ -274,7 +320,7 @@ MI_VARIANT void ImageBlock<Float, Spectrum>::put(const Point2f &pos,
 
         // Base index of the top left corner
         UInt32 index =
-            dr::fmadd(pos_0_u.y(), size.x(), pos_0_u.x()) * m_channel_count;
+            dr::fmadd(pos_0_u.y(), size.x(), pos_0_u.x());
 
         // Compute the number of filter evaluations needed along each axis
         ScalarVector2u count;
@@ -342,35 +388,29 @@ MI_VARIANT void ImageBlock<Float, Spectrum>::put(const Point2f &pos,
                     weights_x[i] *= factor;
             }
 
-            ScalarFloat *ptr = nullptr;
-            if constexpr (!JIT)
-                ptr = m_tensor.array().data();
-            else
-                (void) ptr;
-
             // Accumulate!
             for (uint32_t y = 0; y < count.y(); ++y) {
                 Mask active_1 = active && y < count_u.y();
 
                 for (uint32_t x = 0; x < count.x(); ++x) {
                     Mask active_2 = active_1 && x < count_u.x();
+                    Float weight = weights_x[x] * weights_y[y];
 
-                    for (uint32_t k = 0; k < m_channel_count; ++k) {
-                        Float weight = weights_x[x] * weights_y[y];
-
-                        if constexpr (!JIT) {
-                            if (unlikely(!active_2))
-                                return;
-                            ptr[index] = dr::fmadd(values[k], weight, ptr[index]);
-                        } else {
-                            accum(values[k] * weight, index, active_2);
-                        }
-
-                        index++;
+                    if constexpr (!JIT) {
+                        if (unlikely(!active_2))
+                            return;
+                        ScalarFloat *ptr = m_tensor.array().data() +
+                                           (size_t) index * m_channel_count;
+                        for (uint32_t k = 0; k < m_channel_count; ++k)
+                            ptr[k] = dr::fmadd(values[k], weight, ptr[k]);
+                    } else {
+                        accum_packet(values, weight, index, active_2);
                     }
+
+                    index += 1;
                 }
 
-                index += (size.x() - count.x()) * m_channel_count;
+                index += size.x() - count.x();
             }
 
             // Destruct weight variables
@@ -411,15 +451,16 @@ MI_VARIANT void ImageBlock<Float, Spectrum>::put(const Point2f &pos,
 
                             Mask active_2 =
                                 active_1 && (pos_0_u.x() + xs <= pos_1_u.x());
-                            for (uint32_t k = 0; k < m_channel_count; ++k)
-                                accum(values[k] * weight, index++, active_2);
+
+                            accum_packet(values, weight, index, active_2);
 
                             xs++;
+                            index += 1;
                         },
                         "ImageBlock::put() [2]");
 
                     ys++;
-                    index += (size.x() - count.x()) * m_channel_count;
+                    index += size.x() - count.x();
                 },
                 "ImageBlock::put() [1]");
         }
@@ -450,7 +491,7 @@ MI_VARIANT void ImageBlock<Float, Spectrum>::put(const Point2f &pos,
         // Switch over to unsigned integers, compute pixel index
         UInt32 x = UInt32(pos_i_local.x()),
                y = UInt32(pos_i_local.y()),
-               index = dr::fmadd(y, size.x(), x) * m_channel_count;
+               index = dr::fmadd(y, size.x(), x);
 
         // Evaluate filters weights along the X and Y axes
         Point2f rel_f = Point2f(pos_i) + .5f - pos;
@@ -497,15 +538,15 @@ MI_VARIANT void ImageBlock<Float, Spectrum>::put(const Point2f &pos,
                     Mask active_2 = active_1 && x < size.x();
                     Float weight = weights_y[ys] * weights_x[xs];
 
-                    for (uint32_t k = 0; k < m_channel_count; ++k)
-                        accum(values[k] * weight, index++, active_2);
+                    accum_packet(values, weight, index, active_2);
 
                     x++;
+                    index += 1;
                 }
 
                 x -= count;
                 y += 1;
-                index += (size.x() - count) * m_channel_count;
+                index += size.x() - count;
             }
 
             // Destruct weight variables
@@ -544,15 +585,16 @@ MI_VARIANT void ImageBlock<Float, Spectrum>::put(const Point2f &pos,
                                   weight = weight_x * weight_y;
 
                             Mask active_2 = active_1 && (x + xs < size.x());
-                            for (uint32_t k = 0; k < m_channel_count; ++k)
-                                accum(values[k] * weight, index++, active_2);
+
+                            accum_packet(values, weight, index, active_2);
 
                             xs++;
+                            index += 1;
                         },
                         "ImageBlock::put() [2]");
 
                     ys++;
-                    index += (size.x() - count) * m_channel_count;
+                    index += size.x() - count;
                 },
                 "ImageBlock::put() [1]");
         }

--- a/src/render/imageblock.cpp
+++ b/src/render/imageblock.cpp
@@ -12,11 +12,11 @@ ImageBlock<Float, Spectrum>::ImageBlock(const ScalarVector2u &size,
                                         uint32_t channel_count,
                                         const ReconstructionFilter *rfilter,
                                         bool border, bool normalize,
-                                        bool coalesce, bool compensate,
+                                        bool coalesce,
                                         bool warn_negative, bool warn_invalid)
     : m_offset(offset), m_size(0), m_channel_count(channel_count),
       m_rfilter(rfilter), m_normalize(normalize), m_coalesce(coalesce),
-      m_compensate(compensate), m_warn_negative(warn_negative),
+      m_warn_negative(warn_negative),
       m_warn_invalid(warn_invalid) {
 
     // Detect if a box filter is being used, and just discard it in that case
@@ -35,10 +35,10 @@ ImageBlock<Float, Spectrum>::ImageBlock(const TensorXf &tensor,
                                         const ScalarPoint2i &offset,
                                         const ReconstructionFilter *rfilter,
                                         bool border, bool normalize,
-                                        bool coalesce, bool compensate,
+                                        bool coalesce,
                                         bool warn_negative, bool warn_invalid)
     : m_offset(offset), m_rfilter(rfilter), m_normalize(normalize),
-      m_coalesce(coalesce), m_compensate(compensate),
+      m_coalesce(coalesce),
       m_warn_negative(warn_negative), m_warn_invalid(warn_invalid) {
 
     if (tensor.ndim() != 3)
@@ -77,9 +77,6 @@ MI_VARIANT void ImageBlock<Float, Spectrum>::clear() {
            shape[3]  = { size_ext.y(), size_ext.x(), m_channel_count };
 
     m_tensor = TensorXf(dr::zeros<Array>(size_flat), 3, shape);
-
-    if (m_compensate)
-        m_tensor_compensation = TensorXf(dr::zeros<Array>(size_flat), 3, shape);
 }
 
 MI_VARIANT void
@@ -96,20 +93,10 @@ ImageBlock<Float, Spectrum>::set_size(const ScalarVector2u &size) {
 
     m_tensor = TensorXf(dr::zeros<Array>(size_flat), 3, shape);
 
-    if (m_compensate)
-        m_tensor_compensation = TensorXf(dr::zeros<Array>(size_flat), 3, shape);
-
     m_size = size;
 }
 
 MI_VARIANT typename ImageBlock<Float, Spectrum>::TensorXf &ImageBlock<Float, Spectrum>::tensor() {
-    if constexpr (dr::is_jit_v<Float>) {
-        if (m_compensate) {
-            Float &comp = m_tensor_compensation.array();
-            m_tensor.array() += comp;
-            comp = dr::zeros<Float>(comp.size());
-        }
-    }
     return m_tensor;
 }
 
@@ -119,13 +106,8 @@ MI_VARIANT const typename ImageBlock<Float, Spectrum>::TensorXf &ImageBlock<Floa
 
 MI_VARIANT void ImageBlock<Float, Spectrum>::accum(Float value, UInt32 index, Bool active) {
     if constexpr (dr::is_jit_v<Float>) {
-        if (m_compensate)
-            dr::scatter_add_kahan(m_tensor.array(),
-                                  m_tensor_compensation.array(),
-                                  value, index, active);
-        else
-            dr::scatter_reduce(ReduceOp::Add, m_tensor.array(),
-                               value, index, active);
+        dr::scatter_reduce(ReduceOp::Add, m_tensor.array(),
+                           value, index, active);
     } else {
         DRJIT_MARK_USED(value);
         DRJIT_MARK_USED(index);
@@ -137,17 +119,9 @@ MI_VARIANT void ImageBlock<Float, Spectrum>::accum_packet(const Float *values,
                                                           UInt32 index,
                                                           Bool active) {
     if constexpr (dr::is_jit_v<Float>) {
-        if (!m_compensate) {
-            dr::scatter_reduce_packet_dynamic(
-                ReduceOp::Add, m_channel_count, m_tensor.array(),
-                values, index, active);
-            return;
-        }
-
-        // Kahan compensation has no packet variant; fall back to per-channel
-        UInt32 base = index * m_channel_count;
-        for (uint32_t k = 0; k < m_channel_count; ++k)
-            accum(values[k], base + k, active);
+        dr::scatter_reduce_packet_dynamic(
+            ReduceOp::Add, m_channel_count, m_tensor.array(),
+            values, index, active);
     } else {
         DRJIT_MARK_USED(values);
         DRJIT_MARK_USED(index);
@@ -846,7 +820,6 @@ MI_VARIANT std::string ImageBlock<Float, Spectrum>::to_string() const {
         << "  border_size = " << m_border_size << "," << std::endl
         << "  normalize = " << m_normalize << "," << std::endl
         << "  coalesce = " << m_coalesce << "," << std::endl
-        << "  compensate = " << m_compensate << "," << std::endl
         << "  warn_negative = " << m_warn_negative << "," << std::endl
         << "  warn_invalid = " << m_warn_invalid << "," << std::endl
         << "  rfilter = " << (m_rfilter ? string::indent(m_rfilter) : "BoxFilter[]")

--- a/src/render/python/imageblock_v.cpp
+++ b/src/render/python/imageblock_v.cpp
@@ -9,18 +9,18 @@ MI_PY_EXPORT(ImageBlock) {
     auto image_block = MI_PY_CLASS(ImageBlock, Object)
         .def(nb::init<const ScalarVector2u &, const ScalarPoint2i &, uint32_t,
                       const ReconstructionFilter *, bool, bool, bool,
-                      bool, bool, bool>(),
+                      bool, bool>(),
              "size"_a, "offset"_a, "channel_count"_a, "rfilter"_a = nullptr,
              "border"_a = std::is_scalar_v<Float>, "normalize"_a = false,
-             "coalesce"_a = dr::is_jit_v<Float>, "compensate"_a = false,
+             "coalesce"_a = dr::is_jit_v<Float>,
              "warn_negative"_a = std::is_scalar_v<Float>,
              "warn_invalid"_a  = std::is_scalar_v<Float>)
         .def(nb::init<const TensorXf &, const ScalarPoint2i &,
                       const ReconstructionFilter *, bool, bool, bool,
-                      bool, bool, bool>(),
+                      bool, bool>(),
              "tensor"_a, "offset"_a = ScalarPoint2i(0), "rfilter"_a = nullptr,
              "border"_a = std::is_scalar_v<Float>, "normalize"_a = false,
-             "coalesce"_a = dr::is_jit_v<Float>, "compensate"_a = false,
+             "coalesce"_a = dr::is_jit_v<Float>,
              "warn_negative"_a = std::is_scalar_v<Float>,
              "warn_invalid"_a  = std::is_scalar_v<Float>)
         .def("put_block", &ImageBlock::put_block, D(ImageBlock, put_block),
@@ -51,8 +51,6 @@ MI_PY_EXPORT(ImageBlock) {
         .def_method(ImageBlock, set_size, "size"_a)
         .def_method(ImageBlock, coalesce)
         .def_method(ImageBlock, set_coalesce)
-        .def_method(ImageBlock, compensate)
-        .def_method(ImageBlock, set_compensate)
         .def_method(ImageBlock, width)
         .def_method(ImageBlock, height)
         .def_method(ImageBlock, rfilter)

--- a/src/render/tests/test_imageblock.py
+++ b/src/render/tests/test_imageblock.py
@@ -33,15 +33,11 @@ def test01_construct(variant_scalar_rgb):
 @pytest.mark.parametrize("offset", [ [0, 0], [1, 2] ])
 @pytest.mark.parametrize("normalize", [ False, True ])
 @pytest.mark.parametrize("coalesce", [ False, True ])
-@pytest.mark.parametrize("compensate", [ False, True ])
 @pytest.mark.parametrize("active", [ False, True ])
-def test02_put(variants_all, filter_name, border, offset, normalize, coalesce, compensate, active):
+def test02_put(variants_all, filter_name, border, offset, normalize, coalesce, active):
     # Checks the result of the ImageBlock::put() method
     # against a brute force reference
     scalar = 'scalar' in mi.variant()
-
-    if compensate and scalar:
-        pytest.skip('for now, error compensation is just enabled in JIT modes')
 
     rfilter = mi.load_dict({ 'type' : filter_name })
 
@@ -58,7 +54,6 @@ def test02_put(variants_all, filter_name, border, offset, normalize, coalesce, c
                                   channel_count=1,
                                   rfilter=rfilter,
                                   border=border,
-                                  compensate=compensate,
                                   normalize=normalize,
                                   coalesce=coalesce)
 
@@ -241,25 +236,3 @@ def test05_boundary_effects(variants_vec_rgb, coalesce, normalize):
     else:
         ref = v1
     assert dr.allclose(ib.tensor().array, ref, rtol=1e-2)
-
-@pytest.mark.parametrize("compensate", [ False, True ])
-def test06_error_compensation(variants_any_cuda, compensate):
-    with dr.scoped_set_flag(dr.JitFlag.ScatterReduceLocal, False):
-        ib = mi.ImageBlock(
-            size=(1, 1),
-            offset=(0, 0),
-            channel_count=1,
-            rfilter=None,
-            normalize=False,
-            coalesce=False,
-            compensate=compensate
-        )
-        ib.put(
-            pos=(0.5, 0.5),
-            values = (dr.ones(mi.Float, 2**24+1024),)
-        )
-        print(ib.tensor().array[0])
-        print("vs")
-        print(2**24 + 1024)
-        print(2**24)
-        assert ib.tensor().array[0] ==  2**24 + (1024 if compensate else 0)


### PR DESCRIPTION
Updates `ImageBlock` to use the packet scatter instead of N separate
per-channel scatter-reduces. On the drjit-core side, the CUDA
backend now runs a single warp-reduction shared across
all channels of the packet (previously the reduction ran once per channel).

This gives ~10% speedup on average. On Blackwell-class GPUs
(CC ≥ 120 with a recent CUDA driver 13.2+), the same path additionally
uses vector atomic reductions, for another ~10% on top.

Since the speedup comes entirely from faster atomic aggregation, 
scenes with short per-ray work benefit most.

## Benchmarks

Configurations: butterfly scope (rows) is how contributions are pre-aggregated within a warp, and atomic form (columns) is how the leader stores them.

|                            | Scalar atomics | Vector atomics |
| ---                        | ---            | ---            |
| No butterfly               | `per_channel`  | `v4_only`      |
| Per-channel butterfly      | `baseline`     | n/a            |
| Single packet butterfly    | `bfly_packet`  | `bfly_v4`      |

Tested on the gallery scenes.

**1–8 spp**

<img width="3368" height="3460" alt="bench_results_summary_smaller_spp" src="https://github.com/user-attachments/assets/74fd7b49-1193-40b9-adab-ab2de62f437b" />

**16–1024 spp:**

<img width="2470" height="2886" alt="bench_results_summary" src="https://github.com/user-attachments/assets/3734e8e0-8bbc-4f72-9811-3477769d3344" />


