### PR TITLE
Expose spot emitter's beam parameters in traverse

### DIFF
--- a/src/emitters/spot.cpp
+++ b/src/emitters/spot.cpp
@@ -1,4 +1,5 @@
 #include <mitsuba/core/properties.h>
+#include <mitsuba/core/string.h>
 #include <mitsuba/core/warp.h>
 #include <mitsuba/render/emitter.h>
 #include <mitsuba/render/medium.h>
@@ -103,24 +104,24 @@ public:
 
         ScalarFloat cutoff_angle = props.get<ScalarFloat>("cutoff_angle", 20.0f);
         m_beam_width   = props.get<ScalarFloat>("beam_width", cutoff_angle * 3.0f / 4.0f);
-        m_cutoff_angle = dr::deg_to_rad(cutoff_angle);
-        m_beam_width   = dr::deg_to_rad(m_beam_width);
-        m_inv_transition_width = 1.0f / (m_cutoff_angle - m_beam_width);
-        m_cos_cutoff_angle = dr::cos(m_cutoff_angle);
-        m_cos_beam_width   = dr::cos(m_beam_width);
-        Assert(dr::all(m_cutoff_angle >= m_beam_width));
-        m_uv_factor = dr::tan(m_cutoff_angle);
-
-        dr::make_opaque(m_beam_width, m_cutoff_angle, m_uv_factor,
-                        m_cos_beam_width, m_cos_cutoff_angle,
-                        m_inv_transition_width);
+        m_cutoff_angle = cutoff_angle;
+        update();
     }
 
     void traverse(TraversalCallback *cb) override {
         Base::traverse(cb);
-        cb->put("intensity", m_intensity,  ParamFlags::Differentiable);
-        cb->put("texture",   m_texture,    ParamFlags::Differentiable);
-        cb->put("to_world",  m_to_world,   ParamFlags::NonDifferentiable);
+        cb->put("intensity",    m_intensity,    ParamFlags::Differentiable);
+        cb->put("texture",      m_texture,      ParamFlags::Differentiable);
+        cb->put("cutoff_angle", m_cutoff_angle, ParamFlags::Differentiable);
+        cb->put("beam_width",   m_beam_width,   ParamFlags::Differentiable);
+        cb->put("to_world",     m_to_world,     ParamFlags::NonDifferentiable);
+    }
+
+    void parameters_changed(const std::vector<std::string> &keys = {}) override {
+        Base::parameters_changed(keys);
+        if (keys.empty() || string::contains(keys, "cutoff_angle") || string::contains(keys, "beam_width")) {
+            update();
+        }
     }
 
     /**
@@ -144,7 +145,7 @@ public:
         Float cos_theta    = local_dir.z();
         Float beam_res = dr::select(
             cos_theta >= m_cos_beam_width, 1.f,
-            (m_cutoff_angle - dr::acos(cos_theta)) * m_inv_transition_width);
+            (m_cutoff_angle_rad - dr::acos(cos_theta)) * m_inv_transition_width);
 
         return dr::select(cos_theta > m_cos_cutoff_angle, beam_res, 0.f);
     }
@@ -296,14 +297,28 @@ public:
 
     MI_DECLARE_CLASS(SpotLight)
 private:
+    void update() {
+        m_cutoff_angle_rad     = dr::deg_to_rad(m_cutoff_angle);
+        Float beam_width_rad   = dr::deg_to_rad(m_beam_width);
+        m_inv_transition_width = 1.0f / (m_cutoff_angle_rad - beam_width_rad);
+        m_cos_cutoff_angle     = dr::cos(m_cutoff_angle_rad);
+        m_cos_beam_width       = dr::cos(beam_width_rad);
+        Assert(dr::all(m_cutoff_angle_rad >= beam_width_rad));
+        m_uv_factor = dr::tan(m_cutoff_angle_rad);
+
+        dr::make_opaque(m_beam_width, m_cutoff_angle, beam_width_rad,
+                        m_cutoff_angle_rad, m_uv_factor, m_cos_beam_width,
+                        m_cos_cutoff_angle, m_inv_transition_width);
+    }
+
     ref<Texture> m_intensity;
     ref<Texture> m_texture;
-    Float m_beam_width, m_cutoff_angle, m_uv_factor;
+    Float m_beam_width, m_cutoff_angle, m_cutoff_angle_rad, m_uv_factor;
     Float m_cos_beam_width, m_cos_cutoff_angle, m_inv_transition_width;
 
     MI_TRAVERSE_CB(Base, m_intensity, m_texture, m_beam_width, m_cutoff_angle,
-                   m_uv_factor, m_cos_beam_width, m_cos_cutoff_angle,
-                   m_inv_transition_width)
+                   m_cutoff_angle_rad, m_uv_factor, m_cos_beam_width,
+                   m_cos_cutoff_angle, m_inv_transition_width)
 };
 
 MI_EXPORT_PLUGIN(SpotLight)

--- a/src/emitters/tests/test_spot.py
+++ b/src/emitters/tests/test_spot.py
@@ -180,3 +180,37 @@ def test_eval(variants_vec_spectral, spectrum_key, lookat, cutoff_angle):
     it = dr.zeros(mi.SurfaceInteraction3f, 3)
     it.wi = [0, 1, 0]
     assert dr.allclose(emitter.eval(it), 0.)
+
+
+def test_update_falloff(variant_scalar_spectral):
+    cutoff_angle = 20.0
+    emitter, spectrum = create_emitter_and_spectrum(mi.ScalarTransform4f(), cutoff_angle)
+
+    params = mi.traverse(emitter)
+    assert 'cutoff_angle' in params
+    assert 'beam_width' in params
+    assert dr.allclose(params['cutoff_angle'], 20.0)
+    assert dr.allclose(params['beam_width'], 15.0)
+
+    # Test eval at angle 25 deg (> 20 deg cutoff) -> should be zero
+    angle_rad_25 = 25.0 * dr.pi / 180.0
+    it_pos_25 = [2.0 * dr.sin(angle_rad_25), 0.0, 2.0 * dr.cos(angle_rad_25)]
+
+    it = dr.zeros(mi.SurfaceInteraction3f)
+    it.p = it_pos_25
+    it.time = 0.3
+    it.wavelengths = spectrum.sample_spectrum(it, mi.sample_shifted(0.7))[0]
+
+    _, res = emitter.sample_direction(it, [0, 0])
+    assert dr.allclose(res, 0.0)
+
+    # Update cutoff to 30 deg and beam width to 20 deg
+    params['cutoff_angle'] = 30.0
+    params['beam_width'] = 20.0
+    params.update()
+    assert dr.allclose(params['cutoff_angle'], 30.0)
+    assert dr.allclose(params['beam_width'], 20.0)
+
+    # Now evaluate again at 25 deg -> should be non-zero
+    _, res = emitter.sample_direction(it, [0, 0])
+    assert not dr.allclose(res, 0.0)


### PR DESCRIPTION
This adds the `spot` emitter's `beam_width` and `cutoff_angle` to the `traverse` method. These were previously missing and just not exposed. I also added a test case to validate it.