### PR TITLE
Fix integer overflow issues.

### DIFF
--- a/src/render/integrator.cpp
+++ b/src/render/integrator.cpp
@@ -623,7 +623,7 @@ AdjointIntegrator<Float, Spectrum>::render(Scene *scene,
     }
 
     ScalarFloat sample_scale =
-        dr::prod(crop_size) / ScalarFloat(spp * dr::prod(film_size));
+        dr::prod(crop_size) / ScalarFloat((size_t) spp * (size_t) dr::prod(film_size));
 
     TensorXf result;
     if constexpr (!dr::is_jit_v<Float>) {
@@ -646,7 +646,7 @@ AdjointIntegrator<Float, Spectrum>::render(Scene *scene,
 
         size_t total_samples = samples_per_pass * n_passes;
 
-        seed *= (uint32_t) total_samples / (uint32_t) grain_size;
+        seed *= (uint32_t) (total_samples / grain_size);
         std::atomic<size_t> samples_done(0);
 
         // Start the render timer (used for timeouts & log messages)


### PR DESCRIPTION
<!-- Please add the labels (e.g. bug fix, feature, ..) corresponding to this PR -->

## Description

This PR fixes two separate instances of 32-bit integer overflow inside `integrator.cpp` that occur when rendering at very high resolutions or with high sample counts.

Specific changes:

`AdjointIntegrator::render` (Sample Scale): When multiplying `spp` by `dr::prod(film_size)`, the 32-bit limit is easily exceeded (e.g., 4K resolution at 1024 spp). Fixed by casting the operands to `size_t` before multiplication.

`AdjointIntegrator::render` (Seed Generation): `total_samples` (a 64-bit integer) was prematurely cast down to `uint32_t` before dividing by `grain_size`. If total samples exceeded ~4.29B, the truncation caused the division to result in 0, destroying the random seed. Fixed by evaluating the division in 64-bit space before downcasting.

## Testing

<!-- Please describe the tests that you added to verify your changes. -->

## Checklist

- [x] My code follows the [style guidelines](https://mitsuba.readthedocs.io/en/latest/src/developer_guide.html#coding-style) of this project
- [ ] My changes generate no new warnings
- [ ] My code also compiles for `cuda_*` and `llvm_*` variants. If you can't test this, please leave below
- [ ] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 3 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba/blob/master/LICENSE)