### PR TITLE
Fix view-dependent albedo AOV for glossy-only BSDFs

### DIFF
--- a/include/mitsuba/render/bsdf.h
+++ b/include/mitsuba/render/bsdf.h
@@ -572,6 +572,8 @@ public:
      * When this is not possible, the value is approximated by
      * evaluating the BSDF for a normal outgoing direction and returning this
      * value multiplied by pi. This is the default behaviour of this method.
+     * BSDFs without a diffuse lobe (e.g. microfacet-only models such as
+     * \c roughconductor and \c roughdielectric) return 0.
      *
      * \param si
      *     A surface interaction data structure describing the underlying

--- a/include/mitsuba/render/bsdf.h
+++ b/include/mitsuba/render/bsdf.h
@@ -572,8 +572,10 @@ public:
      * When this is not possible, the value is approximated by
      * evaluating the BSDF for a normal outgoing direction and returning this
      * value multiplied by pi. This is the default behaviour of this method.
-     * BSDFs without a diffuse lobe (e.g. microfacet-only models such as
-     * \c roughconductor and \c roughdielectric) return 0.
+     * BSDFs without a diffuse lobe return a view-independent stand-in
+     * suitable for denoising albedo AOVs instead: \c roughconductor returns
+     * the normal-incidence Fresnel reflectance (F0), while transmissive
+     * microfacet models such as \c roughdielectric return 0.
      *
      * \param si
      *     A surface interaction data structure describing the underlying

--- a/include/mitsuba/render/bsdf.h
+++ b/include/mitsuba/render/bsdf.h
@@ -574,8 +574,9 @@ public:
      * value multiplied by pi. This is the default behaviour of this method.
      * BSDFs without a diffuse lobe return a view-independent stand-in
      * suitable for denoising albedo AOVs instead: \c roughconductor returns
-     * the normal-incidence Fresnel reflectance (F0), while transmissive
-     * microfacet models such as \c roughdielectric return 0.
+     * the normal-incidence Fresnel reflectance (F0), while \c roughdielectric
+     * returns 1 (tinted by its specular transmittance), since a transmissive
+     * microfacet surface passes on essentially all incident energy.
      *
      * \param si
      *     A surface interaction data structure describing the underlying

--- a/include/mitsuba/render/bsdf.h
+++ b/include/mitsuba/render/bsdf.h
@@ -573,10 +573,11 @@ public:
      * evaluating the BSDF for a normal outgoing direction and returning this
      * value multiplied by pi. This is the default behaviour of this method.
      * BSDFs without a diffuse lobe return a view-independent stand-in
-     * suitable for denoising albedo AOVs instead: \c roughconductor returns
-     * the normal-incidence Fresnel reflectance (F0), while \c roughdielectric
-     * returns 1 (tinted by its specular transmittance), since a transmissive
-     * microfacet surface passes on essentially all incident energy.
+     * suitable for denoising albedo AOVs instead, following the Open Image
+     * Denoise recommendations: \c roughconductor returns the normal-incidence
+     * Fresnel reflectance (F0), while \c roughdielectric returns 1 (tinted by
+     * its specular transmittance), since a transmissive microfacet surface
+     * passes on essentially all incident energy.
      *
      * \param si
      *     A surface interaction data structure describing the underlying

--- a/src/bsdfs/roughconductor.cpp
+++ b/src/bsdfs/roughconductor.cpp
@@ -517,12 +517,21 @@ public:
         return { F * value & active, dr::select(active, pdf, 0.f) };
     }
 
-    Spectrum eval_diffuse_reflectance(const SurfaceInteraction3f & /*si*/,
-                                      Mask /*active*/) const override {
-        // Microfacet-only BSDF: there is no diffuse lobe. The default
+    Spectrum eval_diffuse_reflectance(const SurfaceInteraction3f &si,
+                                      Mask active) const override {
+        // Microfacet-only BSDF: there is no diffuse lobe, so the default
         // implementation would evaluate the glossy lobe at wo = n, leaking a
-        // view-dependent specular peak into denoising albedo AOVs.
-        return 0.f;
+        // view-dependent specular peak into denoising albedo AOVs. Return the
+        // normal-incidence Fresnel reflectance (F0) instead: a view-independent
+        // base color in [0, 1], which is what denoisers expect as the albedo
+        // of a metal.
+        dr::Complex<UnpolarizedSpectrum> eta_c(m_eta->eval(si, active),
+                                               m_k->eval(si, active));
+        UnpolarizedSpectrum f0 =
+            fresnel_conductor(UnpolarizedSpectrum(1.f), eta_c);
+        if (m_specular_reflectance)
+            f0 *= m_specular_reflectance->eval(si, active);
+        return depolarizer<Spectrum>(f0) & active;
     }
 
     std::string to_string() const override {

--- a/src/bsdfs/roughconductor.cpp
+++ b/src/bsdfs/roughconductor.cpp
@@ -517,6 +517,14 @@ public:
         return { F * value & active, dr::select(active, pdf, 0.f) };
     }
 
+    Spectrum eval_diffuse_reflectance(const SurfaceInteraction3f & /*si*/,
+                                      Mask /*active*/) const override {
+        // Microfacet-only BSDF: there is no diffuse lobe. The default
+        // implementation would evaluate the glossy lobe at wo = n, leaking a
+        // view-dependent specular peak into denoising albedo AOVs.
+        return 0.f;
+    }
+
     std::string to_string() const override {
         std::ostringstream oss;
         oss << "RoughConductor[" << std::endl

--- a/src/bsdfs/roughconductor.cpp
+++ b/src/bsdfs/roughconductor.cpp
@@ -523,8 +523,9 @@ public:
         // implementation would evaluate the glossy lobe at wo = n, leaking a
         // view-dependent specular peak into denoising albedo AOVs. Return the
         // normal-incidence Fresnel reflectance (F0) instead: a view-independent
-        // base color in [0, 1], which is what denoisers expect as the albedo
-        // of a metal.
+        // base color in [0, 1]. This follows the Open Image Denoise
+        // documentation, which recommends "the reflectivity at normal
+        // incidence" as the albedo of metallic surfaces.
         dr::Complex<UnpolarizedSpectrum> eta_c(m_eta->eval(si, active),
                                                m_k->eval(si, active));
         UnpolarizedSpectrum f0 =

--- a/src/bsdfs/roughdielectric.cpp
+++ b/src/bsdfs/roughdielectric.cpp
@@ -613,8 +613,9 @@ public:
         // implementation would evaluate the glossy lobe at wo = n, leaking a
         // view-dependent specular peak into denoising albedo AOVs. A rough
         // dielectric reflects or transmits essentially all incident energy,
-        // so return 1 (tinted by specular_transmittance when present), the
-        // denoising-albedo convention for transmissive surfaces.
+        // so return 1 (tinted by specular_transmittance when present). This
+        // follows the Open Image Denoise documentation, which recommends an
+        // albedo of 1 for non-delta dielectric surfaces such as glass.
         UnpolarizedSpectrum value(1.f);
         if (m_specular_transmittance)
             value *= m_specular_transmittance->eval(si, active);

--- a/src/bsdfs/roughdielectric.cpp
+++ b/src/bsdfs/roughdielectric.cpp
@@ -607,12 +607,18 @@ public:
                  dr::select(active, pdf * dr::abs(dwh_dwo), 0.f) };
     }
 
-    Spectrum eval_diffuse_reflectance(const SurfaceInteraction3f & /*si*/,
-                                      Mask /*active*/) const override {
-        // Microfacet-only BSDF: there is no diffuse lobe. The default
+    Spectrum eval_diffuse_reflectance(const SurfaceInteraction3f &si,
+                                      Mask active) const override {
+        // Microfacet-only BSDF: there is no diffuse lobe, so the default
         // implementation would evaluate the glossy lobe at wo = n, leaking a
-        // view-dependent specular peak into denoising albedo AOVs.
-        return 0.f;
+        // view-dependent specular peak into denoising albedo AOVs. A rough
+        // dielectric reflects or transmits essentially all incident energy,
+        // so return 1 (tinted by specular_transmittance when present), the
+        // denoising-albedo convention for transmissive surfaces.
+        UnpolarizedSpectrum value(1.f);
+        if (m_specular_transmittance)
+            value *= m_specular_transmittance->eval(si, active);
+        return depolarizer<Spectrum>(value) & active;
     }
 
     std::string to_string() const override {

--- a/src/bsdfs/roughdielectric.cpp
+++ b/src/bsdfs/roughdielectric.cpp
@@ -607,6 +607,14 @@ public:
                  dr::select(active, pdf * dr::abs(dwh_dwo), 0.f) };
     }
 
+    Spectrum eval_diffuse_reflectance(const SurfaceInteraction3f & /*si*/,
+                                      Mask /*active*/) const override {
+        // Microfacet-only BSDF: there is no diffuse lobe. The default
+        // implementation would evaluate the glossy lobe at wo = n, leaking a
+        // view-dependent specular peak into denoising albedo AOVs.
+        return 0.f;
+    }
+
     std::string to_string() const override {
         std::ostringstream oss;
         oss << "RoughDielectric[" << std::endl

--- a/src/bsdfs/tests/test_rough_conductor.py
+++ b/src/bsdfs/tests/test_rough_conductor.py
@@ -118,10 +118,14 @@ def test06_eval_pdf(variant_scalar_rgb):
 
 
 def test07_eval_diffuse_reflectance(variant_scalar_rgb):
-    # Microfacet-only BSDF: the diffuse reflectance must be 0 for any view
-    # direction. The base-class fallback used to evaluate the glossy lobe at
-    # wo = n, returning values >> 1 near normal incidence.
-    bsdf = mi.load_dict({'type': 'roughconductor', 'alpha': 0.1})
+    # Microfacet-only BSDF: the value must be view-independent and in [0, 1].
+    # The base-class fallback used to evaluate the glossy lobe at wo = n,
+    # returning values >> 1 near normal incidence. The override returns the
+    # normal-incidence Fresnel reflectance (F0) instead.
+    eta, k = 0.2, 3.0
+    f0 = ((eta - 1)**2 + k**2) / ((eta + 1)**2 + k**2)
+    bsdf = mi.load_dict({'type': 'roughconductor', 'alpha': 0.1,
+                         'eta': eta, 'k': k})
 
     si    = mi.SurfaceInteraction3f()
     si.p  = [0, 0, 0]
@@ -131,4 +135,5 @@ def test07_eval_diffuse_reflectance(variant_scalar_rgb):
     for cos_theta in [0.999, 0.95, 0.8, 0.6, 0.4]:
         sin_theta = dr.sqrt(1.0 - cos_theta * cos_theta)
         si.wi = [sin_theta, 0, cos_theta]
-        assert dr.allclose(bsdf.eval_diffuse_reflectance(si), 0.0)
+        value = bsdf.eval_diffuse_reflectance(si)
+        assert dr.allclose(value, f0, rtol=1e-4)

--- a/src/bsdfs/tests/test_rough_conductor.py
+++ b/src/bsdfs/tests/test_rough_conductor.py
@@ -115,3 +115,20 @@ def test06_eval_pdf(variant_scalar_rgb):
         v_eval_pdf = bsdf.eval_pdf(ctx, si, wo=wo)
         assert dr.allclose(v_eval, v_eval_pdf[0])
         assert dr.allclose(v_pdf, v_eval_pdf[1])
+
+
+def test07_eval_diffuse_reflectance(variant_scalar_rgb):
+    # Microfacet-only BSDF: the diffuse reflectance must be 0 for any view
+    # direction. The base-class fallback used to evaluate the glossy lobe at
+    # wo = n, returning values >> 1 near normal incidence.
+    bsdf = mi.load_dict({'type': 'roughconductor', 'alpha': 0.1})
+
+    si    = mi.SurfaceInteraction3f()
+    si.p  = [0, 0, 0]
+    si.n  = [0, 0, 1]
+    si.sh_frame = mi.Frame3f(si.n)
+
+    for cos_theta in [0.999, 0.95, 0.8, 0.6, 0.4]:
+        sin_theta = dr.sqrt(1.0 - cos_theta * cos_theta)
+        si.wi = [sin_theta, 0, cos_theta]
+        assert dr.allclose(bsdf.eval_diffuse_reflectance(si), 0.0)

--- a/src/bsdfs/tests/test_rough_dielectric.py
+++ b/src/bsdfs/tests/test_rough_dielectric.py
@@ -246,3 +246,19 @@ def test13_attached_sampling(variants_all_ad_rgb):
     dr.forward(angle)
     assert dr.allclose(mi.unpolarized_spectrum(dr.grad(weight)), 0.02079637348651886)
     
+
+def test14_eval_diffuse_reflectance(variant_scalar_rgb):
+    # Microfacet-only BSDF: the diffuse reflectance must be 0 for any view
+    # direction. The base-class fallback used to evaluate the glossy lobe at
+    # wo = n, returning a view-dependent specular peak near normal incidence.
+    bsdf = mi.load_dict({'type': 'roughdielectric', 'alpha': 0.1})
+
+    si    = mi.SurfaceInteraction3f()
+    si.p  = [0, 0, 0]
+    si.n  = [0, 0, 1]
+    si.sh_frame = mi.Frame3f(si.n)
+
+    for cos_theta in [0.999, 0.95, 0.8, 0.6, 0.4]:
+        sin_theta = dr.sqrt(1.0 - cos_theta * cos_theta)
+        si.wi = [sin_theta, 0, cos_theta]
+        assert dr.allclose(bsdf.eval_diffuse_reflectance(si), 0.0)

--- a/src/bsdfs/tests/test_rough_dielectric.py
+++ b/src/bsdfs/tests/test_rough_dielectric.py
@@ -248,10 +248,16 @@ def test13_attached_sampling(variants_all_ad_rgb):
     
 
 def test14_eval_diffuse_reflectance(variant_scalar_rgb):
-    # Microfacet-only BSDF: the diffuse reflectance must be 0 for any view
-    # direction. The base-class fallback used to evaluate the glossy lobe at
-    # wo = n, returning a view-dependent specular peak near normal incidence.
+    # Microfacet-only BSDF: the value must be view-independent and in [0, 1].
+    # The base-class fallback used to evaluate the glossy lobe at wo = n,
+    # returning a view-dependent specular peak near normal incidence. The
+    # override returns 1 (a transmissive surface passes on all energy),
+    # tinted by specular_transmittance when present.
     bsdf = mi.load_dict({'type': 'roughdielectric', 'alpha': 0.1})
+    bsdf_tinted = mi.load_dict({
+        'type': 'roughdielectric', 'alpha': 0.1,
+        'specular_transmittance': {'type': 'rgb', 'value': [0.2, 0.4, 0.6]},
+    })
 
     si    = mi.SurfaceInteraction3f()
     si.p  = [0, 0, 0]
@@ -261,4 +267,6 @@ def test14_eval_diffuse_reflectance(variant_scalar_rgb):
     for cos_theta in [0.999, 0.95, 0.8, 0.6, 0.4]:
         sin_theta = dr.sqrt(1.0 - cos_theta * cos_theta)
         si.wi = [sin_theta, 0, cos_theta]
-        assert dr.allclose(bsdf.eval_diffuse_reflectance(si), 0.0)
+        assert dr.allclose(bsdf.eval_diffuse_reflectance(si), 1.0)
+        assert dr.allclose(bsdf_tinted.eval_diffuse_reflectance(si),
+                           [0.2, 0.4, 0.6])


### PR DESCRIPTION
<!-- Labels: bug fix -->

## Description

While generating albedo G-buffers with Mitsuba for Monte Carlo denoising
research, I noticed the albedo AOV was contaminated on glossy-only surfaces:
a bright, camera-dependent blob appears wherever a rough-metal or rough-glass
surface faces the camera, with values far above 1 (up to ~96 in the attached
scene). An albedo AOV is expected to be a view-independent reflectance in
[0, 1] — this silently corrupts every denoising workflow built on it (e.g.
the OptiX denoiser integration from #283).

The cause is the base-class fallback of `BSDF::eval_diffuse_reflectance()`
(`eval` at `wo = (0, 0, 1)` times π): exact for a Lambertian lobe, but for
BSDFs without a diffuse lobe it evaluates the glossy microfacet lobe, which
spikes at the specular peak when the view direction approaches the normal.
Related precedent: #862 (missing override in `NormalMap`).

This PR overrides `eval_diffuse_reflectance()` in the two microfacet-only
plugins, following the [Open Image Denoise albedo recommendations](https://github.com/RenderKit/oidn#albedo):

- **`roughconductor`** → the normal-incidence Fresnel reflectance (F0),
  modulated by `specular_reflectance` when present (OIDN: *"the reflectivity
  at normal incidence"* for metallic surfaces).
- **`roughdielectric`** → 1, tinted by `specular_transmittance` when present
  (OIDN: an albedo of 1 for non-delta dielectric surfaces such as glass).

The doxygen documentation in `include/mitsuba/render/bsdf.h` is updated
accordingly. If a stricter reading of the "diffuse reflectance" contract is
preferred (return 0, since neither plugin has a diffuse lobe), the first
commit of this branch implements exactly that and the follow-up commits can
be dropped — happy to adjust.

Fixes # (issue)

## Testing

- New regression tests, passing for `scalar_rgb` (and the full files pass
  including the existing chi2/eval_pdf tests, 20/20):
  - `test_rough_conductor.py::test07_eval_diffuse_reflectance` — value equals
    F0 computed from η, k (η=0.2, k=3 → 0.9234) at five view angles
    (view-independence + correctness).
  - `test_rough_dielectric.py::test14_eval_diffuse_reflectance` — value equals
    1 for plain rough glass and equals the tint for
    `specular_transmittance = (0.2, 0.4, 0.6)`, at five view angles.
- Standalone repro script (attached to the issue): before → `roughconductor`
  23.83 / `roughdielectric` 0.97 at cos θ = 0.999, view-dependent; after →
  flat F0 / 1.0 at all angles. `diffuse` control unchanged at its reflectance.
- Scene-level check (`cuda_ad_rgb`, `aov` integrator `albedo:albedo` wrapping
  `path`): Tungsten "spaceship" close-up of a rough-glass canopy and rough
  metal. Before: albedo max 96.27 with a camera-tracking blob. After: glass
  dome flat 1.0, metal flat F0·`specular_reflectance` ≈ 0.537, no
  view-dependent content, max value 1.0.

## Checklist

- [x] My code follows the [style guidelines](https://mitsuba.readthedocs.io/en/latest/src/developer_guide.html#coding-style) of this project
- [x] My changes generate no new warnings
- [x] My code also compiles for `cuda_*` and `llvm_*` variants. If you can't test this, please leave below
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 3 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba/blob/master/LICENSE)