### PR TITLE
Re-enable parallel scene parsing

### DIFF
--- a/src/core/parser.cpp
+++ b/src/core/parser.cpp
@@ -1802,6 +1802,15 @@ std::vector<ref<Object>> instantiate(const ParserConfig &config, ParserState &st
     if (state.empty())
         Throw("No nodes to instantiate");
 
+#if defined(MI_ENABLE_LLVM) || defined(MI_ENABLE_CUDA) || defined(MI_ENABLE_METAL)
+    // Flush pending side effects here and now, to avoid potentially dirty
+    // user-provided Dr.Jit arrays/tensor from being propagated to plugin
+    // loaders running on a different thread. Side effects are queued in
+    // per-thread data structures.
+    if (config.parallel && !string::starts_with(config.variant, "scalar_"))
+        jit_eval();
+#endif
+
     std::vector<Scratch> scratch(state.size());
     instantiate_node(config, state, scratch, 0);
 

--- a/src/core/parser.cpp
+++ b/src/core/parser.cpp
@@ -1786,7 +1786,7 @@ static Task* instantiate_node(const ParserConfig &config,
         return nullptr;
     } else {
         // Non-root nodes
-        if (config.parallel && !deps.empty()) {
+        if (config.parallel) {
             // Schedule asynchronous instantiation with dependencies
             s.task = dr::do_async(instantiate, deps.data(), deps.size());
             return s.task;


### PR DESCRIPTION
The current parser tries to synchronously instantiate objects without dependencies. However, due to the way the scene is traversed (depth first), this just leads to the scene loading being serialized.

Without this change, a scene with 500 unique 1kx1k PNG textures takes ~30s to load. With this change, it takes 2s.