### PR TITLE
Support for 8-bit bitmap textures

### DIFF
--- a/docs/src/developer_guide/compiling.rst
+++ b/docs/src/developer_guide/compiling.rst
@@ -120,19 +120,12 @@ The build process under Linux requires several external dependencies that are
 easily installed using the system-provided package manager (e.g.,
 :monosp:`apt-get` under Ubuntu).
 
-Note that recent Linux distributions include two different compilers that can
-both be used for C++ software development. `GCC <https://gcc.gnu.org>`_ is
-typically the default, and `Clang <https://clang.llvm.org>`_ can be installed
-optionally. During the development of this project, we encountered many issues
-with GCC (mis-compilations, compiler errors, segmentation faults), and strongly
-recommend that you use Clang instead.
-
-To fetch all dependencies and Clang, enter the following commands on Ubuntu:
+To fetch all dependencies, enter the following commands on Ubuntu:
 
 .. code-block:: bash
 
-    # Install recent versions build tools, including Clang
-    sudo apt install clang-17 cmake ninja-build
+    # Install required build tools
+    sudo apt install g++ cmake ninja-build
 
     # Install libraries for image I/O
     sudo apt install libpng-dev libjpeg-dev nasm
@@ -149,17 +142,7 @@ interesting to you, also enter the following commands:
     # For running tests
     sudo apt install python3-pytest python3-pytest-xdist python3-numpy
 
-Next, ensure that two environment variables :monosp:`CC` and :monosp:`CXX` are
-exported. You can either run these two commands manually before using CMake
-or---even better---add them to your :monosp:`~/.bashrc` file. This ensures that
-CMake will always use the correct compiler.
-
-.. code-block:: bash
-
-    export CC=clang-17 export CXX=clang++-17
-
-If you installed another version of Clang, the version suffix of course has to
-be adjusted. Now, compilation should be as simple as running the following from
+Now, compilation should be as simple as running the following from
 inside the :monosp:`mitsuba3` root directory:
 
 .. code-block:: bash

--- a/src/render/metal_accel.mm
+++ b/src/render/metal_accel.mm
@@ -93,12 +93,11 @@ struct BufferAllocation {
     }
 };
 
-/// Owns the Metal objects of a built scene (ARC frees them when deleted).
+/// Strong references to Metal objects of a built scene
 struct MetalAccelData {
     id<MTLAccelerationStructure> tlas;
     std::vector<id<MTLAccelerationStructure>> blases;
-    /// Strong refs to every buffer the TLAS depends on, including borrowed
-    /// Dr.Jit arrays.
+    /// Refernces to buffers the TLAS depends on
     std::vector<id<MTLBuffer>> buffers;
     /// Dr.Jit-backed scene-resident buffers.
     std::vector<BufferAllocation> allocations;

--- a/src/textures/bitmap.cpp
+++ b/src/textures/bitmap.cpp
@@ -65,16 +65,23 @@ Bitmap texture (:monosp:`bitmap`)
    - Specifies the underlying texture storage format. The following options are
      currently available:
 
-     - ``auto`` (default): If loading a texture from a bitmap, use half
-         precision for bitmap data with 16 or lower bit depth, otherwise use
-         the native floating point representation of the Mitsuba variant. For
-         variants using a spectral color representation this option is the same
-         as `variant`.
+     - ``auto`` (default): Match the storage precision to the source: use 8 bits
+         per channel for 8-bit images, half precision for 16-bit images, and
+         otherwise the native floating point representation of the Mitsuba
+         variant. For variants using a spectral color representation this option
+         is the same as `variant`. Note that 8-bit storage is not differentiable;
+         request ``float16`` or ``variant`` to optimize such textures.
 
      - ``variant``: Use the corresponding native floating point representation
          of the Mitsuba variant
 
-     - ``fp16``: Forcibly store the texture in half precision
+     - ``float16``: Store the texture in half precision
+
+     - ``uint8``: Store the texture using 8 bits per channel. When the source
+         image is sRGB-encoded and :paramtype:`raw` is :monosp:`false`, the
+         values are linearized on each lookup. This mode is the most memory
+         efficient, but not that the texture is *not* differentiable. It is also
+         incompatible with spectral variants of Mitsuba.
 
  * - raw
    - |bool|
@@ -132,50 +139,43 @@ at all.
 template <typename Float, typename Spectrum, typename StoredType>
 class BitmapTextureImpl;
 
+NAMESPACE_BEGIN(detail)
+/// Class name tagged with the storage precision (for diagnostics / RTTI), since
+/// it depends on a template parameter that MI_DECLARE_CLASS() cannot capture.
+template <typename StoredType>
+constexpr const char *bitmap_class_name() {
+    using StoredScalar = dr::scalar_t<StoredType>;
+    if constexpr (std::is_same_v<StoredScalar, double>)
+        return "BitmapTextureImpl[float64]";
+    else if constexpr (std::is_same_v<StoredScalar, float>)
+        return "BitmapTextureImpl[float32]";
+    else if constexpr (std::is_same_v<StoredScalar, dr::half>)
+        return "BitmapTextureImpl[float16]";
+    else if constexpr (std::is_same_v<StoredScalar, uint8_t>)
+        return "BitmapTextureImpl[uint8]";
+    else
+        return "BitmapTextureImpl[?]";
+}
+NAMESPACE_END(detail)
+
 template <typename Float, typename Spectrum>
 class BitmapTexture final : public Texture<Float, Spectrum> {
 public:
     MI_IMPORT_TYPES(Texture)
 
-    /* Recap of numerical precision of lookup operations
-     *
-     * backend | variant | format   | accel  | behavior
-     * ==================================================================
-     * CUDA    | float   | fp16     | true   | fp16 storage, fp32* interp, accel
-     * CUDA    | float   | variant  | true   | fp32 storage, fp32* interp, accel
-     *
-     * CUDA    | float   | fp16     | false  | fp16 storage, fp32 interp, no accel
-     * CUDA    | float   | variant  | false  | fp32 storage, fp32 interp, no accel
-     *
-     * CUDA    | double  | fp16     | true   | fp16 storage, fp32* interp, accel
-     * CUDA    | double  | variant  | true   | fp64 storage, fp64  interp, no accel
-     *
-     * CUDA    | double  | fp16     | false  | fp16 storage, fp64 interp, no accel
-     * CUDA    | double  | variant  | false  | fp64 storage, fp64 interp, no accel
-     *
-     * \* Hardware-accelerated lookups are not exactly fp32 see:
-     *    https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#linear-filtering
-     *
-     * ------------------------------------------------------------------------
-     *
-     * CPU     | float   | fp16     | true   | fp16 storage, fp32 interp, no accel
-     * CPU     | float   | variant  | true   | fp32 storage, fp32 interp, no accel
-     *
-     * CPU     | float   | fp16     | false  | fp16 storage, fp32 interp, no accel
-     * CPU     | float   | variant  | false  | fp32 storage, fp32 interp, no accel
-     *
-     * CPU     | double  | fp16     | true   | fp16 storage, fp64 interp, no accel
-     * CPU     | double  | variant  | true   | fp64 storage, fp64 interp, no accel
-     *
-     * CPU     | double  | fp16     | false  | fp16 storage, fp64 interp, no accel
-     * CPU     | double  | variant  | false  | fp64 storage, fp64 interp, no accel
-     */
+    /// Storage precision of the texture (resolved from the `format` property)
+    enum class Format {
+        Auto,     ///< 8-bit for 8-bit sources, half for 16-bit, native otherwise
+        Variant,  ///< The variant's native floating point precision
+        Float16,  ///< Half precision
+        UInt8     ///< 8 bits per channel (optionally sRGB-decoded on lookup)
+    };
 
     BitmapTexture(const Properties &props) : Texture(props) {
         m_transform = props.get<ScalarAffineTransform3f>("to_uv", ScalarAffineTransform3f());
 
-        /* Should Mitsuba disable transformations to the stored color data?
-           (e.g. sRGB to linear, spectral upsampling, etc.) */
+        // Should Mitsuba disable transformations to the stored color data?
+        // (e.g. sRGB to linear, spectral upsampling, etc.)
         m_raw = props.get<bool>("raw", false);
         m_accel = props.get<bool>("accel", true);
 
@@ -212,11 +212,19 @@ public:
                 m_format = Format::Auto;
             else if (format_str == "variant")
                 m_format = Format::Variant;
-            else if (format_str == "fp16")
-                m_format = Format::Float16;
+            else if (format_str == "float16" || format_str == "fp16")
+                m_format = Format::Float16; // "fp16" kept for backwards compat
+            else if (format_str == "uint8")
+                m_format = Format::UInt8;
             else
                 Throw("Invalid format \"%s\", must be one of: \"auto\", "
-                      "\"variant\", or \"fp16\"!", format_str);
+                      "\"variant\", \"float16\", or \"uint8\"!", format_str);
+
+            if constexpr (is_spectral_v<Spectrum>)
+                if (m_format == Format::UInt8)
+                    Throw("format=\"uint8\" is not supported in spectral variants "
+                          "(8-bit storage cannot hold spectral upsampling "
+                          "coefficients).");
         }
 
         // Store
@@ -254,131 +262,164 @@ public:
     }
 
     std::vector<ref<Object>> expand() const override {
-        return { ref<Object>(expand_1()) };
+        return { ref<Object>(expand_impl()) };
     }
 
     MI_DECLARE_CLASS(BitmapTexture)
 
 protected:
-    Object* expand_1() const {
-        if (m_bitmap) {
-            Format format = m_format;
-            // Format auto means we store texture as FP16 when possible.
-            // Skip this conversion for spectral variants as we want to perform
-            // spectral upsampling in the variant's native FP representation
-            if constexpr (!is_spectral_v<Spectrum>) {
-                size_t bytes_p_ch = m_bitmap->bytes_per_pixel()
-                    / m_bitmap->channel_count();
-                if (m_format == Format::Auto && bytes_p_ch <= 2)
-                    format = Format::Float16;
-            }
+    Object *expand_impl() const {
+        // The `data` tensor path: native float storage, already linear
+        if (!m_bitmap)
+            return instantiate<Float>(std::move(m_tensor), /* srgb = */ false);
 
-            if (format == Format::Float16)
-                return expand_bitmap<dr::replace_scalar_t<Float, dr::half>>();
-            else
-                return expand_bitmap<Float>();
+        // Pick a storage precision and instantiate the matching implementation
+        switch (resolve_format()) {
+            case Format::UInt8:
+                return load_bitmap<dr::replace_scalar_t<Float, uint8_t>>();
+            case Format::Float16:
+                return load_bitmap<dr::replace_scalar_t<Float, dr::half>>();
+            default: // Format::Variant
+                return load_bitmap<Float>();
         }
-
-        // Otherwise, initializing using tensor
-        Properties props;
-        return new BitmapTextureImpl<Float, Spectrum, Float>(
-            props,
-            m_name,
-            m_transform,
-            m_filter_mode,
-            m_wrap_mode,
-            m_raw,
-            m_accel,
-            std::move(m_tensor));
     }
 
-    template <typename StoredType> Object* expand_bitmap() const {
-        using StoredScalar           = dr::scalar_t<StoredType>;
-        using StoredTensorXf         = dr::replace_scalar_t<TensorXf, StoredScalar>;
+    /**
+     * \brief Resolve \ref Format::Auto to a concrete storage precision
+     *
+     * ``auto`` matches the storage to the source bit depth: 8-bit sources are
+     * stored losslessly as 8-bit (and decoded from sRGB on lookup), 16-bit
+     * sources as half precision, and everything else at the variant's native
+     * precision. Spectral variants always use the native precision required for
+     * upsampling.
+     */
+    Format resolve_format() const {
+        if (m_format != Format::Auto)
+            return m_format;
+        if constexpr (is_spectral_v<Spectrum>) {
+            return Format::Variant;
+        } else {
+            size_t bytes_per_channel =
+                m_bitmap->bytes_per_pixel() / m_bitmap->channel_count();
+            if (bytes_per_channel == 1)
+                return Format::UInt8;
+            else if (bytes_per_channel == 2)
+                return Format::Float16;
+            else
+                return Format::Variant;
+        }
+    }
 
-        /* Convert to linear RGB float bitmap, will be converted
-           into spectral profile coefficients below (in place) */
-        Bitmap::PixelFormat pixel_format = m_bitmap->pixel_format();
-        switch (pixel_format) {
+    /**
+     * \brief Load the bitmap into a tensor of the given storage type and build
+     * the implementation object
+     *
+     * ``StoredType`` fixes the storage precision; the sRGB strategy follows from
+     * it and the source encoding: 8-bit storage keeps the sRGB-encoded bytes and
+     * lets the texture decode them on lookup, while float/half storage is
+     * decoded to linear here, at load time.
+     */
+    template <typename StoredType> Object *load_bitmap() const {
+        using StoredScalar = dr::scalar_t<StoredType>;
+        constexpr bool IsUInt8 = std::is_same_v<StoredScalar, uint8_t>;
+
+        // `raw` data carries no color transform: treat it as already linear
+        if (m_raw)
+            m_bitmap->set_srgb_gamma(false);
+
+        Bitmap::PixelFormat pf = target_pixel_format(m_bitmap->pixel_format());
+        bool srgb = IsUInt8 && m_bitmap->srgb_gamma();
+
+        // Bring the bitmap into the storage format (skipped when already matching)
+        m_bitmap = prepare_bitmap(pf, struct_type_v<StoredScalar>,
+                                  /* keep_srgb_gamma = */ srgb);
+
+        // Spectral variants store smooth-spectrum coefficients (float/half only)
+        if constexpr (is_spectral_v<Spectrum>)
+            if (!m_raw)
+                upsample_spectral<StoredScalar>(m_bitmap.get());
+
+        ScalarVector2i res(m_bitmap->size());
+        size_t shape[3] = { (size_t) res.y(), (size_t) res.x(),
+                            m_bitmap->channel_count() };
+        dr::replace_scalar_t<TensorXf, StoredScalar> tensor(m_bitmap->data(), 3,
+                                                            shape);
+
+        return instantiate<StoredType>(std::move(tensor), srgb);
+    }
+
+    /**
+     * \brief Bring the source bitmap into the exact format the texture needs
+     *
+     * The (potentially expensive) \ref Bitmap::convert() is skipped entirely
+     * when the bitmap already matches the target pixel format, component type,
+     * and gamma -- e.g. an sRGB 8-bit PNG stored as ``uint8``. Sub-2x2 images are
+     * up-sampled so that bilinear interpolation has at least one cell.
+     */
+    ref<Bitmap> prepare_bitmap(Bitmap::PixelFormat pf, sj::Type ct,
+                               bool keep_srgb_gamma) const {
+        ref<Bitmap> bitmap = m_bitmap;
+
+        if (bitmap->pixel_format()     != pf ||
+            bitmap->component_format() != ct ||
+            bitmap->srgb_gamma()       != keep_srgb_gamma)
+            bitmap = bitmap->convert(pf, ct, keep_srgb_gamma);
+
+        if (dr::any(bitmap->size() < 2)) {
+            Log(Warn, "Image must be at least 2x2 pixels in size, up-sampling..");
+            ref<Bitmap::ReconstructionFilter> rfilter =
+                PluginManager::instance()
+                    ->create_object<Bitmap::ReconstructionFilter>(
+                        Properties("tent"));
+            bitmap = bitmap->resample(dr::maximum(bitmap->size(), 2), rfilter);
+        }
+        return bitmap;
+    }
+
+    /// Map the source pixel format to the 1- or 3-channel layout the texture
+    /// stores (alpha is dropped and XYZ converted to RGB by \ref convert()).
+    Bitmap::PixelFormat target_pixel_format(Bitmap::PixelFormat pf) const {
+        switch (pf) {
             case Bitmap::PixelFormat::Y:
             case Bitmap::PixelFormat::YA:
-                pixel_format = Bitmap::PixelFormat::Y;
-                break;
-
+                return Bitmap::PixelFormat::Y;
             case Bitmap::PixelFormat::RGB:
             case Bitmap::PixelFormat::RGBA:
             case Bitmap::PixelFormat::XYZ:
             case Bitmap::PixelFormat::XYZA:
-                pixel_format = Bitmap::PixelFormat::RGB;
-                break;
-
+                return Bitmap::PixelFormat::RGB;
             default:
-                Throw("The texture needs to have a known pixel "
-                      "format (Y[A], RGB[A], XYZ[A] are supported).");
+                Throw("The texture needs a known pixel format "
+                      "(Y[A], RGB[A], XYZ[A] are supported).");
         }
+    }
 
-        if (m_raw) {
-            /* Don't undo gamma correction in the conversion below.
-               This is needed, e.g., for normal maps. */
-            m_bitmap->set_srgb_gamma(false);
-        }
-
-        // Convert the image into the working floating point representation
-        m_bitmap =
-            m_bitmap->convert(pixel_format, struct_type_v<StoredScalar>, false);
-
-        if (dr::any(m_bitmap->size() < 2)) {
-            Log(Warn,
-                "Image must be at least 2x2 pixels in size, up-sampling..");
-            using ReconstructionFilter = Bitmap::ReconstructionFilter;
-            ref<ReconstructionFilter> rfilter =
-                PluginManager::instance()->create_object<ReconstructionFilter>(
-                    Properties("tent"));
-            m_bitmap =
-                m_bitmap->resample(dr::maximum(m_bitmap->size(), 2), rfilter);
-        }
-
-        if (is_spectral_v<Spectrum> && !m_raw)
-            convert_spectral<StoredScalar>();
-
-        size_t channels = m_bitmap->channel_count();
-        ScalarVector2i res = ScalarVector2i(m_bitmap->size());
-        size_t shape[3] = { (size_t) res.y(), (size_t) res.x(), channels };
-        StoredTensorXf tensor = StoredTensorXf(m_bitmap->data(), 3, shape);
-
+    /// Construct the concrete \ref BitmapTextureImpl for the chosen storage type
+    template <typename StoredType, typename Tensor>
+    Object *instantiate(Tensor &&tensor, bool srgb) const {
         Properties props;
         return new BitmapTextureImpl<Float, Spectrum, StoredType>(
-            props,
-            m_name,
-            m_transform,
-            m_filter_mode,
-            m_wrap_mode,
-            m_raw,
-            m_accel,
-            std::move(tensor));
+            props, m_name, m_transform, m_filter_mode, m_wrap_mode, m_raw,
+            m_accel, srgb, std::forward<Tensor>(tensor));
     }
 
 private:
-    /// Convert RGB values to spectral coefficients and store them
-    template <typename StoredScalar> void convert_spectral() const {
-        StoredScalar *ptr = (StoredScalar*) m_bitmap->data();
-        size_t pixel_count = m_bitmap->pixel_count();
-
-        if (m_bitmap->channel_count() == 3) {
-            for (size_t i = 0; i < pixel_count; ++i) {
-                ScalarColor3f value = dr::load<ScalarColor3f>(ptr);
-                value = srgb_model_fetch(value);
-                dr::store(ptr, value);
-                ptr += 3;
-            }
+    /// Convert linear RGB pixels to smooth-spectrum coefficients in place
+    template <typename StoredScalar> void upsample_spectral(Bitmap *bitmap) const {
+        if (bitmap->channel_count() != 3)
+            return;
+        StoredScalar *ptr = (StoredScalar *) bitmap->data();
+        size_t pixel_count = bitmap->pixel_count();
+        for (size_t i = 0; i < pixel_count; ++i, ptr += 3) {
+            ScalarColor3f rgb((float) ptr[0], (float) ptr[1], (float) ptr[2]);
+            ScalarColor3f coeff = srgb_model_fetch(rgb);
+            ptr[0] = (StoredScalar) coeff[0];
+            ptr[1] = (StoredScalar) coeff[1];
+            ptr[2] = (StoredScalar) coeff[2];
         }
     }
 
-    enum class Format {
-        Auto,
-        Variant,
-        Float16
-    } m_format;
+    Format m_format;
 
     bool m_accel;
     bool m_raw;
@@ -393,7 +434,7 @@ private:
 };
 
 template <typename Float, typename Spectrum, typename StoredType>
-class BitmapTextureImpl : public Texture<Float, Spectrum> {
+class BitmapTextureImpl final : public Texture<Float, Spectrum> {
 public:
     MI_IMPORT_TYPES(Texture)
 
@@ -401,6 +442,7 @@ public:
     using StoredColor3f          = Color<StoredType, 3>;
     using StoredTensorXf         = dr::replace_scalar_t<TensorXf, StoredScalar>;
     using StoredTexture2f        = dr::Texture<StoredType, 2>;
+    static constexpr bool IsUInt8 = std::is_same_v<StoredScalar, uint8_t>;
 
     template <typename Tensor>
     BitmapTextureImpl(const Properties &props,
@@ -410,31 +452,34 @@ public:
                       dr::WrapMode wrap_mode,
                       bool raw,
                       bool accel,
+                      bool srgb,
                       Tensor&& tensor) :
         Texture(props),
         m_name(name),
         m_transform(transform),
-        m_accel(accel),
-        m_raw(raw) {
+        m_raw(raw),
+        m_srgb(srgb) {
 
-        /* Compute mean without migrating texture data
-           i.e. Avoid call to m_texture.tensor() that triggers migration.
-           For CUDA-variants, ideally want to solely keep data as CUDA texture
-        */
+        /* Compute the mean without migrating texture data, i.e. avoid the
+           m_texture.tensor() call that would trigger a migration. On CUDA we
+           ideally keep the data solely as a GPU texture. */
         rebuild_internals(tensor, true, false);
 
         m_texture = StoredTexture2f(std::forward<Tensor>(tensor), accel, accel,
-                                    filter_mode, wrap_mode);
+                                    filter_mode, wrap_mode, srgb);
     }
 
     void traverse(TraversalCallback *cb) override {
-        cb->put("data", m_texture.tensor(), ParamFlags::Differentiable);
+        // 8-bit textures store integers and are therefore not differentiable
+        cb->put("data", m_texture.tensor(),
+                IsUInt8 ? ParamFlags::NonDifferentiable
+                        : ParamFlags::Differentiable);
         cb->put("to_uv", m_transform, ParamFlags::NonDifferentiable);
     }
 
     void parameters_changed(const std::vector<std::string> &keys = {}) override {
         if (keys.empty() || string::contains(keys, "data")) {
-            const size_t channels = m_texture.shape()[2];
+            const size_t channels = m_texture.channel_count();
             if (channels != 1 && channels != 3)
                 Throw("parameters_changed(): The bitmap texture %s was changed "
                       "to have %d channels, only textures with 1 or 3 channels "
@@ -454,33 +499,26 @@ public:
                              Mask active) const override {
         MI_MASKED_FUNCTION(ProfilerPhase::TextureEvaluate, active);
 
-        const size_t channels = m_texture.shape()[2];
-        if (channels == 3 && is_spectral_v<Spectrum> && m_raw) {
-            DRJIT_MARK_USED(si);
-            Throw("The bitmap texture %s was queried for a spectrum, but "
-                  "texture conversion into spectra was explicitly disabled! "
-                  "(raw=true)",
+        const size_t channels = m_texture.channel_count();
+        if (channels == 3 && is_spectral_v<Spectrum> && m_raw)
+            Throw("eval(): The bitmap texture %s was queried for a spectrum, "
+                  "but texture conversion into spectra was explicitly "
+                  "disabled! (raw=true)",
                   to_string());
-        } else {
-            if (dr::none_or<false>(active))
-                return dr::zeros<UnpolarizedSpectrum>();
 
-            if constexpr (is_monochromatic_v<Spectrum>) {
-                if (channels == 1)
-                    return interpolate_1(si, active);
-                else // 3 channels
-                    return luminance(interpolate_3(si, active));
-            }
-            else{
-                if (channels == 1)
-                    return interpolate_1(si, active);
-                else { // 3 channels
-                    if constexpr (is_spectral_v<Spectrum>)
-                        return interpolate_spectral(si, active);
-                    else
-                        return interpolate_3(si, active);
-                }
-            }
+        if (dr::none_or<false>(active))
+            return dr::zeros<UnpolarizedSpectrum>();
+
+        if constexpr (is_monochromatic_v<Spectrum>) {
+            // Identical to eval_1() in this variant
+            return eval_1(si, active);
+        } else {
+            if (channels == 1)
+                return interpolate_1(si, active);
+            else if constexpr (is_spectral_v<Spectrum>)
+                return interpolate_spectral(si, active);
+            else
+                return interpolate_3(si, active);
         }
     }
 
@@ -488,110 +526,99 @@ public:
                  Mask active = true) const override {
         MI_MASKED_FUNCTION(ProfilerPhase::TextureEvaluate, active);
 
-        const size_t channels = m_texture.shape()[2];
-        if (channels == 3 && is_spectral_v<Spectrum> && !m_raw) {
-            DRJIT_MARK_USED(si);
+        const size_t channels = m_texture.channel_count();
+        if (stores_spectral_coeffs(channels))
             Throw("eval_1(): The bitmap texture %s was queried for a "
                   "monochromatic value, but texture conversion to color "
                   "spectra had previously been requested! (raw=false)",
                   to_string());
-        } else {
-            if (dr::none_or<false>(active))
-                return dr::zeros<Float>();
 
-            if (channels == 1)
-                return interpolate_1(si, active);
-            else // 3 channels
-                return luminance(interpolate_3(si, active));
-        }
+        if (dr::none_or<false>(active))
+            return dr::zeros<Float>();
+
+        if (channels == 1)
+            return interpolate_1(si, active);
+        else // 3 channels
+            return luminance(interpolate_3(si, active));
     }
 
     Vector2f eval_1_grad(const SurfaceInteraction3f &si,
                          Mask active = true) const override {
         MI_MASKED_FUNCTION(ProfilerPhase::TextureEvaluate, active);
 
-        const size_t channels = m_texture.shape()[2];
-        if (channels == 3 && is_spectral_v<Spectrum> && !m_raw) {
-            DRJIT_MARK_USED(si);
+        const size_t channels = m_texture.channel_count();
+        if (stores_spectral_coeffs(channels))
             Throw(
                 "eval_1_grad(): The bitmap texture %s was queried for a "
                 "monochromatic gradient value, but texture conversion to color "
                 "spectra had previously been requested! (raw=false)",
                 to_string());
-        } else {
-            if (dr::none_or<false>(active))
-                return dr::zeros<Vector2f>();
 
-            if (m_texture.filter_mode() == dr::FilterMode::Linear) {
-                if constexpr (!dr::is_array_v<Mask>)
-                    active = true;
+        if (dr::none_or<false>(active))
+            return dr::zeros<Vector2f>();
 
-                Point2f uv = m_transform * si.uv;
-
-                Float f00, f10, f01, f11;
-                if (channels == 1) {
-                    using Data1 = dr::Array<Float, 1>;
-                    dr::Array<Data1, 4> c =
-                        m_texture.template eval_fetch<Data1>(uv, active);
-                    f00 = c[0].x(); f10 = c[1].x();
-                    f01 = c[2].x(); f11 = c[3].x();
-                } else { // 3 channels
-                    dr::Array<Color3f, 4> c =
-                        m_texture.template eval_fetch<Color3f>(uv, active);
-                    f00 = luminance(c[0]);
-                    f10 = luminance(c[1]);
-                    f01 = luminance(c[2]);
-                    f11 = luminance(c[3]);
-                }
-
-                ScalarVector2i res = resolution();
-                uv = dr::fmadd(uv, res, -0.5f);
-                Vector2i uv_i = dr::floor2int<Vector2i>(uv);
-                Point2f w1 = uv - Point2f(uv_i),
-                        w0 = 1.f - w1;
-
-                // Partials w.r.t. pixel coordinate x and y
-                Vector2f df_xy{
-                    dr::fmadd(w0.y(), f10 - f00, w1.y() * (f11 - f01)),
-                    dr::fmadd(w0.x(), f01 - f00, w1.x() * (f11 - f10))
-                };
-
-                // Partials w.r.t. u and v (include uv transform by transpose
-                // multiply)
-                Matrix3f uv_tm = m_transform.matrix;
-                Vector2f df_uv{ uv_tm.entry(0, 0) * df_xy.x() +
-                                    uv_tm.entry(1, 0) * df_xy.y(),
-                                uv_tm.entry(0, 1) * df_xy.x() +
-                                    uv_tm.entry(1, 1) * df_xy.y() };
-                return res * df_uv;
-            }
-            // m_filter_type == FilterType::Nearest
+        // The gradient of a nearest-neighbor lookup is zero almost everywhere
+        if (m_texture.filter_mode() != dr::FilterMode::Linear)
             return Vector2f(0.f);
+
+        if constexpr (!dr::is_array_v<Mask>)
+            active = true;
+
+        Point2f uv = m_transform * si.uv;
+
+        Float f00, f10, f01, f11;
+        if (channels == 1) {
+            using Data1 = dr::Array<Float, 1>;
+            dr::Array<Data1, 4> c =
+                m_texture.template eval_fetch<Data1>(uv, active);
+            f00 = c[0].x(); f10 = c[1].x();
+            f01 = c[2].x(); f11 = c[3].x();
+        } else { // 3 channels
+            dr::Array<Color3f, 4> c =
+                m_texture.template eval_fetch<Color3f>(uv, active);
+            f00 = luminance(c[0]);
+            f10 = luminance(c[1]);
+            f01 = luminance(c[2]);
+            f11 = luminance(c[3]);
         }
+
+        BilinearWeights bw = bilinear_weights(uv);
+        const Point2f &w0 = bw.w0, &w1 = bw.w1;
+
+        // Partials w.r.t. pixel coordinate x and y
+        Vector2f df_xy{
+            dr::fmadd(w0.y(), f10 - f00, w1.y() * (f11 - f01)),
+            dr::fmadd(w0.x(), f01 - f00, w1.x() * (f11 - f10))
+        };
+
+        // Partials w.r.t. u and v (include uv transform by transpose multiply)
+        Matrix3f uv_tm = m_transform.matrix;
+        Vector2f df_uv{ uv_tm.entry(0, 0) * df_xy.x() +
+                            uv_tm.entry(1, 0) * df_xy.y(),
+                        uv_tm.entry(0, 1) * df_xy.x() +
+                            uv_tm.entry(1, 1) * df_xy.y() };
+        return resolution() * df_uv;
     }
 
     Color3f eval_3(const SurfaceInteraction3f &si,
                    Mask active = true) const override {
         MI_MASKED_FUNCTION(ProfilerPhase::TextureEvaluate, active);
 
-        const size_t channels = m_texture.shape()[2];
-        if (channels != 3) {
-            DRJIT_MARK_USED(si);
+        const size_t channels = m_texture.channel_count();
+        if (channels != 3)
             Throw("eval_3(): The bitmap texture %s was queried for a RGB "
                   "value, but it is monochromatic!",
                   to_string());
-        } else if (is_spectral_v<Spectrum> && !m_raw) {
-            DRJIT_MARK_USED(si);
+        if (stores_spectral_coeffs(channels))
             Throw("eval_3(): The bitmap texture %s was queried for a RGB "
                   "value, but texture conversion to color spectra had "
                   "previously been requested! (raw=false)",
                   to_string());
-        } else {
-            if (dr::none_or<false>(active))
-                return dr::zeros<Color3f>();
 
-            return interpolate_3(si, active);
-        }
+        if (dr::none_or<false>(active))
+            return dr::zeros<Color3f>();
+
+        return interpolate_3(si, active);
     }
 
     std::pair<Point2f, Float>
@@ -643,15 +670,9 @@ public:
 
         ScalarVector2i res = resolution();
         if (m_texture.filter_mode() == dr::FilterMode::Linear) {
-            // Scale to bitmap resolution and apply shift
-            Point2f uv = dr::fmadd(pos_, res, -.5f);
-
-            // Integer pixel positions for bilinear interpolation
-            Vector2i uv_i = dr::floor2int<Vector2i>(uv);
-
-            // Interpolation weights
-            Point2f w1 = uv - Point2f(uv_i),
-                    w0 = 1.f - w1;
+            BilinearWeights bw = bilinear_weights(pos_);
+            const Vector2i &uv_i = bw.i;
+            const Point2f &w0 = bw.w0, &w1 = bw.w1;
 
             Float v00 = m_distr2d->pdf(m_texture.wrap(uv_i + Point2i(0, 0)),
                                        active),
@@ -718,9 +739,43 @@ public:
         return oss.str();
     }
 
-    MI_DECLARE_CLASS(BitmapTextureImpl)
+    static constexpr const char *ClassName = detail::bitmap_class_name<StoredType>();
+    std::string_view class_name() const override { return ClassName; }
 
 protected:
+    /**
+     * \brief Do the stored values represent spectral upsampling coefficients
+     * rather than plain RGB?
+     *
+     * This is the case for a 3-channel texture in a spectral variant with color
+     * conversion enabled (\c raw=false). Such textures can only answer spectral
+     * queries; monochromatic and RGB lookups are rejected.
+     */
+    bool stores_spectral_coeffs(size_t channels) const {
+        return is_spectral_v<Spectrum> && !m_raw && channels == 3;
+    }
+
+    /// Interpolation weights (and base texel) of a bilinear lookup
+    struct BilinearWeights {
+        Vector2i i;        ///< Lower-left integer texel coordinate
+        Point2f w0, w1;    ///< Weights toward the lower / upper texel
+    };
+
+    /**
+     * \brief Compute the bilinear interpolation weights for a texture-space
+     * coordinate
+     *
+     * Applies the half-texel shift between the UV and texel-center conventions,
+     * then returns the lower-left integer texel and the interpolation weights.
+     */
+    BilinearWeights bilinear_weights(const Point2f &uv) const {
+        Point2f p    = dr::fmadd(uv, resolution(), -0.5f);
+        Vector2i i   = dr::floor2int<Vector2i>(p);
+        Point2f w1   = p - Point2f(i),
+                w0   = 1.f - w1;
+        return { i, w0, w1 };
+    }
+
     /**
      * \brief Evaluates the texture at the given surface interaction using
      * spectral upsampling
@@ -733,6 +788,9 @@ protected:
         Point2f uv = m_transform * si.uv;
 
         if (m_texture.filter_mode() == dr::FilterMode::Linear) {
+            // Fetch the four enclosing texels and spectrally upsample each
+            // *before* interpolating. Upsampling is nonlinear, so blending the
+            // RGB values first (e.g. via m_texture.eval()) would be incorrect.
             dr::Array<Color3f, 4> v =
                 m_texture.template eval_fetch<Color3f>(uv, active);
 
@@ -742,12 +800,8 @@ protected:
             c01 = srgb_model_eval<UnpolarizedSpectrum>(v[2], si.wavelengths);
             c11 = srgb_model_eval<UnpolarizedSpectrum>(v[3], si.wavelengths);
 
-            ScalarVector2i res = resolution();
-            uv = dr::fmadd(uv, res, -.5f);
-            Vector2i uv_i = dr::floor2int<Vector2i>(uv);
-
-            // Interpolation weights
-            Point2f w1 = uv - Point2f(uv_i), w0 = 1.f - w1;
+            BilinearWeights bw = bilinear_weights(uv);
+            const Point2f &w0 = bw.w0, &w1 = bw.w1;
 
             c0 = dr::fmadd(w0.x(), c00, w1.x() * c10);
             c1 = dr::fmadd(w0.x(), c01, w1.x() * c11);
@@ -792,6 +846,26 @@ protected:
     }
 
     /**
+     * \brief Decode a raw stored value to linear, mirroring the texture's own
+     * sampling-time conversion
+     *
+     * For 8-bit storage this normalizes to [0, 1] and undoes the sRGB curve (if
+     * enabled); for float/half storage it is a plain cast resolved at compile
+     * time. Used to derive the mean and 2D distribution from the stored tensor.
+     * Works for a scalar value or a Dr.Jit array of stored values alike.
+     */
+    template <typename T>
+    MI_INLINE dr::replace_scalar_t<T, ScalarFloat> decode(const T &v) const {
+        using Result = dr::replace_scalar_t<T, ScalarFloat>;
+        if constexpr (IsUInt8) {
+            Result f = Result(v) * ScalarFloat(1.0 / 255.0);
+            return m_srgb ? dr::srgb_to_linear(f) : f;
+        } else {
+            return Result(v);
+        }
+    }
+
+    /**
      * \brief Recompute mean and 2D sampling distribution (if requested)
      * following an update
      */
@@ -805,74 +879,63 @@ protected:
 
         bool range_issue = false;
         using FloatStorage = DynamicBuffer<Float>;
-        using StoredTypeArray= DynamicBuffer<StoredType>;
         FloatStorage values;
 
-        if (channels == 3) {
-            if constexpr (dr::is_jit_v<Float>) {
-                StoredColor3f colors = dr::gather<StoredColor3f>(
-                    tensor.array(),
-                    dr::arange<UInt32>(pixel_count));
-
-                // Potentially upcast values before attempting to compute mean
-                Color<FloatStorage, 3> colors_fl = colors;
+        if constexpr (dr::is_jit_v<Float>) {
+            if (channels == 3) {
+                StoredColor3f stored = dr::gather<StoredColor3f>(
+                    tensor.array(), dr::arange<UInt32>(pixel_count));
+                Color<FloatStorage, 3> c3(decode(stored.x()), decode(stored.y()),
+                                          decode(stored.z()));
 
                 if (is_spectral_v<Spectrum> && !m_raw)
-                    values = srgb_model_mean(colors_fl);
+                    values = srgb_model_mean(c3);
                 else
-                    values = luminance(colors_fl);
+                    values = luminance(c3);
             } else {
-                StoredScalar* ptr = (StoredScalar*) tensor.data();
-                ScalarFloat *out = nullptr, mean = 0;
-                if (init_distr) {
-                    values = dr::empty<FloatStorage>(pixel_count);
-                    out = values.data();
-                }
-
-                for (size_t i = 0; i < pixel_count; ++i) {
-                    Color3f col(ptr[0], ptr[1], ptr[2]);
-                    ptr += 3;
-
-                    ScalarFloat lum;
-                    if (is_spectral_v<Spectrum> && !m_raw)
-                        lum = srgb_model_mean(col);
-                    else
-                        lum = luminance(col);
-
-                    if (init_distr)
-                        *out++ = lum;
-                    mean += lum;
-                    range_issue |= lum < 0 || lum > 1;
-                }
-
-                m_mean = mean / pixel_count;
+                values = decode(tensor.array());
             }
-        } else {
-            if constexpr (dr::is_jit_v<Float>) {
-                values = tensor.array();
-            } else {
-                StoredScalar* ptr = (StoredScalar*) tensor.data();
-                ScalarFloat *out = nullptr, mean = 0;
-                if (init_distr) {
-                    values = dr::empty<FloatStorage>(pixel_count);
-                    out = values.data();
-                }
-                for (size_t i = 0; i < pixel_count; ++i) {
-                    ScalarFloat value = ptr[i];
-                    if (init_distr)
-                        *out++ = value;
-                    mean += value;
-                    range_issue |= value < 0 || value > 1;
-                }
-                m_mean = mean / pixel_count;
-            }
-        }
 
-        if constexpr (dr::is_jit_v<Float>) {
             if (init_mean)
                 m_mean = dr::mean(values);
             if (!m_raw)
                 range_issue = dr::any(values < 0 || values > 1);
+        } else {
+            // Reduce each texel to a single value (luminance, or spectral mean)
+            // in one pass, accumulating the average, a [0, 1] range check, and —
+            // when requested — the per-texel values backing the 2D distribution.
+            StoredScalar *ptr = (StoredScalar *) tensor.data();
+            ScalarFloat *out = nullptr;
+            if (init_distr) {
+                values = dr::empty<FloatStorage>(pixel_count);
+                out = values.data();
+            }
+
+            auto reduce = [&](auto texel_value) {
+                ScalarFloat mean = 0;
+                for (size_t i = 0; i < pixel_count; ++i) {
+                    ScalarFloat v = texel_value(ptr);
+                    if (out)
+                        *out++ = v;
+                    mean += v;
+                    range_issue |= v < 0 || v > 1;
+                }
+                m_mean = mean / pixel_count;
+            };
+
+            if (channels == 3) {
+                reduce([&](StoredScalar *&p) {
+                    Color3f c3(decode(p[0]), decode(p[1]), decode(p[2]));
+                    p += 3;
+                    if (is_spectral_v<Spectrum> && !m_raw)
+                        return ScalarFloat(srgb_model_mean(c3));
+                    return ScalarFloat(luminance(c3));
+                });
+            } else {
+                reduce([&](StoredScalar *&p) {
+                    return ScalarFloat(decode(*p++));
+                });
+            }
         }
 
         if (init_distr) {
@@ -905,8 +968,8 @@ protected:
 protected:
     std::string m_name;
     ScalarAffineTransform3f m_transform;
-    bool m_accel;
     bool m_raw;
+    bool m_srgb;
     Float m_mean;
     StoredTexture2f m_texture;
 
@@ -918,19 +981,5 @@ protected:
 };
 
 MI_EXPORT_PLUGIN(BitmapTexture)
-
-/* This class has a name that depends on extra template parameters, so
-   the standard MI_IMPLEMENT_CLASS_VARIANT macro cannot be used */
-
-NAMESPACE_BEGIN(detail)
-template <typename StoredType>
-constexpr const char * bitmap_class_name() {
-    if constexpr (std::is_same_v<dr::scalar_t<StoredType>, dr::half>)
-        return "BitmapTextureImpl_FP16";
-
-    return "BitmapTextureImpl";
-}
-NAMESPACE_END(detail)
-
 
 NAMESPACE_END(mitsuba)

--- a/src/textures/tests/test_bitmap.py
+++ b/src/textures/tests/test_bitmap.py
@@ -279,3 +279,39 @@ def test08_to_uv(variant_scalar_rgb):
 
     params = mi.traverse(bitmap)
     assert params["to_uv"] == transform
+
+
+@fresolver_append_path
+def test09_eval_u8(variants_vec_backends_once_rgb):
+    # 8-bit sRGB storage decodes on lookup; it should agree with the float path
+    # (which decodes the same 8-bit source at load time) to within 8-bit /
+    # hardware-sRGB tolerance, for evaluation and the importance-sampling mean.
+    common = {
+        'type'     : 'bitmap',
+        'filename' : 'resources/data/common/textures/carrot.png'
+    }
+    tex_ref = mi.load_dict({ **common, 'format' : 'variant' })
+    tex_u8  = mi.load_dict({ **common, 'format' : 'uint8' })
+
+    x_res, y_res = tex_ref.resolution()
+    # Coordinates of green pixel: (7, 1)
+    x = (1 / x_res) * 7 + (1 / (2 * x_res))
+    y = (1 / y_res) * 1 + (1 / (2 * y_res))
+
+    si = dr.zeros(mi.SurfaceInteraction3f)
+    si.uv = [x, y]
+
+    assert dr.allclose(tex_ref.eval_3(si), tex_u8.eval_3(si), atol=2e-3)
+    assert dr.allclose(tex_ref.eval_1(si), tex_u8.eval_1(si), atol=2e-3)
+    assert dr.allclose(tex_ref.mean(), tex_u8.mean(), atol=2e-3)
+
+
+@fresolver_append_path
+def test10_u8_unsupported_in_spectral(variants_vec_backends_once_spectral):
+    # 8-bit storage cannot hold spectral upsampling coefficients
+    with pytest.raises(RuntimeError):
+        mi.load_dict({
+            'type'     : 'bitmap',
+            'filename' : 'resources/data/common/textures/carrot.png',
+            'format'   : 'uint8'
+        })

--- a/src/volumes/grid.cpp
+++ b/src/volumes/grid.cpp
@@ -446,7 +446,7 @@ public:
             << "  bbox = " << string::indent(m_bbox) << "," << std::endl
             << "  dimensions = " << resolution() << "," << std::endl
             << "  max = " << m_max << "," << std::endl
-            << "  channels = " << m_texture.shape()[3] << std::endl
+            << "  channels = " << m_texture.channel_count() << std::endl
             << "]";
         return oss.str();
     }
@@ -461,7 +461,7 @@ protected:
      * holds all scaling coefficients is omitted.
      */
     MI_INLINE size_t nchannels() const {
-        const size_t channels = m_texture.shape()[3];
+        const size_t channels = m_texture.channel_count();
         // When spectral upsampling is requested, a fourth channel is added to
         // the internal texture data to handle scaling coefficients.
         if (is_spectral_v<Spectrum> && channels == 4 && !m_raw)
@@ -483,8 +483,7 @@ protected:
         if (m_texture.filter_mode() == dr::FilterMode::Linear) {
             using Data4 = dr::Array<Float, 4>;
             dr::Array<Data4, 8> d =
-                m_accel ? m_texture.template eval_fetch<Data4>(p, active)
-                        : m_texture.template eval_fetch_nonaccel<Data4>(p, active);
+                m_texture.template eval_fetch<Data4>(p, active);
             const Data4 &d000 = d[0], &d100 = d[1], &d010 = d[2], &d110 = d[3],
                         &d001 = d[4], &d101 = d[5], &d011 = d[6], &d111 = d[7];
 


### PR DESCRIPTION
This commit introduces a new ``format="uint8"`` storage mode for the ``bitmap`` texture. When the data is sRGB-encoded and ``raw=false``, the texture plugin linearizes the data on the fly during lookups, using hardware texture units on the CUDA/Metal backend if available.

The ``format="auto"`` heuristic now maps 8-bit sources to ``uint8`` storage, 16-bit sources to ``float16``, and everything else to the variant's native precision. ``fp16`` is renamed to ``float16`` but the former name is still accepted for compatibility.

The commit also includes some minor refactoring and test coverage.

Warning: Once merged, Mitsuba will use 8-bit textures by default when loading from 8-bit data sources, causing these textures to be non-differentiable.  Optimizations that are, e.g.,  initialized with state loaded from JPEGs or PNGs will require an extra `format="variant"` XML/dict attribute to promote to the variant's precision.