### PR TITLE
Fix uint8 texture minimal texture size bug

### DIFF
--- a/include/mitsuba/core/bitmap.h
+++ b/include/mitsuba/core/bitmap.h
@@ -467,6 +467,19 @@ public:
                  -dr::Infinity<ScalarFloat>, dr::Infinity<ScalarFloat> }) const;
 
     /**
+     * \brief Pad the bitmap so that each dimension is at least \c min_size
+     *
+     * Dimensions already >= \c min_size are left unchanged.  The extra
+     * pixels are filled by replicating the nearest edge row or column
+     * (simple edge-clamp), so this works with any component format
+     * (including integer types that \ref resample() does not support).
+     *
+     * \return A new bitmap with the padded size, or a reference to \c this
+     *         if no padding is needed.
+     */
+    ref<Bitmap> pad_to(const ScalarVector2u &min_size) const;
+
+    /**
      * \brief Convert the bitmap into another pixel and/or component format
      *
      * This helper function can be used to efficiently convert a bitmap

--- a/src/core/bitmap.cpp
+++ b/src/core/bitmap.cpp
@@ -394,6 +394,38 @@ ref<Bitmap> Bitmap::resample(
     return result;
 }
 
+ref<Bitmap> Bitmap::pad_to(const ScalarVector2u &min_size) const {
+    ScalarVector2u new_size = dr::maximum(m_size, min_size);
+    if (dr::all(new_size == m_size))
+        return const_cast<Bitmap *>(this);
+
+    ref<Bitmap> result =
+        new Bitmap(m_pixel_format, m_component_format, new_size, channel_count());
+    result->m_struct = m_struct;
+    result->m_metadata = m_metadata;
+    result->set_srgb_gamma(m_srgb_gamma);
+    result->set_premultiplied_alpha(m_premultiplied_alpha);
+
+    size_t bpp = bytes_per_pixel(),
+           src_row = bpp * m_size.x(),
+           dst_row = bpp * new_size.x();
+
+    // Copy source rows, extending columns by replicating the last pixel
+    for (uint32_t y = 0; y < m_size.y(); ++y) {
+        uint8_t *dst = result->uint8_data() + y * dst_row;
+        memcpy(dst, uint8_data() + y * src_row, src_row);
+        for (uint32_t x = m_size.x(); x < new_size.x(); ++x)
+            memcpy(dst + x * bpp, dst + (m_size.x() - 1) * bpp, bpp);
+    }
+
+    // Extend height by replicating the last (already complete) row
+    for (uint32_t y = m_size.y(); y < new_size.y(); ++y)
+        memcpy(result->uint8_data() + y * dst_row,
+               result->uint8_data() + (m_size.y() - 1) * dst_row, dst_row);
+
+    return result;
+}
+
 ref<Bitmap> Bitmap::convert(PixelFormat pixel_format,
                             sj::Type component_format,
                             bool srgb_gamma, Bitmap::AlphaTransform alpha_transform) const {

--- a/src/textures/bitmap.cpp
+++ b/src/textures/bitmap.cpp
@@ -367,11 +367,7 @@ protected:
 
         if (dr::any(bitmap->size() < 2)) {
             Log(Warn, "Image must be at least 2x2 pixels in size, up-sampling..");
-            ref<Bitmap::ReconstructionFilter> rfilter =
-                PluginManager::instance()
-                    ->create_object<Bitmap::ReconstructionFilter>(
-                        Properties("tent"));
-            bitmap = bitmap->resample(dr::maximum(bitmap->size(), 2), rfilter);
+            bitmap = bitmap->pad_to(ScalarVector2u(2));
         }
         return bitmap;
     }

--- a/src/textures/tests/test_bitmap.py
+++ b/src/textures/tests/test_bitmap.py
@@ -315,3 +315,26 @@ def test10_u8_unsupported_in_spectral(variants_vec_backends_once_spectral):
             'filename' : 'resources/data/common/textures/carrot.png',
             'format'   : 'uint8'
         })
+
+
+def test11_u8_small_bitmap_upsample(variants_vec_backends_once_rgb, tmpdir):
+    # A 1x1 uint8 bitmap must be padded to 2x2 for bilinear filtering.
+    import numpy as np
+    import os
+
+    bmp = mi.Bitmap(np.array([[[200, 100, 50]]], dtype=np.uint8))
+    bmp.set_srgb_gamma(True)
+
+    tmp_file = os.path.join(str(tmpdir), 'out.png')
+    bmp.write(tmp_file)
+
+    tex = mi.load_dict({
+        'type'     : 'bitmap',
+        'filename' : tmp_file,
+        'format'   : 'uint8',
+    })
+
+    si = dr.zeros(mi.SurfaceInteraction3f)
+    si.uv = [0.5, 0.5]
+    val = tex.eval_3(si)
+    assert dr.all(val > 0)


### PR DESCRIPTION
<!-- Please add the labels (e.g. bug fix, feature, ..) corresponding to this PR -->

## Description

When loading a texture, where one of the dimensions is less than 2 i.e. `1x100`, Mitsuba would use the `resample` method to upsample the texture to `2x100`. However, `resample` does not work with the newly added uint8 textures. This PR replaces the use of resample for this case with a simple memory copy, extending the dimensions without requiring any filter.

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes # (issue)

## Testing

The behaviour is tested by loading a 1x1 texture.

<!-- Please describe the tests that you added to verify your changes. -->

## Checklist

<!-- Please make sure to complete this checklist before requesting a review. -->

- [ ] My code follows the [style guidelines](https://mitsuba.readthedocs.io/en/latest/src/developer_guide.html#coding-style) of this project
- [ ] My changes generate no new warnings
- [ ] My code also compiles for `cuda_*` and `llvm_*` variants. If you can't test this, please leave below
- [ ] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I cleaned the commit history and removed any "Merge" commits
- [ ] I give permission that the Mitsuba 3 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba/blob/master/LICENSE)