### PR TITLE
Pad environment maps to minimum size

### DIFF
--- a/src/emitters/envmap.cpp
+++ b/src/emitters/envmap.cpp
@@ -134,9 +134,7 @@ public:
             bitmap = new Bitmap(file_path);
         }
 
-        if (bitmap->width() < 2 || bitmap->height() < 3)
-            Throw("\"%s\": the environment map resolution must be at least "
-                  "2x3 pixels", (m_filename.empty() ? "<Bitmap>" : m_filename));
+        bitmap = bitmap->pad_to(ScalarVector2u(2, 3));
 
         // Convert to linear RGBA float bitmap, will undergo further
         // conversion into coefficients of a spectral upsampling model below

--- a/src/emitters/tests/test_envmap.py
+++ b/src/emitters/tests/test_envmap.py
@@ -308,3 +308,12 @@ def test09_data_gradient(variant_llvm_ad_rgb):
         fd = (eval_value(dp) - eval_value(dm)) / (2 * h)
         assert np.allclose(fd, grad[y, x, c], atol=1e-3), \
             f"grad mismatch at {(y, x, c)}: AD={grad[y, x, c]}, FD={fd}"
+
+
+def test10_pad_to(variants_vec_backends_once_rgb):
+    bitmap = mi.Bitmap(np.ones((2, 1, 3), dtype=np.float32))
+    emitter = mi.load_dict({"type" : "envmap", "bitmap" : bitmap})
+    params = mi.traverse(emitter)
+
+    # Initially pads to (3, 2), and then adds 2 to width => (3, 4)
+    assert params['data'].shape[:2] == (3, 4)


### PR DESCRIPTION
Similar to 3f00b72372a24d0811a56186f137a817c9174f1f for regular textures, we can use the `Bitmap::pad_to` function to allow using environment maps of arbitrary size. This makes Mitsuba a bit more tolerant to scenes that were authored externally. With this fix, `envmap` emitters and `bitmap` textures behave consistently (= silent padding without warning or error).

The `pad_to` is invoked unconditionally, since it internally already has logic to do nothing if the size is met.

Currently, `hdmitsuba` implements a [workaround](https://github.com/google/hdmitsuba/blob/989ab7f8d000d5b326f18831ed2c7133def6e297/hdmitsuba/prim_translator.cc#L647) to prevent runtime errors 