### PR TITLE
Resolve BoundingSphere/Box Python binding ambiguity

### DIFF
--- a/src/core/python/bbox_v.cpp
+++ b/src/core/python/bbox_v.cpp
@@ -5,11 +5,17 @@
 #include <nanobind/stl/string.h>
 #include <nanobind/stl/tuple.h>
 
-template <typename BBox, typename Ray> auto bind_bbox(nb::module_ &m, const char *name) {
+template <typename BBox, typename Ray> void bind_bbox(nb::module_ &m, const char *name) {
         using Point = typename BBox::Point;
         using Float = typename BBox::Value;
 
-        MI_PY_CHECK_ALIAS(BBox, name) {
+        // BBox only depends on Float, so variants sharing a Float type alias
+        // the same class here; ray_intersect() is bound separately below
+        // since it depends on Spectrum (via Ray) and must exist per-variant.
+        nb::handle alias = nb::type<BBox>();
+        if (alias.is_valid()) {
+            m.attr(name) = alias;
+        } else {
             auto bbox = nb::class_<BBox>(m, name, D(BoundingBox))
                 .def(nb::init<>(), D(BoundingBox, BoundingBox))
                 .def(nb::init<Point>(), D(BoundingBox, BoundingBox, 2), "p"_a)
@@ -73,14 +79,18 @@ template <typename BBox, typename Ray> auto bind_bbox(nb::module_ &m, const char
                 .def_repr(BBox);
 
             if constexpr (dr::size_v<Point> == 3) {
-                bbox.def("ray_intersect",
-                         [](const BBox &self, const Ray &ray) {
-                             return self.ray_intersect(ray);
-                         }, D(BoundingBox, ray_intersect), "ray"_a);
                 bbox.def("bounding_sphere", &BBox::bounding_sphere,
                          D(BoundingBox, bounding_sphere));
             }
-    }
+        }
+
+        if constexpr (dr::size_v<Point> == 3) {
+            nb::borrow<nb::class_<BBox>>(nb::type<BBox>())
+                .def("ray_intersect",
+                     [](const BBox &self, const Ray &ray) {
+                         return self.ray_intersect(ray);
+                     }, D(BoundingBox, ray_intersect), "ray"_a);
+        }
 }
 
 MI_PY_EXPORT(BoundingBox) {

--- a/src/core/python/bsphere_v.cpp
+++ b/src/core/python/bsphere_v.cpp
@@ -5,32 +5,41 @@
 #include <nanobind/stl/string.h>
 #include <nanobind/stl/tuple.h>
 
-template <typename BSphere, typename Ray> auto bind_bsphere(nb::module_ &m, const char *name) {
+template <typename BSphere, typename Ray> void bind_bsphere(nb::module_ &m, const char *name) {
         using Point = typename BSphere::Point;
         using Float = typename BSphere::Float;
 
-        MI_PY_CHECK_ALIAS(BSphere, name) {
-        nb::class_<BSphere, drjit::TraversableBase>(m, name, D(BoundingSphere))
-            .def(nb::init<>(), D(BoundingSphere, BoundingSphere))
-            .def(nb::init<Point, Float>(), D(BoundingSphere, BoundingSphere, 2))
-            .def(nb::init<const BSphere &>())
-            .def("empty", &BSphere::empty, D(BoundingSphere, empty))
-            .def("contains",
-                [](const BSphere &self, const Point &p, bool strict) {
-                    return strict ? self.template contains<true>(p)
-                                  : self.template contains<false>(p);
-                }, D(BoundingSphere, contains), "p"_a, "strict"_a = false)
-            .def("expand", &BSphere::expand, D(BoundingSphere, expand))
+        // BSphere only depends on Float, so variants sharing a Float type
+        // alias the same class here; ray_intersect() is bound separately
+        // below since it depends on Spectrum (via Ray) and must exist
+        // per-variant.
+        nb::handle alias = nb::type<BSphere>();
+        if (alias.is_valid()) {
+            m.attr(name) = alias;
+        } else {
+            nb::class_<BSphere, drjit::TraversableBase>(m, name, D(BoundingSphere))
+                .def(nb::init<>(), D(BoundingSphere, BoundingSphere))
+                .def(nb::init<Point, Float>(), D(BoundingSphere, BoundingSphere, 2))
+                .def(nb::init<const BSphere &>())
+                .def("empty", &BSphere::empty, D(BoundingSphere, empty))
+                .def("contains",
+                    [](const BSphere &self, const Point &p, bool strict) {
+                        return strict ? self.template contains<true>(p)
+                                      : self.template contains<false>(p);
+                    }, D(BoundingSphere, contains), "p"_a, "strict"_a = false)
+                .def("expand", &BSphere::expand, D(BoundingSphere, expand))
+                .def(nb::self == nb::self)
+                .def(nb::self != nb::self)
+                .def_rw("center", &BSphere::center)
+                .def_rw("radius", &BSphere::radius)
+                .def_repr(BSphere);
+        }
+
+        nb::borrow<nb::class_<BSphere>>(nb::type<BSphere>())
             .def("ray_intersect",
                 [](const BSphere &self, const Ray &ray) {
                     return self.ray_intersect(ray);
-                }, D(BoundingSphere, ray_intersect), "ray"_a)
-            .def(nb::self == nb::self)
-            .def(nb::self != nb::self)
-            .def_rw("center", &BSphere::center)
-            .def_rw("radius", &BSphere::radius)
-            .def_repr(BSphere);
-        }
+                }, D(BoundingSphere, ray_intersect), "ray"_a);
 }
 
 MI_PY_EXPORT(BoundingSphere) {

--- a/src/core/python/transform_v.cpp
+++ b/src/core/python/transform_v.cpp
@@ -15,14 +15,25 @@ inline void transform_affine_is_deprecated_warning() {
     }
 }
 
+// Tracks which Ray types already have overloads on `cls`, to avoid
+// double-registering when multiple variants/aliases share both types.
+static bool record_ray_overload(nb::handle cls, const std::type_info &ray_type) {
+    const char *attr = "_mi_registered_ray_overloads";
+    nb::str tag(ray_type.name());
+    nb::set tags;
+    if (nb::hasattr(cls, attr)) {
+        tags = nb::borrow<nb::set>(nb::getattr(cls, attr));
+        if (tags.contains(tag))
+            return false;
+    } else {
+        cls.attr(attr) = tags;
+    }
+    tags.add(tag);
+    return true;
+}
+
 template <typename Transform, typename Float, typename Spectrum, size_t Dimension>
 void bind_transform(nb::module_ &m, const char *name) {
-    // Check if already bound, if so just return existing handle
-    if (auto h = nb::type<Transform>(); h.is_valid()) {
-        m.attr(name) = h;
-        return;
-    }
-
     MI_IMPORT_CORE_TYPES()
 
     using ScalarType = dr::scalar_t<Float>;
@@ -34,6 +45,24 @@ void bind_transform(nb::module_ &m, const char *name) {
     using ScalarPoint = Point<ScalarType, Dimension>;
     using NdMatrix = nb::ndarray<ScalarType, nb::shape<Dimension, Dimension>,
                                  nb::c_contig, nb::device::cpu>;
+
+    // Transform only depends on Float, so variants sharing a Float type
+    // alias the same class here; the Ray-typed __matmul__/transform_affine
+    // overloads depend on Spectrum too and must be (re-)bound per variant.
+    if (auto h = nb::type<Transform>(); h.is_valid()) {
+        m.attr(name) = h;
+        if (record_ray_overload(h, typeid(RayType))) {
+            nb::borrow<nb::class_<Transform>>(h)
+                .def("__matmul__", [](const Transform &a, const RayType &b) {
+                    return a * b;
+                }, nb::is_operator())
+                .def("transform_affine", [](const Transform &a, const RayType &b) {
+                    transform_affine_is_deprecated_warning();
+                    return a * b;
+                }, "ray"_a, D(Transform, transform_affine));
+        }
+        return;
+    }
 
     constexpr bool IsAffine = Transform::IsAffine;
     constexpr bool IsProjective = !IsAffine;
@@ -103,6 +132,8 @@ void bind_transform(nb::module_ &m, const char *name) {
         .def("__matmul__", [](const Transform &a, const RayType &b) {
             return a * b;
         }, nb::is_operator());
+
+    record_ray_overload(cls, typeid(RayType));
 
     // Deprecated transform_affine methods with warnings
     cls.def("transform_affine", [](const Transform &a, const PointType &b) {

--- a/src/core/tests/test_bbox.py
+++ b/src/core/tests/test_bbox.py
@@ -137,3 +137,23 @@ def test06_ray_intersect_vec(variant_scalar_rgb):
 
     from mitsuba.test.util import check_vectorization
     check_vectorization(kernel, arg_dims = [3, 3, 3])
+
+
+def test07_ray_intersect_cross_variant_alias():
+    if 'llvm_ad_rgb' not in mi.variants() or 'scalar_rgb' not in mi.variants():
+        pytest.skip("Missing variants to properly run the test.")
+
+    # Run in a subprocess: whether this reproduces depends on which variant's
+    # module is imported first in the process, which other tests running
+    # earlier in the same session may have already influenced.
+    import subprocess, sys, textwrap
+    script = textwrap.dedent("""
+        import mitsuba as mi
+        mi.set_variant('llvm_ad_rgb')
+        mi.set_variant('scalar_rgb')
+        bbox = mi.BoundingBox3f([-1, -1, -1], [1, 1, 1])
+        hit, mint, maxt = bbox.ray_intersect(mi.Ray3f([-5, 0, 0], [1, 0, 0]))
+        assert hit and abs(mint - 4.0) < 1e-6 and abs(maxt - 6.0) < 1e-6
+    """)
+    result = subprocess.run([sys.executable, '-c', script], capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr

--- a/src/core/tests/test_bsphere.py
+++ b/src/core/tests/test_bsphere.py
@@ -48,3 +48,23 @@ def test06_ray_intersect_vec(variant_scalar_rgb):
 
     from mitsuba.test.util import check_vectorization
     check_vectorization(kernel, arg_dims = [3, 3, 1])
+
+
+def test07_ray_intersect_cross_variant_alias():
+    if 'llvm_ad_rgb' not in mi.variants() or 'scalar_rgb' not in mi.variants():
+        pytest.skip("Missing variants to properly run the test.")
+
+    # Run in a subprocess: whether this reproduces depends on which variant's
+    # module is imported first in the process, which other tests running
+    # earlier in the same session may have already influenced.
+    import subprocess, sys, textwrap
+    script = textwrap.dedent("""
+        import mitsuba as mi
+        mi.set_variant('llvm_ad_rgb')
+        mi.set_variant('scalar_rgb')
+        bsphere = mi.BoundingSphere3f([0, 0, 0], 1)
+        hit, mint, maxt = bsphere.ray_intersect(mi.Ray3f([-5, 0, 0], [1, 0, 0]))
+        assert hit and abs(mint - 4.0) < 1e-6 and abs(maxt - 6.0) < 1e-6
+    """)
+    result = subprocess.run([sys.executable, '-c', script], capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr

--- a/src/core/tests/test_transform.py
+++ b/src/core/tests/test_transform.py
@@ -273,3 +273,25 @@ def test06_dual_callable(variant_scalar_rgb, transform_type):
     t1 = T.translate([1, 0, 0]).rotate([0, 1, 0], 45).scale([2, 2, 2])
     t2 = T().translate([1, 0, 0]).rotate([0, 1, 0], 45).scale([2, 2, 2])
     assert dr.allclose(t1.matrix, t2.matrix)
+
+
+def test09_matmul_ray_cross_variant_alias():
+    if ('llvm_ad_rgb' not in mi.variants() or
+        'llvm_ad_spectral' not in mi.variants()):
+        pytest.skip("Missing variants to properly run the test.")
+
+    # Run in a subprocess: whether this reproduces depends on which variant's
+    # module is imported first in the process, which other tests running
+    # earlier in the same session may have already influenced.
+    import subprocess, sys, textwrap
+    script = textwrap.dedent("""
+        import mitsuba as mi
+        mi.set_variant('llvm_ad_rgb')
+        mi.set_variant('llvm_ad_spectral')
+        t = mi.Transform4f.translate([1, 0, 0])
+        ray = mi.Ray3f([0, 0, 0], [1, 0, 0])
+        transformed = t @ ray
+        assert abs(transformed.o[0] - 1.0) < 1e-6
+    """)
+    result = subprocess.run([sys.executable, '-c', script], capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
<!-- Please add the labels (e.g. bug fix, feature, ..) corresponding to this PR -->

## Description

BoundingBox, BoundingSphere and Transform Python bindings only depend on the variant's Float type, not its Spectrum type. When two variants share a Float type, nanobind's per-type registry causes the second variant's module to detect that the class already exists and simply re-export the existing type, instead of creating its own.

Fix: register the Ray-dependent overloads unconditionally, once per variant module, even when the surrounding class itself is just an alias of an already-registered type from another variant.

Fixes mitsuba-renderer/mitsuba3#676.

## Testing

Added tests that fail on ambiguities. These tests run in separate subprocess so they become independent on which tests may have run before in the same session.

<details><summary>pytest log before the fix</summary>
<code>
❯ pytest src/core/tests/test_transform.py src/core/tests/test_bbox.py
====================================== test session starts ======================================
platform darwin -- Python 3.14.3, pytest-9.1.1, pluggy-1.6.0
rootdir: ~/code/mitsuba3
configfile: pyproject.toml
collected 34 items

src/core/tests/test_transform.py ....                                                     [ 11%]
src/core/tests/test_bbox.py ...F.F                                                        [ 29%]
src/core/tests/test_transform.py ..................                                       [ 82%]
src/core/tests/test_bbox.py F                                                             [ 85%]
src/core/tests/test_transform.py ....F                                                    [100%]

=========================================== FAILURES ============================================
_____________________________________ test04_ray_intersect ______________________________________

variant_scalar_rgb = 'scalar_rgb'

    def test04_ray_intersect(variant_scalar_rgb):
        bbox = mi.BoundingBox3f([-1, -1, -1], [1, 1, 1])

>       hit, mint, maxt = bbox.ray_intersect(mi.Ray3f([-5, 0, 0], [1, 0, 0]))
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E       TypeError: ray_intersect(): incompatible function arguments. The following argument types are supported:
E           1. ray_intersect(self, ray: mitsuba.Ray3f) -> tuple[drjit.llvm.ad.Bool, drjit.llvm.ad.Float, drjit.llvm.ad.Float]
E
E       Invoked with types: mitsuba.ScalarBoundingBox3f, mitsuba.ScalarRay3f

src/core/tests/test_bbox.py:102: TypeError
___________________________________ test06_ray_intersect_vec ____________________________________

variant_scalar_rgb = 'scalar_rgb'

    def test06_ray_intersect_vec(variant_scalar_rgb):
        def kernel(o, min, max):
            bbox = mi.BoundingBox3f(-min, max)
            hit, mint, maxt = bbox.ray_intersect(mi.Ray3f(o, dr.normalize(-o)))

            mint = dr.select(hit, mint, -1.0)
            maxt = dr.select(hit, maxt, -1.0)

            return mint, maxt

        from mitsuba.test.util import check_vectorization
>       check_vectorization(kernel, arg_dims = [3, 3, 3])

src/core/tests/test_bbox.py:139:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
build/python/mitsuba/python/test/util.py:145: in check_vectorization
    res = kernel(*args)
          ^^^^^^^^^^^^^
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

o = [0.636962, 0.269787, 0.0409735], min = [0.725758, 0.0828086, 0.352743]
max = [0.247285, 0.772616, 0.757362]

    def kernel(o, min, max):
        bbox = mi.BoundingBox3f(-min, max)
>       hit, mint, maxt = bbox.ray_intersect(mi.Ray3f(o, dr.normalize(-o)))
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E       TypeError: ray_intersect(): incompatible function arguments. The following argument types are supported:
E           1. ray_intersect(self, ray: mitsuba.Ray3f) -> tuple[drjit.llvm.ad.Bool, drjit.llvm.ad.Float, drjit.llvm.ad.Float]
E
E       Invoked with types: mitsuba.ScalarBoundingBox3f, mitsuba.ScalarRay3f

src/core/tests/test_bbox.py:131: TypeError
___________________________ test07_ray_intersect_cross_variant_alias ____________________________

    def test07_ray_intersect_cross_variant_alias():
        if 'llvm_ad_rgb' not in mi.variants() or 'scalar_rgb' not in mi.variants():
            pytest.skip("Missing variants to properly run the test.")

        # Run in a subprocess: whether this reproduces depends on which variant's
        # module is imported first in the process, which other tests running
        # earlier in the same session may have already influenced.
        import subprocess, sys, textwrap
        script = textwrap.dedent("""
            import mitsuba as mi
            mi.set_variant('llvm_ad_rgb')
            mi.set_variant('scalar_rgb')
            bbox = mi.BoundingBox3f([-1, -1, -1], [1, 1, 1])
            hit, mint, maxt = bbox.ray_intersect(mi.Ray3f([-5, 0, 0], [1, 0, 0]))
            assert hit and abs(mint - 4.0) < 1e-6 and abs(maxt - 6.0) < 1e-6
        """)
        result = subprocess.run([sys.executable, '-c', script], capture_output=True, text=True)
>       assert result.returncode == 0, result.stderr
E       AssertionError: Traceback (most recent call last):
E           File "<string>", line 6, in <module>
E             hit, mint, maxt = bbox.ray_intersect(mi.Ray3f([-5, 0, 0], [1, 0, 0]))
E                               ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E         TypeError: ray_intersect(): incompatible function arguments. The following argument types are supported:
E             1. ray_intersect(self, ray: mitsuba.Ray3f) -> tuple[drjit.llvm.ad.Bool, drjit.llvm.ad.Float, drjit.llvm.ad.Float]
E
E         Invoked with types: mitsuba.ScalarBoundingBox3f, mitsuba.ScalarRay3f
E
E       assert 1 == 0
E        +  where 1 = CompletedProcess(args=['/Users/tjueterb/code/mitsuba3/.venv/bin/python3', '-c', "\nimport mitsuba as mi\nmi.set_varian..., drjit.llvm.ad.Float, drjit.llvm.ad.Float]\n\nInvoked with types: mitsuba.ScalarBoundingBox3f, mitsuba.ScalarRay3f\n').returncode

src/core/tests/test_bbox.py:159: AssertionError
_____________________________ test09_matmul_ray_cross_variant_alias _____________________________

    def test09_matmul_ray_cross_variant_alias():
        if ('llvm_ad_rgb' not in mi.variants() or
            'llvm_ad_spectral' not in mi.variants()):
            pytest.skip("Missing variants to properly run the test.")

        # Run in a subprocess: whether this reproduces depends on which variant's
        # module is imported first in the process, which other tests running
        # earlier in the same session may have already influenced.
        import subprocess, sys, textwrap
        script = textwrap.dedent("""
            import mitsuba as mi
            mi.set_variant('llvm_ad_rgb')
            mi.set_variant('llvm_ad_spectral')
            t = mi.Transform4f.translate([1, 0, 0])
            ray = mi.Ray3f([0, 0, 0], [1, 0, 0])
            transformed = t @ ray
            assert abs(transformed.o[0] - 1.0) < 1e-6
        """)
        result = subprocess.run([sys.executable, '-c', script], capture_output=True, text=True)
>       assert result.returncode == 0, result.stderr
E       AssertionError: Traceback (most recent call last):
E           File "<string>", line 7, in <module>
E             transformed = t @ ray
E                           ~~^~~~~
E         TypeError: unsupported operand type(s) for @: 'mitsuba.AffineTransform4f' and 'mitsuba.Ray3f'
E
E       assert 1 == 0
E        +  where 1 = CompletedProcess(args=['/Users/tjueterb/code/mitsuba3/.venv/bin/python3', '-c', "\nimport mitsuba as mi\nmi.set_varian...         ~~^~~~~\nTypeError: unsupported operand type(s) for @: \'mitsuba.AffineTransform4f\' and \'mitsuba.Ray3f\'\n').returncode

src/core/tests/test_transform.py:297: AssertionError
==================================== short test summary info ====================================
FAILED src/core/tests/test_bbox.py::test04_ray_intersect - TypeError: ray_intersect(): incompatible function arguments. The following argument types ar...
FAILED src/core/tests/test_bbox.py::test06_ray_intersect_vec - TypeError: ray_intersect(): incompatible function arguments. The following argument types ar...
FAILED src/core/tests/test_bbox.py::test07_ray_intersect_cross_variant_alias - AssertionError: Traceback (most recent call last):
FAILED src/core/tests/test_transform.py::test09_matmul_ray_cross_variant_alias - AssertionError: Traceback (most recent call last):
================================= 4 failed, 30 passed in 0.53s ==================================
</code>
</details>

All tests pass after the fix.

## Checklist

<!-- Please make sure to complete this checklist before requesting a review. -->

- [x] My code follows the [style guidelines](https://mitsuba.readthedocs.io/en/latest/src/developer_guide.html#coding-style) of this project
- [x] My changes generate no new warnings
- [x] My code also compiles for `cuda_*` and `llvm_*` variants. If you can't test this, please leave below
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 3 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba/blob/master/LICENSE)