### PR TITLE
Force libstdc++.so.6 DT_NEEDED to fix symbol interposition segfaults

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -298,6 +298,21 @@ endif()
 
 set(CMAKE_INSTALL_RPATH "${MI_ORIGIN};${MI_ORIGIN}/../drjit")
 
+# Force a libstdc++.so.6 DT_NEEDED entry so std:: symbols never bind to copies in vendored libraries
+if (UNIX AND NOT APPLE AND CMAKE_CXX_COMPILER_ID MATCHES "(GNU|Clang)"
+    AND NOT CMAKE_CXX_FLAGS MATCHES "libc\\+\\+")
+  include(CheckLinkerFlag OPTIONAL RESULT_VARIABLE MI_CHECK_LINKER_FLAG)
+  if (MI_CHECK_LINKER_FLAG)
+    set(MI_LINK_LIBSTDCXX "-Wl,--push-state,--no-as-needed -l:libstdc++.so.6 -Wl,--pop-state")
+    string(REPLACE " " ";" MI_LINK_LIBSTDCXX_LIST "${MI_LINK_LIBSTDCXX}")
+    check_linker_flag(CXX "${MI_LINK_LIBSTDCXX_LIST}" MI_LINK_LIBSTDCXX_SUPPORTED)
+    if (MI_LINK_LIBSTDCXX_SUPPORTED)
+      set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${MI_LINK_LIBSTDCXX}")
+      set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} ${MI_LINK_LIBSTDCXX}")
+    endif()
+  endif()
+endif()
+
 # Build the dependencies
 add_subdirectory(ext)
 


### PR DESCRIPTION
## Description

Edit: The culprit was `gcc 16.1.1+r346+g4e03491b401d-3`, see comment below.

~On newer Linux toolchains (observed on Arch Linux with binutils 2.46.1, glibc 2.43, GCC 16 / Clang 22), binutils' default `--as-needed` drops `libstdc++.so.6` from `DT_NEEDED` when a library only references libstdc++ via vague-linkage (inline template) symbols — in my build, no produced `.so` file has a `libstdc++.so.6` dependency. `std::` symbols then bind to incomplete copies exported by vendored libraries (e.g. `libpugixml.so`) and crash, e.g. when printing any plugin. Because plugins are dlopen'd with `RTLD_DEEPBIND`, this is not fixable via `LD_PRELOAD`.~

~Fix: Force the `DT_NEEDED` entry at link time via `-Wl,--push-state,--no-as-needed -l:libstdc++.so.6 -Wl,--pop-state` in the top-level `CMakeLists.txt` (the `-l:` soname form is required; plain `-lstdc++` is dropped even under `--no-as-needed`). Gated behind `check_linker_flag()` and a Linux/GCC/Clang guard, so unaffected platforms and toolchains see no change. Set before `add_subdirectory(ext)`, so vendored libraries inherit the flags without changes under `ext/`.~

## Testing

`pytest src/bsdfs/tests/test_diffuse.py` segfaults before the fix and passes after.

## Checklist

- [x] My code follows the [style guidelines](https://mitsuba.readthedocs.io/en/latest/src/developer_guide.html#coding-style) of this project
- [x] My changes generate no new warnings
- [x] My code also compiles for `cuda_*` and `llvm_*` variants. If you can't test this, please leave below
- [x] I have commented my code
- [ ] I have made corresponding changes to the documentation (not necessary)
- [ ] I have added tests that prove my fix is effective or that my feature works (not necessary)
- [x] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 3 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba/blob/master/LICENSE)
