### PR TITLE
Performance: Improve AOV rendering, prevent duplicate rendering passes

### DIFF
--- a/src/integrators/aov.cpp
+++ b/src/integrators/aov.cpp
@@ -85,7 +85,7 @@ the material, this value might only be an approximation.
  */
 
 template <typename Float, typename Spectrum>
-class AOVIntegrator final : public SamplingIntegrator<Float, Spectrum> {
+class AOVIntegratorImpl final : public SamplingIntegrator<Float, Spectrum> {
 public:
     MI_IMPORT_BASE(SamplingIntegrator)
     MI_IMPORT_TYPES(Scene, Shape, Sensor, Sampler, Medium, BSDFPtr, ShapePtr)
@@ -103,36 +103,10 @@ public:
         dUVdy,
         PrimIndex,
         ShapeIndex,
-        IntegratorRGBA
     };
 
-    AOVIntegrator(const Properties &props) : Base(props),
-        m_integrator_aovs_count(0) {
-        std::vector<std::string> tokens = string::tokenize(props.get<std::string_view>("aovs"));
-
-        // First pass: collect integrators and their RGBA channels
-        std::vector<std::pair<std::string, Base*>> integrators_with_names;
-        for (auto &prop : props.objects()) {
-            Base *integrator = prop.try_get<Base>();
-            if (!integrator)
-                Throw("Child objects must be of type 'SamplingIntegrator'!");
-            std::string name(prop.name());
-            integrators_with_names.push_back({name, integrator});
-            m_integrators.push_back(integrator);
-            m_aov_types.push_back(AOVType::IntegratorRGBA);
-            m_aov_names.push_back(name + ".R");
-            m_aov_names.push_back(name + ".G");
-            m_aov_names.push_back(name + ".B");
-            m_aov_names.push_back(name + ".A");
-            m_integrator_aovs_count += 4;
-        }
-
-        // Second pass: collect AOVs from integrators
-        for (auto &[name, integrator] : integrators_with_names) {
-            std::vector<std::string> aovs = integrator->aov_names();
-            for (auto aov_name: aovs)
-                m_aov_names.push_back(name + "." + aov_name);
-        }
+    AOVIntegratorImpl(std::string_view aovs_spec) : Base(Properties()) {
+        std::vector<std::string> tokens = string::tokenize(aovs_spec);
 
         for (const std::string &token: tokens) {
             std::vector<std::string> item = string::tokenize(token, ":");
@@ -191,26 +165,22 @@ public:
             } else if (item[1] == "shape_index") {
                 m_aov_types.push_back(AOVType::ShapeIndex);
                 m_aov_names.push_back(item[0] + ".I");
+                m_has_shape_index_aov = true;
             } else {
                 Throw("Invalid AOV type \"%s\"!", item[1]);
             }
         }
-
-        if (m_aov_names.empty())
-            Log(Warn, "No AOVs were specified!");
     }
 
     std::pair<Spectrum, Mask> sample(const Scene *scene,
-                                     Sampler * sampler,
+                                     Sampler * /*sampler*/,
                                      const RayDifferential3f &ray,
-                                     const Medium * medium,
-                                     Float *_aovs,
+                                     const Medium * /*medium*/,
+                                     Float *aovs,
                                      Mask active) const override {
         MI_MASKED_FUNCTION(ProfilerPhase::SamplingIntegratorSample, active);
 
         std::pair<Spectrum, Mask> result { 0.f, false };
-
-        // Don't reorder threads - let the inner integrator do it
         SurfaceInteraction3f si =
             scene->ray_intersect(ray, (uint32_t) RayFlags::Default, true, false, 0, 0, active);
         dr::masked(si, !si.is_valid()) = dr::zeros<SurfaceInteraction3f>();
@@ -231,19 +201,6 @@ public:
             }
         };
 
-        // Shape indexing data structure for scalar variants
-        std::unordered_map<const Shape*, uint32_t> shape_to_idx{};
-        std::vector<ref<Shape>> shapes = scene->shapes();
-        size_t counter = 1; // 0 reserved for background
-        for (const ref<Shape>& shape: shapes)
-            shape_to_idx[shape.get()] = (uint32_t) counter++;
-
-        // We want to pack the channels such that base_channels and inner-integrator
-        // RGBA channels are contiguous
-        Float* aovs_rgba_integrator = _aovs;
-        Float* aovs = _aovs + m_integrator_aovs_count;
-
-        size_t inner_idx = 0;
         for (size_t i = 0; i < m_aov_types.size(); ++i) {
             switch (m_aov_types[i]) {
                 case AOVType::Albedo: {
@@ -333,8 +290,8 @@ public:
                         if (!target)
                             target = si.shape;
 
-                        auto it = shape_to_idx.find(target);
-                        if (it == shape_to_idx.end())
+                        auto it = m_shape_to_idx.find(target);
+                        if (it == m_shape_to_idx.end())
                             *aovs++ = 0;
                         else
                             *aovs++ = Float(it->second);
@@ -342,24 +299,6 @@ public:
                         *aovs++ = Float(dr::reinterpret_array<UInt32>(si.shape));
                     }
                     break;
-
-                case AOVType::IntegratorRGBA: {
-                    auto [inner_spec, inner_mask] 
-                        = m_integrators[inner_idx]->sample(scene, sampler, ray, medium, aovs, active);
-                    dr::disable_grad(inner_spec);
-
-                    Color3f rgb = spectrum_to_color3f(inner_spec, ray, active);
-
-                    aovs += m_integrators[inner_idx]->aov_names().size();
-                    *aovs_rgba_integrator++ = rgb.r();
-                    *aovs_rgba_integrator++ = rgb.g();
-                    *aovs_rgba_integrator++ = rgb.b();
-                    *aovs_rgba_integrator++ = dr::select(inner_mask, Float(1.f), Float(0.f));
-                    if (inner_idx == 0)
-                        result = {inner_spec, inner_mask};
-
-                    inner_idx++;
-                } break;
             }
         }
 
@@ -373,25 +312,141 @@ public:
                     bool develop,
                     bool evaluate) override {
 
-        std::vector<TensorXf> inner_images;
+        // Prepare shape indexing data structure for scalar variants
+        if constexpr (!dr::is_jit_v<Float>) {
+            if (m_has_shape_index_aov) {
+                m_shape_to_idx.clear();
+                size_t counter = 1;
+                for (const ref<Shape>& shape : scene->shapes())
+                    m_shape_to_idx[shape.get()] = (uint32_t) counter++;
+            }
+        }
+        return Base::render(scene, sensor, seed, spp, develop, evaluate);
+    }
+
+    std::vector<std::string> aov_names() const override {
+        return m_aov_names;
+    }
+
+    std::string to_string() const override {
+        std::ostringstream oss;
+        oss << "AOVIntegratorImpl[" << std::endl
+            << "  aovs = " << m_aov_names << std::endl
+            << "]";
+        return oss.str();
+    }
+
+private:
+    std::vector<AOVType> m_aov_types;
+    std::vector<std::string> m_aov_names;
+    bool m_has_shape_index_aov = false;
+    std::unordered_map<const Shape*, uint32_t> m_shape_to_idx;
+};
+
+template <typename Float, typename Spectrum>
+class AOVIntegrator final : public SamplingIntegrator<Float, Spectrum> {
+public:
+    MI_IMPORT_BASE(SamplingIntegrator)
+    MI_IMPORT_TYPES(Scene, Shape, Sensor, Sampler, Medium, BSDFPtr, ShapePtr, Film, ImageBlock)
+    using AOVIntegratorImpl = AOVIntegratorImpl<Float, Spectrum>;
+
+    AOVIntegrator(const Properties &props) : Base(props),
+        m_nested_aovs_count(0) {
+
+        // Collect integrators and their AOV / RGBA channels
+        for (auto &prop : props.objects()) {
+            Base *integrator = prop.try_get<Base>();
+            if (!integrator)
+                Throw("Child objects must be of type 'SamplingIntegrator'!");
+            std::string name(prop.name());
+            m_integrators.push_back(integrator);
+            m_aov_names.push_back(name + ".R");
+            m_aov_names.push_back(name + ".G");
+            m_aov_names.push_back(name + ".B");
+            m_aov_names.push_back(name + ".A");
+
+            std::vector<std::string> child_aovs = integrator->aov_names();
+            for (const auto &child_aov : child_aovs)
+                m_aov_names.push_back(name + "." + child_aov);
+        }
+
+        std::string_view aovs = props.get<std::string_view>("aovs");
+        if (!aovs.empty()) {
+            ref<AOVIntegratorImpl> aov_integrator = new AOVIntegratorImpl(aovs);
+            if (!aov_integrator->aov_names().empty()) {
+                m_aov_integrator = aov_integrator;
+                for (const auto &name : m_aov_integrator->aov_names())
+                    m_aov_names.push_back(name);
+                m_nested_aovs_count = m_aov_integrator->aov_names().size();
+            }
+        }
+
+        if (m_aov_names.empty())
+            Log(Warn, "No AOVs were specified!");
+    }
+
+
+    TensorXf render(Scene *scene,
+                    Sensor *sensor,
+                    UInt32 seed,
+                    uint32_t spp,
+                    bool develop,
+                    bool evaluate) override {
+        Film *film = sensor->film();
+        size_t base_channel_count = film->base_channels_count();
+        size_t raw_channel_count = base_channel_count + 1 /* W channel */;
+
+        std::vector<TensorXf> inner_images, inner_raw_tensors;
         for (auto& integrator : m_integrators) {
             auto image = integrator->render(scene, sensor, seed, spp, develop, evaluate);
             inner_images.push_back(image);
+            inner_raw_tensors.push_back(film->develop(true));
         }
 
-        TensorXf aovs_image;
-        {
-            aovs_image = Base::render(scene, sensor, seed, spp, develop, evaluate);
-
-            // AOVs image above includes film target inner integrator channels as well so get slice
-            // just with AOVs
-            size_t num_aovs = m_aov_names.size() - m_integrator_aovs_count;
+        TensorXf aovs_image, aovs_raw_tensor;
+        if (m_aov_integrator) {
+            aovs_image = m_aov_integrator->render(scene, sensor, seed, spp, develop, evaluate);
+            aovs_raw_tensor = film->develop(true);
             if (develop)
-                aovs_image = get_channels_slice(aovs_image, aovs_image.shape(2) - num_aovs, num_aovs);
+                aovs_image = get_channels_slice(aovs_image, base_channel_count, m_nested_aovs_count);
         }
 
-        if (develop)
-            return merge_channels(inner_images, aovs_image);
+        // Propagate nested integrator results to the shared film
+        ScalarVector2u crop_size = film->crop_size();
+        size_t total_raw_channels = raw_channel_count + m_aov_names.size();
+        size_t assembled_shape[3] = { crop_size.y(), crop_size.x(), total_raw_channels };
+        size_t n_elements = crop_size.y() * crop_size.x() * total_raw_channels;
+        TensorXf assembled_raw(dr::zeros<typename TensorXf::Array>(n_elements), 3, assembled_shape);
+        if (!inner_raw_tensors.empty()) {
+            copy_channels_slice(inner_raw_tensors[0], 0, assembled_raw, 0, raw_channel_count);
+        } else if (m_aov_integrator) {
+            copy_channels_slice(aovs_raw_tensor, 0, assembled_raw, 0, raw_channel_count);
+        }
+        uint32_t dst_offset = (uint32_t) raw_channel_count;
+        for (size_t i = 0; i < m_integrators.size(); ++i) {
+            copy_channels_slice(inner_raw_tensors[i], 0, assembled_raw, dst_offset, 4);
+            dst_offset += 4;
+            uint32_t child_aov_count = (uint32_t) m_integrators[i]->aov_names().size();
+            if (child_aov_count > 0) {
+                copy_channels_slice(inner_raw_tensors[i], raw_channel_count, assembled_raw, dst_offset, child_aov_count);
+                dst_offset += child_aov_count;
+            }
+        }
+        if (m_aov_integrator) {
+            copy_channels_slice(aovs_raw_tensor, raw_channel_count, assembled_raw, dst_offset, m_nested_aovs_count);
+            dst_offset += m_nested_aovs_count;
+        }
+        film->prepare(m_aov_names);
+        film->clear();
+        ref<ImageBlock> block = new ImageBlock(assembled_raw, film->crop_offset());
+        film->put_block(block);
+
+        if (develop) {
+            TensorXf result = merge_channels(inner_images, aovs_image);
+            if (evaluate)
+                dr::eval(result);
+            return result;
+        }
 
         return {};
     }
@@ -404,13 +459,10 @@ public:
 
         // Perform forward mode propagation just for AOV image
         TensorXf aovs_grad;
-        {
-            TensorXf aovs_image = Base::render(scene, sensor, seed, spp);
-
-            // AOVs image above includes film target inner integrator channels as well so get slice
-            // just with AOVs
-            size_t num_aovs = m_aov_names.size() - m_integrator_aovs_count;
-            aovs_image = get_channels_slice(aovs_image, aovs_image.shape(2) - num_aovs, num_aovs);
+        if (m_aov_integrator) {
+            TensorXf aovs_image = m_aov_integrator->render(scene, sensor, seed, spp);
+            // Extract only the AOV channel, omitting the RGB/RGBA default channels
+            aovs_image = get_channels_slice(aovs_image, sensor->film()->base_channels_count(), m_nested_aovs_count);
 
             // Perform an AD traversal of all registered AD variables that
             // influence 'aovs_image' in a differentiable manner
@@ -440,13 +492,10 @@ public:
         auto [image_grads, aovs_grad] = split_channels(base_ch_count, grad_in);
 
         // Perform AD back-propagation just for AOV image
-        {
-            TensorXf aovs_image = Base::render(scene, sensor, seed, spp);
-
-            // AOVs image above includes film target inner integrator channels as well so get slice
-            // just with AOVs
-            size_t num_aovs = m_aov_names.size() - m_integrator_aovs_count;
-            aovs_image = get_channels_slice(aovs_image, aovs_image.shape(2) - num_aovs, num_aovs);
+        if (m_aov_integrator) {
+            TensorXf aovs_image = m_aov_integrator->render(scene, sensor, seed, spp);
+            // Extract only the AOV channel, omitting the RGB/RGBA default channels
+            aovs_image = get_channels_slice(aovs_image, base_ch_count, m_nested_aovs_count);
 
             dr::backward_from((aovs_image * aovs_grad).array(), dr::ADFlag::ClearInterior | dr::ADFlag::AllowNoGrad);
         }
@@ -486,6 +535,25 @@ public:
     MI_DECLARE_CLASS(AOVIntegrator)
 protected:
 
+    void copy_channels_slice(const TensorXf& src, size_t src_channel_offset,
+                             TensorXf& dst, size_t dst_channel_offset,
+                             size_t num_channels) const {
+        auto* src_shape = src.shape().data();
+        uint32_t src_flat = (uint32_t) (src_shape[0] * src_shape[1] * num_channels);
+
+        DynamicBuffer<UInt32> idx = dr::arange<DynamicBuffer<UInt32>>(src_flat);
+        DynamicBuffer<UInt32> pixel_idx = idx / num_channels;
+        DynamicBuffer<UInt32> channel_offset = dr::fmadd(pixel_idx, uint32_t(-(int)num_channels), idx);
+
+        DynamicBuffer<UInt32> src_idx = dr::fmadd(pixel_idx, (uint32_t) src.shape(2), channel_offset + (uint32_t) src_channel_offset);
+        DynamicBuffer<UInt32> dst_idx = dr::fmadd(pixel_idx, (uint32_t) dst.shape(2), channel_offset + (uint32_t) dst_channel_offset);
+
+        dr::scatter(
+            dst.array(),
+            dr::gather<typename TensorXf::Array>(src.array(), src_idx),
+            dst_idx);
+    }
+
     TensorXf get_channels_slice(const TensorXf& src, size_t channel_offset, size_t num_channels) const {
         using Array = typename TensorXf::Array;
 
@@ -524,12 +592,10 @@ protected:
                             const TensorXf& aovs_image) const {
         using Array = typename TensorXf::Array;
 
-        size_t num_aovs = m_aov_names.size();
-
-        auto* aovs_image_shape = aovs_image.shape().data();
+        auto* shape = !inner_images.empty() ? inner_images[0].shape().data() : aovs_image.shape().data();
 
         // Figure out entire number of channels of combined image
-        size_t combined_shape[3] = { aovs_image_shape[0], aovs_image_shape[1], num_aovs - m_integrator_aovs_count };
+        size_t combined_shape[3] = { shape[0], shape[1], m_nested_aovs_count };
         for (const auto& image : inner_images)
             combined_shape[2] += image.shape(2);
 
@@ -544,15 +610,14 @@ protected:
         }
 
         // Load aovs image into combined
-        set_channels_slice(aovs_image, combined_image, channel_offset);
+        if (m_aov_integrator)
+            set_channels_slice(aovs_image, combined_image, channel_offset);
 
         return combined_image;
     }
 
     /// Split up an image into image generated by inner-integrators and AOV image
     std::pair<std::vector<TensorXf>, TensorXf> split_channels(size_t base_channel_count, const TensorXf& combined_image) const {
-        using Array = typename TensorXf::Array;
-
         std::vector<TensorXf> inner_images;
 
         size_t channel_offset = 0;
@@ -564,18 +629,18 @@ protected:
             channel_offset += image_channels;
         }
 
-        size_t num_aovs = m_aov_names.size() - m_integrator_aovs_count;
-        TensorXf aovs_image = get_channels_slice(combined_image, channel_offset, num_aovs);
+        TensorXf aovs_image;
+        if (m_aov_integrator)
+            aovs_image = get_channels_slice(combined_image, channel_offset, m_nested_aovs_count);
 
         return { inner_images, aovs_image };
     }
 
 private:
-    size_t m_integrator_aovs_count;
-    std::vector<AOVType> m_aov_types;
+    size_t m_nested_aovs_count;
     std::vector<std::string> m_aov_names;
     std::vector<ref<Base>> m_integrators;
-
+    ref<Base> m_aov_integrator;
     MI_TRAVERSE_CB(Base, m_integrators)
 };
 

--- a/src/integrators/tests/test_aov.py
+++ b/src/integrators/tests/test_aov.py
@@ -328,3 +328,64 @@ def test07_test_aov_normalmap(variants_all_ad_rgb):
     assert(dr.allclose(
         image[:,:,3:6].array,
         dr.tile(n, image.shape[0] * image.shape[1])))
+
+
+def test08_nested_aov_integrators(variants_all_rgb):
+    scene = mi.load_file(find_resource('resources/data/scenes/cbox/cbox.xml'), res=32)
+
+    direct_integrator = mi.load_dict({'type': 'direct'})
+    outer_aov = mi.load_dict({
+        'type': 'aov',
+        'aovs': 'dd:depth',
+        'inner_aov': {
+            'type': 'aov',
+            'aovs': 'nn:sh_normal',
+            'inner_direct': direct_integrator,
+        },
+    })
+
+    spp = 4
+    direct_image = direct_integrator.render(scene, seed=0, spp=spp)
+    aov_image = outer_aov.render(scene, seed=0, spp=spp)
+    expected_aov_names = [
+        'inner_aov.R',
+        'inner_aov.G',
+        'inner_aov.B',
+        'inner_aov.A',
+        'inner_aov.inner_direct.R',
+        'inner_aov.inner_direct.G',
+        'inner_aov.inner_direct.B',
+        'inner_aov.inner_direct.A',
+        'inner_aov.nn.X',
+        'inner_aov.nn.Y',
+        'inner_aov.nn.Z',
+        'dd.T',
+    ]
+    assert outer_aov.aov_names() == expected_aov_names
+    # Developed RGB image contains 7 channels (6 from inner_aov + 1 depth)
+    assert aov_image.shape[2] == 7
+    assert dr.allclose(direct_image[:, :, :3], aov_image[:, :, :3], atol=1e-2)
+    assert dr.any(aov_image[:, :, 3:6] != 0.0) # non-zero normal values
+    assert dr.any(aov_image[:, :, 6] > 0.0)  # positive depth values
+
+    # Verify that bitmap.split() cleanly splits channels into expected layer sub-bitmaps
+    split_layers = dict(scene.sensors()[0].film().bitmap().split())
+    assert split_layers.keys() == {
+        '<root>',
+        'inner_aov',
+        'inner_aov.inner_direct',
+        'inner_aov.nn',
+        'dd',
+    }
+
+    # inner_aov layer contains the developed RGBA image from inner_aov
+    inner_aov_layer = mi.TensorXf(split_layers['inner_aov'])
+    assert dr.allclose(direct_image[:, :, :3], inner_aov_layer[:, :, :3], atol=1e-2)
+
+    # inner_aov.inner_direct layer contains the developed RGBA image from inner_direct
+    inner_direct_layer = mi.TensorXf(split_layers['inner_aov.inner_direct'])
+    assert dr.allclose(direct_image[:, :, :3], inner_direct_layer[:, :, :3], atol=1e-2)
+
+    # <root> layer contains the developed base RGB image
+    root_layer = mi.TensorXf(split_layers['<root>'])
+    assert dr.allclose(direct_image[:, :, :3], root_layer[:, :, :3], atol=1e-2)


### PR DESCRIPTION
Attempt to address issue #1917: Currently, the AOV integrator queries the nested RGBA integrator values both in it's `sample` function, as well as (separately) by calling `render` recursively in the `render` function.

Originally, the AOV integrator did not override `render`, so the `sample` function was correct. However, later, `render` was modified to query nested integrators that may override `render` themselves. That change should have removed the nested integrator query in `sample`, which is most likely an oversight.

**Update 21.7.2026:** The PR now correctly prevents duplicate rendering, while carefully updating the film's content. I also added a unit test to check the correct handling of nested integrators. The change required adding a new API to retrieve a film's storage, and a new API to write to image blocks. This PR also removes expensive per-sample heap allocations in scalar mode.

With the change, I get these timings on an RTX A5000:

```
=========================================================
 Cornell Box Benchmark (1024x1024, 64 SPP, Filter: 'box')
=========================================================

0 AOVs (Pure Path)                         | Avg: 129.42 ms
1 AOV (Depth)                              | Avg: 138.58 ms
5 AOVs (Depth, Normal, Albedo, Pos, UV)    | Avg: 144.48 ms

=========================================================
 Cornell Box Benchmark (1024x1024, 64 SPP, Filter: 'gaussian')
=========================================================

0 AOVs (Pure Path)                         | Avg: 345.43 ms
1 AOV (Depth)                              | Avg: 371.60 ms
5 AOVs (Depth, Normal, Albedo, Pos, UV)    | Avg: 517.41 ms
```

Without the change, I get:
```
=========================================================
 Cornell Box Benchmark (1024x1024, 64 SPP, Filter: 'box')
=========================================================

0 AOVs (Pure Path)                         | Avg: 130.62 ms
1 AOV (Depth)                              | Avg: 316.08 ms
5 AOVs (Depth, Normal, Albedo, Pos, UV)    | Avg: 414.57 ms

=========================================================
 Cornell Box Benchmark (1024x1024, 64 SPP, Filter: 'gaussian')
=========================================================

0 AOVs (Pure Path)                         | Avg: 352.10 ms
1 AOV (Depth)                              | Avg: 1857.04 ms
5 AOVs (Depth, Normal, Albedo, Pos, UV)    | Avg: 3638.11 ms
=========================================================
```
