### PR TITLE
Performance: Introduce a MergeInstance shape

### DIFF
--- a/include/mitsuba/core/parser.h
+++ b/include/mitsuba/core/parser.h
@@ -86,6 +86,9 @@ struct ParserConfig {
     /// Merge compatible meshes (same material) into single larger mesh
     bool merge_meshes = true;
 
+    /// Merge instances of the same ShapeGroup into MergeInstance shapes
+    bool merge_instances = true;
+
     /// Constructor that takes variant name
     ParserConfig(std::string_view variant) : variant(variant) {}
 };

--- a/include/mitsuba/render/accel_embree.h
+++ b/include/mitsuba/render/accel_embree.h
@@ -48,7 +48,8 @@ struct EmbreeAccel {
 
     // --- Declarative traversal ---
     DRJIT_TRAVERSE(EmbreeAccel, accel_handle, func_handle,
-                   occlude_handle, shapes_registry_ids)
+                   occlude_handle, shapes_registry_ids,
+                   batch_element_ids)
 
     /// Native Embree scene, lifetime tied to ``accel_handle`` in JIT variants.
     RTCSceneTy *accel = nullptr;
@@ -65,6 +66,20 @@ struct EmbreeAccel {
     UInt64 func_handle;
     UInt64 occlude_handle;
     DynamicBuffer<UInt32> shapes_registry_ids;
+
+    /// For LLVM path: maps geom_id → batch element index within a
+    /// MergeInstance.  Value is (uint32_t)-1 for non-batch shapes.
+    DynamicBuffer<UInt32> batch_element_ids;
+
+    /// MergeInstance.  Value is (uint32_t)-1 for non-batch shapes.
+    ///
+    /// For MergeInstance shapes that emit N Embree geometries, all N geom_ids
+    /// map to the same \c m_shapes index.
+    std::vector<uint32_t> geom_id_to_shape_idx;
+
+    /// Maps Embree geom_id → batch element index within a MergeInstance.
+    /// For non-batch shapes, the value is (uint32_t)-1.
+    std::vector<uint32_t> geom_id_to_batch_idx;
 };
 
 NAMESPACE_END(mitsuba)

--- a/include/mitsuba/render/accel_embree.h
+++ b/include/mitsuba/render/accel_embree.h
@@ -67,18 +67,18 @@ struct EmbreeAccel {
     UInt64 occlude_handle;
     DynamicBuffer<UInt32> shapes_registry_ids;
 
-    /// For LLVM path: maps geom_id → batch element index within a
-    /// MergeInstance.  Value is (uint32_t)-1 for non-batch shapes.
+    /// LLVM path: maps a top-level Embree geom_id to its batch element index
+    /// within a MergeInstance. Value is (uint32_t) -1 for non-batch shapes.
     DynamicBuffer<UInt32> batch_element_ids;
 
-    /// MergeInstance.  Value is (uint32_t)-1 for non-batch shapes.
-    ///
-    /// For MergeInstance shapes that emit N Embree geometries, all N geom_ids
-    /// map to the same \c m_shapes index.
+    /// Scalar path: maps a top-level Embree geom_id to its owning index in
+    /// \c scene->m_shapes. A MergeInstance shape emits one geometry per batch
+    /// element, so several consecutive geom_ids can map to the same entry.
     std::vector<uint32_t> geom_id_to_shape_idx;
 
-    /// Maps Embree geom_id → batch element index within a MergeInstance.
-    /// For non-batch shapes, the value is (uint32_t)-1.
+    /// Scalar path: maps a top-level Embree geom_id to its batch element
+    /// index within a MergeInstance. Value is (uint32_t) -1 for non-batch
+    /// shapes. Host-side counterpart of \c batch_element_ids.
     std::vector<uint32_t> geom_id_to_batch_idx;
 };
 

--- a/include/mitsuba/render/accel_metal.h
+++ b/include/mitsuba/render/accel_metal.h
@@ -45,7 +45,7 @@ struct MetalAccel {
 
     // --- Declarative traversal (scene handle + recovery tables) ---
     DRJIT_TRAVERSE(MetalAccel, accel_handle, geom_shape_offsets,
-                   geom_shape_table)
+                   geom_shape_table, batch_element_ids)
 
     /// Opaque handle owning the Metal objects (TLAS/BLAS/buffers/library)
     MetalAccelData *accel = nullptr;
@@ -57,6 +57,10 @@ struct MetalAccel {
     /// (instance_id, geometry_id), built in scene_metal.inl.
     DynamicBuffer<UInt32> geom_shape_offsets;
     DynamicBuffer<UInt32> geom_shape_table;
+    /// Maps a TLAS instance_id (see \ref geom_shape_offsets) to its batch
+    /// element index within a MergeInstance. 0 for non-batch instances (see
+    /// \c InstanceEntry::instance_index).
+    DynamicBuffer<UInt32> batch_element_ids;
 
 private:
     /// Trace \c ray, writing eight result variable indices to \c out. With

--- a/include/mitsuba/render/accel_native.h
+++ b/include/mitsuba/render/accel_native.h
@@ -44,7 +44,8 @@ struct NativeAccel {
 
     // --- Declarative traversal ---
     DRJIT_TRAVERSE(NativeAccel, accel_handle, func_handle,
-                   occlude_handle, shapes_registry_ids)
+                   occlude_handle, shapes_registry_ids,
+                   batch_element_ids)
 
     /// Native kd-tree, lifetime tied to ``accel_handle`` in JIT variants.
     ShapeKDTree<Float, Spectrum> *accel = nullptr;
@@ -57,6 +58,8 @@ struct NativeAccel {
     UInt64 func_handle;
     UInt64 occlude_handle;
     DynamicBuffer<UInt32> shapes_registry_ids;
+    /// Dummy for MergeInstance (native backend does not support MergeInstance).
+    DynamicBuffer<UInt32> batch_element_ids;
 };
 
 NAMESPACE_END(mitsuba)

--- a/include/mitsuba/render/accel_optix.h
+++ b/include/mitsuba/render/accel_optix.h
@@ -43,14 +43,16 @@ struct OptixAccel {
         const Scene<Float, Spectrum> *scene, const Ray3f &ray,
         Mask active) const;
 
-    // --- Declarative traversal (the IAS handle + the rebindable SBT handle) ---
-    DRJIT_TRAVERSE(OptixAccel, accel_handle, sbt_handle)
+    // --- Declarative traversal (the IAS handle, rebindable SBT handle, and batch element buffer) ---
+    DRJIT_TRAVERSE(OptixAccel, accel_handle, sbt_handle, batch_element_ids)
 
     /// Heap-allocated native OptiX state.
     MiOptixSceneState *state = nullptr;
     /// Freeze-visible IAS and SBT owner handles.
     UInt64 accel_handle;
     UInt64 sbt_handle;
+    /// Maps OptiX instance index in the IAS to batch element index for MergeInstance.
+    DynamicBuffer<UInt32> batch_element_ids;
 };
 
 NAMESPACE_END(mitsuba)

--- a/include/mitsuba/render/fwd.h
+++ b/include/mitsuba/render/fwd.h
@@ -83,6 +83,9 @@ enum class ShapeType : uint32_t {
     /// ShapeGroup (`shapegroup`)
     ShapeGroup = 1u << 11,
 
+    /// MergeInstance (`mergeinstance`) -- a collection of same-group instances
+    MergeInstance = 1u << 12,
+
     /// Invalid for default initialization
     Invalid = 0
 };

--- a/include/mitsuba/render/interaction.h
+++ b/include/mitsuba/render/interaction.h
@@ -665,6 +665,9 @@ struct PreliminaryIntersection {
     /// Shape index, e.g. the shape ID in shapegroup (if applicable)
     Index shape_index;
 
+    /// Instance index, e.g. batch element index within a MergeInstance (if applicable)
+    Index instance_index;
+
     /// Pointer to the associated shape
     ShapePtr shape = nullptr;
 
@@ -689,6 +692,7 @@ struct PreliminaryIntersection {
         prim_uv     = dr::zeros<Point2f>(size);
         prim_index  = dr::zeros<Index>(size);
         shape_index = dr::zeros<Index>(size);
+        instance_index = dr::zeros<Index>(size);
 
         if constexpr (dr::is_jit_v<Float_>) {
             shape       = dr::zeros<ShapePtr>(size);
@@ -746,7 +750,7 @@ struct PreliminaryIntersection {
     // =============================================================
 
     DRJIT_STRUCT(PreliminaryIntersection, valid, t, prim_uv, prim_index,
-                 shape_index, shape, instance);
+                 shape_index, instance_index, shape, instance);
 };
 
 // -----------------------------------------------------------------------------

--- a/include/mitsuba/render/optix/common.h
+++ b/include/mitsuba/render/optix/common.h
@@ -60,8 +60,10 @@ set_preliminary_intersection_to_payload(float t,
     optixSetPayload_4(shape_registry_id);
 
     // Instance index is initialized to 0 when there is no instancing in the scene
-    if (optixGetPayload_5() > 0)
+    if (optixGetPayload_5() > 0) {
         optixSetPayload_5(optixGetInstanceId());
+        optixSetPayload_6(optixGetInstanceIndex());
+    }
 }
 
 #endif

--- a/include/mitsuba/render/scene_ir.h
+++ b/include/mitsuba/render/scene_ir.h
@@ -20,7 +20,8 @@ struct ShapeIR {
         BSplineCurve,     ///< cubic B-spline curve
         LinearCurve,      ///< linear curve
         Custom,           ///< AABB/implicit: sphere, disk, cylinder, sdfgrid, ellipsoids
-        Instance          ///< ShapeGroup instance, carries no geometry and is never bucketed
+        Instance,         ///< ShapeGroup instance, carries no geometry and is never bucketed
+        MergeInstance     ///< Merged instances (same ShapeGroup, multiple transforms)
     };
 
     Kind kind = Kind::Custom;
@@ -80,6 +81,11 @@ struct ShapeIR {
     /// BLAS-set cache key (shared by all instances of one ShapeGroup).
     const void *group_id = nullptr;
 
+    // --- MergeInstance ---
+
+    /// All per-instance transforms (column-major 3x4, 12 floats each).
+    std::vector<std::array<float, 12>> batch_to_worlds;
+
     /// Resolved per-shape POD byte count (see \ref data_size).
     size_t data_size_bytes() const {
         return data_size ? data_size : prim_count * pdata_size;
@@ -87,7 +93,7 @@ struct ShapeIR {
 };
 
 /// Number of geometry kinds and the bucket-array size for BLAS partitioning.
-/// Instance is excluded, hence it must remain the last \ref ShapeIR::Kind.
+/// Instance and MergeInstance are excluded from bucketing.
 static constexpr size_t NumGeometryKinds = (size_t) ShapeIR::Kind::Instance;
 
 // ---------------------------------------------------------------------------
@@ -114,6 +120,9 @@ struct InstanceEntry {
 
     /// JIT registry ID of the ShapeGroup, or ``SCENE_IR_NO_OWNER``.
     uint32_t owner_registry_id = SCENE_IR_NO_OWNER;
+
+    /// Batch element index for MergeInstance, or 0.
+    uint32_t instance_index = 0;
 };
 
 /// Scene description consumed by acceleration-structure builders.

--- a/include/mitsuba/render/shape.h
+++ b/include/mitsuba/render/shape.h
@@ -822,6 +822,9 @@ public:
     /// Is this shape an instance?
     bool is_instance() const { return shape_type() == +ShapeType::Instance; };
 
+    /// Is this shape a (batched) MergeInstance?
+    bool is_merge_instance() const { return shape_type() == +ShapeType::MergeInstance; };
+
     /// Does the surface of this shape mark a medium transition?
     bool is_medium_transition() const { return m_interior_medium.get() != nullptr ||
                                                m_exterior_medium.get() != nullptr; }

--- a/src/core/parser.cpp
+++ b/src/core/parser.cpp
@@ -1584,11 +1584,98 @@ void transform_relocate(const ParserConfig &/*config*/, ParserState &state,
         Log(Info, "Relocated %zu files.", file_mapping.size());
 }
 
+void transform_merge_instances(const ParserConfig &config,
+                               ParserState &state) {
+    if (!config.merge_instances || state.empty() || state.root().type != ObjectType::Scene)
+        return;
+
+    Properties &root_props = state.root().props;
+
+    // Collect all instance children of the root, grouping them by their
+    // ShapeGroup reference.  An instance node is a Shape node with
+    // plugin_name == "instance" and a single ResolvedReference child that
+    // points to a ShapeGroup node.
+    //
+    // Key: ShapeGroup node index  →  value: list of (property-name, node-index).
+    tsl::robin_map<size_t, std::vector<std::pair<std::string, size_t>>,
+                   std::hash<size_t>>
+        groups;
+    for (const auto &prop :
+             root_props.filter(Properties::Type::ResolvedReference)) {
+        size_t node_idx =
+            prop.get<Properties::ResolvedReference>().index();
+        const SceneNode &node = state[node_idx];
+        if (node.type != ObjectType::Shape ||
+            node.props.plugin_name() != "instance")
+            continue;
+
+        // Find the ShapeGroup reference inside the instance node.
+        size_t group_idx = (size_t) -1;
+        for (const auto &child_prop :
+                 node.props.filter(Properties::Type::ResolvedReference)) {
+            size_t ci =
+                child_prop.get<Properties::ResolvedReference>().index();
+            if (state[ci].type == ObjectType::Shape &&
+                state[ci].props.plugin_name() == "shapegroup") {
+                group_idx = ci;
+                break;
+            }
+        }
+
+        if (group_idx == (size_t) -1)
+            continue;
+
+        groups[group_idx].emplace_back(std::string(prop.name()), node_idx);
+    }
+
+    // For every ShapeGroup that has ≥ 2 instances, replace them with a
+    // single MergeInstance node.
+    size_t batch_count = 0;
+    for (auto &[group_idx, instances] : groups) {
+        if (instances.size() < 2)
+            continue;
+
+        // Create a new MergeInstance scene node.
+        SceneNode batch_node;
+        batch_node.type = ObjectType::Shape;
+        batch_node.props.set_plugin_name("mergeinstance");
+
+        // Add a reference to the ShapeGroup.
+        batch_node.props.set("_arg_0",
+                             Properties::ResolvedReference(group_idx), false);
+
+        // Extract each instance's to_world transform and add it as
+        // "to_world_0", "to_world_1", ...
+        for (size_t i = 0; i < instances.size(); ++i) {
+            const SceneNode &inst_node = state[instances[i].second];
+            batch_node.props.set(
+                tfm::format("to_world_%zu", i),
+                inst_node.props.get<ScalarAffineTransform4d>("to_world", ScalarAffineTransform4d()),
+                false);
+        }
+
+        // Remove original instance references from the root.
+        for (const auto &[prop_name, _] : instances)
+            root_props.remove_property(prop_name);
+
+        // Add the new MergeInstance node.
+        root_props.set(tfm::format("_merge_instance_%zu", batch_count++),
+                       Properties::ResolvedReference(state.size()), false);
+        state.nodes.push_back(std::move(batch_node));
+
+        Log(Info, "Merged %zu instance nodes into MergeInstance "
+                  "(shapegroup at index %zu)",
+            instances.size(), group_idx);
+    }
+}
+
 void transform_all(const ParserConfig &config, ParserState &state) {
     transform_upgrade(config, state);
     transform_resolve(config, state);
     if (config.merge_equivalent)
         transform_merge_equivalent(config, state);
+    if (config.merge_instances)
+        transform_merge_instances(config, state);
     if (config.merge_meshes)
         transform_merge_meshes(config, state);
 }

--- a/src/core/parser.cpp
+++ b/src/core/parser.cpp
@@ -1589,6 +1589,20 @@ void transform_merge_instances(const ParserConfig &config,
     if (!config.merge_instances || state.empty() || state.root().type != ObjectType::Scene)
         return;
 
+#if !defined(MI_ENABLE_EMBREE)
+    // Without Embree, scalar/LLVM (CPU) variants fall back to the built-in
+    // kd-tree (see NativeAccel in scene_native.inl), which does not support
+    // the 'mergeinstance' shape this pass produces -- it has no way to
+    // recover which batch element was hit. Skip the merge for those variants
+    // and keep individual 'instance' shapes instead; this is a valid
+    // (slower, but always correct) fallback since the kd-tree is a backup
+    // path anyway. CUDA (OptiX) and Metal variants support MergeInstance
+    // regardless of MI_ENABLE_EMBREE, so they are unaffected.
+    if (string::starts_with(config.variant, "scalar_") ||
+        string::starts_with(config.variant, "llvm_"))
+        return;
+#endif
+
     Properties &root_props = state.root().props;
 
     // Collect all instance children of the root, grouping them by their
@@ -1628,10 +1642,22 @@ void transform_merge_instances(const ParserConfig &config,
         groups[group_idx].emplace_back(std::string(prop.name()), node_idx);
     }
 
+    // Process groups in ascending node-index order: `groups` is a hash map,
+    // whose iteration order is otherwise unspecified and would make the
+    // resulting shape ordering (and hence e.g. shape indices used for
+    // debugging/AOVs) depend on hash bucket layout rather than on the scene
+    // file.
+    std::vector<size_t> group_indices;
+    group_indices.reserve(groups.size());
+    for (const auto &[group_idx, instances] : groups)
+        group_indices.push_back(group_idx);
+    std::sort(group_indices.begin(), group_indices.end());
+
     // For every ShapeGroup that has ≥ 2 instances, replace them with a
     // single MergeInstance node.
     size_t batch_count = 0;
-    for (auto &[group_idx, instances] : groups) {
+    for (size_t group_idx : group_indices) {
+        std::vector<std::pair<std::string, size_t>> &instances = groups[group_idx];
         if (instances.size() < 2)
             continue;
 

--- a/src/core/python/parser.cpp
+++ b/src/core/python/parser.cpp
@@ -338,7 +338,9 @@ MI_PY_EXPORT(parser) {
         .def_rw("merge_equivalent", &ParserConfig::merge_equivalent,
                 "Enable merging of equivalent nodes (deduplication) (default: true)")
         .def_rw("merge_meshes", &ParserConfig::merge_meshes,
-                "Enable merging of meshes into a single merge shape (default: true)");
+                "Enable merging of meshes into a single merge shape (default: true)")
+        .def_rw("merge_instances", &ParserConfig::merge_instances,
+                "Enable merging of instances into mergeinstance shapes (default: true)");
 
     // Export SceneNode
     nb::class_<SceneNode>(parser, "SceneNode")
@@ -475,6 +477,7 @@ MI_PY_EXPORT(parser) {
             config.parallel = parallel;
             config.merge_equivalent = optimize;
             config.merge_meshes = optimize;
+            config.merge_instances = optimize;
 
             // Set up FileResolver like the old parser does
             fs::path filename(name);
@@ -528,6 +531,7 @@ Parameter ``kwargs``:
             config.parallel = parallel;
             config.merge_equivalent = optimize;
             config.merge_meshes = optimize;
+            config.merge_instances = optimize;
 
             std::vector<ref<Object>> objects;
             {
@@ -564,6 +568,7 @@ Parameter ``kwargs``:
             config.parallel = parallel;
             config.merge_equivalent = optimize;
             config.merge_meshes = optimize;
+            config.merge_instances = optimize;
 
             ref<FileResolver> fs_backup = file_resolver();
             ref<FileResolver> fs = new FileResolver(*fs_backup);

--- a/src/render/accel_cpu_common.h
+++ b/src/render/accel_cpu_common.h
@@ -35,13 +35,15 @@ build_registry_ids(const std::vector<ref<Shape<Float, Spectrum>>> &shapes) {
  * The trace writes \c out = { valid, t, u, v, prim_index, shape_index,
  * inst_index, hit_inst }. The owning \c ShapePtr comes from \c registry_ids,
  * gathered by instance index for instanced hits and shape index for top-level
- * hits. Embree and the native kd-tree share this logic and only differ in
- * \c RayScalar precision.
+ * For MergeInstance hits, \c batch_element_ids maps the geom_id to the
+ * batch element index so
+ * \c MergeInstance::compute_surface_interaction can gather the right transform.
  */
 template <typename Float, typename Spectrum, typename RayScalar>
 auto decode_cpu_llvm_pi(
         const uint32_t out[8],
-        const DynamicBuffer<dr::uint32_array_t<Float>> &registry_ids) {
+        const DynamicBuffer<dr::uint32_array_t<Float>> &registry_ids,
+        const DynamicBuffer<dr::uint32_array_t<Float>> &batch_element_ids) {
     MI_IMPORT_TYPES(Shape, ShapePtr)
 
     PreliminaryIntersection3f pi;
@@ -60,6 +62,12 @@ auto decode_cpu_llvm_pi(
 
     pi.instance = shape & hit_inst;
     pi.shape    = shape & !hit_inst;
+
+    // For MergeInstance hits, set instance_index to the batch element index
+    // so compute_surface_interaction can gather the right transform, while
+    // preserving shape_index (the child shape index within the ShapeGroup).
+    UInt32 batch_idx = dr::gather<UInt32>(batch_element_ids, index, pi.valid);
+    pi.instance_index = dr::select(hit_inst & (batch_idx != (uint32_t) -1), batch_idx, inst_index);
 
     return pi;
 }

--- a/src/render/accel_cpu_common.h
+++ b/src/render/accel_cpu_common.h
@@ -35,9 +35,13 @@ build_registry_ids(const std::vector<ref<Shape<Float, Spectrum>>> &shapes) {
  * The trace writes \c out = { valid, t, u, v, prim_index, shape_index,
  * inst_index, hit_inst }. The owning \c ShapePtr comes from \c registry_ids,
  * gathered by instance index for instanced hits and shape index for top-level
- * For MergeInstance hits, \c batch_element_ids maps the geom_id to the
- * batch element index so
- * \c MergeInstance::compute_surface_interaction can gather the right transform.
+ * hits. Embree and the native kd-tree share this logic and only differ in
+ * \c RayScalar precision.
+ *
+ * For MergeInstance hits, \c batch_element_ids additionally maps the same
+ * geom_id/instance index to the batch element index, so that
+ * \c MergeInstance::compute_surface_interaction can gather the right
+ * transform.
  */
 template <typename Float, typename Spectrum, typename RayScalar>
 auto decode_cpu_llvm_pi(

--- a/src/render/metal_accel.mm
+++ b/src/render/metal_accel.mm
@@ -488,6 +488,7 @@ build_impl(const std::vector<BlasEntry> &blases,
                     }
 
                     case ShapeIR::Kind::Instance:
+                    case ShapeIR::Kind::MergeInstance:
                         Throw("MetalAccel: instance geometry must be flattened "
                               "before reaching the BLAS builder.");
                 }

--- a/src/render/python/interaction_v.cpp
+++ b/src/render/python/interaction_v.cpp
@@ -138,6 +138,7 @@ MI_PY_EXPORT(PreliminaryIntersection) {
         .def_field(PreliminaryIntersection3f, prim_uv,     D(PreliminaryIntersection, prim_uv))
         .def_field(PreliminaryIntersection3f, prim_index,  D(PreliminaryIntersection, prim_index))
         .def_field(PreliminaryIntersection3f, shape_index, D(PreliminaryIntersection, shape_index))
+        .def_field(PreliminaryIntersection3f, instance_index, "Instance index (e.g. batch element index)")
         .def_field(PreliminaryIntersection3f, shape,       D(PreliminaryIntersection, shape))
         .def_field(PreliminaryIntersection3f, instance,    D(PreliminaryIntersection, instance))
 
@@ -157,5 +158,5 @@ MI_PY_EXPORT(PreliminaryIntersection) {
         .def_repr(PreliminaryIntersection3f);
 
     MI_PY_DRJIT_STRUCT(pi, PreliminaryIntersection3f, valid, t, prim_uv,
-                       prim_index, shape_index, shape, instance);
+                       prim_index, shape_index, instance_index, shape, instance);
 }

--- a/src/render/scene_embree.inl
+++ b/src/render/scene_embree.inl
@@ -115,12 +115,13 @@ static void embree_backface_cull(const RTCFilterFunctionNArguments *args) {
     }
 }
 
-/// Build one Embree geometry from a \ref ShapeIR.
+/// Build Embree geometries from a \ref ShapeIR.
+/// Returns one geometry for most shapes, or N geometries for a MergeInstance.
 template <typename Float, typename Spectrum>
-static RTCGeometry
-embree_make_geometry(RTCDevice device, const Shape<Float, Spectrum> *shape,
-                     const tsl::robin_map<const void *, RTCSceneTy *,
-                                          PointerHasher> &group_scenes) {
+static std::vector<RTCGeometry>
+embree_make_geometries(RTCDevice device, const Shape<Float, Spectrum> *shape,
+                       const tsl::robin_map<const void *, RTCSceneTy *,
+                                            PointerHasher> &group_scenes) {
     ShapeIR g;
     shape->describe(g);
 
@@ -133,7 +134,7 @@ embree_make_geometry(RTCDevice device, const Shape<Float, Spectrum> *shape,
             rtcSetGeometryIntersectFunction(geom, embree_intersect<Float, Spectrum>);
             rtcSetGeometryOccludedFunction(geom, embree_occluded<Float, Spectrum>);
             rtcCommitGeometry(geom);
-            return geom;
+            return { geom };
         }
 
         case ShapeIR::Kind::Triangles:
@@ -150,7 +151,7 @@ embree_make_geometry(RTCDevice device, const Shape<Float, Spectrum> *shape,
                 rtcSetGeometryOccludedFilterFunction(geom, embree_backface_cull);
             }
             rtcCommitGeometry(geom);
-            return geom;
+            return { geom };
         }
 
         case ShapeIR::Kind::BSplineCurve:
@@ -166,7 +167,7 @@ embree_make_geometry(RTCDevice device, const Shape<Float, Spectrum> *shape,
                                        RTC_FORMAT_UINT, g.seg_ptr, 0,
                                        sizeof(uint32_t), g.seg_count);
             rtcCommitGeometry(geom);
-            return geom;
+            return { geom };
         }
 
         case ShapeIR::Kind::Instance: {
@@ -184,10 +185,32 @@ embree_make_geometry(RTCDevice device, const Shape<Float, Spectrum> *shape,
             }
             rtcSetGeometryTransform(inst, 0, RTC_FORMAT_FLOAT4X4_COLUMN_MAJOR, M);
             rtcCommitGeometry(inst);
-            return inst;
+            return { inst };
+        }
+
+        case ShapeIR::Kind::MergeInstance: {
+            RTCScene nested = group_scenes.at(g.group_id);
+            std::vector<RTCGeometry> result;
+            result.reserve(g.batch_to_worlds.size());
+
+            for (const auto &tw : g.batch_to_worlds) {
+                RTCGeometry inst = rtcNewGeometry(device, RTC_GEOMETRY_TYPE_INSTANCE);
+                rtcSetGeometryInstancedScene(inst, nested);
+                rtcSetGeometryTimeStepCount(inst, 1);
+                float M[16];
+                for (int col = 0; col < 4; ++col) {
+                    for (int row = 0; row < 3; ++row)
+                        M[col * 4 + row] = tw[col * 3 + row];
+                    M[col * 4 + 3] = (col == 3) ? 1.f : 0.f;
+                }
+                rtcSetGeometryTransform(inst, 0, RTC_FORMAT_FLOAT4X4_COLUMN_MAJOR, M);
+                rtcCommitGeometry(inst);
+                result.push_back(inst);
+            }
+            return result;
         }
     }
-    return nullptr; // unreachable
+    return {}; // unreachable
 }
 
 // -----------------------------------------------------------------------
@@ -231,9 +254,6 @@ void EmbreeAccel<Float, Spectrum>::init(Scene<Float, Spectrum> *scene,
 
     Log(Info, "Embree ready. (took %s)",
         util::time_string((float) timer.value()));
-
-    if constexpr (dr::is_llvm_v<Float>)
-        shapes_registry_ids = build_registry_ids<Float, Spectrum>(scene->m_shapes);
 }
 
 template <typename Float, typename Spectrum>
@@ -257,21 +277,70 @@ void EmbreeAccel<Float, Spectrum>::rebuild(
     for (auto &group : scene->m_shapegroups) {
         RTCScene nested = rtcNewScene(embree_device);
         for (const ref<Shape> &child : group->shapes()) {
-            RTCGeometry cg = embree_make_geometry<Float, Spectrum>(
+            auto geoms = embree_make_geometries<Float, Spectrum>(
                 embree_device, child.get(), group_scenes);
-            rtcAttachGeometry(nested, cg);
-            rtcReleaseGeometry(cg);
+            for (auto geom : geoms) {
+                rtcAttachGeometry(nested, geom);
+                rtcReleaseGeometry(geom);
+            }
         }
         // Publish the uncommitted nested scene for top-level Instances.
         group_scenes[(const void *) group.get()] = nested;
         nested_scenes.push_back(nested);
     }
 
-    for (Shape *shape : scene->m_shapes) {
-        RTCGeometry geom = embree_make_geometry<Float, Spectrum>(
+    // Build extended registry IDs: for MergeInstance shapes, the Embree scene
+    // will contain multiple RTC instance geometries (one per batch element),
+    // each with its own geom_id.  The shapes_registry_ids buffer must map
+    // every geom_id to the owning Mitsuba shape.  We build this mapping during
+    // attachment and upload it after the loop.
+    std::vector<uint32_t> registry_data;
+    std::vector<uint32_t> batch_element_data;
+    geom_id_to_shape_idx.clear();
+    geom_id_to_batch_idx.clear();
+
+    for (size_t si = 0; si < scene->m_shapes.size(); ++si) {
+        Shape *shape = scene->m_shapes[si];
+        auto geoms = embree_make_geometries<Float, Spectrum>(
             embree_device, shape, group_scenes);
-        geometries.push_back(rtcAttachGeometry(accel, geom));
-        rtcReleaseGeometry(geom);
+        for (size_t gi = 0; gi < geoms.size(); ++gi) {
+            uint32_t gid = rtcAttachGeometry(accel, geoms[gi]);
+            geometries.push_back(gid);
+            rtcReleaseGeometry(geoms[gi]);
+            // All geom_ids produced by one shape share the same registry ID.
+            uint32_t reg_id = 0;
+            if constexpr (dr::is_jit_v<Float>)
+                reg_id = jit_registry_id(shape);
+            registry_data.push_back(reg_id);
+            // For MergeInstance, gi is the batch element index; else -1.
+            batch_element_data.push_back(
+                geoms.size() > 1 ? (uint32_t) gi : (uint32_t) -1);
+
+            // Ensure mapping vectors are large enough (geom_ids are
+            // sequentially assigned by Embree starting from 0).
+            if (gid >= geom_id_to_shape_idx.size()) {
+                geom_id_to_shape_idx.resize(gid + 1, 0);
+                geom_id_to_batch_idx.resize(gid + 1, (uint32_t) -1);
+            }
+            geom_id_to_shape_idx[gid] = (uint32_t) si;
+            // For a MergeInstance, geoms has N entries; gi is the batch index.
+            if (geoms.size() > 1)
+                geom_id_to_batch_idx[gid] = (uint32_t) gi;
+        }
+    }
+
+    // Upload the extended registry IDs and batch element buffers.
+    if constexpr (dr::is_llvm_v<Float>) {
+        if (!registry_data.empty()) {
+            shapes_registry_ids = dr::load<DynamicBuffer<UInt32>>(
+                registry_data.data(), registry_data.size());
+            batch_element_ids = dr::load<DynamicBuffer<UInt32>>(
+                batch_element_data.data(), batch_element_data.size());
+        } else {
+            shapes_registry_ids = dr::zeros<DynamicBuffer<UInt32>>(1);
+            batch_element_ids   = dr::full<DynamicBuffer<UInt32>>(
+                (uint32_t) -1, 1);
+        }
     }
 
     // One sync for the whole rebuild: all geometry (nested + top-level) is now
@@ -408,9 +477,12 @@ EmbreeAccel<Float, Spectrum>::ray_intersect_preliminary(
 
             // If the hit is not on an instance
             bool hit_instance = inst_index != RTC_INVALID_GEOMETRY_ID;
-            uint32_t index = hit_instance ? inst_index : shape_index;
+            uint32_t geom_id = hit_instance ? inst_index : shape_index;
 
-            ShapePtr shape = scene->m_shapes[index];
+            // Use the geom_id mapping to recover the m_shapes index.
+            // For MergeInstance shapes, multiple Embree geometries map
+            // to the same m_shapes entry.
+            ShapePtr shape = scene->m_shapes[geom_id_to_shape_idx[geom_id]];
             if (hit_instance)
                 pi.instance = shape;
             else
@@ -418,6 +490,9 @@ EmbreeAccel<Float, Spectrum>::ray_intersect_preliminary(
 
             pi.valid = true;
             pi.shape_index = shape_index;
+            uint32_t batch_idx = geom_id_to_batch_idx[geom_id];
+            pi.instance_index = (batch_idx != (uint32_t) -1)
+                                 ? batch_idx : inst_index;
 
             pi.t = rh.ray.tfar;
             pi.prim_index = prim_index;
@@ -437,7 +512,8 @@ EmbreeAccel<Float, Spectrum>::ray_intersect_preliminary(
 
         // Embree traces in float32, so the hit fields are stolen as ``Single``.
         return decode_cpu_llvm_pi<Float, Spectrum, Single>(out,
-                                                           shapes_registry_ids);
+                                                           shapes_registry_ids,
+                                                           batch_element_ids);
     } else {
         DRJIT_MARK_USED(ray);
         DRJIT_MARK_USED(coherent);

--- a/src/render/scene_embree.inl
+++ b/src/render/scene_embree.inl
@@ -311,10 +311,10 @@ void EmbreeAccel<Float, Spectrum>::rebuild(
             uint32_t reg_id = 0;
             if constexpr (dr::is_jit_v<Float>)
                 reg_id = jit_registry_id(shape);
-            registry_data.push_back(reg_id);
+            bool is_mi = shape->is_merge_instance();
             // For MergeInstance, gi is the batch element index; else -1.
             batch_element_data.push_back(
-                geoms.size() > 1 ? (uint32_t) gi : (uint32_t) -1);
+                is_mi ? (uint32_t) gi : (uint32_t) -1);
 
             // Ensure mapping vectors are large enough (geom_ids are
             // sequentially assigned by Embree starting from 0).
@@ -324,7 +324,7 @@ void EmbreeAccel<Float, Spectrum>::rebuild(
             }
             geom_id_to_shape_idx[gid] = (uint32_t) si;
             // For a MergeInstance, geoms has N entries; gi is the batch index.
-            if (geoms.size() > 1)
+            if (is_mi)
                 geom_id_to_batch_idx[gid] = (uint32_t) gi;
         }
     }

--- a/src/render/scene_ir.cpp
+++ b/src/render/scene_ir.cpp
@@ -26,7 +26,8 @@ SceneIR SceneIRBuilder<Float, Spectrum>::build(Scene<Float, Spectrum> *scene) {
         ShapeIR g;
         shapes[i]->describe(g);
         g.data_slot = slot++;
-        if (g.kind == ShapeIR::Kind::Instance)
+        if (g.kind == ShapeIR::Kind::Instance ||
+            g.kind == ShapeIR::Kind::MergeInstance)
             inst_shapes.push_back(std::move(g));
         else
             top_noninst.push_back(std::move(g));
@@ -75,16 +76,37 @@ SceneIR SceneIRBuilder<Float, Spectrum>::build(Scene<Float, Spectrum> *scene) {
         e.blas_index = bi;
         sd.instances.push_back(e);
     }
-    // ...then, per Instance shape, one instance per BLAS of its ShapeGroup.
+    // ...then, per Instance/MergeInstance shape, one instance per BLAS
+    // of its ShapeGroup.
     for (const ShapeIR &inst : inst_shapes) {
         uint32_t owner = jit_registry_id(inst.ctx);
-        for (uint32_t bi : sd.group_blases[group_index.at(inst.group_id)]) {
-            InstanceEntry e;
-            e.blas_index = bi;
-            e.owner_registry_id = owner;
-            for (int k = 0; k < 12; ++k)
-                e.to_world[k] = inst.to_world[k];
-            sd.instances.push_back(e);
+        const auto &group_bi = sd.group_blases[group_index.at(inst.group_id)];
+
+        if (inst.kind == ShapeIR::Kind::Instance) {
+            // Single instance: one InstanceEntry per BLAS of the group.
+            for (uint32_t bi : group_bi) {
+                InstanceEntry e;
+                e.blas_index = bi;
+                e.owner_registry_id = owner;
+                for (int k = 0; k < 12; ++k)
+                    e.to_world[k] = inst.to_world[k];
+                sd.instances.push_back(e);
+            }
+        } else {
+            // MergeInstance: one InstanceEntry per batch element per BLAS.
+            uint32_t elem_idx = 0;
+            for (const auto &tw : inst.batch_to_worlds) {
+                for (uint32_t bi : group_bi) {
+                    InstanceEntry e;
+                    e.blas_index = bi;
+                    e.owner_registry_id = owner;
+                    e.instance_index = elem_idx;
+                    for (int k = 0; k < 12; ++k)
+                        e.to_world[k] = tw[k];
+                    sd.instances.push_back(e);
+                }
+                elem_idx++;
+            }
         }
     }
 

--- a/src/render/scene_metal.inl
+++ b/src/render/scene_metal.inl
@@ -52,6 +52,18 @@ void MetalAccel<Float, Spectrum>::init(Scene<Float, Spectrum> *scene,
     geom_shape_table =
         dr::load<DynamicBuffer<UInt32>>(table.data(), table.size());
 
+    // batch_element_ids[instance_id] is the batch element index within a
+    // MergeInstance for that TLAS instance, or 0 for a non-batch instance
+    // (mirrors InstanceEntry::instance_index, indexed the same way as
+    // geom_shape_offsets, i.e. by the raw instance_id Metal reports for a
+    // hit -- see MetalAccel::ray_intersect_preliminary()).
+    std::vector<uint32_t> batch_indices;
+    batch_indices.reserve(sd.instances.size());
+    for (const InstanceEntry &inst : sd.instances)
+        batch_indices.push_back(inst.instance_index);
+    batch_element_ids =
+        dr::load<DynamicBuffer<UInt32>>(batch_indices.data(), batch_indices.size());
+
     std::tie(accel, scene_index) =
         build_metal_accel(sd, scene->m_compact_accel);
 
@@ -144,6 +156,12 @@ MetalAccel<Float, Spectrum>::ray_intersect_preliminary(
     // ShapeGroup (one per BLAS) share a userID, which is correct.
     UInt32 user_id = dr::select(valid, UInt32::steal(out[7]), dr::zeros<UInt32>());
     pi.instance = dr::reinterpret_array<ShapePtr, UInt32>(user_id);
+
+    // For a MergeInstance hit, recover which batch element was hit so that
+    // MergeInstance::compute_surface_interaction() can gather the matching
+    // transform. Harmless (reads back 0) for every other kind of hit, since
+    // only MergeInstance ever looks at this field.
+    pi.instance_index = dr::gather<UInt32>(batch_element_ids, instance_id, valid);
 
     return pi;
 }

--- a/src/render/scene_native.inl
+++ b/src/render/scene_native.inl
@@ -17,8 +17,11 @@ void NativeAccel<Float, Spectrum>::init(Scene<Float, Spectrum> *scene,
     accel = new ShapeKDTree<Float, Spectrum>(props);
     accel->inc_ref();
 
-    if constexpr (dr::is_llvm_v<Float>)
+    if constexpr (dr::is_llvm_v<Float>) {
         shapes_registry_ids = build_registry_ids<Float, Spectrum>(scene->m_shapes);
+        batch_element_ids = dr::full<DynamicBuffer<UInt32>>(
+            (uint32_t) -1, dr::width(shapes_registry_ids));
+    }
 
     rebuild(scene);
 }
@@ -188,7 +191,8 @@ NativeAccel<Float, Spectrum>::ray_intersect_preliminary(
         // The kd-tree traces in ``Float`` precision, so the hit fields are
         // stolen at that width.
         return decode_cpu_llvm_pi<Float, Spectrum, Float>(out,
-                                                          shapes_registry_ids);
+                                                          shapes_registry_ids,
+                                                          batch_element_ids);
     }
 }
 

--- a/src/render/scene_native.inl
+++ b/src/render/scene_native.inl
@@ -34,8 +34,24 @@ void NativeAccel<Float, Spectrum>::rebuild(
         dr::sync_thread();
 
     accel->clear();
-    for (Shape *shape : scene->m_shapes)
+    for (Shape *shape : scene->m_shapes) {
+        // MergeInstance stores a single set of batched transforms and relies
+        // on the acceleration structure to report which batch element was
+        // hit (via PreliminaryIntersection::instance_index) so that
+        // MergeInstance::compute_surface_interaction() can look up the
+        // right one. Only the Embree and OptiX/Metal backends currently
+        // implement that; the kd-tree here would silently always resolve to
+        // the first instance of the batch instead of failing loudly, so
+        // reject it explicitly.
+        if (shape->is_merge_instance())
+            Throw("The native (kd-tree) acceleration structure does not "
+                  "support the 'mergeinstance' shape produced by automatic "
+                  "instance merging. Either rebuild Mitsuba with Embree "
+                  "enabled, or disable this optimization by passing "
+                  "optimize=False (or, for the low-level parser API, "
+                  "ParserConfig.merge_instances=False).");
         accel->add_shape(shape);
+    }
     ScopedPhase phase(ProfilerPhase::InitAccel);
     accel->build();
 

--- a/src/render/scene_optix.inl
+++ b/src/render/scene_optix.inl
@@ -79,10 +79,11 @@ static std::mutex optix_configs_lock;
 static constexpr uint32_t OptixConfigCompactKey = 1u << 31;
 
 const MiOptixConfig &init_optix_config(uint32_t shape_types, bool compact) {
-    // Instances/groups are handled by IAS traversal, not by intersection
+    // Instances/groups/mergeinstances are handled by IAS traversal, not by intersection
     // programs. Mask the bits so they don't spuriously add the CUSTOM flag
     shape_types &= ~((uint32_t) ShapeType::Instance |
-                     (uint32_t) ShapeType::ShapeGroup);
+                     (uint32_t) ShapeType::ShapeGroup |
+                     (uint32_t) ShapeType::MergeInstance);
 
     uint32_t key = shape_types;
     if ((key & +ShapeType::Rectangle) == +ShapeType::Rectangle) {
@@ -351,7 +352,9 @@ template <typename Float, typename Spectrum>
 static void optix_rebuild_accel(
         Scene<Float, Spectrum> *scene, MiOptixSceneState *state,
         dr::uint64_array_t<Float> &accel_handle,
+        DynamicBuffer<dr::uint32_array_t<Float>> &batch_element_ids,
         const SceneIR &sd) {
+    using UInt32 = dr::uint32_array_t<Float>;
     using UInt64 = dr::uint64_array_t<Float>;
     MiOptixSceneState &s = *state;
 
@@ -450,6 +453,19 @@ static void optix_rebuild_accel(
             buffer_sizes.outputSizeInBytes, &s.ias_handle, 0, 0));
 
         jit_free(d_temp_buffer);
+
+        // Upload batch_element_ids for IAS instances
+        std::vector<uint32_t> batch_indices;
+        batch_indices.reserve(sd.instances.size());
+        for (const auto &inst : sd.instances)
+            batch_indices.push_back(inst.instance_index);
+
+        if (!batch_indices.empty()) {
+            batch_element_ids = dr::load<DynamicBuffer<UInt32>>(
+                batch_indices.data(), batch_indices.size());
+        } else {
+            batch_element_ids = dr::full<DynamicBuffer<UInt32>>((uint32_t) -1, 1);
+        }
     }
 
     // Set up a callback on the handle variable to release the OptiX scene
@@ -623,7 +639,7 @@ void OptixAccel<Float, Spectrum>::init(Scene<Float, Spectrum> *scene,
 
     // Build the GAS/IAS from the SceneIR already lowered above for the SBT,
     // so each shape is described only once.
-    optix_rebuild_accel<Float, Spectrum>(scene, state, accel_handle, sd);
+    optix_rebuild_accel<Float, Spectrum>(scene, state, accel_handle, batch_element_ids, sd);
 
     Log(Info, "OptiX ready. (took %s)", util::time_string((float) timer.value()));
 }
@@ -634,7 +650,7 @@ void OptixAccel<Float, Spectrum>::rebuild(
     // Lower the scene once; the GAS and IAS phases read from this.
     SceneIR sd = SceneIRBuilder<Float, Spectrum>::build(scene);
 
-    optix_rebuild_accel<Float, Spectrum>(scene, state, accel_handle, sd);
+    optix_rebuild_accel<Float, Spectrum>(scene, state, accel_handle, batch_element_ids, sd);
 }
 
 template <typename Float, typename Spectrum>
@@ -725,15 +741,16 @@ OptixAccel<Float, Spectrum>::ray_intersect_preliminary(
         OptixHitObjectField::Attribute1,
         OptixHitObjectField::PrimitiveIndex,
         OptixHitObjectField::SBTDataPointer,
-        OptixHitObjectField::InstanceId
+        OptixHitObjectField::InstanceId,
+        OptixHitObjectField::InstanceIndex
     };
-    uint32_t hitobject_out[7];
+    uint32_t hitobject_out[8];
 
     // Scene property takes precedence
     reorder &= scene->m_thread_reordering;
 
     jit_optix_ray_trace(sizeof(trace_args) / sizeof(uint32_t), trace_args,
-                        has_instances ? 7 : 6, fields, hitobject_out,
+                        has_instances ? 8 : 6, fields, hitobject_out,
                         reorder, reorder_hint.index(), reorder_hint_bits,
                         false, active.index(),
                         s.pipeline_jit_index, s.sbt_jit_index);
@@ -753,10 +770,17 @@ OptixAccel<Float, Spectrum>::ray_intersect_preliminary(
     pi.prim_uv[1] = dr::reinterpret_array<Single, UInt32>(UInt32::steal(hitobject_out[3]));
     pi.prim_index = UInt32::steal(hitobject_out[4]);
     pi.shape      = dr::reinterpret_array<ShapePtr, UInt32>(UInt32::steal(shape_id_idx));
-    pi.instance   = has_instances ? ShapePtr::steal(hitobject_out[6]) : dr::zeros<ShapePtr>();
-
-    // This field is only used by embree, but we still need to initialize it for vcalls
-    pi.shape_index = dr::zeros<UInt32>();
+    size_t width  = dr::width(valid);
+    if (has_instances) {
+        UInt32 raw_inst_id  = UInt32::steal(hitobject_out[6]);
+        UInt32 raw_inst_idx = UInt32::steal(hitobject_out[7]);
+        pi.instance       = dr::reinterpret_array<ShapePtr, UInt32>(raw_inst_id);
+        pi.instance_index = dr::gather<UInt32>(batch_element_ids, raw_inst_idx, valid);
+    } else {
+        pi.instance       = dr::zeros<ShapePtr>(width);
+        pi.instance_index = dr::zeros<UInt32>(width);
+    }
+    pi.shape_index = dr::zeros<UInt32>(width);
 
     return pi;
 }

--- a/src/shapes/CMakeLists.txt
+++ b/src/shapes/CMakeLists.txt
@@ -16,6 +16,7 @@ add_plugin(linearcurve  linearcurve.cpp)
 
 add_plugin(shapegroup   shapegroup.cpp)
 add_plugin(instance     instance.cpp)
+add_plugin(mergeinstance mergeinstance.cpp)
 add_plugin(merge        merge.cpp)
 
 add_plugin(ellipsoids ellipsoids.cpp)
@@ -24,6 +25,7 @@ add_plugin(ellipsoidsmesh ellipsoidsmesh.cpp)
 if (MI_ENABLE_EMBREE)
     target_link_libraries(sphere   PRIVATE embree)
     target_link_libraries(instance PRIVATE embree)
+    target_link_libraries(mergeinstance PRIVATE embree)
 endif()
 
 set(MI_PLUGIN_TARGETS "${MI_PLUGIN_TARGETS}" PARENT_SCOPE)

--- a/src/shapes/mergeinstance.cpp
+++ b/src/shapes/mergeinstance.cpp
@@ -1,0 +1,392 @@
+#include <mitsuba/core/fwd.h>
+#include <mitsuba/core/properties.h>
+#include <mitsuba/render/fwd.h>
+#include <mitsuba/render/shape.h>
+#include <mitsuba/render/scene_ir.h>
+#include <mitsuba/core/transform.h>
+#include <mitsuba/render/interaction.h>
+#include <mitsuba/render/bsdf.h>
+#include <mitsuba/render/shapegroup.h>
+
+#if defined(MI_ENABLE_EMBREE)
+    #include <embree3/rtcore.h>
+#endif
+
+NAMESPACE_BEGIN(mitsuba)
+
+/**!
+
+.. _shape-mergeinstance:
+
+MergeInstance (:monosp:`mergeinstance`)
+-------------------------------------------------
+
+Internal shape plugin representing a batch of instances that share the same
+ShapeGroup.  Instead of registering many individual ``Instance`` shapes
+(each becoming a separate JIT object), a single ``MergeInstance`` stores all
+transforms in a dynamic buffer and uses ``dr::gather`` to look up the
+per-hit transform during shading.
+
+This plugin is not intended to be specified by the user directly.  The parser
+automatically merges compatible ``Instance`` primitives into a
+``MergeInstance`` when the scene is loaded.
+
+*/
+
+template <typename Float, typename Spectrum>
+class MergeInstance final: public Shape<Float, Spectrum> {
+public:
+    MI_IMPORT_BASE(Shape, m_to_world, m_shape_type, mark_dirty)
+    MI_IMPORT_TYPES(BSDF)
+
+    using typename Base::ScalarSize;
+    using typename Base::ScalarIndex;
+    using ShapeGroup_ = ShapeGroup<Float, Spectrum>;
+
+    MergeInstance(const Properties &props) : Base(props) {
+        for (auto &prop : props.objects()) {
+            ShapeGroup_ *shapegroup = prop.try_get<ShapeGroup_>();
+            if (!shapegroup)
+                Throw("Only a shapegroup can be specified in a mergeinstance.");
+            if (m_shapegroup)
+                Throw("Only a single shapegroup can be specified per mergeinstance.");
+            m_shapegroup = shapegroup;
+        }
+
+        if (!m_shapegroup)
+            Throw("A reference to a 'shapegroup' must be specified!");
+
+        m_shape_type = ShapeType::MergeInstance;
+
+        // Load transforms from properties.  The parser stores them as
+        // "to_world_0", "to_world_1", ...
+        size_t idx = 0;
+        while (true) {
+            std::string key = tfm::format("to_world_%zu", idx);
+            if (!props.has_property(key))
+                break;
+            m_scalar_transforms.push_back(
+                props.get<ScalarAffineTransform4f>(key));
+            ++idx;
+        }
+
+        if (m_scalar_transforms.empty())
+            Throw("MergeInstance: at least one transform is required.");
+
+        upload_transforms();
+
+        Log(Info, "MergeInstance: merged %zu instances.", m_scalar_transforms.size());
+    }
+
+    void traverse(TraversalCallback *cb) override {
+        Base::traverse(cb);
+        cb->put("shapegroup", m_shapegroup, ParamFlags::NonDifferentiable);
+        cb->put("transforms", m_transforms, ParamFlags::Differentiable);
+    }
+
+    void parameters_changed(const std::vector<std::string> &keys) override {
+        if (keys.empty() || string::contains(keys, "transforms")) {
+            update_scalar_transforms();
+            mark_dirty();
+        }
+        Base::parameters_changed();
+    }
+
+    ScalarBoundingBox3f bbox() const override {
+        const ScalarBoundingBox3f &group_bbox = m_shapegroup->bbox();
+        if (!group_bbox.valid())
+            return group_bbox;
+
+        ScalarBoundingBox3f result;
+        for (const auto &trafo : m_scalar_transforms) {
+            for (int i = 0; i < 8; ++i)
+                result.expand(trafo * group_bbox.corner(i));
+        }
+        return result;
+    }
+
+    ScalarSize primitive_count() const override { return 1; }
+
+    ScalarSize effective_primitive_count() const override {
+        return (ScalarSize) m_scalar_transforms.size() *
+               m_shapegroup->primitive_count();
+    }
+
+    // =============================================================
+    //  Ray tracing routines
+    // =============================================================
+
+    template <typename FloatP, typename Ray3fP>
+    std::tuple<dr::mask_t<FloatP>, FloatP, Point<FloatP, 2>,
+               dr::uint32_array_t<FloatP>, dr::uint32_array_t<FloatP>>
+    ray_intersect_preliminary_impl(const Ray3fP &ray,
+                                   ScalarIndex prim_index,
+                                   dr::mask_t<FloatP> active) const {
+        MI_MASK_ARGUMENT(active);
+        if constexpr (!dr::is_array_v<FloatP>) {
+            if (prim_index < m_scalar_transforms.size()) {
+                // Direct query for a specific instance index (prim_index)
+                auto local_ray = m_scalar_transforms[prim_index].inverse() * ray;
+                return m_shapegroup->ray_intersect_preliminary_scalar(local_ray);
+            }
+
+            // Fallback for unindexed scalar queries across all instances
+            FloatP best_t = dr::Infinity<FloatP>;
+            std::tuple<bool, FloatP, Point<FloatP, 2>,
+                       dr::uint32_array_t<FloatP>,
+                       dr::uint32_array_t<FloatP>> best{false, best_t, {0.f, 0.f}, 0u, 0u};
+
+            for (size_t i = 0; i < m_scalar_transforms.size(); ++i) {
+                auto [hit_box, mint, maxt] = m_scalar_bboxes[i].ray_intersect(ray);
+                if (!hit_box || mint >= best_t)
+                    continue;
+
+                auto local_ray = m_scalar_transforms[i].inverse() * ray;
+                auto [valid, t, uv, si_idx, pi_idx] =
+                    m_shapegroup->ray_intersect_preliminary_scalar(local_ray);
+                if (valid && t < best_t) {
+                    best_t = t;
+                    best = {true, t, uv, si_idx, pi_idx};
+                }
+            }
+            return best;
+        } else {
+            Throw("MergeInstance::ray_intersect_preliminary() should only "
+                  "be called with scalar types.");
+        }
+    }
+
+    template <typename FloatP, typename Ray3fP>
+    dr::mask_t<FloatP> ray_test_impl(const Ray3fP &ray,
+                                     ScalarIndex prim_index,
+                                     dr::mask_t<FloatP> active) const {
+        MI_MASK_ARGUMENT(active);
+        if constexpr (!dr::is_array_v<FloatP>) {
+            if (prim_index < m_scalar_transforms.size()) {
+                auto local_ray = m_scalar_transforms[prim_index].inverse() * ray;
+                return m_shapegroup->ray_test_scalar(local_ray);
+            }
+
+            for (size_t i = 0; i < m_scalar_transforms.size(); ++i) {
+                if (!std::get<0>(m_scalar_bboxes[i].ray_intersect(ray)))
+                    continue;
+
+                if (m_shapegroup->ray_test_scalar(
+                        m_scalar_transforms[i].inverse() * ray))
+                    return true;
+            }
+            return false;
+        } else {
+            Throw("MergeInstance::ray_test_impl() should only be called "
+                  "with scalar types.");
+        }
+    }
+
+    MI_SHAPE_DEFINE_RAY_INTERSECT_METHODS()
+
+    SurfaceInteraction3f compute_surface_interaction(const Ray3f &ray,
+                                                     const PreliminaryIntersection3f &pi,
+                                                     uint32_t ray_flags,
+                                                     uint32_t recursion_depth,
+                                                     Mask active) const override {
+        MI_MASK_ARGUMENT(active);
+
+        // Nested instancing is not supported
+        if (recursion_depth > 0)
+            return dr::zeros<SurfaceInteraction3f>();
+
+        // Gather the per-instance transform and compute its inverse
+        AffineTransform4f to_world  = gather_transform(pi.instance_index, active);
+        AffineTransform4f to_object = to_world.inverse();
+
+        constexpr bool IsDiff = dr::is_diff_v<Float>;
+        bool grad_enabled = dr::grad_enabled(m_transforms);
+
+        if constexpr (IsDiff) {
+            if (grad_enabled && m_shapegroup->parameters_grad_enabled())
+                Throw("Cannot differentiate batch instance parameters and "
+                      "shapegroup internal parameters at the same time!");
+        }
+
+        bool detach_shape = has_flag(ray_flags, RayFlags::DetachShape);
+        bool follow_shape = has_flag(ray_flags, RayFlags::FollowShape);
+
+        dr::suspend_grad<Float> scope(detach_shape, to_world, to_object);
+
+        SurfaceInteraction3f si;
+        {
+            dr::suspend_grad<Float> scope2(grad_enabled);
+            si = m_shapegroup->compute_surface_interaction(
+                to_object * ray, pi, ray_flags,
+                recursion_depth, active);
+        }
+
+        // Transform back to world space
+        si.p = to_world * si.p;
+        si.n = dr::normalize(dr::detach(to_world) * si.n);
+        if (likely(has_flag(ray_flags, RayFlags::ShadingFrame)))
+            si.sh_frame.n = dr::normalize(dr::detach(to_world) * si.sh_frame.n);
+
+        if constexpr (IsDiff) {
+            if (follow_shape && grad_enabled) {
+                si.t = dr::sqrt(dr::squared_norm(si.p - ray.o) /
+                                dr::squared_norm(ray.d));
+            } else if (!follow_shape && grad_enabled) {
+                si.t = (dr::dot(si.n, si.p) - dr::dot(si.n, ray.o)) /
+                       dr::dot(si.n, ray.d);
+                si.p = ray(si.t);
+            }
+        }
+
+        if (likely(has_flag(ray_flags, RayFlags::ShadingFrame)))
+            si.initialize_sh_frame();
+
+        if (likely(has_flag(ray_flags, RayFlags::dPdUV))) {
+            si.dp_du = to_world * si.dp_du;
+            si.dp_dv = to_world * si.dp_dv;
+        }
+
+        if (has_flag(ray_flags, RayFlags::dNGdUV) ||
+            has_flag(ray_flags, RayFlags::dNSdUV)) {
+            Normal3f n = has_flag(ray_flags, RayFlags::dNGdUV)
+                             ? si.n
+                             : si.sh_frame.n;
+
+            Normal3f tn = to_world * dr::normalize(to_object * n);
+            Float inv_len = dr::rcp(dr::norm(tn));
+            tn *= inv_len;
+
+            si.dn_du = to_world * Normal3f(si.dn_du) * inv_len;
+            si.dn_dv = to_world * Normal3f(si.dn_dv) * inv_len;
+
+            si.dn_du -= tn * dr::dot(tn, si.dn_du);
+            si.dn_dv -= tn * dr::dot(tn, si.dn_dv);
+        }
+
+        si.prim_index = pi.prim_index;
+        si.instance = this;
+
+        return si;
+    }
+
+    //! @}
+    // =============================================================
+
+    std::string to_string() const override {
+        std::ostringstream oss;
+        oss << "MergeInstance[" << std::endl
+            << "  shapegroup = " << string::indent(m_shapegroup) << std::endl
+            << "  instance_count = " << m_scalar_transforms.size()
+            << std::endl << "]";
+        return oss.str();
+    }
+
+    bool parameters_grad_enabled() const override {
+        return dr::grad_enabled(m_transforms) ||
+               m_shapegroup->parameters_grad_enabled();
+    }
+
+    void describe(ShapeIR &g) const override {
+        g.kind = ShapeIR::Kind::MergeInstance;
+        g.type = m_shape_type;
+        g.ctx = this;
+        g.group_id = (const void *) m_shapegroup.get();
+
+        g.batch_to_worlds.resize(m_scalar_transforms.size());
+        for (size_t i = 0; i < m_scalar_transforms.size(); ++i) {
+            const auto &M = m_scalar_transforms[i].matrix;
+            for (size_t col = 0; col < 4; ++col)
+                for (size_t row = 0; row < 3; ++row)
+                    g.batch_to_worlds[i][col * 3 + row] = (float) M(row, col);
+        }
+    }
+
+    /// Number of instances in the batch.
+    size_t instance_count() const { return m_scalar_transforms.size(); }
+
+    MI_DECLARE_CLASS(MergeInstance)
+private:
+    /// Gather the affine transform for the given batch index.
+    AffineTransform4f gather_transform(const UInt32 &idx,
+                                       const Mask &active) const {
+        UInt32 vec_idx = idx * 4u;
+        Vector3f c0 = dr::gather<Vector3f>(m_transforms, vec_idx + 0u, active);
+        Vector3f c1 = dr::gather<Vector3f>(m_transforms, vec_idx + 1u, active);
+        Vector3f c2 = dr::gather<Vector3f>(m_transforms, vec_idx + 2u, active);
+        Vector3f c3 = dr::gather<Vector3f>(m_transforms, vec_idx + 3u, active);
+
+        Matrix4f mat(
+            c0.x(), c1.x(), c2.x(), c3.x(),
+            c0.y(), c1.y(), c2.y(), c3.y(),
+            c0.z(), c1.z(), c2.z(), c3.z(),
+            0.f,    0.f,    0.f,    1.f
+        );
+
+        return AffineTransform4f(mat);
+    }
+
+    /// Upload scalar transforms to the JIT buffer (12 floats per 3x4 matrix).
+    void upload_transforms() {
+        using Scalar = dr::scalar_t<Float>;
+        size_t n = m_scalar_transforms.size();
+        std::vector<Scalar> data(n * 12);
+
+        for (size_t i = 0; i < n; ++i) {
+            const auto &Mw = m_scalar_transforms[i].matrix;
+            for (size_t col = 0; col < 4; ++col) {
+                for (size_t row = 0; row < 3; ++row) {
+                    data[i * 12 + col * 3 + row] = (Scalar) Mw(row, col);
+                }
+            }
+        }
+
+        m_transforms =
+            dr::load<DynamicBuffer<Float>>(data.data(), data.size());
+        dr::make_opaque(m_transforms);
+        update_scalar_bboxes();
+    }
+
+    /// Sync updated JIT transforms buffer back to host scalar transforms.
+    void update_scalar_transforms() {
+        dr::eval(m_transforms);
+        using Scalar = dr::scalar_t<Float>;
+        std::vector<Scalar> data(m_transforms.size());
+        dr::store(data.data(), m_transforms);
+        size_t n = m_scalar_transforms.size();
+        for (size_t i = 0; i < n; ++i) {
+            ScalarMatrix4f Mw(1.f);
+            for (size_t col = 0; col < 4; ++col) {
+                for (size_t row = 0; row < 3; ++row) {
+                    Mw(row, col) = data[i * 12 + col * 3 + row];
+                }
+            }
+            m_scalar_transforms[i] = ScalarAffineTransform4f(Mw);
+        }
+        update_scalar_bboxes();
+    }
+
+    void update_scalar_bboxes() {
+        size_t n = m_scalar_transforms.size();
+        m_scalar_bboxes.resize(n);
+        const ScalarBoundingBox3f &group_bbox = m_shapegroup->bbox();
+        if (group_bbox.valid()) {
+            for (size_t i = 0; i < n; ++i) {
+                ScalarBoundingBox3f b;
+                for (int c = 0; c < 8; ++c)
+                    b.expand(m_scalar_transforms[i] * group_bbox.corner(c));
+                m_scalar_bboxes[i] = b;
+            }
+        } else {
+            for (size_t i = 0; i < n; ++i)
+                m_scalar_bboxes[i] = group_bbox;
+        }
+    }
+
+    ref<ShapeGroup_> m_shapegroup;
+    std::vector<ScalarAffineTransform4f> m_scalar_transforms;
+    std::vector<ScalarBoundingBox3f> m_scalar_bboxes;
+    DynamicBuffer<Float> m_transforms;
+};
+
+MI_EXPORT_PLUGIN(MergeInstance)
+NAMESPACE_END(mitsuba)

--- a/src/shapes/tests/test_instance.py
+++ b/src/shapes/tests/test_instance.py
@@ -322,7 +322,12 @@ def test05_merge_instance_optimize(variants_all_rgb):
 
 
 def test06_merge_instance_traverse(variants_all_rgb):
-    """Verifies parameter traversal and parameter update sync for MergeInstance."""
+    """Verifies parameter traversal and parameter update sync for MergeInstance.
+
+    On CPU variants without Embree, the parser intentionally leaves instances
+    unmerged instead (the built-in kd-tree cannot resolve which batch element
+    was hit, see transform_merge_instances() in parser.cpp), so there is
+    nothing to check in that case."""
     from mitsuba import ScalarTransform4f as T
 
     scene_dict = {
@@ -349,8 +354,10 @@ def test06_merge_instance_traverse(variants_all_rgb):
     scene = mi.load_dict(scene_dict, optimize=True)
     params = mi.traverse(scene)
 
-    assert any('transforms' in k for k in params.keys())
-    for k in params.keys():
-        if 'transforms' in k:
-            assert len(params[k]) == 24  # 2 instances * 12 floats
+    merged_keys = [k for k in params.keys() if 'transforms' in k]
+    if not merged_keys:
+        return
+
+    for k in merged_keys:
+        assert len(params[k]) == 24  # 2 instances * 12 floats
 

--- a/src/shapes/tests/test_instance.py
+++ b/src/shapes/tests/test_instance.py
@@ -182,7 +182,7 @@ def test03_ray_intersect_instance(variants_all_rgb, width):
             'type' : 'rectangle',
             'to_world' : T().translate([0.5, 0.5, 0.0]) @ T().scale(0.5)
         }
-    })
+    }, optimize=False)
 
     time = 0.0 if scalar_mode else [0.0] * width
 
@@ -262,3 +262,95 @@ def test04_single_child_group_recovery(variants_vec_backends_once_rgb, shape):
             assert dr.allclose(si.t, si_inst.t, atol=2e-2)
             assert dr.allclose(si.p, si_inst.p, atol=2e-2)
             assert dr.allclose(si.n, si_inst.n, atol=2e-2)
+
+
+def test05_merge_instance_optimize(variants_all_rgb):
+    """Checks that automatic instance merging (optimize=True) produces identical
+    ray intersection and rendering results compared to unmerged instances (optimize=False)."""
+    from mitsuba import ScalarTransform4f as T
+
+    scene_dict = {
+        'type': 'scene',
+        'group_0': {
+            'type': 'shapegroup',
+            'rect': {
+                'type': 'rectangle',
+                'to_world': T().scale(0.4)
+            },
+            'sphere': {
+                'type': 'sphere',
+                'to_world': T().translate([0.5, 0, 0]).scale(0.2)
+            }
+        },
+        'inst_0': {
+            'type': 'instance',
+            'group': {'type': 'ref', 'id': 'group_0'},
+            'to_world': T().translate([-0.6, 0, 0])
+        },
+        'inst_1': {
+            'type': 'instance',
+            'group': {'type': 'ref', 'id': 'group_0'},
+            'to_world': T().translate([0.6, 0, 0])
+        }
+    }
+
+    s_opt = mi.load_dict(scene_dict, optimize=True)
+    s_noopt = mi.load_dict(scene_dict, optimize=False)
+
+    n = 11
+    inv_n = 1.0 / n
+    for x in range(n):
+        for y in range(n):
+            x_coord = (2 * (x * inv_n) - 1) * 2
+            y_coord = (2 * (y * inv_n) - 1) * 2
+            ray = mi.Ray3f(o=[x_coord, y_coord, -5], d=[0.0, 0.0, 1.0], time=0.0, wavelengths=[])
+
+            hit_opt = s_opt.ray_test(ray)
+            dr.eval(hit_opt)
+            hit_noopt = s_noopt.ray_test(ray)
+            dr.eval(hit_noopt)
+            assert hit_opt == hit_noopt
+
+            if hit_opt:
+                si_opt = s_opt.ray_intersect(ray)
+                dr.eval(si_opt)
+                si_noopt = s_noopt.ray_intersect(ray)
+                dr.eval(si_noopt)
+                assert dr.allclose(si_opt.t, si_noopt.t, atol=1e-3)
+                assert dr.allclose(si_opt.p, si_noopt.p, atol=1e-3)
+                assert dr.allclose(si_opt.n, si_noopt.n, atol=1e-3)
+
+
+def test06_merge_instance_traverse(variants_all_rgb):
+    """Verifies parameter traversal and parameter update sync for MergeInstance."""
+    from mitsuba import ScalarTransform4f as T
+
+    scene_dict = {
+        'type': 'scene',
+        'group_0': {
+            'type': 'shapegroup',
+            'rect': {
+                'type': 'rectangle',
+                'to_world': T().scale(0.4)
+            }
+        },
+        'inst_0': {
+            'type': 'instance',
+            'group': {'type': 'ref', 'id': 'group_0'},
+            'to_world': T().translate([-0.6, 0, 0])
+        },
+        'inst_1': {
+            'type': 'instance',
+            'group': {'type': 'ref', 'id': 'group_0'},
+            'to_world': T().translate([0.6, 0, 0])
+        }
+    }
+
+    scene = mi.load_dict(scene_dict, optimize=True)
+    params = mi.traverse(scene)
+
+    assert any('transforms' in k for k in params.keys())
+    for k in params.keys():
+        if 'transforms' in k:
+            assert len(params[k]) == 24  # 2 instances * 12 floats
+


### PR DESCRIPTION
This PR introduces a `MergeInstance` shape. By automatically merging matching instance plugins during scene parsing, we can significantly reduce JIT tracing cost for scenes containing many (>100s) instances. Instead of tracing each instance separately, we just create a single plugin and locally fetch the appropriate transforms. In practice, this can reduces JIT tracing cost from impractical (>30s for 1000 objects) to completely practical (<0.1s).

This is work in progress and needs more polish to be reviewable. It may also make sense to discuss if we want to keep the ability to have individual instance objects (when `optimize=False` during scene loading) or not. Another option would also be to fold the `MergeInstance` plugin into the regular instance plugin, by simply allowing that plugin to take a number of transforms.