### PR TITLE
Simplification pass over the ``compute_surface_interaction()`` implementations

### DIFF
--- a/include/mitsuba/core/transform.h
+++ b/include/mitsuba/core/transform.h
@@ -245,9 +245,38 @@ struct Transform {
             for (size_t j = i; j < Size - 1; ++j) {
                 Float sum = 0.f;
                 for (size_t k = 0; k < Size - 1; ++k)
-                    sum += matrix[i][k] * matrix[j][k];
+                    sum = dr::fmadd(matrix[i][k], matrix[j][k], sum);
 
                 mask |= dr::abs(sum - (i == j ? 1.f : 0.f)) > 1e-3f;
+            }
+        }
+        return mask;
+    }
+
+    /**
+     * \brief Test whether the linear part is a similarity, i.e., a
+     * rotation/reflection, potentially with a uniform scale and translation.
+     *
+     * The implementation checks whether <tt>M . M^T</tt> is a multiple of the
+     * identity.
+     */
+    Mask is_similarity() const {
+        constexpr size_t N = Size - 1;
+
+        // Compute the shared uniform scale, if present.
+        Float ref = 0.f;
+        for (size_t i = 0; i < N; ++i)
+            for (size_t k = 0; k < N; ++k)
+                ref = dr::fmadd(matrix[i][k], matrix[i][k], ref);
+        ref *= Scalar(1) / Scalar(N);
+
+        Mask mask(true);
+        for (size_t i = 0; i < N; ++i) {
+            for (size_t j = i; j < N; ++j) {
+                Float sum = 0.f;
+                for (size_t k = 0; k < N; ++k)
+                    sum += matrix[i][k] * matrix[j][k];
+                mask &= dr::abs(sum - (i == j ? ref : 0.f)) <= ref * 1e-3f;
             }
         }
         return mask;

--- a/include/mitsuba/python/docstr.h
+++ b/include/mitsuba/python/docstr.h
@@ -11274,6 +11274,13 @@ static const char *__doc_mitsuba_Transform_from_frame =
 R"doc(Creates a transformation that converts from 'frame' to the standard
 basis)doc";
 
+static const char *__doc_mitsuba_Transform_is_similarity =
+R"doc(Test whether the linear part is a similarity, i.e., a
+rotation/reflection, potentially with a uniform scale and translation.
+
+The implementation checks whether ``M . M^T`` is a multiple of the
+identity.)doc";
+
 static const char *__doc_mitsuba_Transform_has_scale =
 R"doc(Test for a scale component in each transform matrix by checking
 whether ``M . M^T == I`` (where ``M`` is the matrix in question and

--- a/include/mitsuba/python/docstr.h
+++ b/include/mitsuba/python/docstr.h
@@ -7806,27 +7806,46 @@ compute_surface_interaction().
 It also specifies whether the SurfaceInteraction should be
 differentiable with respect to the shapes parameters.)doc";
 
-static const char *__doc_mitsuba_RayFlags_All = R"doc(//! Compound compute flags)doc";
+static const char *__doc_mitsuba_RayFlags_Shading =
+R"doc(Additionally compute the UV coordinates, the position partials and the
+shading frame
 
-static const char *__doc_mitsuba_RayFlags_AllNonDifferentiable = R"doc(Compute all fields of the surface interaction ignoring shape's motion)doc";
+The tangent of the shading frame follows ``dp_du``, hence the two
+cannot be requested separately. Without this flag, ``uv``, ``dp_du``,
+``dp_dv``, ``sh_frame`` and ``wi`` are left undefined.)doc";
+
+static const char *__doc_mitsuba_RayFlags_All =
+R"doc(Deprecated alias for Shading
+
+This is the detail level that ``All`` selected in Mitsuba 3.9 and
+earlier.)doc";
+
+static const char *__doc_mitsuba_RayFlags_Default = R"doc(The detail level requested by default, i.e. everything but NormalPartials)doc";
+
 
 static const char *__doc_mitsuba_RayFlags_DetachShape = R"doc(Derivatives of the SurfaceInteraction fields ignore shape's motion)doc";
 
-static const char *__doc_mitsuba_RayFlags_Empty = R"doc(No flags set)doc";
 
 static const char *__doc_mitsuba_RayFlags_FollowShape = R"doc(Derivatives of the SurfaceInteraction fields follow shape's motion)doc";
 
-static const char *__doc_mitsuba_RayFlags_Minimal = R"doc(Compute position and geometric normal)doc";
+static const char *__doc_mitsuba_RayFlags_Minimal = R"doc(Compute the distance, position and geometric normal
 
-static const char *__doc_mitsuba_RayFlags_ShadingFrame = R"doc(Compute shading normal and shading frame)doc";
+This is the baseline: it is the absence of Shading rather than a flag
+of its own, so ``has_flag(flags, Minimal)`` is always false.)doc";
 
-static const char *__doc_mitsuba_RayFlags_UV = R"doc(Compute UV coordinates)doc";
+static const char *__doc_mitsuba_RayFlags_NormalPartials =
+R"doc(Additionally compute the partial derivatives of the shading normal
+wrt. the UV parameterization
+
+Depends on Shading: the partials differentiate the parameterization
+that flag defines, hence they are not computed without it. Shapes with
+a flat shading normal, and those that do not implement the partials,
+report zero.)doc";
 
 
 
-static const char *__doc_mitsuba_RayFlags_dNSdUV = R"doc(Compute the shading normal partials wrt. the UV coordinates)doc";
 
-static const char *__doc_mitsuba_RayFlags_dPdUV = R"doc(Compute position partials wrt. UV coordinates)doc";
+
 
 static const char *__doc_mitsuba_Ray_Ray = R"doc(Construct a new ray (o, d) at time 'time')doc";
 
@@ -8507,7 +8526,7 @@ traced, that the user desires access to all fields of the
 SurfaceInteraction, and that no thread reordering is requested. In
 other words, it simply invokes the general ``ray_intersect``()
 overload with ``coherent=false``, ``ray_flags`` equal to
-RayFlags::All, and ``reorder=false``.
+RayFlags::Default, and ``reorder=false``.
 
 Parameter ``ray``:
     A 3D ray including maximum extent (Ray::maxt) and time (Ray::time)
@@ -8553,7 +8572,7 @@ In the context of differentiable rendering, the ``ray_flags``
 parameter also influences how derivatives propagate between the input
 ray, the shape parameters, and the computed intersection (see
 RayFlags::FollowShape and RayFlags::DetachShape for details on this).
-The default, RayFlags::All, propagates derivatives through all steps
+The default, RayFlags::Default, propagates derivatives through all steps
 of the intersection computation.
 
 The ``coherent`` flag is a hint that can improve performance in the
@@ -8622,7 +8641,7 @@ In the context of differentiable rendering, the ``ray_flags``
 parameter also influences how derivatives propagate between the input
 ray, the shape parameters, and the computed intersection (see
 RayFlags::FollowShape and RayFlags::DetachShape for details on this).
-The default, RayFlags::All, propagates derivatives through all steps
+The default, RayFlags::Default, propagates derivatives through all steps
 of the intersection computation.
 
 The ``coherent`` flag is a hint that can improve performance in the

--- a/include/mitsuba/python/docstr.h
+++ b/include/mitsuba/python/docstr.h
@@ -7822,7 +7822,7 @@ static const char *__doc_mitsuba_RayFlags_ShadingFrame = R"doc(Compute shading n
 
 static const char *__doc_mitsuba_RayFlags_UV = R"doc(Compute UV coordinates)doc";
 
-static const char *__doc_mitsuba_RayFlags_dNGdUV = R"doc(Compute the geometric normal partials wrt. the UV coordinates)doc";
+
 
 static const char *__doc_mitsuba_RayFlags_dNSdUV = R"doc(Compute the shading normal partials wrt. the UV coordinates)doc";
 
@@ -10401,9 +10401,11 @@ static const char *__doc_mitsuba_SurfaceInteraction_bsdf_2 = R"doc()doc";
 
 static const char *__doc_mitsuba_SurfaceInteraction_compute_uv_partials = R"doc(Computes texture coordinate partials)doc";
 
-static const char *__doc_mitsuba_SurfaceInteraction_dn_du = R"doc(Normal partials wrt. the UV parameterization)doc";
 
-static const char *__doc_mitsuba_SurfaceInteraction_dn_dv = R"doc(Normal partials wrt. the UV parameterization)doc";
+
+static const char *__doc_mitsuba_SurfaceInteraction_dn_du = R"doc(Shading normal partials wrt. the UV parameterization)doc";
+
+static const char *__doc_mitsuba_SurfaceInteraction_dn_dv = R"doc(Shading normal partials wrt. the UV parameterization)doc";
 
 static const char *__doc_mitsuba_SurfaceInteraction_dp_du = R"doc(Position partials wrt. the UV parameterization)doc";
 
@@ -10435,11 +10437,11 @@ Parameter ``ray``:
 Parameter ``ray_flags``:
     Flags specifying which information should be computed)doc";
 
+
 static const char *__doc_mitsuba_SurfaceInteraction_has_n_partials = R"doc()doc";
 
 static const char *__doc_mitsuba_SurfaceInteraction_has_uv_partials = R"doc()doc";
 
-static const char *__doc_mitsuba_SurfaceInteraction_initialize_sh_frame = R"doc(Initialize local shading frame using Gram-schmidt orthogonalization)doc";
 
 static const char *__doc_mitsuba_SurfaceInteraction_instance = R"doc(Stores a pointer to the parent instance (if applicable))doc";
 
@@ -11274,17 +11276,17 @@ static const char *__doc_mitsuba_Transform_from_frame =
 R"doc(Creates a transformation that converts from 'frame' to the standard
 basis)doc";
 
+static const char *__doc_mitsuba_Transform_has_scale =
+R"doc(Test for a scale component in each transform matrix by checking
+whether ``M . M^T == I`` (where ``M`` is the matrix in question and
+``I`` is the identity).)doc";
+
 static const char *__doc_mitsuba_Transform_is_similarity =
 R"doc(Test whether the linear part is a similarity, i.e., a
 rotation/reflection, potentially with a uniform scale and translation.
 
 The implementation checks whether ``M . M^T`` is a multiple of the
 identity.)doc";
-
-static const char *__doc_mitsuba_Transform_has_scale =
-R"doc(Test for a scale component in each transform matrix by checking
-whether ``M . M^T == I`` (where ``M`` is the matrix in question and
-``I`` is the identity).)doc";
 
 static const char *__doc_mitsuba_Transform_inverse = R"doc()doc";
 

--- a/include/mitsuba/render/interaction.h
+++ b/include/mitsuba/render/interaction.h
@@ -274,19 +274,6 @@ struct SurfaceInteraction : Interaction<Float_, Spectrum_> {
         }
     }
 
-    /// Initialize local shading frame using Gram-schmidt orthogonalization
-    void initialize_sh_frame() {
-        sh_frame.s = dr::normalize(
-            dr::fmadd(sh_frame.n, -dr::dot(sh_frame.n, dp_du), dp_du));
-
-        // When dp_du is invalid, use an orthonormal basis
-        Mask singularity_mask = dr::all(dp_du == 0.f);
-        if (unlikely(dr::any_or<true>(singularity_mask)))
-            sh_frame.s[singularity_mask] = coordinate_system(sh_frame.n).first;
-
-        sh_frame.t = dr::cross(sh_frame.n, sh_frame.s);
-    }
-
     /// Convert a local shading-space vector into world space
     Vector3f to_world(const Vector3f &v) const {
         return sh_frame.to_world(v);
@@ -506,11 +493,29 @@ struct SurfaceInteraction : Interaction<Float_, Spectrum_> {
         time        = ray.time;
         wavelengths = ray.wavelengths;
 
-        if (has_flag(ray_flags, RayFlags::ShadingFrame))
-            initialize_sh_frame();
+        if (has_flag(ray_flags, RayFlags::ShadingFrame)) {
+            // Orthogonalize ``dp_du`` against the shading normal
+            Vector3f n = sh_frame.n,
+                     s = dr::fnmadd(n, dr::dot(n, dp_du), dp_du);
+            Float sqr_norm = dr::squared_norm(s);
 
-        // Incident direction in local coordinates
-        wi = dr::select(active, to_local(-ray.d), -ray.d);
+            std::tie(sh_frame.s, sh_frame.t) = dr::if_stmt(
+                std::make_tuple(n, s, sqr_norm), sqr_norm > 0.f,
+
+                [](Vector3f &n, Vector3f &s, Float &sqr_norm) {
+                    Vector3f s2 = s * dr::rsqrt(sqr_norm);
+                    return std::make_pair(s2, Vector3f(dr::cross(n, s2)));
+                },
+
+                // Fall back to an arbitrary basis when degenerate
+                [](Vector3f &n, Vector3f &, Float &) {
+                    return coordinate_system(n);
+                },
+
+                "SurfaceInteraction::finalize_surface_interaction()"
+            );
+            wi = dr::select(active, to_local(-ray.d), -ray.d);
+        }
 
         duv_dx = duv_dy = dr::zeros<Point2f>();
     }

--- a/include/mitsuba/render/interaction.h
+++ b/include/mitsuba/render/interaction.h
@@ -10,11 +10,11 @@
 NAMESPACE_BEGIN(mitsuba)
 
 /**
- * \brief This list of flags is used to determine which members of \ref SurfaceInteraction
+ * \brief Flags to determine which members of \ref SurfaceInteraction
  * should be computed when calling \ref compute_surface_interaction().
  *
- * It also specifies whether the \ref SurfaceInteraction should be differentiable with
- * respect to the shapes parameters.
+ * It also specifies differentiation behavior with respect to shape
+ * parameters.
  */
 enum class RayFlags : uint32_t {
 
@@ -22,44 +22,68 @@ enum class RayFlags : uint32_t {
     //             Surface interaction compute flags
     // =============================================================
 
-    /// No flags set
-    Empty = 0x0,
+    /// Compute the distance, position and geometric normal (cannot be disabled)
+    Minimal = 0x0,
 
-    /// Compute position and geometric normal
-    Minimal = 0x1,
+    /** \brief Additionally compute the UV coordinates (``uv``), position
+     * partials (``dp_du``, ``dp_dv``), shading frame (``sh_frame``), and the
+     * incident direction in the shading frame (``wi``).
+     *
+     * This is also the default option selected by \ref Default.
+     */
+    Shading = 0x1,
 
-    /// Compute UV coordinates
-    UV = 0x2,
+    /** \brief Additionally compute normal partial derivatives (``dn_du``,
+     * ``dn_dv``), which encode information about curvature.
+     *
+     * Depends on \ref Shading.
+     */
+    NormalPartials = 0x2,
 
-    /// Compute position partials wrt. UV coordinates
-    dPdUV = 0x4,
+    /// The detail level requested by default, i.e. everything but \ref
+    /// NormalPartials
+    Default = Shading,
 
-    /// Compute shading normal and shading frame
-    ShadingFrame = 0x8,
-
-    /// Compute the shading normal partials wrt. the UV coordinates
-    dNSdUV = 0x10,
+    /// Deprecated alias for \ref Shading
+    All [[deprecated("Deprecated, change to RayFlags::Default.")]] = Shading,
 
     // =============================================================
     //!              Differentiability compute flags
     // =============================================================
 
-    /// Derivatives of the SurfaceInteraction fields follow shape's motion
-    FollowShape = 0x80,
+    /** \brief Track differentiable dependence of the \ref SurfaceInteraction
+     * with respect to shape parameters.
+     *
+     * By default (i.e., when neither \ref FollowShape nor \ref DetachShape is
+     * specified), intersections differentiably depend on both the ray
+     * (``ray.o``, ``ray.d``) and shape parameters. They conceptually slide
+     * along the surface as either the ray or the geometry moves.
+     *
+     * With ``FollowShape``, the intersection is instead rigidly glued to the
+     * surface. The hit is first located non-differentiably, and the resulting
+     * point is then differentiably re-evaluated using a local parameterization.
+     * The point consequently moves along with and no longer tracks
+     * infinitesimal changes of the ray. This is the same quantity that
+     * \ref Shape::differential_motion() returns.
+     *
+     * At most one of FollowShape or \ref DetachShape can be specified. The flag
+     * has no effect in non-differentiable variants.
+     */
+    FollowShape = 0x4,
 
-    /// Derivatives of the SurfaceInteraction fields ignore shape's motion
-    DetachShape = 0x100,
-
-    // =============================================================
-    //!                 Compound compute flags
-    // =============================================================
-
-    /* \brief Default: compute all fields of the surface interaction data
-       structure except shading/geometric normal derivatives */
-    All = UV | dPdUV | ShadingFrame,
-
-    /// Compute all fields of the surface interaction ignoring shape's motion
-    AllNonDifferentiable = All | DetachShape,
+    /** \brief Ignore the differentiable dependence of the \ref
+     * SurfaceInteraction on respect to shape parameters.
+     *
+     * With ``DetachShape``, the shape's parameters are detached before the
+     * interaction is computed, which amounts to intersecting a differentiable
+     * ray with a static surface. Derivatives then originate exclusively from
+     * ``ray.o`` and ``ray.d``, and the hit point slides across a surface that
+     * is held in place.
+     *
+     * At most one of FollowShape or \ref DetachShape can be specified. The flag
+     * has no effect in non-differentiable variants.
+     */
+    DetachShape = 0x8,
 };
 
 MI_DECLARE_ENUM_OPERATORS(RayFlags)
@@ -490,7 +514,7 @@ struct SurfaceInteraction : Interaction<Float_, Spectrum_> {
         time        = ray.time;
         wavelengths = ray.wavelengths;
 
-        if (has_flag(ray_flags, RayFlags::ShadingFrame)) {
+        if (has_flag(ray_flags, RayFlags::Shading)) {
             // Orthogonalize ``dp_du`` against the shading normal
             Vector3f n = sh_frame.n,
                      s = dr::fnmadd(n, dr::dot(n, dp_du), dp_du);
@@ -717,7 +741,7 @@ struct PreliminaryIntersection {
      *      A data structure containing the detailed information
      */
     auto compute_surface_interaction(const Ray3f &ray,
-                                     uint32_t ray_flags = +RayFlags::All,
+                                     uint32_t ray_flags = +RayFlags::Default,
                                      Mask active = true) {
         if constexpr (!std::is_same_v<Shape_, Shape<Float, Spectrum>>) {
             Throw("PreliminaryIntersection::compute_surface_interaction(): not implemented!");

--- a/include/mitsuba/render/interaction.h
+++ b/include/mitsuba/render/interaction.h
@@ -492,6 +492,49 @@ struct SurfaceInteraction : Interaction<Float_, Spectrum_> {
     }
 
     /**
+     * \brief Attach the motion of this interaction under the requested
+     * differentiation mode
+     *
+     * This function exists for use within implementations of \ref
+     * Shape::compute_surface_interaction(). It reads \c t, \c p and \c n and
+     * updates the AD state of \c t and \c p, so that their derivatives express
+     * how the interaction point responds to a change of the scene parameters:
+     * it either stays on the ray while the surface moves underneath it (the
+     * default), or follows the surface (\ref RayFlags::FollowShape).
+     * The case \ref RayFlags::DetachShape must be handled on the caller's end.
+     *
+     * Shapes that recover their local coordinates from \c p need nothing
+     * further. Those parameterized by \c pi.prim_uv must furthermore update it
+     * to match \ref p by projecting the (primal-zero) displacement ``p -
+     * p_att`` onto the tangent basis and attaching it via \c dr::replace_grad.
+     *
+     * \param p_att
+     *      Surface position at the *detached* parameterization, attached to the
+     *      shape's parameters. Its primal value equals \c p.
+     */
+    void attach_motion(const Ray3f &ray, const Point3f &p_att, uint32_t ray_flags) {
+        if constexpr (!dr::is_diff_v<Float>) {
+            DRJIT_MARK_USED(ray);
+            DRJIT_MARK_USED(p_att);
+            DRJIT_MARK_USED(ray_flags);
+        } else if (has_flag(ray_flags, RayFlags::FollowShape)) {
+            // Glue the interaction point to the shape: it is then no longer
+            // tied to the ray, and the distance follows the surface motion.
+            Float t_att = dr::norm(p_att - ray.o) / dr::norm(ray.d);
+            t = dr::replace_grad(t, t_att);
+            p = dr::replace_grad(p, p_att);
+        } else {
+            // Keep the interaction point on the ray, intersecting the moving
+            // tangent plane at the hit point. The normal is detached (dependence
+            // on it would be a higher order effect.)
+            Normal3f nd = dr::detach(n);
+            Float t_att = dr::dot(p_att - ray.o, nd) / dr::dot(nd, ray.d);
+            t = dr::replace_grad(t, t_att);
+            p = dr::replace_grad(p, ray(t));
+        }
+    }
+
+    /**
      * \brief Fills uninitialized fields after a call to \ref Shape::compute_surface_interaction()
      *
      * \param pi

--- a/include/mitsuba/render/interaction.h
+++ b/include/mitsuba/render/interaction.h
@@ -37,11 +37,8 @@ enum class RayFlags : uint32_t {
     /// Compute shading normal and shading frame
     ShadingFrame = 0x8,
 
-    /// Compute the geometric normal partials wrt. the UV coordinates
-    dNGdUV = 0x10,
-
     /// Compute the shading normal partials wrt. the UV coordinates
-    dNSdUV = 0x20,
+    dNSdUV = 0x10,
 
     // =============================================================
     //!              Differentiability compute flags
@@ -213,7 +210,7 @@ struct SurfaceInteraction : Interaction<Float_, Spectrum_> {
     /// Position partials wrt. the UV parameterization
     Vector3f dp_du, dp_dv;
 
-    /// Normal partials wrt. the UV parameterization
+    /// Shading normal partials wrt. the UV parameterization
     Vector3f dn_du, dn_dv;
 
     /// UV partials wrt. changes in screen-space

--- a/include/mitsuba/render/mesh.h
+++ b/include/mitsuba/render/mesh.h
@@ -290,7 +290,7 @@ public:
                              Mask active = true) const override;
 
     SurfaceInteraction3f eval_parameterization(const Point2f &uv,
-                                               uint32_t ray_flags = +RayFlags::All,
+                                               uint32_t ray_flags = +RayFlags::Default,
                                                Mask active = true) const override;
 
     void set_scene(Scene<Float, Spectrum> *scene) { m_scene = scene; }

--- a/include/mitsuba/render/mesh.h
+++ b/include/mitsuba/render/mesh.h
@@ -156,6 +156,13 @@ public:
         return dr::gather<Result>(m_vertex_texcoords, index, active);
     }
 
+    /// Returns the normal direction of a face with the given vertex positions
+    template <typename Point3>
+    static MI_INLINE auto face_normal(const Point3 &p0, const Point3 &p1,
+                                      const Point3 &p2) {
+        return dr::normalize(dr::cross(p1 - p0, p2 - p0));
+    }
+
     /// Returns the normal direction of the face with index \c index
     template <typename Index>
     MI_INLINE auto face_normal(Index index,
@@ -165,7 +172,7 @@ public:
                           vertex_position(vertex_indices[1], active),
                           vertex_position(vertex_indices[2], active) };
 
-        return dr::normalize(dr::cross(v[1] - v[0], v[2] - v[0]));
+        return face_normal(v[0], v[1], v[2]);
     }
 
     /**

--- a/include/mitsuba/render/scene.h
+++ b/include/mitsuba/render/scene.h
@@ -64,7 +64,7 @@ public:
      * that the user desires access to all fields of the
      * \ref SurfaceInteraction, and that no thread reordering is requested. In
      * other words, it simply invokes the general \c ray_intersect() overload
-     * with <tt>coherent=false</tt>, \c ray_flags equal to \ref RayFlags::All,
+     * with <tt>coherent=false</tt>, \c ray_flags equal to \ref RayFlags::Default,
      * and <tt>reorder=false</tt>.
      *
      * \param ray
@@ -77,7 +77,7 @@ public:
      */
     SurfaceInteraction3f ray_intersect(const Ray3f &ray,
                                        Mask active = true) const {
-        return ray_intersect(ray, +RayFlags::All, false, false, 0, 0, active);
+        return ray_intersect(ray, +RayFlags::Default, false, false, 0, 0, active);
     }
 
     /**
@@ -116,7 +116,7 @@ public:
      * also influences how derivatives propagate between the input ray, the
      * shape parameters, and the computed intersection (see
      * \ref RayFlags::FollowShape and \ref RayFlags::DetachShape for details on
-     * this). The default, \ref RayFlags::All, propagates derivatives through
+     * this). The default, \ref RayFlags::Default, propagates derivatives through
      * all steps of the intersection computation.
      *
      * The \c coherent flag is a hint that can improve performance in the first
@@ -191,7 +191,7 @@ public:
      * also influences how derivatives propagate between the input ray, the
      * shape parameters, and the computed intersection (see
      * \ref RayFlags::FollowShape and \ref RayFlags::DetachShape for details on
-     * this). The default, \ref RayFlags::All, propagates derivatives through
+     * this). The default, \ref RayFlags::Default, propagates derivatives through
      * all steps of the intersection computation.
      *
      * The \c coherent flag is a hint that can improve performance in the first

--- a/include/mitsuba/render/shape.h
+++ b/include/mitsuba/render/shape.h
@@ -541,8 +541,8 @@ public:
      * \brief Compute and return detailed information related to a surface interaction
      *
      * The implementation should at most compute the fields \c p, \c uv, \c n,
-     * \c sh_frame.n, \c dp_du, \c dp_dv, \c dn_du and \c dn_dv. The \c flags parameter
-     * specifies which of those fields should be computed.
+     * \c sh_frame.n, \c dp_du, \c dp_dv, \c dn_du and \c dn_dv. The \c flags
+     * parameter specifies which of those fields should be computed.
      *
      * The fields \c t, \c time, \c wavelengths, \c shape, \c prim_index, \c instance,
      * will already have been initialized by the caller. The field \c wi is initialized
@@ -563,7 +563,7 @@ public:
      */
     virtual SurfaceInteraction3f compute_surface_interaction(const Ray3f &ray,
                                                              const PreliminaryIntersection3f &pi,
-                                                             uint32_t ray_flags = +RayFlags::All,
+                                                             uint32_t ray_flags = +RayFlags::Default,
                                                              uint32_t recursion_depth = 0,
                                                              Mask active = true) const;
 
@@ -580,7 +580,7 @@ public:
      *     Describe how the detailed information should be computed
      */
     SurfaceInteraction3f ray_intersect(const Ray3f &ray,
-                                       uint32_t ray_flags = +RayFlags::All,
+                                       uint32_t ray_flags = +RayFlags::Default,
                                        Mask active = true) const;
 
     //! @}
@@ -793,7 +793,7 @@ public:
      * The default implementation throws.
      */
     virtual SurfaceInteraction3f eval_parameterization(const Point2f &uv,
-                                                       uint32_t ray_flags = +RayFlags::All,
+                                                       uint32_t ray_flags = +RayFlags::Default,
                                                        Mask active = true) const;
 
     //! @}

--- a/src/core/python/transform_v.cpp
+++ b/src/core/python/transform_v.cpp
@@ -181,6 +181,7 @@ void bind_transform(nb::module_ &m, const char *name) {
     cls.def("inverse", &Transform::inverse, D(Transform, inverse))
         .def("translation", &Transform::translation, D(Transform, translation))
         .def("has_scale", &Transform::has_scale, D(Transform, has_scale))
+        .def("is_similarity", &Transform::is_similarity, D(Transform, is_similarity))
         .def_rw("matrix", &Transform::matrix)
         .def_rw("inverse_transpose", &Transform::inverse_transpose)
         .def_repr(Transform);

--- a/src/emitters/area.cpp
+++ b/src/emitters/area.cpp
@@ -141,7 +141,7 @@ public:
             auto [uv, pdf] = m_radiance->sample_position(sample, active);
             active &= (pdf != 0.f);
 
-            si = m_shape->eval_parameterization(uv, +RayFlags::All, active);
+            si = m_shape->eval_parameterization(uv, +RayFlags::Default, active);
             si.wavelengths = it.wavelengths;
             active &= si.is_valid();
 
@@ -186,7 +186,7 @@ public:
             value = m_shape->pdf_direction(it, ds, active);
         } else {
             // This surface intersection would be nice to avoid..
-            SurfaceInteraction3f si = m_shape->eval_parameterization(ds.uv, +RayFlags::dPdUV, active);
+            SurfaceInteraction3f si = m_shape->eval_parameterization(ds.uv, +RayFlags::Default, active);
             active &= si.is_valid();
 
             value = m_radiance->pdf_position(ds.uv, active) * dr::square(ds.dist) /
@@ -231,7 +231,7 @@ public:
             auto [uv, pdf] = m_radiance->sample_position(sample, active);
             active &= (pdf != 0.f);
 
-            auto si = m_shape->eval_parameterization(uv, +RayFlags::All, active);
+            auto si = m_shape->eval_parameterization(uv, +RayFlags::Default, active);
             active &= si.is_valid();
             pdf /= dr::norm(dr::cross(si.dp_du, si.dp_dv));
 

--- a/src/integrators/aov.cpp
+++ b/src/integrators/aov.cpp
@@ -212,7 +212,7 @@ public:
 
         // Don't reorder threads - let the inner integrator do it
         SurfaceInteraction3f si =
-            scene->ray_intersect(ray, (uint32_t) RayFlags::All, true, false, 0, 0, active);
+            scene->ray_intersect(ray, (uint32_t) RayFlags::Default, true, false, 0, 0, active);
         dr::masked(si, !si.is_valid()) = dr::zeros<SurfaceInteraction3f>();
 
         auto spectrum_to_color3f = [](const Spectrum& spec, const Ray3f& ray, Mask active) {

--- a/src/integrators/direct.cpp
+++ b/src/integrators/direct.cpp
@@ -120,7 +120,7 @@ public:
         MI_MASKED_FUNCTION(ProfilerPhase::SamplingIntegratorSample, active);
 
         SurfaceInteraction3f si = scene->ray_intersect(
-            ray, +RayFlags::All, /* coherent = */ true, active);
+            ray, +RayFlags::Default, /* coherent = */ true, active);
 
         Spectrum result(0.f);
 
@@ -136,7 +136,7 @@ public:
                 PreliminaryIntersection3f pi =
                     Base::skip_area_emitters(scene, ray_skip, true, skip_emitters);
                 SurfaceInteraction3f si_after_skip = pi.compute_surface_interaction(
-                        ray, +RayFlags::All, skip_emitters);
+                        ray, +RayFlags::Default, skip_emitters);
                 dr::masked(si, skip_emitters) = si_after_skip;
             }
         } else {

--- a/src/integrators/path.cpp
+++ b/src/integrators/path.cpp
@@ -292,7 +292,7 @@ public:
                samples and discontinuous visibility. We need to re-evaluate the
                BSDF differentiably with the detached sample in that case. */
             if (dr::grad_enabled(ls.ray)) {
-                ls.ray = dr::detach<true>(ls.ray);
+                ls.ray = dr::detach(ls.ray);
 
                 // Recompute 'wo' to propagate derivatives to cosine term
                 Vector3f wo_2 = si.to_local(ls.ray.d);
@@ -360,7 +360,7 @@ public:
         pdf_a *= pdf_a;
         pdf_b *= pdf_b;
         Float w = pdf_a / (pdf_a + pdf_b);
-        return dr::detach<true>(dr::select(dr::isfinite(w), w, 0.f));
+        return dr::detach(dr::select(dr::isfinite(w), w, 0.f));
     }
 
     /**

--- a/src/integrators/path.cpp
+++ b/src/integrators/path.cpp
@@ -199,7 +199,7 @@ public:
 
             // Fill out all information of the interaction
             SurfaceInteraction3f si =
-                ls.pi.compute_surface_interaction(ls.ray, +RayFlags::All);
+                ls.pi.compute_surface_interaction(ls.ray, +RayFlags::Default);
 
             // ---------------------- Direct emission ----------------------
 

--- a/src/integrators/ptracer.cpp
+++ b/src/integrators/ptracer.cpp
@@ -248,7 +248,7 @@ public:
             [](const LoopState& ls) { return ls.active; },
             [this, scene, sensor, block, sample_scale](LoopState& ls) {
 
-            SurfaceInteraction3f si = ls.pi.compute_surface_interaction(ls.ray, +RayFlags::All);
+            SurfaceInteraction3f si = ls.pi.compute_surface_interaction(ls.ray, +RayFlags::Default);
 
             BSDFPtr bsdf = si.bsdf(ls.ray);
 

--- a/src/integrators/volpath.cpp
+++ b/src/integrators/volpath.cpp
@@ -317,7 +317,7 @@ public:
                         PreliminaryIntersection3f pi =
                             Base::skip_area_emitters(scene, ray, true, skip_emitters);
                         SurfaceInteraction3f si_after_skip =
-                            pi.compute_surface_interaction(ray, +RayFlags::All, skip_emitters);
+                            pi.compute_surface_interaction(ray, +RayFlags::Default, skip_emitters);
                         dr::masked(si, skip_emitters) = si_after_skip;
                     }
                 }

--- a/src/integrators/volpathmis.cpp
+++ b/src/integrators/volpathmis.cpp
@@ -374,7 +374,7 @@ public:
                         PreliminaryIntersection3f pi =
                             Base::skip_area_emitters(scene, ray, true, skip_emitters);
                         SurfaceInteraction3f si_after_skip =
-                            pi.compute_surface_interaction(ray, +RayFlags::All, skip_emitters);
+                            pi.compute_surface_interaction(ray, +RayFlags::Default, skip_emitters);
                         dr::masked(si, skip_emitters) = si_after_skip;
                     }
                 }

--- a/src/python/python/ad/integrators/direct_projective.py
+++ b/src/python/python/ad/integrators/direct_projective.py
@@ -145,7 +145,7 @@ class DirectProjectiveIntegrator(PSIntegrator):
             si = si_shade
         else:
             with dr.resume_grad(when=not primal):
-                si = scene.ray_intersect(ray, ray_flags=mi.RayFlags.All,
+                si = scene.ray_intersect(ray, ray_flags=mi.RayFlags.Default,
                                          coherent=True, active=active)
 
         # Hide the environment emitter if necessary
@@ -331,7 +331,7 @@ class DirectProjectiveIntegrator(PSIntegrator):
             # The ray origin is wrong, but this is fine if we only need the primal
             # radiance
             si_fg = pi_fg.compute_surface_interaction(
-                dummy_ray, mi.RayFlags.All, active)
+                dummy_ray, mi.RayFlags.Default, active)
 
             # We know the incident direction is valid since this is the
             # foreground interaction. Overwrite the incident direction to avoid
@@ -362,7 +362,7 @@ class DirectProjectiveIntegrator(PSIntegrator):
             # The ray origin is wrong, but this is fine if we only need the primal
             # radiance
             si_fg = pi_fg.compute_surface_interaction(
-                dummy_ray, mi.RayFlags.All, active)
+                dummy_ray, mi.RayFlags.Default, active)
 
             # If smooth normals are used, it is possible that the computed
             # shading normal near visibility silhouette points to the wrong side
@@ -411,7 +411,7 @@ class DirectProjectiveIntegrator(PSIntegrator):
         ss_importance.d = -ss_importance.d
         ray_boundary = ss_importance.spawn_ray(wavelengths)
         si_boundary = scene.ray_intersect(ray_boundary,
-                                          ray_flags=mi.RayFlags.All,
+                                          ray_flags=mi.RayFlags.Default,
                                           coherent=False,
                                           reorder=True,
                                           active=active)

--- a/src/python/python/ad/integrators/prb.py
+++ b/src/python/python/ad/integrators/prb.py
@@ -127,7 +127,7 @@ class PRBIntegrator(RBIntegrator):
             # from differentiable shape parameters (position, normals, etc.)
             # In primal mode, this is just an ordinary ray tracing operation.
             with dr.resume_grad(when=not primal):
-                si = pi.compute_surface_interaction(ray, ray_flags=mi.RayFlags.All)
+                si = pi.compute_surface_interaction(ray, ray_flags=mi.RayFlags.Default)
 
                 # Recompute an attached si.wi to account for motion of the
                 # previous surface interaction

--- a/src/python/python/ad/integrators/prb_basic.py
+++ b/src/python/python/ad/integrators/prb_basic.py
@@ -108,12 +108,12 @@ class BasicPRBIntegrator(RBIntegrator):
             # from differentiable shape parameters (position, normals, etc.)
             # In primal mode, this is just an ordinary ray tracing operation.
             with dr.resume_grad(when=not primal):
-                si = pi.compute_surface_interaction(ray, ray_flags=mi.RayFlags.All)
+                si = pi.compute_surface_interaction(ray, ray_flags=mi.RayFlags.Default)
 
                 # Recompute an attached si.wi to account for motion of the
                 # previous surface interaction
                 if (not primal) & mi.Bool(depth >= 1):
-                    si_prev = pi_prev.compute_surface_interaction(ray_prev, ray_flags=mi.RayFlags.All)
+                    si_prev = pi_prev.compute_surface_interaction(ray_prev, ray_flags=mi.RayFlags.Default)
                     # We should not account for the current interaction's motion
                     si_detach = dr.detach(si)
                     wi_global = dr.normalize(si_prev.p - si_detach.p)
@@ -164,7 +164,7 @@ class BasicPRBIntegrator(RBIntegrator):
 
             if dr.hint(not primal, mode='scalar'):
                 si_next = pi_next.compute_surface_interaction(ray_next,
-                                                              ray_flags=mi.RayFlags.All,
+                                                              ray_flags=mi.RayFlags.Default,
                                                               active=active_next)
 
                 with dr.resume_grad():

--- a/src/python/python/ad/integrators/prb_projective.py
+++ b/src/python/python/ad/integrators/prb_projective.py
@@ -196,7 +196,7 @@ class PathProjectiveIntegrator(PSIntegrator):
             use_si_shade = ignore_ray & (depth == depth_init)
             with dr.resume_grad(when=not primal):
                 si = pi.compute_surface_interaction(ray,
-                                                    ray_flags=mi.RayFlags.All,
+                                                    ray_flags=mi.RayFlags.Default,
                                                     active=active_next & ~use_si_shade)
 
                 # Recompute an attached si.wi to account for motion of the
@@ -489,7 +489,7 @@ class PathProjectiveIntegrator(PSIntegrator):
         # The ray origin is wrong, but this is fine if we only need the primal
         # radiance
         si_fg = pi_fg.compute_surface_interaction(
-            dummy_ray, mi.RayFlags.All, active)
+            dummy_ray, mi.RayFlags.Default, active)
 
         # If smooth normals are used, it is possible that the computed
         # shading normal near visibility silhouette points to the wrong side
@@ -531,7 +531,7 @@ class PathProjectiveIntegrator(PSIntegrator):
         ss_importance.d = -ss_importance.d
         ray_boundary = ss_importance.spawn_ray(wavelengths)
         si_boundary = scene.ray_intersect(ray_boundary,
-                                          ray_flags=mi.RayFlags.All,
+                                          ray_flags=mi.RayFlags.Default,
                                           coherent=False,
                                           reorder=True,
                                           active=active)
@@ -596,7 +596,7 @@ class PathProjectiveIntegrator(PSIntegrator):
             # Get the next surface interaction
             ray_next = si_loop.spawn_ray(wo_bsdf_world)
             si_loop[active_loop] = scene.ray_intersect(ray_next,
-                                                       ray_flags=mi.RayFlags.All,
+                                                       ray_flags=mi.RayFlags.Default,
                                                        coherent=False,
                                                        reorder=dr.flag(dr.JitFlag.LoopRecord),
                                                        active=active_loop)

--- a/src/python/python/ad/integrators/prbvolpath.py
+++ b/src/python/python/ad/integrators/prbvolpath.py
@@ -227,7 +227,7 @@ class PRBVolpathIntegrator(RBIntegrator):
 
                     ray_skip = si.spawn_ray(ray.d)
                     pi = self.skip_area_emitters(scene, ray_skip, True, skip_emitters)
-                    si_after_skip = pi.compute_surface_interaction(ray, mi.RayFlags.All, skip_emitters)
+                    si_after_skip = pi.compute_surface_interaction(ray, mi.RayFlags.Default, skip_emitters)
                     si[skip_emitters] = si_after_skip
 
                 # ----------------- Intersection with emitters -----------------

--- a/src/python/python/ad/integrators/volprim_rf_basic.py
+++ b/src/python/python/ad/integrators/volprim_rf_basic.py
@@ -123,7 +123,7 @@ class BasicVolumetricPrimitiveRadianceFieldIntegrator(RBIntegrator):
             si = scene.ray_intersect(
                 ray,
                 coherent=(depth == 0),
-                ray_flags=mi.RayFlags.All,
+                ray_flags=mi.RayFlags.Default,
                 active=active,
             )
 

--- a/src/python/python/ad/projective.py
+++ b/src/python/python/ad/projective.py
@@ -225,8 +225,9 @@ class ProjectiveDetail():
         )
 
         # Get the intersection struct for the shape pointer
-        flags = mi.RayFlags.All | mi.RayFlags.dNSdUV
-        si = scene.ray_intersect(ray_seed, ray_flags=flags, coherent=True, active=active)
+        si = scene.ray_intersect(
+            ray_seed, ray_flags=mi.RayFlags.Default | mi.RayFlags.NormalPartials,
+            coherent=True, active=active)
         active &= si.is_valid()
 
         # Is the shape we hit being differentiated in this scene?
@@ -696,8 +697,9 @@ class ProjectiveDetail():
                     projected_p + projected_normal * mi.math.RayEpsilon,
                     -projected_normal
                 )
-                si = scene.ray_intersect(ray_new, mi.RayFlags.All | mi.RayFlags.dNSdUV,
-                                         coherent=False, active=loop_active)
+                si = scene.ray_intersect(
+                    ray_new, mi.RayFlags.Default | mi.RayFlags.NormalPartials,
+                    coherent=False, active=loop_active)
                 loop_active &= si.is_valid() & (si.shape == shape)
 
                 # Check if we hit a silhouette
@@ -738,7 +740,8 @@ class ProjectiveDetail():
             pi.shape = ss.shape
             dummy_ray = dr.zeros(mi.Ray3f, dr.width(ss))
             si_jump = pi.compute_surface_interaction(
-                dummy_ray, mi.RayFlags.All | mi.RayFlags.dNSdUV, active=active)
+                dummy_ray, mi.RayFlags.Default | mi.RayFlags.NormalPartials,
+                active=active)
 
             # Perform the jump operation
             ss_jump, valid_jump = self.mesh_jump(scene, si_jump, viewpoint, sampler.state, active_jump, 1)

--- a/src/python/python/test/util.py
+++ b/src/python/python/test/util.py
@@ -172,3 +172,83 @@ def check_vectorization(kernel, arg_dims = [], width = 125, atol=1e-6,
         # Compare results
         for i in range(len(results_scalar)):
             assert dr.allclose(results_vec[i], np.transpose(results_scalar[i]), atol=atol)
+
+
+def curved_triangle(flip_normals=False, texcoords=True):
+    """
+    Build a single triangle whose randomly generated vertex normals give it
+    curvature, and return an exact model of its shading normal along with it.
+
+    Parameter ``texcoords`` (bool):
+        Assign a random parameterization, which is not the barycentric one.
+
+    Returns a ``(mesh, normal_field)`` pair, where ``normal_field(u, v)``
+    evaluates the unit shading normal in double precision.
+    """
+    import numpy as np
+    import mitsuba as mi
+
+    props = mi.Properties()
+    props['flip_normals'] = flip_normals
+    mesh = mi.Mesh("curved_triangle", 3, 1, props, has_vertex_normals=True,
+                   has_vertex_texcoords=texcoords)
+
+    rng = np.random.default_rng(0)
+    p = mi.traverse(mesh)
+    p['faces'] = [0, 1, 2]
+    p['vertex_positions'] = [0, 0, 0,  1, 0, 0,  0, 1, 0]
+    # Tilt the normals away from the triangle's own, but keep them on its side
+    p['vertex_normals'] = (rng.normal(size=(3, 3)) + [0, 0, 4]).ravel()
+    if texcoords:
+        p['vertex_texcoords'] = rng.random(6)
+    p.update()
+
+    # Without texture coordinates the parameterization is barycentric, which
+    # the identity below turns into the same change of variables
+    n = np.array(p['vertex_normals'], dtype=np.float64).reshape(3, 3)
+    uv = (np.array(p['vertex_texcoords'], dtype=np.float64).reshape(3, 2)
+          if texcoords else np.array([[0., 0.], [1., 0.], [0., 1.]]))
+    to_bary = np.linalg.inv(np.column_stack((uv[1] - uv[0], uv[2] - uv[0])))
+
+    def normal_field(u, v):
+        b = to_bary @ (np.array([u, v]) - uv[0])
+        ni = (1 - b[0] - b[1]) * n[0] + b[0] * n[1] + b[1] * n[2]
+        return (-1 if flip_normals else 1) * ni / np.linalg.norm(ni)
+
+    return mesh, normal_field
+
+
+def check_normal_partials(si, normal_field, to_world=None, h=1e-3, rtol=2e-3):
+    """
+    Check ``si.dn_du``/``si.dn_dv`` against central differences of an exact
+    normal field, and return the relative error.
+
+    Parameter ``normal_field`` (callable):
+        Maps ``(u, v)`` to the unit shading normal, in double precision.
+
+    Parameter ``to_world`` (``mi.ScalarTransform4f``):
+        If given, map the field to world space through the inverse transpose,
+        as a shape's ``to_world`` or an instance transform does.
+    """
+    import numpy as np
+
+    field = normal_field
+    if to_world is not None:
+        N = np.linalg.inv(np.array(to_world.matrix, dtype=np.float64)[:3, :3]).T
+
+        def field(u, v):
+            n = N @ normal_field(u, v)
+            return n / np.linalg.norm(n)
+
+    u, v = float(si.uv[0]), float(si.uv[1])
+    ref = [(field(u + h, v) - field(u - h, v)) / (2 * h),
+           (field(u, v + h) - field(u, v - h)) / (2 * h)]
+
+    scale = max(np.linalg.norm(ref[0]), np.linalg.norm(ref[1]), 1.0)
+    err = max(np.abs(np.array(d).ravel() - r).max()
+              for d, r in zip((si.dn_du, si.dn_dv), ref)) / scale
+
+    assert err < rtol, (f"normal partials at uv=({u}, {v}) are off by {err}:\n"
+                        f"  dn_du = {si.dn_du}, expected {ref[0]}\n"
+                        f"  dn_dv = {si.dn_dv}, expected {ref[1]}")
+    return err

--- a/src/render/mesh.cpp
+++ b/src/render/mesh.cpp
@@ -1577,10 +1577,12 @@ Mesh<Float, Spectrum>::compute_surface_interaction(const Ray3f &ray,
     // Texture coordinates (if available)
     si.uv = Point2f(b1, b2);
 
-    std::tie(si.dp_du, si.dp_dv) = coordinate_system(si.n);
-
     Vector3f dp0 = p1 - p0,
              dp1 = p2 - p0;
+
+    // Without texture coordinates the parameterization is barycentric
+    si.dp_du = p1 - p0;
+    si.dp_dv = p2 - p0;
 
     if (has_vertex_texcoords() &&
         likely(has_flag(ray_flags, RayFlags::UV) ||
@@ -1597,6 +1599,9 @@ Mesh<Float, Spectrum>::compute_surface_interaction(const Ray3f &ray,
         si.uv = dr::fmadd(uv2, b2, dr::fmadd(uv1, b1, uv0 * b0));
 
         if (likely(has_flag(ray_flags, RayFlags::dPdUV))) {
+            // Fall back to an arbitrary basis for degenerate parameterizations
+            std::tie(si.dp_du, si.dp_dv) = coordinate_system(si.n);
+
             Vector2f duv0 = uv1 - uv0,
                      duv1 = uv2 - uv0;
 

--- a/src/render/mesh.cpp
+++ b/src/render/mesh.cpp
@@ -1577,13 +1577,6 @@ Mesh<Float, Spectrum>::compute_surface_interaction(const Ray3f &ray,
     // Texture coordinates (if available)
     si.uv = Point2f(b1, b2);
 
-    Vector3f dp0 = p1 - p0,
-             dp1 = p2 - p0;
-
-    // Without texture coordinates the parameterization is barycentric
-    si.dp_du = p1 - p0;
-    si.dp_dv = p2 - p0;
-
     if (has_vertex_texcoords() &&
         likely(has_flag(ray_flags, RayFlags::UV) ||
                has_flag(ray_flags, RayFlags::dPdUV))) {
@@ -1602,6 +1595,8 @@ Mesh<Float, Spectrum>::compute_surface_interaction(const Ray3f &ray,
             // Fall back to an arbitrary basis for degenerate parameterizations
             std::tie(si.dp_du, si.dp_dv) = coordinate_system(si.n);
 
+            Vector3f dp0 = p1 - p0,
+                     dp1 = p2 - p0;
             Vector2f duv0 = uv1 - uv0,
                      duv1 = uv2 - uv0;
 
@@ -1613,6 +1608,10 @@ Mesh<Float, Spectrum>::compute_surface_interaction(const Ray3f &ray,
             si.dp_du[valid] = dr::fmsub( duv1.y(), dp0, duv0.y() * dp1) * inv_det;
             si.dp_dv[valid] = dr::fnmadd(duv1.x(), dp0, duv0.x() * dp1) * inv_det;
         }
+    } else if (likely(has_flag(ray_flags, RayFlags::dPdUV))) {
+        // Without texture coordinates the parameterization is barycentric
+        si.dp_du = p1 - p0;
+        si.dp_dv = p2 - p0;
     }
 
     // Fetch shading normal (if available)

--- a/src/render/mesh.cpp
+++ b/src/render/mesh.cpp
@@ -1575,9 +1575,17 @@ Mesh<Float, Spectrum>::compute_surface_interaction(const Ray3f &ray,
     // Texture coordinates (if available)
     si.uv = Point2f(b1, b2);
 
+    /* The position and normal partials are both derivatives of the
+       parameterization reported in ``si.uv``, hence they share the change of
+       variables from the barycentric coordinates */
+    bool need_dn_duv = has_flag(ray_flags, RayFlags::dNSdUV),
+         need_jac    = need_dn_duv || has_flag(ray_flags, RayFlags::dPdUV);
+
+    Vector2f duv0 = 0.f, duv1 = 0.f;
+    Float inv_det = 0.f;
+
     if (has_vertex_texcoords() &&
-        likely(has_flag(ray_flags, RayFlags::UV) ||
-               has_flag(ray_flags, RayFlags::dPdUV))) {
+        likely(has_flag(ray_flags, RayFlags::UV) || need_jac)) {
         Point2f uv0 = vertex_texcoord(fi[0], active),
                 uv1 = vertex_texcoord(fi[1], active),
                 uv2 = vertex_texcoord(fi[2], active);
@@ -1589,22 +1597,21 @@ Mesh<Float, Spectrum>::compute_surface_interaction(const Ray3f &ray,
 
         si.uv = dr::fmadd(uv2, b2, dr::fmadd(uv1, b1, uv0 * b0));
 
-        if (likely(has_flag(ray_flags, RayFlags::dPdUV))) {
-            // Fall back to an arbitrary basis for degenerate parameterizations
-            std::tie(si.dp_du, si.dp_dv) = coordinate_system(si.n);
+        if (likely(need_jac)) {
+            duv0 = uv1 - uv0;
+            duv1 = uv2 - uv0;
 
+            Float det = dr::fmsub(duv0.x(), duv1.y(), duv0.y() * duv1.x());
+            inv_det   = dr::select(det != 0.f, dr::rcp(det), 0.f);
+        }
+
+        if (likely(has_flag(ray_flags, RayFlags::dPdUV))) {
             Vector3f dp0 = p1 - p0,
                      dp1 = p2 - p0;
-            Vector2f duv0 = uv1 - uv0,
-                     duv1 = uv2 - uv0;
 
-            Float det     = dr::fmsub(duv0.x(), duv1.y(), duv0.y() * duv1.x()),
-                  inv_det = dr::rcp(det);
-
-            Mask valid = (det != 0.f);
-
-            si.dp_du[valid] = dr::fmsub( duv1.y(), dp0, duv0.y() * dp1) * inv_det;
-            si.dp_dv[valid] = dr::fnmadd(duv1.x(), dp0, duv0.x() * dp1) * inv_det;
+            // Change of variables to the texture parameterization
+            si.dp_du = dr::fmsub( duv1.y(), dp0, duv0.y() * dp1) * inv_det;
+            si.dp_dv = dr::fnmadd(duv1.x(), dp0, duv0.x() * dp1) * inv_det;
         }
     } else if (likely(has_flag(ray_flags, RayFlags::dPdUV))) {
         // Without texture coordinates the parameterization is barycentric
@@ -1637,18 +1644,29 @@ Mesh<Float, Spectrum>::compute_surface_interaction(const Ray3f &ray,
 
         si.sh_frame.n = n;
 
-        if (has_flag(ray_flags, RayFlags::dNSdUV)) {
-            /* Now compute the derivative of "normalize(u*n1 + v*n2 + (1-u-v)*n0)"
-               with respect to [u, v] in the local triangle parameterization.
+        if (need_dn_duv) {
+            /* Derivative of "normalize(b0*n0 + b1*n1 + b2*n2)" with respect to
+               the barycentric coordinates. Since d/du [f(u)/|f(u)|] =
+               [d/du f(u)]/|f(u)| - f(u)/|f(u)|^3 <f(u), d/du f(u)> */
+            Vector3f dn_db1 = (n1 - n0) * il,
+                     dn_db2 = (n2 - n0) * il;
 
-               Since d/du [f(u)/|f(u)|] = [d/du f(u)]/|f(u)|
-                   - f(u)/|f(u)|^3 <f(u), d/du f(u)>, this results in
-            */
-            si.dn_du = (n1 - n0) * il;
-            si.dn_dv = (n2 - n0) * il;
+            dn_db1 = dr::fnmadd(n, dr::dot(n, dn_db1), dn_db1);
+            dn_db2 = dr::fnmadd(n, dr::dot(n, dn_db2), dn_db2);
 
-            si.dn_du = dr::fnmadd(n, dr::dot(n, si.dn_du), si.dn_du);
-            si.dn_dv = dr::fnmadd(n, dr::dot(n, si.dn_dv), si.dn_dv);
+            if (m_flip_normals) {
+                dn_db1 = -dn_db1;
+                dn_db2 = -dn_db2;
+            }
+
+            if (has_vertex_texcoords()) {
+                // Change of variables to the texture parameterization
+                si.dn_du = dr::fmsub( duv1.y(), dn_db1, duv0.y() * dn_db2) * inv_det;
+                si.dn_dv = dr::fnmadd(duv1.x(), dn_db1, duv0.x() * dn_db2) * inv_det;
+            } else {
+                si.dn_du = dn_db1;
+                si.dn_dv = dn_db2;
+            }
         } else {
             si.dn_du = si.dn_dv = dr::zeros<Vector3f>();
         }

--- a/src/render/mesh.cpp
+++ b/src/render/mesh.cpp
@@ -1325,7 +1325,7 @@ Mesh<Float, Spectrum>::precompute_silhouette(
             Pt3f v0           = dr::load<Pt3f>(V + 3 * idx.x());
             Pt3f v1           = dr::load<Pt3f>(V + 3 * idx.y());
             Pt3f v2           = dr::load<Pt3f>(V + 3 * idx.z());
-            Vec3f n           = dr::normalize(dr::cross(v1 - v0, v2 - v0));
+            Vec3f n           = face_normal(v0, v1, v2);
 
             Vec3f to_v0 = dr::normalize(v0 - viewpoint);
             Vec3f to_v1 = dr::normalize(v1 - viewpoint);
@@ -1348,8 +1348,7 @@ Mesh<Float, Spectrum>::precompute_silhouette(
                     Pt3f v0_oppo = dr::load<Pt3f>(V + 3 * v_idx_oppo.x());
                     Pt3f v1_oppo = dr::load<Pt3f>(V + 3 * v_idx_oppo.y());
                     Pt3f v2_oppo = dr::load<Pt3f>(V + 3 * v_idx_oppo.z());
-                    Vec3f n_oppo = dr::normalize(
-                        dr::cross(v1_oppo - v0_oppo, v2_oppo - v0_oppo));
+                    Vec3f n_oppo = face_normal(v0_oppo, v1_oppo, v2_oppo);
 
                     if (dr::dot(dir1, n) * dr::dot(dir1, n_oppo) <= 0.f &&
                         dr::abs(dr::dot(n, n_oppo)) < 1.f) {
@@ -1571,8 +1570,7 @@ Mesh<Float, Spectrum>::compute_surface_interaction(const Ray3f &ray,
 
     si.t = dr::select(active, t, dr::Infinity<Float>);
 
-    // Face normal
-    si.n = face_normal(pi.prim_index, active);
+    si.n = face_normal(p0, p1, p2);
 
     // Texture coordinates (if available)
     si.uv = Point2f(b1, b2);

--- a/src/render/mesh.cpp
+++ b/src/render/mesh.cpp
@@ -1502,6 +1502,7 @@ Mesh<Float, Spectrum>::compute_surface_interaction(const Ray3f &ray,
         return dr::zeros<SurfaceInteraction3f>();
 
     constexpr bool IsDiff = dr::is_diff_v<Float>;
+    bool detach = IsDiff && has_flag(ray_flags, RayFlags::DetachShape);
 
     Vector3u fi = face_indices(pi.prim_index, active);
 
@@ -1509,66 +1510,48 @@ Mesh<Float, Spectrum>::compute_surface_interaction(const Ray3f &ray,
             p1 = vertex_position(fi[1], active),
             p2 = vertex_position(fi[2], active);
 
-    Float t = pi.t;
-    Point2f prim_uv = pi.prim_uv;
-
-    if constexpr (IsDiff) {
-        /* On a high level, the computed surface interaction has gradients
-           attached due to (1) ray.o, (2) ray.d, (3) motion of the intersected
-           triangle.
-           Moeller and Trumbore method bridges the gradients at 'ray' and the
-           computed surface interaction. But the effects of the third part
-           remains ambiguous. 'DetachShape' explicitly detaches the three
-           vertices, which is equivalent to computing a 'hit point' of a laser
-           characterized by 'ray'. 'FollowShape' on the other hand first finds
-           the 'hit point', then glues the interaction point with the
-           intersected triangle. For this reason, it no longer tracks
-           infinitesimal changes of the laser ('ray') itself.
-           Note that these two flags not only affects the interaction point
-           position, but also the distance and local differential geometry. */
-        if (has_flag(ray_flags, RayFlags::DetachShape) &&
-            has_flag(ray_flags, RayFlags::FollowShape))
-            Throw("Invalid combination of RayFlags: DetachShape | FollowShape");
-
-        if (has_flag(ray_flags, RayFlags::DetachShape)) {
-            p0 = dr::detach<true>(p0);
-            p1 = dr::detach<true>(p1);
-            p2 = dr::detach<true>(p2);
-        }
-
-        /* When either the input ray or the vertex positions (p0, p1, p2) have
-           gradient tracking enabled, we need to perform a differentiable
-           ray-triangle intersection (done here via the method by Moeller and
-           Trumbore). The result is mapped through `dr::replace_grad` so that we
-           don't actually recompute the primal intersection but only use the
-           intersection computation graph for derivative tracking (this assumes
-           that the function is eventually differentiated). When the
-           'FollowShape' ray flag is specified, we skip this part since the
-           intersection position should be rigidly attached to the mesh. */
-        if (dr::grad_enabled(p0, p1, p2, ray.o, ray.d /* <- any enabled? */) &&
-            !has_flag(ray_flags, RayFlags::FollowShape)) {
-            auto [t_d, prim_uv_d, hit] =
-                moeller_trumbore(ray, p0, p1, p2);
-
-            prim_uv = dr::replace_grad(prim_uv, prim_uv_d);
-            t = dr::replace_grad(t, t_d);
-        }
+    if (detach) {
+        p0 = dr::detach(p0);
+        p1 = dr::detach(p1);
+        p2 = dr::detach(p2);
     }
 
-    Float b1 = prim_uv.x(),
-          b2 = prim_uv.y(),
+    Float b1 = pi.prim_uv.x(),
+          b2 = pi.prim_uv.y(),
           b0 = 1.f - b1 - b2;
 
     SurfaceInteraction3f si = dr::zeros<SurfaceInteraction3f>();
 
-    // Re-interpolate intersection using barycentric coordinates
-    si.p = dr::fmadd(p0, b0, dr::fmadd(p1, b1, p2 * b2));
+    // Surface position at the detached barycentric coordinates
+    Point3f p_att = dr::fmadd(p0, b0, dr::fmadd(p1, b1, p2 * b2));
 
-    // Potentially recompute the distance traveled to the surface interaction hit point
-    if (IsDiff && has_flag(ray_flags, RayFlags::FollowShape))
-        t = dr::sqrt(dr::squared_norm(si.p - ray.o) / dr::squared_norm(ray.d));
+    si.t = pi.t;
+    si.p = dr::detach(p_att);
+    si.n = dr::detach(face_normal(p0, p1, p2));
 
-    si.t = dr::select(active, t, dr::Infinity<Float>);
+    si.attach_motion(ray, p_att, ray_flags);
+
+    if constexpr (IsDiff) {
+        /* Let the barycentric coordinates follow the sliding of the
+           interaction point across the moving triangle */
+        if (!has_flag(ray_flags, RayFlags::FollowShape) &&
+            dr::grad_enabled(p0, p1, p2, ray.o, ray.d)) {
+            Vector3f du  = p1 - p0,
+                     dv  = p2 - p0,
+                     rel = si.p - p_att;
+
+            Float a11 = dr::dot(du, du), a12 = dr::dot(du, dv),
+                  a22 = dr::dot(dv, dv),
+                  inv_det = dr::rcp(dr::fmsub(a11, a22, a12 * a12)),
+                  r1 = dr::dot(du, rel), r2 = dr::dot(dv, rel);
+
+            b1 = dr::replace_grad(b1, b1 + dr::fmsub (a22, r1, a12 * r2) * inv_det);
+            b2 = dr::replace_grad(b2, b2 + dr::fnmadd(a12, r1, a11 * r2) * inv_det);
+            b0 = 1.f - b1 - b2;
+        }
+    }
+
+    si.t = dr::select(active, si.t, dr::Infinity<Float>);
 
     si.n = face_normal(p0, p1, p2);
 
@@ -1576,7 +1559,6 @@ Mesh<Float, Spectrum>::compute_surface_interaction(const Ray3f &ray,
         si.n = -si.n;
 
     if (likely(has_flag(ray_flags, RayFlags::Shading))) {
-        bool detach  = IsDiff && has_flag(ray_flags, RayFlags::DetachShape);
         bool need_dn = has_vertex_normals() &&
                        has_flag(ray_flags, RayFlags::NormalPartials);
 
@@ -1587,10 +1569,11 @@ Mesh<Float, Spectrum>::compute_surface_interaction(const Ray3f &ray,
             Normal3f n0 = vertex_normal(fi[0], active),
                      n1 = vertex_normal(fi[1], active),
                      n2 = vertex_normal(fi[2], active);
+
             if (detach) {
-                n0 = dr::detach<true>(n0);
-                n1 = dr::detach<true>(n1);
-                n2 = dr::detach<true>(n2);
+                n0 = dr::detach(n0);
+                n1 = dr::detach(n1);
+                n2 = dr::detach(n2);
             }
 
             Normal3f n = dr::fmadd(n2, b2, dr::fmadd(n1, b1, n0 * b0));
@@ -1620,10 +1603,11 @@ Mesh<Float, Spectrum>::compute_surface_interaction(const Ray3f &ray,
             Point2f uv0 = vertex_texcoord(fi[0], active),
                     uv1 = vertex_texcoord(fi[1], active),
                     uv2 = vertex_texcoord(fi[2], active);
+
             if (detach) {
-                uv0 = dr::detach<true>(uv0);
-                uv1 = dr::detach<true>(uv1);
-                uv2 = dr::detach<true>(uv2);
+                uv0 = dr::detach(uv0);
+                uv1 = dr::detach(uv1);
+                uv2 = dr::detach(uv2);
             }
 
             si.uv = dr::fmadd(uv2, b2, dr::fmadd(uv1, b1, uv0 * b0));

--- a/src/render/mesh.cpp
+++ b/src/render/mesh.cpp
@@ -1572,111 +1572,91 @@ Mesh<Float, Spectrum>::compute_surface_interaction(const Ray3f &ray,
 
     si.n = face_normal(p0, p1, p2);
 
-    // Texture coordinates (if available)
-    si.uv = Point2f(b1, b2);
+    if (m_flip_normals)
+        si.n = -si.n;
 
-    /* The position and normal partials are both derivatives of the
-       parameterization reported in ``si.uv``, hence they share the change of
-       variables from the barycentric coordinates */
-    bool need_dn_duv = has_flag(ray_flags, RayFlags::dNSdUV),
-         need_jac    = need_dn_duv || has_flag(ray_flags, RayFlags::dPdUV);
+    if (likely(has_flag(ray_flags, RayFlags::Shading))) {
+        bool detach  = IsDiff && has_flag(ray_flags, RayFlags::DetachShape);
+        bool need_dn = has_vertex_normals() &&
+                       has_flag(ray_flags, RayFlags::NormalPartials);
 
-    Vector2f duv0 = 0.f, duv1 = 0.f;
-    Float inv_det = 0.f;
+        // Shading normal, and its partials wrt. the barycentric coordinates
+        Vector3f dn_db1 = 0.f, dn_db2 = 0.f;
 
-    if (has_vertex_texcoords() &&
-        likely(has_flag(ray_flags, RayFlags::UV) || need_jac)) {
-        Point2f uv0 = vertex_texcoord(fi[0], active),
-                uv1 = vertex_texcoord(fi[1], active),
-                uv2 = vertex_texcoord(fi[2], active);
-        if (IsDiff && has_flag(ray_flags, RayFlags::DetachShape)) {
-            uv0 = dr::detach<true>(uv0);
-            uv1 = dr::detach<true>(uv1);
-            uv2 = dr::detach<true>(uv2);
-        }
-
-        si.uv = dr::fmadd(uv2, b2, dr::fmadd(uv1, b1, uv0 * b0));
-
-        if (likely(need_jac)) {
-            duv0 = uv1 - uv0;
-            duv1 = uv2 - uv0;
-
-            Float det = dr::fmsub(duv0.x(), duv1.y(), duv0.y() * duv1.x());
-            inv_det   = dr::select(det != 0.f, dr::rcp(det), 0.f);
-        }
-
-        if (likely(has_flag(ray_flags, RayFlags::dPdUV))) {
-            Vector3f dp0 = p1 - p0,
-                     dp1 = p2 - p0;
-
-            // Change of variables to the texture parameterization
-            si.dp_du = dr::fmsub( duv1.y(), dp0, duv0.y() * dp1) * inv_det;
-            si.dp_dv = dr::fnmadd(duv1.x(), dp0, duv0.x() * dp1) * inv_det;
-        }
-    } else if (likely(has_flag(ray_flags, RayFlags::dPdUV))) {
-        // Without texture coordinates the parameterization is barycentric
-        si.dp_du = p1 - p0;
-        si.dp_dv = p2 - p0;
-    }
-
-    // Fetch shading normal (if available)
-    Normal3f n0, n1, n2;
-    if (has_vertex_normals() &&
-        likely(has_flag(ray_flags, RayFlags::ShadingFrame) ||
-               has_flag(ray_flags, RayFlags::dNSdUV))) {
-        n0 = vertex_normal(fi[0], active);
-        n1 = vertex_normal(fi[1], active);
-        n2 = vertex_normal(fi[2], active);
-    }
-
-    if (has_vertex_normals() &&
-        likely(has_flag(ray_flags, RayFlags::ShadingFrame) ||
-               has_flag(ray_flags, RayFlags::dNSdUV))) {
-        if (IsDiff && has_flag(ray_flags, RayFlags::DetachShape)) {
-            n0 = dr::detach<true>(n0);
-            n1 = dr::detach<true>(n1);
-            n2 = dr::detach<true>(n2);
-        }
-
-        Normal3f n = dr::fmadd(n2, b2, dr::fmadd(n1, b1, n0 * b0));
-        Float il = dr::rsqrt(dr::squared_norm(n));
-        n *= il;
-
-        si.sh_frame.n = n;
-
-        if (need_dn_duv) {
-            /* Derivative of "normalize(b0*n0 + b1*n1 + b2*n2)" with respect to
-               the barycentric coordinates. Since d/du [f(u)/|f(u)|] =
-               [d/du f(u)]/|f(u)| - f(u)/|f(u)|^3 <f(u), d/du f(u)> */
-            Vector3f dn_db1 = (n1 - n0) * il,
-                     dn_db2 = (n2 - n0) * il;
-
-            dn_db1 = dr::fnmadd(n, dr::dot(n, dn_db1), dn_db1);
-            dn_db2 = dr::fnmadd(n, dr::dot(n, dn_db2), dn_db2);
-
-            if (m_flip_normals) {
-                dn_db1 = -dn_db1;
-                dn_db2 = -dn_db2;
+        if (has_vertex_normals()) {
+            Normal3f n0 = vertex_normal(fi[0], active),
+                     n1 = vertex_normal(fi[1], active),
+                     n2 = vertex_normal(fi[2], active);
+            if (detach) {
+                n0 = dr::detach<true>(n0);
+                n1 = dr::detach<true>(n1);
+                n2 = dr::detach<true>(n2);
             }
 
-            if (has_vertex_texcoords()) {
-                // Change of variables to the texture parameterization
-                si.dn_du = dr::fmsub( duv1.y(), dn_db1, duv0.y() * dn_db2) * inv_det;
-                si.dn_dv = dr::fnmadd(duv1.x(), dn_db1, duv0.x() * dn_db2) * inv_det;
-            } else {
+            Normal3f n = dr::fmadd(n2, b2, dr::fmadd(n1, b1, n0 * b0));
+            Float il = dr::rsqrt(dr::squared_norm(n));
+            n *= il;
+
+            si.sh_frame.n = m_flip_normals ? -n : n;
+
+            if (need_dn) {
+                /* Derivative of ``normalize(b0*n0 + b1*n1 + b2*n2)``. Since
+                   d/du [f(u)/|f(u)|] = [d/du f(u)]/|f(u)|
+                       - f(u)/|f(u)|^3 <f(u), d/du f(u)>, this results in */
+                dn_db1 = dr::fnmadd(n, dr::dot(n, (n1 - n0) * il), (n1 - n0) * il);
+                dn_db2 = dr::fnmadd(n, dr::dot(n, (n2 - n0) * il), (n2 - n0) * il);
+
+                if (m_flip_normals) {
+                    dn_db1 = -dn_db1;
+                    dn_db2 = -dn_db2;
+                }
+            }
+        } else {
+            si.sh_frame.n = si.n;
+        }
+
+        // Texture coordinates and the associated partials
+        if (has_vertex_texcoords()) {
+            Point2f uv0 = vertex_texcoord(fi[0], active),
+                    uv1 = vertex_texcoord(fi[1], active),
+                    uv2 = vertex_texcoord(fi[2], active);
+            if (detach) {
+                uv0 = dr::detach<true>(uv0);
+                uv1 = dr::detach<true>(uv1);
+                uv2 = dr::detach<true>(uv2);
+            }
+
+            si.uv = dr::fmadd(uv2, b2, dr::fmadd(uv1, b1, uv0 * b0));
+
+            Vector2f duv0 = uv1 - uv0,
+                     duv1 = uv2 - uv0;
+
+            Float det     = dr::fmsub(duv0.x(), duv1.y(), duv0.y() * duv1.x()),
+                  inv_det = dr::select(det != 0.f, dr::rcp(det), 0.f);
+
+            /* Change of variables from the barycentric coordinates to the
+               texture parameterization */
+            auto to_uv_basis = [&](const Vector3f &d1, const Vector3f &d2) {
+                return std::make_pair(
+                    Vector3f(dr::fmsub( duv1.y(), d1, duv0.y() * d2) * inv_det),
+                    Vector3f(dr::fnmadd(duv1.x(), d1, duv0.x() * d2) * inv_det));
+            };
+
+            std::tie(si.dp_du, si.dp_dv) = to_uv_basis(p1 - p0, p2 - p0);
+
+            if (need_dn)
+                std::tie(si.dn_du, si.dn_dv) = to_uv_basis(dn_db1, dn_db2);
+        } else {
+            // Without texture coordinates the parameterization is barycentric
+            si.uv    = Point2f(b1, b2);
+            si.dp_du = p1 - p0;
+            si.dp_dv = p2 - p0;
+
+            if (need_dn) {
                 si.dn_du = dn_db1;
                 si.dn_dv = dn_db2;
             }
-        } else {
-            si.dn_du = si.dn_dv = dr::zeros<Vector3f>();
         }
-    } else {
-        si.sh_frame.n = si.n;
-    }
-
-    if (m_flip_normals) {
-        si.n = -si.n;
-        si.sh_frame.n = -si.sh_frame.n;
     }
 
     si.prim_index = pi.prim_index;

--- a/src/render/python/interaction.cpp
+++ b/src/render/python/interaction.cpp
@@ -7,7 +7,6 @@ MI_PY_EXPORT(RayFlags) {
         .def_value(RayFlags, Minimal)
         .def_value(RayFlags, UV)
         .def_value(RayFlags, dPdUV)
-        .def_value(RayFlags, dNGdUV)
         .def_value(RayFlags, dNSdUV)
         .def_value(RayFlags, ShadingFrame)
         .def_value(RayFlags, FollowShape)

--- a/src/render/python/interaction.cpp
+++ b/src/render/python/interaction.cpp
@@ -3,14 +3,12 @@
 
 MI_PY_EXPORT(RayFlags) {
     auto e = nb::enum_<RayFlags>(m, "RayFlags", nb::is_arithmetic(), D(RayFlags))
-        .def_value(RayFlags, Empty)
         .def_value(RayFlags, Minimal)
-        .def_value(RayFlags, UV)
-        .def_value(RayFlags, dPdUV)
-        .def_value(RayFlags, dNSdUV)
-        .def_value(RayFlags, ShadingFrame)
+        .def_value(RayFlags, Shading)
+        .def_value(RayFlags, NormalPartials)
+        .def_value(RayFlags, Default)
+        // Spelled out to avoid a deprecation warning for ``RayFlags::All``
+        .value("All", RayFlags::Shading, D(RayFlags, All))
         .def_value(RayFlags, FollowShape)
-        .def_value(RayFlags, DetachShape)
-        .def_value(RayFlags, All)
-        .def_value(RayFlags, AllNonDifferentiable);
+        .def_value(RayFlags, DetachShape);
 }

--- a/src/render/python/interaction_v.cpp
+++ b/src/render/python/interaction_v.cpp
@@ -150,7 +150,7 @@ MI_PY_EXPORT(PreliminaryIntersection) {
                        std::forward<const Ray3f&>(ray), ray_flags, active);
            },
            D(PreliminaryIntersection, compute_surface_interaction),
-           "ray"_a, "ray_flags"_a = +RayFlags::All, "active"_a = true)
+           "ray"_a, "ray_flags"_a = +RayFlags::Default, "active"_a = true)
         .def("zero_", &PreliminaryIntersection3f::zero_, D(PreliminaryIntersection, zero))
         .def_repr(PreliminaryIntersection3f);
 

--- a/src/render/python/interaction_v.cpp
+++ b/src/render/python/interaction_v.cpp
@@ -57,8 +57,6 @@ MI_PY_EXPORT(SurfaceInteraction) {
         .def(nb::init<const SurfaceInteraction3f &>(), "Copy constructor")
         .def(nb::init<const PositionSample3f &, const Wavelength &>(), "ps"_a,
             "wavelengths"_a, D(SurfaceInteraction, SurfaceInteraction))
-        .def("initialize_sh_frame", &SurfaceInteraction3f::initialize_sh_frame,
-            D(SurfaceInteraction, initialize_sh_frame))
         .def("to_world", &SurfaceInteraction3f::to_world, "v"_a, D(SurfaceInteraction, to_world))
         .def("to_local", &SurfaceInteraction3f::to_local, "v"_a, D(SurfaceInteraction, to_local))
         .def("to_world_mueller", &SurfaceInteraction3f::to_world_mueller, "M_local"_a,

--- a/src/render/python/shape_v.cpp
+++ b/src/render/python/shape_v.cpp
@@ -13,6 +13,7 @@
 #include <nanobind/stl/string_view.h>
 #include <nanobind/stl/vector.h>
 #include <nanobind/stl/tuple.h>
+#include <nanobind/stl/pair.h>
 #include <nanobind/stl/optional.h>
 #include <drjit/python.h>
 
@@ -113,7 +114,7 @@ template <typename Ptr, typename Cls> void bind_shape_generic(Cls &cls) {
                Mask active) {
                 return shape->compute_surface_interaction(ray, pi, ray_flags, 0, active);
             },
-            "ray"_a, "pi"_a, "ray_flags"_a = +RayFlags::All,
+            "ray"_a, "pi"_a, "ray_flags"_a = +RayFlags::Default,
             "active"_a = true, D(Shape, compute_surface_interaction))
        .def("has_attribute",
             [](Ptr shape, const std::string &name, const Mask &active) {
@@ -153,7 +154,7 @@ template <typename Ptr, typename Cls> void bind_shape_generic(Cls &cls) {
             [](Ptr shape, const Ray3f &ray, uint32_t flags, const Mask &active) {
                 return shape->ray_intersect(ray, flags, active);
             },
-            "ray"_a, "ray_flags"_a = +RayFlags::All, "active"_a = true,
+            "ray"_a, "ray_flags"_a = +RayFlags::Default, "active"_a = true,
             D(Shape, ray_intersect))
        .def("ray_test",
             [](Ptr shape, const Ray3f &ray, const Mask &active) {
@@ -229,7 +230,7 @@ template <typename Ptr, typename Cls> void bind_shape_generic(Cls &cls) {
             [](Ptr shape, const Point2f &uv, uint32_t ray_flags, Mask active) {
                 return shape->eval_parameterization(uv, ray_flags, active);
             },
-            "uv"_a, "ray_flags"_a = +RayFlags::All, "active"_a = true,
+            "uv"_a, "ray_flags"_a = +RayFlags::Default, "active"_a = true,
             D(Shape, eval_parameterization))
        .def("surface_area",
             [](Ptr shape) {

--- a/src/render/scene_native.inl
+++ b/src/render/scene_native.inl
@@ -223,7 +223,7 @@ NativeAccel<Float, Spectrum>::ray_intersect_naive(
     PreliminaryIntersection3f pi =
         accel->template ray_intersect_naive<false>(ray, active);
 
-    return pi.compute_surface_interaction(ray, +RayFlags::All, active);
+    return pi.compute_surface_interaction(ray, +RayFlags::Default, active);
 }
 
 NAMESPACE_END(mitsuba)

--- a/src/render/tests/test_mesh.py
+++ b/src/render/tests/test_mesh.py
@@ -1467,3 +1467,26 @@ def test39_custom_vertex_normals(variants_vec_rgb):
 
     # The custom vertex normals should not have been modified.
     assert dr.allclose(params['vertex_normals'], normals)
+
+
+@pytest.mark.parametrize("texcoords", [True, False])
+@pytest.mark.parametrize("flip_normals", [False, True])
+def test40_normal_partials(variant_scalar_rgb, texcoords, flip_normals):
+    from drjit.scalar import ArrayXf as ScalarF
+    from mitsuba.scalar_rgb.test.util import curved_triangle, check_normal_partials
+
+    mesh, normal_field = curved_triangle(flip_normals, texcoords)
+    scene = mi.load_dict({'type': 'scene', 'shape': mesh})
+    flags = mi.RayFlags.All | mi.RayFlags.dNSdUV
+
+    hits = 0
+    for x in dr.linspace(ScalarF, 0.05, 0.5, 6):
+        for y in dr.linspace(ScalarF, 0.05, 0.5, 6):
+            ray = mi.Ray3f(mi.Point3f(x, y, 5), mi.Vector3f(0, 0, -1))
+            si = scene.ray_intersect(ray, flags, True)
+            if not si.is_valid():
+                continue
+            hits += 1
+            check_normal_partials(si, normal_field)
+
+    assert hits > 10, hits

--- a/src/render/tests/test_mesh.py
+++ b/src/render/tests/test_mesh.py
@@ -405,7 +405,7 @@ def test12_differentiable_surface_interaction_automatic(variants_all_ad_rgb):
 
     # si should be attached if ray is attached (even when we pass RayFlags.DetachShape)
     dr.enable_grad(ray.o)
-    si = pi.compute_surface_interaction(ray, mi.RayFlags.DetachShape)
+    si = pi.compute_surface_interaction(ray, mi.RayFlags.Default | mi.RayFlags.DetachShape)
     assert dr.grad_enabled(si.p)
     assert dr.grad_enabled(si.uv)
     assert not dr.grad_enabled(si.n) # Face normal doesn't depend on ray
@@ -765,7 +765,7 @@ def test17_sticky_differentiable_surface_interaction_params_forward(variants_all
 
     # If the vertices are shifted along x-axis, sticky si.p should follow
     apply_transformation(lambda v : mi.Transform4f().translate(v))
-    si = pi.compute_surface_interaction(ray, mi.RayFlags.All | mi.RayFlags.FollowShape)
+    si = pi.compute_surface_interaction(ray, mi.RayFlags.Default | mi.RayFlags.FollowShape)
     p = si.p + mi.Float(0.001) # Ensure p is a AD leaf node
     dr.forward(diff_vector.x)
     assert dr.allclose(dr.grad(p), [1.0, 0.0, 0.0], atol=1e-5)
@@ -778,14 +778,14 @@ def test17_sticky_differentiable_surface_interaction_params_forward(variants_all
 
     # If the vertices are shifted along x-axis, sticky si.uv shouldn't move
     apply_transformation(lambda v : mi.Transform4f().translate(v))
-    si = pi.compute_surface_interaction(ray, mi.RayFlags.All | mi.RayFlags.FollowShape)
+    si = pi.compute_surface_interaction(ray, mi.RayFlags.Default | mi.RayFlags.FollowShape)
     dr.forward(diff_vector.x)
     assert dr.allclose(dr.grad(si.uv), [0.0, 0.0], atol=1e-5)
 
     # TODO fix this!
     # If the vertices are shifted along x-axis, sticky si.t should follow
     # apply_transformation(lambda v : Transform4f.translate(v))
-    # si = pi.compute_surface_interaction(ray, RayFlags.All | RayFlags.FollowShape)
+    # si = pi.compute_surface_interaction(ray, RayFlags.Default | RayFlags.FollowShape)
     # dr.forward(diff_vector.y)
     # assert dr.allclose(dr.grad(si.t), 10.0, atol=1e-5)
 
@@ -1477,7 +1477,7 @@ def test40_normal_partials(variant_scalar_rgb, texcoords, flip_normals):
 
     mesh, normal_field = curved_triangle(flip_normals, texcoords)
     scene = mi.load_dict({'type': 'scene', 'shape': mesh})
-    flags = mi.RayFlags.All | mi.RayFlags.dNSdUV
+    flags = mi.RayFlags.Default | mi.RayFlags.NormalPartials
 
     hits = 0
     for x in dr.linspace(ScalarF, 0.05, 0.5, 6):

--- a/src/shapes/bsplinecurve.cpp
+++ b/src/shapes/bsplinecurve.cpp
@@ -882,8 +882,7 @@ public:
             return dr::zeros<SurfaceInteraction3f>();
 
         // Fields requirement dependencies
-        bool need_dn_duv = has_flag(ray_flags, RayFlags::dNSdUV) ||
-                           has_flag(ray_flags, RayFlags::dNGdUV);
+        bool need_dn_duv = has_flag(ray_flags, RayFlags::dNSdUV);
         bool need_dp_duv  = has_flag(ray_flags, RayFlags::dPdUV) || need_dn_duv;
         bool need_uv      = has_flag(ray_flags, RayFlags::UV) || need_dp_duv;
         bool detach_shape = has_flag(ray_flags, RayFlags::DetachShape);

--- a/src/shapes/bsplinecurve.cpp
+++ b/src/shapes/bsplinecurve.cpp
@@ -494,7 +494,7 @@ public:
             ss.uv = Point2f(sample.y(), sample.x()); // We use the x-axis as the cylindrical axis
             auto [dp_du, dp_dv, dn_du, dn_dv, L, M, N] = partials(ss.uv, active);
             SurfaceInteraction3f si = eval_parameterization(
-                ss.uv, +RayFlags::AllNonDifferentiable, active);
+                ss.uv, RayFlags::Default | RayFlags::DetachShape, active);
             ss.p = si.p;
 
             /// Sample a tangential direction at the point
@@ -763,7 +763,7 @@ public:
 
             ss.uv = Point2f(u_lower, si.uv.y());
             SurfaceInteraction3f si_ = eval_parameterization(
-                ss.uv, +RayFlags::AllNonDifferentiable, active);
+                ss.uv, RayFlags::Default | RayFlags::DetachShape, active);
             ss.p = si_.p;
             ss.n = si_.n;
             ss.d = dr::normalize(ss.p - viewpoint);
@@ -881,10 +881,7 @@ public:
         if (!m_is_instance && recursion_depth > 0)
             return dr::zeros<SurfaceInteraction3f>();
 
-        // Fields requirement dependencies
-        bool need_dn_duv = has_flag(ray_flags, RayFlags::dNSdUV);
-        bool need_dp_duv  = has_flag(ray_flags, RayFlags::dPdUV) || need_dn_duv;
-        bool need_uv      = has_flag(ray_flags, RayFlags::UV) || need_dp_duv;
+        bool shading      = has_flag(ray_flags, RayFlags::Shading);
         bool detach_shape = has_flag(ray_flags, RayFlags::DetachShape);
         bool follow_shape = has_flag(ray_flags, RayFlags::FollowShape);
 
@@ -989,14 +986,14 @@ public:
             (dr::squared_norm(dc_dv) - correction) * rad_vec -
             (dr_dv * radius) * dc_dv
         );
-        si.n = si.sh_frame.n = n;
+        si.n = n;
 
         // Embree and OptiX cull curve backfaces at trace time; Metal's HW
         // intersector reports both sides. Drop inside hits to match (a no-op
         // on backends that already cull).
         this->cull_backface(si, ray, active);
 
-        if (need_uv) {
+        if (shading) {
             Float u = dr::atan2(dr::dot(u_rot, rad_vec_normalized),
                                 dr::dot(u_rad, rad_vec_normalized));
             u += dr::select(u < 0.f, dr::TwoPi<Float>, 0.f);
@@ -1004,18 +1001,19 @@ public:
             Float v = (v_local + prim_idx) / dr::width(m_indices);
 
             si.uv = Point2f(u, v);
-        }
 
-        if (need_dp_duv) {
             Vector3f dp_du, dp_dv, dn_du, dn_dv;
             std::tie(dp_du, dp_dv, dn_du, dn_dv, std::ignore, std::ignore,
                      std::ignore) = partials(si.uv, active);
             si.dp_du = dp_du;
             si.dp_dv = dp_dv;
-            if (need_dn_duv) {
+
+            if (has_flag(ray_flags, RayFlags::NormalPartials)) {
                 si.dn_du = dn_du;
                 si.dn_dv = dn_dv;
             }
+
+            si.sh_frame.n = si.n;
         }
 
         si.prim_index = pi.prim_index;

--- a/src/shapes/bsplinecurve.cpp
+++ b/src/shapes/bsplinecurve.cpp
@@ -881,6 +881,7 @@ public:
         if (!m_is_instance && recursion_depth > 0)
             return dr::zeros<SurfaceInteraction3f>();
 
+        // Fields requirement dependencies
         bool shading      = has_flag(ray_flags, RayFlags::Shading);
         bool detach_shape = has_flag(ray_flags, RayFlags::DetachShape);
         bool follow_shape = has_flag(ray_flags, RayFlags::FollowShape);
@@ -905,88 +906,64 @@ public:
         Vector3f u_rot, u_rad;
         std::tie(u_rot, u_rad) = local_frame(dc_dv_normalized);
 
+        // Primal geometry at the hit point
+        si.t = pi.t;
+        si.p = dr::detach(ray(pi.t));
+
+        Vector3f rad_vec_d = si.p - dr::detach(c);
+        si.n = dr::normalize(
+            (dr::squared_norm(dr::detach(dc_dv)) -
+             dr::dot(rad_vec_d, dr::detach(dc_dvv))) * rad_vec_d -
+            (dr::detach(dr_dv) * dr::detach(radius)) * dr::detach(dc_dv));
+
+        /* Surface position at the detached parameterization: the angular
+           coordinate does not move with the curve. */
+        Vector3f rad_vec_dn = dr::normalize(rad_vec_d);
+        Float u = dr::atan2(dr::dot(dr::detach(u_rot), rad_vec_dn),
+                            dr::dot(dr::detach(u_rad), rad_vec_dn));
+        u += dr::select(u < 0.f, dr::TwoPi<Float>, 0.f);
+        u *= dr::InvTwoPi<Float>;
+
+        auto [sin_u, cos_u] = dr::sincos(u * dr::TwoPi<Float>);
+        Point3f p_att = c + (cos_u * u_rad + sin_u * u_rot) * radius;
+
+        si.attach_motion(ray, p_att, ray_flags);
+
         if constexpr (IsDiff) {
-            // Compute attached interaction point (w.r.t curve parameters)
-            Point3f p = ray(pi.t);
-            Vector3f rad_vec = p - c;
-            Vector3f rad_vec_normalized = dr::normalize(rad_vec);
-
-            Float u = dr::atan2(dr::dot(u_rot, rad_vec_normalized),
-                                dr::dot(u_rad, rad_vec_normalized));
-            u += dr::select(u < 0.f, dr::TwoPi<Float>, 0.f);
-            u *= dr::InvTwoPi<Float>;
-            u = dr::detach(u); // u has no motion
-
-            auto [sin_v, cos_v] = dr::sincos(u * dr::TwoPi<Float>);
-            Point3f p_diff = c + cos_v * u_rad * radius + sin_v * u_rot * radius;
-            p = dr::replace_grad(p, p_diff);
-
-            if (follow_shape) {
-                /* FollowShape glues the interaction point with the shape.
-                   Therefore, to also account for a possible differential motion
-                   of the shape, the interaction point must be completely
-                   differentiable w.r.t. the curve parameters. */
-                si.p = p;
-                Float t_diff = dr::sqrt(dr::squared_norm(si.p - ray.o) /
-                                        dr::squared_norm(ray.d));
-                si.t = dr::replace_grad(pi.t, t_diff);
-            } else {
-                /* To ensure that the differential interaction point stays along
-                   the traced ray, we first recompute the intersection distance
-                   in a differentiable way (w.r.t. the curve parameters) and
-                   then compute the corresponding point along the ray. (Instead
-                   of computing an intersection with the curve, we compute an
-                   intersection with the tangent plane.) */
-                Vector3f rad_vec_diff = si.p - c;
-                rad_vec = dr::replace_grad(rad_vec, rad_vec_diff);
-
-                // Differentiable tangent plane normal
-                Float correction = dr::dot(rad_vec, dc_dvv);
-                Vector3f n = dr::normalize(
-                    (dr::squared_norm(dc_dv) - correction) * rad_vec -
-                    (dr_dv * radius) * dc_dv
-                );
-
-                // Tangent plane intersection
-                Float t_diff = dr::dot(p - ray.o, n) / dr::dot(n, ray.d);
-                si.t = dr::replace_grad(pi.t, t_diff);
-                si.p = ray(si.t);
-
-                // Compute `v_local` with correct (hit point) motion
+            if (!follow_shape) {
+                /* Let the curve parameter follow the sliding of the
+                   interaction point across the moving surface */
                 Float v_global = (v_local + prim_idx) / dr::width(m_indices);
                 Vector3f dp_dv;
                 std::tie(std::ignore, dp_dv, std::ignore, std::ignore,
                          std::ignore, std::ignore, std::ignore) =
                     partials(Point2f(u, v_global), active);
                 dp_dv = dr::detach(dp_dv);
-                Float dp_dv_sqrnorm = dr::squared_norm(dp_dv);
-                Float v_diff = dr::dot(si.p - p_diff, dp_dv) / dp_dv_sqrnorm;
-                v_global = dr::replace_grad(v_global, v_diff);
-                Float v_local_diff = v_global * dr::width(m_indices) - prim_idx;;
-                v_local =  dr::replace_grad(v_local, v_local_diff);
 
-                // Recompute values with new `v_local` motion
-                std::tie(c, dc_dv, dc_dvv, std::ignore, radius, dr_dv, std::ignore) =
+                Float v_diff = dr::dot(si.p - p_att, dp_dv) /
+                               dr::squared_norm(dp_dv);
+                v_global = dr::replace_grad(v_global, v_global + v_diff);
+                v_local  = dr::replace_grad(
+                    v_local, v_global * dr::width(m_indices) - prim_idx);
+
+                // Recompute the center line with the correct motion
+                std::tie(c, dc_dv, dc_dvv, std::ignore, radius, dr_dv,
+                         std::ignore) =
                     cubic_interpolation(v_local, prim_idx, active);
                 dc_dv_normalized = dr::normalize(dc_dv);
                 std::tie(u_rot, u_rad) = local_frame(dc_dv_normalized);
             }
-        } else {
-            si.t = pi.t;
-            si.p = ray(si.t);
         }
 
         si.t = dr::select(active, si.t, dr::Infinity<Float>);
 
         // Normal
         Vector3f rad_vec = si.p - c;
-        Vector3f rad_vec_normalized = dr::normalize(rad_vec);
         Float correction = dr::dot(rad_vec, dc_dvv);  // curvature correction
-        Normal3f n = dr::normalize(
+        si.n = dr::normalize(
             (dr::squared_norm(dc_dv) - correction) * rad_vec -
             (dr_dv * radius) * dc_dv
         );
-        si.n = n;
 
         // Embree and OptiX cull curve backfaces at trace time; Metal's HW
         // intersector reports both sides. Drop inside hits to match (a no-op
@@ -994,13 +971,19 @@ public:
         this->cull_backface(si, ray, active);
 
         if (shading) {
-            Float u = dr::atan2(dr::dot(u_rot, rad_vec_normalized),
-                                dr::dot(u_rad, rad_vec_normalized));
-            u += dr::select(u < 0.f, dr::TwoPi<Float>, 0.f);
-            u *= dr::InvTwoPi<Float>;
+            /* Recompute the angular coordinate so that it tracks the motion of
+               the interaction point, unlike the one that defined ``p_att`` */
+            Vector3f rad_vec_n = dr::normalize(rad_vec);
+            Float u_att = dr::atan2(dr::dot(u_rot, rad_vec_n),
+                                    dr::dot(u_rad, rad_vec_n));
+            u_att += dr::select(u_att < 0.f, dr::TwoPi<Float>, 0.f);
+            u_att *= dr::InvTwoPi<Float>;
+            if constexpr (IsDiff)
+                u_att = dr::replace_grad(u, u_att);
+
             Float v = (v_local + prim_idx) / dr::width(m_indices);
 
-            si.uv = Point2f(u, v);
+            si.uv = Point2f(u_att, v);
 
             Vector3f dp_du, dp_dv, dn_du, dn_dv;
             std::tie(dp_du, dp_dv, dn_du, dn_dv, std::ignore, std::ignore,

--- a/src/shapes/cylinder.cpp
+++ b/src/shapes/cylinder.cpp
@@ -678,14 +678,12 @@ public:
                                                      uint32_t recursion_depth,
                                                      Mask active) const override {
         MI_MASK_ARGUMENT(active);
-        constexpr bool IsDiff = dr::is_diff_v<Float>;
 
         // Early exit when tracing isn't necessary
         if (!m_is_instance && recursion_depth > 0)
             return dr::zeros<SurfaceInteraction3f>();
 
         bool detach_shape = has_flag(ray_flags, RayFlags::DetachShape);
-        bool follow_shape = has_flag(ray_flags, RayFlags::FollowShape);
 
         const Float& radius = m_radius.value();
         const AffineTransform4f& to_world = m_to_world.value();
@@ -698,50 +696,32 @@ public:
 
         SurfaceInteraction3f si = dr::zeros<SurfaceInteraction3f>();
 
+        /* Local coordinates of the hit point, re-projected onto the unit
+           cylinder to mitigate roundoff error */
+        Point3f local = dr::detach(to_object * ray(pi.t));
+        Float inv_r = dr::rcp(dr::norm(dr::head<2>(local)));
+        local.x() *= inv_r;
+        local.y() *= inv_r;
+
         si.t = pi.t;
-        si.p = ray(si.t);
-        Point3f local;
-        if constexpr (IsDiff) {
-            if (follow_shape) {
-                /* FollowShape glues the interaction point with the shape.
-                   Therefore, to also account for a possible differential motion
-                   of the shape, we first compute a detached intersection point
-                   in local space and transform it back in world space to get a
-                   point rigidly attached to the shape's motion, including
-                   translation, scaling and rotation. */
-                local = to_object * si.p;
-                Float r = dr::norm(dr::head<2>(local));
-                local.x() /= r;
-                local.y() /= r;
-                local = dr::detach(local);
-                si.p = to_world * local;
-                si.t = dr::sqrt(dr::squared_norm(si.p - ray.o) / dr::squared_norm(ray.d));
-            } else {
-                /* To ensure that the differential interaction point stays along
-                   the traced ray, we first recompute the intersection distance
-                   in a differentiable way (w.r.t. to the cylindrical parameters) and
-                   then compute the corresponding point along the ray. */
-                si.t = dr::replace_grad(si.t, ray_intersect_preliminary(ray, 0, active).t);
-                si.p = ray(si.t);
-                local = to_object * si.p;
-            }
-        } else {
-            local = to_object * si.p;
-        }
+        si.p = dr::detach(to_world) * local;
+        si.n = Normal3f(dr::normalize(
+            dr::detach(to_world) * Normal3f(local.x(), local.y(), 0.f)));
+
+        // The local coordinates are static as the cylinder moves
+        Point3f p_att = to_world * local;
+
+        si.attach_motion(ray, p_att, ray_flags);
 
         si.t = dr::select(active, si.t, dr::Infinity<Float>);
+
+        local = to_object * si.p;
 
         Vector3f dp_du = to_world * (dr::TwoPi<Float> *
                                      Vector3f(-local.y(), local.x(), 0.f)),
                  dp_dv = to_world * Vector3f(0.f, 0.f, 1.f);
 
         si.n = Normal3f(dr::normalize(dr::cross(dp_du, dp_dv)));
-
-        if constexpr (!IsDiff) {
-            /* Mitigate roundoff error issues by a normal shift of the computed
-               intersection point */
-            si.p += si.n * (1.f - dr::norm(dr::head<2>(local)));
-        }
 
         if (m_flip_normals)
             si.n = -si.n;

--- a/src/shapes/cylinder.cpp
+++ b/src/shapes/cylinder.cpp
@@ -684,8 +684,6 @@ public:
         if (!m_is_instance && recursion_depth > 0)
             return dr::zeros<SurfaceInteraction3f>();
 
-        // Fields requirement dependencies
-        bool need_dn_duv  = has_flag(ray_flags, RayFlags::dNSdUV);
         bool detach_shape = has_flag(ray_flags, RayFlags::DetachShape);
         bool follow_shape = has_flag(ray_flags, RayFlags::FollowShape);
 
@@ -733,16 +731,11 @@ public:
 
         si.t = dr::select(active, si.t, dr::Infinity<Float>);
 
-        // si.uv
-        Float phi = dr::atan2(local.y(), local.x());
-        dr::masked(phi, phi < 0.f) += dr::TwoPi<Float>;
-        si.uv = Point2f(phi * dr::InvTwoPi<Float>, local.z());
-        // si.dp_duv & si.n
-        Vector3f dp_du = dr::TwoPi<Float> * Vector3f(-local.y(), local.x(), 0.f);
-        Vector3f dp_dv = Vector3f(0.f, 0.f, 1.f);
-        si.dp_du = to_world * dp_du;
-        si.dp_dv = to_world * dp_dv;
-        si.n = Normal3f(dr::normalize(dr::cross(si.dp_du, si.dp_dv)));
+        Vector3f dp_du = to_world * (dr::TwoPi<Float> *
+                                     Vector3f(-local.y(), local.x(), 0.f)),
+                 dp_dv = to_world * Vector3f(0.f, 0.f, 1.f);
+
+        si.n = Normal3f(dr::normalize(dr::cross(dp_du, dp_dv)));
 
         if constexpr (!IsDiff) {
             /* Mitigate roundoff error issues by a normal shift of the computed
@@ -752,11 +745,20 @@ public:
 
         if (m_flip_normals)
             si.n = -si.n;
-        si.sh_frame.n = si.n;
 
-        if (likely(need_dn_duv)) {
-            si.dn_du = si.dp_du / (radius * (m_flip_normals ? -1.f : 1.f));
-            si.dn_dv = Vector3f(0.f);
+        if (likely(has_flag(ray_flags, RayFlags::Shading))) {
+            Float phi = dr::atan2(local.y(), local.x());
+            dr::masked(phi, phi < 0.f) += dr::TwoPi<Float>;
+
+            si.uv         = Point2f(phi * dr::InvTwoPi<Float>, local.z());
+            si.dp_du      = dp_du;
+            si.dp_dv      = dp_dv;
+            si.sh_frame.n = si.n;
+
+            // The normal partial along 'v' vanishes, the cylinder is straight
+            if (has_flag(ray_flags, RayFlags::NormalPartials))
+                si.dn_du = dp_du * ((m_flip_normals ? -1.f : 1.f) *
+                                    dr::rcp(m_radius.value()));
         }
 
         si.prim_index = pi.prim_index;

--- a/src/shapes/cylinder.cpp
+++ b/src/shapes/cylinder.cpp
@@ -685,8 +685,7 @@ public:
             return dr::zeros<SurfaceInteraction3f>();
 
         // Fields requirement dependencies
-        bool need_dn_duv  = has_flag(ray_flags, RayFlags::dNSdUV) ||
-                            has_flag(ray_flags, RayFlags::dNGdUV);
+        bool need_dn_duv  = has_flag(ray_flags, RayFlags::dNSdUV);
         bool detach_shape = has_flag(ray_flags, RayFlags::DetachShape);
         bool follow_shape = has_flag(ray_flags, RayFlags::FollowShape);
 

--- a/src/shapes/disk.cpp
+++ b/src/shapes/disk.cpp
@@ -201,8 +201,8 @@ public:
     SurfaceInteraction3f eval_parameterization(const Point2f &uv,
                                                uint32_t ray_flags,
                                                Mask active) const override {
-        Point2f uniform_disk = warp::square_to_uniform_disk_concentric(uv);
-        Point3f local = Point3f(uniform_disk.x(), uniform_disk.y(), 0.f);
+        auto [sin_phi, cos_phi] = dr::sincos(dr::TwoPi<Float> * uv.y());
+        Point3f local(uv.x() * cos_phi, uv.x() * sin_phi, 0.f);
 
         Point3f p = m_to_world.value() * local;
 
@@ -502,19 +502,21 @@ public:
 
         if (likely(has_flag(ray_flags, RayFlags::UV) ||
                    has_flag(ray_flags, RayFlags::dPdUV))) {
-            Float r = dr::norm(Point2f(prim_uv.x(), prim_uv.y())),
-                  inv_r = dr::rcp(r);
+            Float r_2   = dr::squared_norm(prim_uv),
+                  inv_r = dr::select(r_2 != 0.f, dr::rsqrt(r_2), 0.f),
+                  r     = r_2 * inv_r;
 
             Float v = dr::atan2(prim_uv.y(), prim_uv.x()) * dr::InvTwoPi<Float>;
             dr::masked(v, v < 0.f) += 1.f;
             si.uv = Point2f(r, v);
 
             if (likely(has_flag(ray_flags, RayFlags::dPdUV))) {
-                Float cos_phi = dr::select(r != 0.f, prim_uv.x() * inv_r, 1.f),
-                      sin_phi = dr::select(r != 0.f, prim_uv.y() * inv_r, 0.f);
+                Float cos_phi = prim_uv.x() * inv_r,
+                      sin_phi = prim_uv.y() * inv_r;
 
                 si.dp_du = to_world * Vector3f( cos_phi, sin_phi, 0.f);
-                si.dp_dv = to_world * Vector3f(-sin_phi, cos_phi, 0.f);
+                si.dp_dv = to_world * Vector3f(-sin_phi, cos_phi, 0.f) *
+                           (dr::TwoPi<Float> * r);
             }
         }
 

--- a/src/shapes/disk.cpp
+++ b/src/shapes/disk.cpp
@@ -440,14 +440,12 @@ public:
                                                      uint32_t recursion_depth,
                                                      Mask active) const override {
         MI_MASK_ARGUMENT(active);
-        constexpr bool IsDiff = dr::is_diff_v<Float>;
 
         // Early exit when tracing isn't necessary
         if (!m_is_instance && recursion_depth > 0)
             return dr::zeros<SurfaceInteraction3f>();
 
         bool detach_shape = has_flag(ray_flags, RayFlags::DetachShape);
-        bool follow_shape = has_flag(ray_flags, RayFlags::FollowShape);
 
         AffineTransform4f to_world = m_to_world.value();
         AffineTransform4f to_object = to_world.inverse();
@@ -455,50 +453,26 @@ public:
         dr::suspend_grad<Float> scope(detach_shape, to_world, to_object, m_frame);
 
         SurfaceInteraction3f si = dr::zeros<SurfaceInteraction3f>();
-        Point2f prim_uv = pi.prim_uv;
 
-        if constexpr (IsDiff) {
-            if (follow_shape) {
-                /* FollowShape glues the interaction point with the shape.
-                   Therefore, to also account for a possible differential motion
-                   of the shape, we first compute a detached intersection point
-                   in local space and transform it back in world space to get a
-                   point rigidly attached to the shape's motion, including
-                   translation, scaling and rotation. */
-                Point3f local = to_object * ray(pi.t);
-                /* With FollowShape the local position should always be static as
-                   the intersection point follows any motion of the sphere. */
-                local = dr::detach(local);
-                si.p = to_world * local;
-                si.t = dr::sqrt(dr::squared_norm(si.p - ray.o) / dr::squared_norm(ray.d));
-                prim_uv = dr::head<2>(local);
-            } else {
-                /* To ensure that the differential interaction point stays along
-                   the traced ray, we first recompute the intersection distance
-                   in a differentiable way (w.r.t. to the disk parameters) and
-                   then compute the corresponding point along the ray. */
-                PreliminaryIntersection3f pi_d = ray_intersect_preliminary(ray, 0, active);
-                si.t = dr::replace_grad(pi.t, pi_d.t);
-                si.p = ray(si.t);
-                prim_uv = dr::replace_grad(pi.prim_uv, pi_d.prim_uv);
-            }
-        } else {
-            si.t = pi.t;
-            // Re-project onto the disk to improve accuracy
-            Point3f p = ray(pi.t);
-            Float dist = dr::dot(to_world.translation() - p, m_frame.n);
-            si.p = p + dist * m_frame.n;
-        }
+        si.t = pi.t;
+        si.n = dr::detach(m_frame.n);
+
+        // Re-project onto the disk to improve accuracy
+        Point3f p = ray(pi.t);
+        si.p = dr::detach(
+            p + dr::dot(dr::detach(to_world).translation() - p, si.n) * si.n);
+
+        /* Surface position at the detached parameterization: the local
+           coordinates are static as the disk moves. */
+        Point3f p_att = to_world * dr::detach(to_object * si.p);
+
+        si.attach_motion(ray, p_att, ray_flags);
 
         si.t = dr::select(active, si.t, dr::Infinity<Float>);
 
-        // The Metal intersection function cannot forward prim_uv, so recompute
-        // it from si.p. Done after the diff branches, which would otherwise
-        // propagate Metal's zero value through ``replace_grad``.
-        if constexpr (dr::is_metal_v<Float>) {
-            Point3f local = to_object * si.p;
-            prim_uv = Point2f(local.x(), local.y());
-        }
+        // Recover the local coordinates (``pi.prim_uv`` is not set on all backends)
+        Point3f local = to_object * si.p;
+        Point2f prim_uv(local.x(), local.y());
 
         si.n = m_frame.n;
 

--- a/src/shapes/disk.cpp
+++ b/src/shapes/disk.cpp
@@ -500,8 +500,9 @@ public:
             prim_uv = Point2f(local.x(), local.y());
         }
 
-        if (likely(has_flag(ray_flags, RayFlags::UV) ||
-                   has_flag(ray_flags, RayFlags::dPdUV))) {
+        si.n = m_frame.n;
+
+        if (likely(has_flag(ray_flags, RayFlags::Shading))) {
             Float r_2   = dr::squared_norm(prim_uv),
                   inv_r = dr::select(r_2 != 0.f, dr::rsqrt(r_2), 0.f),
                   r     = r_2 * inv_r;
@@ -510,20 +511,16 @@ public:
             dr::masked(v, v < 0.f) += 1.f;
             si.uv = Point2f(r, v);
 
-            if (likely(has_flag(ray_flags, RayFlags::dPdUV))) {
-                Float cos_phi = prim_uv.x() * inv_r,
-                      sin_phi = prim_uv.y() * inv_r;
+            Float cos_phi = prim_uv.x() * inv_r,
+                  sin_phi = prim_uv.y() * inv_r;
 
-                si.dp_du = to_world * Vector3f( cos_phi, sin_phi, 0.f);
-                si.dp_dv = to_world * Vector3f(-sin_phi, cos_phi, 0.f) *
-                           (dr::TwoPi<Float> * r);
-            }
+            // The ``v`` coordinate is the azimuth scaled into [0, 1]
+            si.dp_du = to_world * Vector3f( cos_phi, sin_phi, 0.f);
+            si.dp_dv = to_world * Vector3f(-sin_phi, cos_phi, 0.f) *
+                       (dr::TwoPi<Float> * r);
+
+            si.sh_frame.n = m_frame.n;
         }
-
-        si.n          = m_frame.n;
-        si.sh_frame.n = m_frame.n;
-
-        si.dn_du = si.dn_dv = dr::zeros<Vector3f>();
 
         si.prim_index = pi.prim_index;
         si.shape    = this;

--- a/src/shapes/ellipsoids.cpp
+++ b/src/shapes/ellipsoids.cpp
@@ -398,14 +398,27 @@ public:
         ellipsoid.scale *= m_ellipsoids.template extents<Float>(pi.prim_index, active);
         auto rot = dr::quat_to_matrix<Matrix3f>(ellipsoid.quat);
 
-        si.t = dr::select(active, pi.t, dr::Infinity<Float>);
-        si.p = ray(pi.t);
+        // The local coordinates are static as the ellipsoid moves
+        si.t = pi.t;
+        si.p = dr::detach(ray(pi.t));
+        Point3f local_d =
+            dr::detach(dr::transpose(rot) * (si.p - ellipsoid.center));
+
+        si.n = dr::detach(
+            dr::normalize(rot * (local_d / dr::square(ellipsoid.scale))));
+
+        Point3f p_att = ellipsoid.center +
+                        rot * (ellipsoid.scale *
+                               (local_d / dr::detach(ellipsoid.scale)));
+
+        si.attach_motion(ray, p_att, ray_flags);
+
+        si.t = dr::select(active, si.t, dr::Infinity<Float>);
 
         Point3f local = dr::transpose(rot) * (si.p - ellipsoid.center);
         si.sh_frame.n = dr::normalize(rot * (local / dr::square(ellipsoid.scale)));
 
         si.n = si.sh_frame.n;
-
 
         si.prim_index = pi.prim_index;
         si.shape      = this;

--- a/src/shapes/ellipsoids.cpp
+++ b/src/shapes/ellipsoids.cpp
@@ -405,6 +405,7 @@ public:
         si.sh_frame.n = dr::normalize(rot * (local / dr::square(ellipsoid.scale)));
 
         si.n = si.sh_frame.n;
+
         si.uv    = Point2f(0.f, 0.f);
         si.dp_du = Vector3f(0.f);
         si.dp_dv = Vector3f(0.f);

--- a/src/shapes/ellipsoids.cpp
+++ b/src/shapes/ellipsoids.cpp
@@ -406,10 +406,6 @@ public:
 
         si.n = si.sh_frame.n;
 
-        si.uv    = Point2f(0.f, 0.f);
-        si.dp_du = Vector3f(0.f);
-        si.dp_dv = Vector3f(0.f);
-        si.dn_du = si.dn_dv = dr::zeros<Vector3f>();
 
         si.prim_index = pi.prim_index;
         si.shape      = this;

--- a/src/shapes/instance.cpp
+++ b/src/shapes/instance.cpp
@@ -213,9 +213,6 @@ public:
             }
         }
 
-        if (likely(has_flag(ray_flags, RayFlags::ShadingFrame)))
-            si.initialize_sh_frame();
-
         if (likely(has_flag(ray_flags, RayFlags::dPdUV))) {
             si.dp_du = to_world * si.dp_du;
             si.dp_dv = to_world * si.dp_dv;

--- a/src/shapes/instance.cpp
+++ b/src/shapes/instance.cpp
@@ -192,8 +192,27 @@ public:
         // Hit point `si.p` is only attached to the surface motion
         si.p = to_world * si.p;
         si.n = dr::normalize(dr::detach(to_world) * si.n);
-        if (likely(has_flag(ray_flags, RayFlags::ShadingFrame)))
-            si.sh_frame.n = dr::normalize(dr::detach(to_world) * si.sh_frame.n);
+
+        if (likely(has_flag(ray_flags, RayFlags::ShadingFrame) ||
+                   has_flag(ray_flags, RayFlags::dNSdUV))) {
+            AffineTransform4f to_world_d = dr::detach(to_world);
+
+            /* Transforming a normal applies the inverse transpose, which does
+               not preserve its length. Differentiating the re-normalization
+               projects the transformed partials back onto the tangent plane. */
+            Normal3f n = to_world_d * si.sh_frame.n;
+            Float inv_len = dr::rcp(dr::norm(n));
+            n *= inv_len;
+            si.sh_frame.n = n;
+
+            if (has_flag(ray_flags, RayFlags::dNSdUV)) {
+                Vector3f dn_du = to_world_d * Normal3f(si.dn_du) * inv_len,
+                         dn_dv = to_world_d * Normal3f(si.dn_dv) * inv_len;
+
+                si.dn_du = dr::fnmadd(n, dr::dot(n, dn_du), dn_du);
+                si.dn_dv = dr::fnmadd(n, dr::dot(n, dn_dv), dn_dv);
+            }
+        }
 
         if constexpr (IsDiff) {
             if (follow_shape && grad_enabled) {
@@ -216,22 +235,6 @@ public:
         if (likely(has_flag(ray_flags, RayFlags::dPdUV))) {
             si.dp_du = to_world * si.dp_du;
             si.dp_dv = to_world * si.dp_dv;
-        }
-
-        if (has_flag(ray_flags, RayFlags::dNGdUV) || has_flag(ray_flags, RayFlags::dNSdUV)) {
-            Normal3f n = has_flag(ray_flags, RayFlags::dNGdUV) ? si.n : si.sh_frame.n;
-
-            // Determine the length of the transformed normal before it was re-normalized
-            Normal3f tn = to_world * dr::normalize(to_object * n);
-            Float inv_len = dr::rcp(dr::norm(tn));
-            tn *= inv_len;
-
-            // Apply transform to dn_du and dn_dv
-            si.dn_du = to_world * Normal3f(si.dn_du) * inv_len;
-            si.dn_dv = to_world * Normal3f(si.dn_dv) * inv_len;
-
-            si.dn_du -= tn * dr::dot(tn, si.dn_du);
-            si.dn_dv -= tn * dr::dot(tn, si.dn_dv);
         }
 
         si.prim_index = pi.prim_index;

--- a/src/shapes/instance.cpp
+++ b/src/shapes/instance.cpp
@@ -193,8 +193,7 @@ public:
         si.p = to_world * si.p;
         si.n = dr::normalize(dr::detach(to_world) * si.n);
 
-        if (likely(has_flag(ray_flags, RayFlags::ShadingFrame) ||
-                   has_flag(ray_flags, RayFlags::dNSdUV))) {
+        if (likely(has_flag(ray_flags, RayFlags::Shading))) {
             AffineTransform4f to_world_d = dr::detach(to_world);
 
             /* Transforming a normal applies the inverse transpose, which does
@@ -205,7 +204,7 @@ public:
             n *= inv_len;
             si.sh_frame.n = n;
 
-            if (has_flag(ray_flags, RayFlags::dNSdUV)) {
+            if (has_flag(ray_flags, RayFlags::NormalPartials)) {
                 Vector3f dn_du = to_world_d * Normal3f(si.dn_du) * inv_len,
                          dn_dv = to_world_d * Normal3f(si.dn_dv) * inv_len;
 
@@ -232,7 +231,7 @@ public:
             }
         }
 
-        if (likely(has_flag(ray_flags, RayFlags::dPdUV))) {
+        if (likely(has_flag(ray_flags, RayFlags::Shading))) {
             si.dp_du = to_world * si.dp_du;
             si.dp_dv = to_world * si.dp_dv;
         }

--- a/src/shapes/linearcurve.cpp
+++ b/src/shapes/linearcurve.cpp
@@ -332,9 +332,13 @@ public:
 
         bool shading = has_flag(ray_flags, RayFlags::Shading);
 
+        /* If necessary, temporally suspend gradient tracking for all shape
+           parameters to construct a surface interaction completely detached
+           from the shape. */
+        dr::suspend_grad<Float> scope(
+            has_flag(ray_flags, RayFlags::DetachShape), m_control_points);
+
         SurfaceInteraction3f si = dr::zeros<SurfaceInteraction3f>();
-        si.t = dr::select(active, pi.t, dr::Infinity<Float>);
-        si.p = ray(pi.t);
 
         Float v_local = pi.prim_uv.x();
         UInt32 prim_idx = pi.prim_index;
@@ -349,10 +353,45 @@ public:
         Point3f p0 = Point3f(c0.x(), c0.y(), c0.z()),
                 p1 = Point3f(c1.x(), c1.y(), c1.z());
 
+        Vector3f axis = dr::normalize(p1 - p0);
+
         Vector3f u_rot, u_rad;
-        std::tie(u_rot, u_rad) = local_frame(dr::normalize(p1 - p0));
+        std::tie(u_rot, u_rad) = local_frame(axis);
 
         Point3f c = p0 * (1.f - v_local) + p1 * v_local;
+
+        si.t = pi.t;
+        si.p = dr::detach(ray(pi.t));
+
+        Vector3f rad_vec_d = si.p - dr::detach(c);
+        si.n = dr::normalize(rad_vec_d);
+
+        /* Surface position at the detached parameterization: the offset from the
+           center line is held fixed in the curve's frame, so that it rotates
+           along with the segment. */
+        Point3f p_att = c + dr::dot(rad_vec_d, dr::detach(u_rad)) * u_rad +
+                            dr::dot(rad_vec_d, dr::detach(u_rot)) * u_rot +
+                            dr::dot(rad_vec_d, dr::detach(axis))  * axis;
+
+        si.attach_motion(ray, p_att, ray_flags);
+
+        if constexpr (dr::is_diff_v<Float>) {
+            if (!has_flag(ray_flags, RayFlags::FollowShape)) {
+                /* Let the curve parameter follow the sliding of the interaction
+                   point across the moving surface */
+                Vector3f dp_dv = dr::detach(
+                    (p1 - p0) + (c1.w() - c0.w()) * dr::normalize(rad_vec_d));
+
+                v_local = dr::replace_grad(
+                    v_local, v_local + dr::dot(si.p - p_att, dp_dv) /
+                                           dr::squared_norm(dp_dv));
+
+                // Recompute the center line with the correct motion
+                c = p0 * (1.f - v_local) + p1 * v_local;
+            }
+        }
+
+        si.t = dr::select(active, si.t, dr::Infinity<Float>);
         si.n = dr::normalize(si.p - c);
 
         // Embree and OptiX cull linear-curve backfaces at trace time; Metal's
@@ -370,6 +409,14 @@ public:
             Float v = (v_local + prim_idx) / dr::width(m_indices);
 
             si.uv = Point2f(u, v);
+
+            /* Tangents of the (u, v) parameterization: ``u`` runs around the
+               curve, ``v`` along all segments. */
+            Float segment_count = (Float) dr::width(m_indices);
+            si.dp_du = dr::TwoPi<Float> * dr::cross(axis, si.p - c);
+            si.dp_dv = segment_count *
+                       ((p1 - p0) + (c1.w() - c0.w()) * rad_vec_normalized);
+
             si.sh_frame.n = si.n;
         }
 

--- a/src/shapes/linearcurve.cpp
+++ b/src/shapes/linearcurve.cpp
@@ -330,7 +330,7 @@ public:
         if (!m_is_instance && recursion_depth > 0)
             return dr::zeros<SurfaceInteraction3f>();
 
-        bool need_uv = has_flag(ray_flags, RayFlags::UV);
+        bool shading = has_flag(ray_flags, RayFlags::Shading);
 
         SurfaceInteraction3f si = dr::zeros<SurfaceInteraction3f>();
         si.t = dr::select(active, pi.t, dr::Infinity<Float>);
@@ -353,16 +353,15 @@ public:
         std::tie(u_rot, u_rad) = local_frame(dr::normalize(p1 - p0));
 
         Point3f c = p0 * (1.f - v_local) + p1 * v_local;
-        si.n = si.sh_frame.n = dr::normalize(si.p - c);
+        si.n = dr::normalize(si.p - c);
 
         // Embree and OptiX cull linear-curve backfaces at trace time; Metal's
         // HW intersector reports both sides. Drop inside hits to match (a no-op
         // on backends that already cull).
         this->cull_backface(si, ray, active);
 
-        if (need_uv) {
-            Vector3f rad_vec = si.p - c;
-            Vector3f rad_vec_normalized = dr::normalize(rad_vec);
+        if (shading) {
+            Vector3f rad_vec_normalized = dr::normalize(si.p - c);
 
             Float u = dr::atan2(dr::dot(u_rot, rad_vec_normalized),
                                 dr::dot(u_rad, rad_vec_normalized));
@@ -371,6 +370,7 @@ public:
             Float v = (v_local + prim_idx) / dr::width(m_indices);
 
             si.uv = Point2f(u, v);
+            si.sh_frame.n = si.n;
         }
 
         si.prim_index = pi.prim_index;

--- a/src/shapes/rectangle.cpp
+++ b/src/shapes/rectangle.cpp
@@ -247,7 +247,6 @@ public:
         si.dp_du     = m_frame.s;
         si.dp_dv     = m_frame.t;
         si.uv        = uv;
-        si.dn_du = si.dn_dv = dr::zeros<Vector3f>();
         si.shape    = this;
         si.instance = nullptr;
         si.t        = dr::select(active, 0, dr::Infinity<Float>);
@@ -255,7 +254,7 @@ public:
         /// Zero-initialize remaining fields
         si.time        = 0.f;
         si.wavelengths = Wavelength(0.f);
-        si.dn_du = si.dn_dv = si.wi = Vector3f(0);
+        si.wi          = Vector3f(0);
         si.duv_dx = si.duv_dy = 0;
         si.prim_index = 0;
 

--- a/src/shapes/sdfgrid.cpp
+++ b/src/shapes/sdfgrid.cpp
@@ -342,7 +342,6 @@ public:
                                 uint32_t ray_flags, uint32_t recursion_depth,
                                 Mask active) const override {
         MI_MASK_ARGUMENT(active);
-        constexpr bool IsDiff = dr::is_diff_v<Float>;
 
         // Early exit when tracing isn't necessary
         if (!m_is_instance && recursion_depth > 0)
@@ -351,7 +350,6 @@ public:
         SurfaceInteraction3f si = dr::zeros<SurfaceInteraction3f>();
 
         bool detach_shape = has_flag(ray_flags, RayFlags::DetachShape);
-        bool follow_shape = has_flag(ray_flags, RayFlags::FollowShape);
 
         AffineTransform4f to_world  = m_to_world.value();
         AffineTransform4f to_object = to_world.inverse();
@@ -359,71 +357,27 @@ public:
         dr::suspend_grad<Float> scope(detach_shape, to_world, to_object,
                                       m_grid_texture.value());
 
-        if constexpr (IsDiff) {
-            if (follow_shape) {
-                /* FollowShape glues the interaction point with the shape.
-                   Therefore, to also account for a possible differential motion
-                   of the shape, we first compute a detached intersection point
-                   in local space and transform it back in world space to get a
-                   point rigidly attached to the shape's motion, including
-                   translation, scaling and rotation. */
-                Point3f local_p =
-                    dr::detach(to_object * ray(pi.t));
-                Vector3f local_grad = dr::detach(sdf_grad(local_p));
-                Normal3f local_n    = dr::normalize(local_grad);
-                Ray3f local_ray = dr::detach(to_object * ray);
+        Point3f local_p = dr::detach(to_object * ray(pi.t));
+        Vector3f local_grad = dr::detach(sdf_grad(local_p));
+        Normal3f local_n = dr::normalize(local_grad);
 
-                /* Note: Only when applying a motion to the entire shape is the
-                 * interaction point truly "glued" to the shape. For a single
-                 * voxel, the motion of the surface is ambiguous and therefore
-                 * the interaction point is not "glued" to the shape. */
+        si.t = pi.t;
+        si.p = dr::detach(to_world) * local_p;
+        si.n = dr::normalize(dr::detach(to_world) * local_n);
 
-                // Capture gradients of `m_grid_texture`
-                Float sdf_value = m_grid_texture.template eval<dr::Array<Float, 1>>(
-                    rescale_point(local_p)).x();
-                Point3f local_motion =
-                    sdf_value * (-local_n) / dr::dot(local_n, local_grad);
-                local_p = dr::replace_grad(local_p, local_motion);
-
-                // Capture gradients of `m_to_world`
-                si.p = to_world * local_p;
-                si.t = dr::sqrt(dr::squared_norm(si.p - ray.o) /
-                                dr::squared_norm(ray.d));
-            } else {
-                /* To ensure that the differential interaction point stays along
-                   the traced ray, we first recompute the intersection distance
-                   in a differentiable way (w.r.t. to the grid parameters) and
-                   then compute the corresponding point along the ray. (Instead
-                   of computing an intersection with the SDF, we compute an
-                   intersection with the tangent plane.) */
-                Point3f local_p =
-                    dr::detach(to_object * ray(pi.t));
-                Ray3f local_ray = dr::detach(to_object * ray);
-
-                /// Differentiable tangent plane normal
-                // Capture gradients of `m_grid_texture`
-                Normal3f local_n = dr::normalize(sdf_grad(local_p));
-                // Capture gradients of `m_to_world`
-                Normal3f n = to_world * local_n;
-
-                /// Differentiable tangent plane point
-                // Capture gradients of `m_grid_texture`
-                Float sdf_value = m_grid_texture.template eval<dr::Array<Float, 1>>(
-                    rescale_point(local_p)).x();
-
-                Float t_diff =
-                    sdf_value / dr::dot(dr::detach(local_n), -local_ray.d);
-                t_diff = dr::replace_grad(pi.t, t_diff);
-                // Capture gradients of `m_to_world`
-                Point3f p = to_world * local_ray(t_diff);
-
-                si.t = dr::dot(p - ray.o, n) / dr::dot(n, ray.d);
-                si.p = ray(si.t);
-            }
-        } else {
-            si.t = pi.t;
-            si.p = ray(si.t);
+        Point3f p_att = si.p;
+        if constexpr (dr::is_diff_v<Float>) {
+            /* Position at the detached parameterization. Only a motion of the
+               entire shape truly glues the interaction point to the surface:
+               for a single voxel the motion is ambiguous. */
+            Float sdf_value = m_grid_texture.template eval<dr::Array<Float, 1>>(
+                rescale_point(local_p)).x();
+            Point3f local_motion =
+                sdf_value * (-local_n) / dr::dot(local_n, local_grad);
+            p_att = to_world * dr::replace_grad(local_p, local_motion);
         }
+
+        si.attach_motion(ray, p_att, ray_flags);
 
         si.t = dr::select(active, si.t, dr::Infinity<Float>);
 
@@ -445,7 +399,6 @@ public:
                     Throw("Unknown normal computation.");
             }
         }
-
 
         si.prim_index = pi.prim_index;
         si.shape    = this;

--- a/src/shapes/sdfgrid.cpp
+++ b/src/shapes/sdfgrid.cpp
@@ -432,7 +432,7 @@ public:
         si.n =
             dr::normalize(m_to_world.value() * Normal3f(grad));
 
-        if (likely(has_flag(ray_flags, RayFlags::ShadingFrame))) {
+        if (likely(has_flag(ray_flags, RayFlags::Shading))) {
             switch (m_normal_method) {
                 case Analytic:
                     si.sh_frame.n = si.n;
@@ -446,10 +446,6 @@ public:
             }
         }
 
-        si.uv    = Point2f(0.f, 0.f);
-        si.dp_du = Vector3f(0.f);
-        si.dp_dv = Vector3f(0.f);
-        si.dn_du = si.dn_dv = dr::zeros<Vector3f>();
 
         si.prim_index = pi.prim_index;
         si.shape    = this;

--- a/src/shapes/sphere.cpp
+++ b/src/shapes/sphere.cpp
@@ -638,10 +638,7 @@ public:
         if (!m_is_instance && recursion_depth > 0)
             return dr::zeros<SurfaceInteraction3f>();
 
-        // Fields requirement dependencies
-        bool need_dn_duv  = has_flag(ray_flags, RayFlags::dNSdUV);
-        bool need_dp_duv  = has_flag(ray_flags, RayFlags::dPdUV) || need_dn_duv;
-        bool need_uv      = has_flag(ray_flags, RayFlags::UV) || need_dp_duv;
+        bool shading      = has_flag(ray_flags, RayFlags::Shading);
         bool detach_shape = has_flag(ray_flags, RayFlags::DetachShape);
         bool follow_shape = has_flag(ray_flags, RayFlags::FollowShape);
 
@@ -693,7 +690,7 @@ public:
 
         si.t = dr::select(active, si.t, dr::Infinity<Float>);
 
-        if (likely(need_uv)) {
+        if (likely(shading)) {
             Point2f angles = dir_to_sph(Vector3f(local));
             Float theta = angles.x();
             Float phi = angles.y();
@@ -701,38 +698,34 @@ public:
             dr::masked(phi, phi < 0.f) += 2.f * dr::Pi<Float>;
             si.uv = Point2f(phi * dr::InvTwoPi<Float>, theta * dr::InvPi<Float>);
 
-            if (likely(need_dp_duv)) {
-                si.dp_du = Vector3f(-local.y(), local.x(), 0.f);
+            si.dp_du = Vector3f(-local.y(), local.x(), 0.f);
 
-                Float rd_2    = dr::square(local.x()) + dr::square(local.y()),
-                      rd      = dr::sqrt(rd_2),
-                      inv_rd  = dr::rcp(rd),
-                      cos_phi = local.x() * inv_rd,
-                      sin_phi = local.y() * inv_rd;
+            Float rd_2    = dr::square(local.x()) + dr::square(local.y()),
+                  rd      = dr::sqrt(rd_2),
+                  inv_rd  = dr::rcp(rd),
+                  cos_phi = local.x() * inv_rd,
+                  sin_phi = local.y() * inv_rd;
 
-                si.dp_dv = Vector3f(local.z() * cos_phi,
-                                    local.z() * sin_phi,
-                                    -rd);
+            si.dp_dv = Vector3f(local.z() * cos_phi, local.z() * sin_phi, -rd);
 
-                Mask singularity_mask = active && (rd == 0.f);
-                if (unlikely(dr::any_or<true>(singularity_mask)))
-                    si.dp_dv[singularity_mask] = Vector3f(1.f, 0.f, 0.f);
+            Mask singularity_mask = active && (rd == 0.f);
+            if (unlikely(dr::any_or<true>(singularity_mask)))
+                si.dp_dv[singularity_mask] = Vector3f(1.f, 0.f, 0.f);
 
-                si.dp_du = to_world * si.dp_du * (2.f * dr::Pi<Float>);
-                si.dp_dv = to_world * si.dp_dv * dr::Pi<Float>;
+            si.dp_du = to_world * si.dp_du * (2.f * dr::Pi<Float>);
+            si.dp_dv = to_world * si.dp_dv * dr::Pi<Float>;
+
+            if (has_flag(ray_flags, RayFlags::NormalPartials)) {
+                Float inv_radius =
+                    (m_flip_normals ? -1.f : 1.f) * dr::rcp(radius);
+                si.dn_du = si.dp_du * inv_radius;
+                si.dn_dv = si.dp_dv * inv_radius;
             }
         }
 
         if (m_flip_normals)
             si.sh_frame.n = -si.sh_frame.n;
         si.n = si.sh_frame.n;
-
-        if (need_dn_duv) {
-            Float inv_radius =
-                (m_flip_normals ? -1.f : 1.f) * dr::rcp(radius);
-            si.dn_du = si.dp_du * inv_radius;
-            si.dn_dv = si.dp_dv * inv_radius;
-        }
 
         si.prim_index = pi.prim_index;
         si.shape    = this;

--- a/src/shapes/sphere.cpp
+++ b/src/shapes/sphere.cpp
@@ -639,8 +639,7 @@ public:
             return dr::zeros<SurfaceInteraction3f>();
 
         // Fields requirement dependencies
-        bool need_dn_duv  = has_flag(ray_flags, RayFlags::dNSdUV) ||
-                            has_flag(ray_flags, RayFlags::dNGdUV);
+        bool need_dn_duv  = has_flag(ray_flags, RayFlags::dNSdUV);
         bool need_dp_duv  = has_flag(ray_flags, RayFlags::dPdUV) || need_dn_duv;
         bool need_uv      = has_flag(ray_flags, RayFlags::UV) || need_dp_duv;
         bool detach_shape = has_flag(ray_flags, RayFlags::DetachShape);

--- a/src/shapes/sphere.cpp
+++ b/src/shapes/sphere.cpp
@@ -632,7 +632,6 @@ public:
                                                      uint32_t recursion_depth,
                                                      Mask active) const override {
         MI_MASK_ARGUMENT(active);
-        constexpr bool IsDiff = dr::is_diff_v<Float>;
 
         // Early exit when tracing isn't necessary
         if (!m_is_instance && recursion_depth > 0)
@@ -640,7 +639,6 @@ public:
 
         bool shading      = has_flag(ray_flags, RayFlags::Shading);
         bool detach_shape = has_flag(ray_flags, RayFlags::DetachShape);
-        bool follow_shape = has_flag(ray_flags, RayFlags::FollowShape);
 
         const Point3f& center = m_center.value();
         const Float& radius = m_radius.value();
@@ -654,41 +652,21 @@ public:
 
         SurfaceInteraction3f si = dr::zeros<SurfaceInteraction3f>();
 
-        Point3f local;
-        if constexpr (IsDiff) {
-            if (follow_shape) {
-                /* FollowShape glues the interaction point with the shape.
-                   Therefore, to also account for a possible differential motion
-                   of the shape, we first compute a detached intersection point
-                   in local space and transform it back in world space to get a
-                   point rigidly attached to the shape's motion, including
-                   translation, scaling and rotation. */
-                local = to_object * ray(pi.t);
-                /* With FollowShape the local position should always be static as
-                   the intersection point follows any motion of the sphere. */
-                local = dr::detach(local);
-                si.p = to_world * local;
-                si.sh_frame.n = (si.p - center) / radius;
-                si.t = dr::sqrt(dr::squared_norm(si.p - ray.o) / dr::squared_norm(ray.d));
-            } else {
-                /* To ensure that the differential interaction point stays along
-                   the traced ray, we first recompute the intersection distance
-                   in a differentiable way (w.r.t. to the sphere parameters) and
-                   then compute the corresponding point along the ray. */
-                si.t = dr::replace_grad(pi.t, ray_intersect_preliminary(ray, 0, active).t);
-                si.p = ray(si.t);
-                si.sh_frame.n = dr::normalize(si.p - center);
-                local = to_object * si.p;
-            }
-        } else {
-            si.t = pi.t;
-            si.sh_frame.n = dr::normalize(ray(si.t) - center);
-            // Re-project onto the sphere to improve accuracy
-            si.p = dr::fmadd(si.sh_frame.n, radius, center);
-            local = to_object * si.p;
-        }
+        // Re-project onto the sphere to improve accuracy
+        si.t = pi.t;
+        si.n = dr::detach(dr::normalize(ray(pi.t) - center));
+        si.p = dr::detach(dr::fmadd(si.n, radius, center));
+
+        /* Surface position at the detached parameterization: the local
+           coordinates are static as the sphere moves. */
+        Point3f p_att = to_world * dr::detach(to_object * si.p);
+
+        si.attach_motion(ray, p_att, ray_flags);
 
         si.t = dr::select(active, si.t, dr::Infinity<Float>);
+
+        si.sh_frame.n = dr::normalize(si.p - center);
+        Point3f local = to_object * si.p;
 
         if (likely(shading)) {
             Point2f angles = dir_to_sph(Vector3f(local));

--- a/src/shapes/sphere.cpp
+++ b/src/shapes/sphere.cpp
@@ -152,12 +152,10 @@ public:
         // Extract center and radius from to_world matrix (25 iterations for numerical accuracy)
         auto [S, Q, T] = dr::transform_decompose(m_to_world.scalar().matrix, 25);
 
-        if (dr::abs(S[0][1]) > 1e-6f || dr::abs(S[0][2]) > 1e-6f || dr::abs(S[1][0]) > 1e-6f ||
-            dr::abs(S[1][2]) > 1e-6f || dr::abs(S[2][0]) > 1e-6f || dr::abs(S[2][1]) > 1e-6f)
-            Log(Warn, "'to_world' transform shouldn't contain any shearing!");
-
-        if (!(dr::abs(S[0][0] - S[1][1]) < 1e-6f && dr::abs(S[0][0] - S[2][2]) < 1e-6f))
-            Log(Warn, "'to_world' transform shouldn't contain non-uniform scaling!");
+        // A sphere must be uniformly scaled (else it is an ellipsoid)
+        if (!m_to_world.scalar().is_similarity())
+            Log(Warn, "'to_world' transform shouldn't contain non-uniform "
+                      "scaling or shearing!");
 
         m_radius = dr::norm(m_to_world.value() * Vector3f(1.f, 0.f, 0.f));
         m_center = m_to_world.value() * Point3f(0.f);

--- a/src/shapes/tests/test_bsplinecurve.py
+++ b/src/shapes/tests/test_bsplinecurve.py
@@ -99,7 +99,8 @@ def test05_ray_intersect(variant_scalar_rgb):
                     ray = mi.Ray3f(o=[x, y, -10], d=[0, 0, 1],
                                 time=0.0, wavelengths=[])
 
-                    si = s.ray_intersect(ray, mi.RayFlags.All | mi.RayFlags.dNSdUV, True)
+                    si = s.ray_intersect(
+                        ray, mi.RayFlags.Default | mi.RayFlags.NormalPartials, True)
                     ray_u = mi.Ray3f(ray)
                     ray_v = mi.Ray3f(ray)
                     eps = 1e-4
@@ -169,7 +170,7 @@ def test07_differentiable_surface_interaction_ray_forward_follow_shape(variant_l
     )
     params.update()
     pi = scene.ray_intersect_preliminary(ray)
-    si = pi.compute_surface_interaction(ray, mi.RayFlags.All | mi.RayFlags.DetachShape)
+    si = pi.compute_surface_interaction(ray, mi.RayFlags.Default | mi.RayFlags.DetachShape)
 
     dr.forward(theta)
 
@@ -193,7 +194,7 @@ def test07_differentiable_surface_interaction_ray_forward_follow_shape(variant_l
     params.update()
 
     pi = scene.ray_intersect_preliminary(ray)
-    si = pi.compute_surface_interaction(ray, mi.RayFlags.All)
+    si = pi.compute_surface_interaction(ray, mi.RayFlags.Default)
 
     dr.forward(theta)
 
@@ -217,7 +218,7 @@ def test07_differentiable_surface_interaction_ray_forward_follow_shape(variant_l
     params.update()
 
     pi = scene.ray_intersect_preliminary(ray)
-    si = pi.compute_surface_interaction(ray, mi.RayFlags.All | mi.RayFlags.FollowShape)
+    si = pi.compute_surface_interaction(ray, mi.RayFlags.Default | mi.RayFlags.FollowShape)
 
     dr.forward(theta)
 
@@ -243,7 +244,7 @@ def test08_eval_parameterization(variants_vec_rgb):
     ray = mi.Ray3f(mi.Vector3f(x, y, 2), mi.Vector3f(0, 0, -1))
 
     pi = scene.ray_intersect_preliminary(ray)
-    si = pi.compute_surface_interaction(ray, mi.RayFlags.All | mi.RayFlags.DetachShape)
+    si = pi.compute_surface_interaction(ray, mi.RayFlags.Default | mi.RayFlags.DetachShape)
 
     curve = scene.shapes()[0]
     eval_param_si = curve.eval_parameterization(si.uv, active=si.is_valid())

--- a/src/shapes/tests/test_cylinder.py
+++ b/src/shapes/tests/test_cylinder.py
@@ -68,7 +68,8 @@ def test03_ray_intersect(variant_scalar_rgb):
                     ray = mi.Ray3f(o=[x, -10, z], d=[0, 1, 0],
                                 time=0.0, wavelengths=[])
                     si_found = s.ray_test(ray)
-                    si = s.ray_intersect(ray, mi.RayFlags.All | mi.RayFlags.dNSdUV, True)
+                    si = s.ray_intersect(
+                        ray, mi.RayFlags.Default | mi.RayFlags.NormalPartials, True)
 
                     assert si_found == si.is_valid()
                     assert si_found == dr.allclose(si.p[0]**2 + si.p[1]**2, r**2)
@@ -195,7 +196,7 @@ def test07_differentiable_surface_interaction_ray_forward(variants_all_ad_rgb):
     dr.enable_grad(theta)
     params['to_world'] = mi.Transform4f().scale(1 + theta)
     params.update()
-    si = shape.ray_intersect(ray, mi.RayFlags.All)
+    si = shape.ray_intersect(ray, mi.RayFlags.Default)
 
     dr.forward(theta)
 
@@ -213,7 +214,7 @@ def test07_differentiable_surface_interaction_ray_forward(variants_all_ad_rgb):
     dr.enable_grad(theta)
     params['to_world'] = mi.Transform4f().scale(1 + theta)
     params.update()
-    si = shape.ray_intersect(ray, mi.RayFlags.All | mi.RayFlags.FollowShape)
+    si = shape.ray_intersect(ray, mi.RayFlags.Default | mi.RayFlags.FollowShape)
 
     dr.forward(theta)
 
@@ -231,7 +232,7 @@ def test07_differentiable_surface_interaction_ray_forward(variants_all_ad_rgb):
     dr.enable_grad(theta)
     params['to_world'] = mi.Transform4f().translate([0, 0, theta])
     params.update()
-    si = shape.ray_intersect(ray, mi.RayFlags.All | mi.RayFlags.FollowShape)
+    si = shape.ray_intersect(ray, mi.RayFlags.Default | mi.RayFlags.FollowShape)
 
     dr.forward(theta)
 
@@ -249,7 +250,7 @@ def test07_differentiable_surface_interaction_ray_forward(variants_all_ad_rgb):
     dr.enable_grad(theta)
     params['to_world'] = mi.Transform4f().rotate([0, 0, 1], 90 * theta)
     params.update()
-    si = shape.ray_intersect(ray, mi.RayFlags.All | mi.RayFlags.FollowShape)
+    si = shape.ray_intersect(ray, mi.RayFlags.Default | mi.RayFlags.FollowShape)
 
     dr.forward(theta)
 
@@ -267,7 +268,7 @@ def test07_differentiable_surface_interaction_ray_forward(variants_all_ad_rgb):
     dr.enable_grad(theta)
     params['to_world'] = mi.Transform4f().rotate([0, 0, 1], 90 * theta)
     params.update()
-    si = shape.ray_intersect(ray, mi.RayFlags.All)
+    si = shape.ray_intersect(ray, mi.RayFlags.Default)
 
     dr.forward(theta)
 

--- a/src/shapes/tests/test_disk.py
+++ b/src/shapes/tests/test_disk.py
@@ -154,7 +154,7 @@ def test05_differentiable_surface_interaction_ray_forward(variants_all_ad_rgb):
     si = shape.ray_intersect(ray)
     si.dp_dv *= 1.0
     dr.forward(ray.o.y)
-    assert dr.allclose(dr.grad(si.dp_dv), [-1, 0, 0])
+    assert dr.allclose(dr.grad(si.dp_dv), [-2 * dr.pi, 0, 0], atol=1e-5)
 
 
 def test06_differentiable_surface_interaction_ray_backward(variants_all_ad_rgb):
@@ -295,6 +295,11 @@ def test08_eval_parameterization(variants_all_ad_rgb):
     si_after = shape.eval_parameterization(mi.Point2f(0.3, 0.6))
     assert dr.allclose(si_before.uv, si_after.uv)
 
+    # ``eval_parameterization`` must invert the reported UV parameterization
+    uv = mi.Point2f(dr.meshgrid(dr.linspace(mi.Float, 0.05, 0.95, 5),
+                                dr.linspace(mi.Float, 0.05, 0.95, 5)))
+    assert dr.allclose(shape.eval_parameterization(uv).uv, uv)
+
 
 def test09_sample_silhouette_wrong_type(variants_all_rgb):
     disk = mi.load_dict({ 'type': 'disk' })
@@ -423,3 +428,31 @@ def test16_sample_precomputed_silhouette(variants_vec_rgb):
 def test17_shape_type(variant_scalar_rgb):
     disk = mi.load_dict({ 'type': 'disk' })
     assert disk.shape_type() == mi.ShapeType.Disk.value;
+
+
+def test18_position_partials(variant_scalar_rgb):
+    """``dp_du``/``dp_dv`` must be the derivatives of ``si.uv = (r, phi/2pi)``"""
+    import numpy as np
+
+    to_world = mi.ScalarTransform4f().scale([2, 3, 1])
+    scene = mi.load_dict({'type': 'scene',
+                          'shape': {'type': 'disk', 'to_world': to_world}})
+    M = np.array(to_world.matrix, dtype=np.float64)[:3, :3]
+
+    def position(u, v):
+        phi = 2 * np.pi * v
+        return M @ np.array([u * np.cos(phi), u * np.sin(phi), 0.0])
+
+    h = 1e-5
+    for x in dr.linspace(Float, -1.5, 1.5, 5):
+        for y in dr.linspace(Float, -1.5, 1.5, 5):
+            ray = mi.Ray3f(mi.Point3f(x, y, 5), mi.Vector3f(0, 0, -1))
+            si = scene.ray_intersect(ray, mi.RayFlags.All, True)
+            # The azimuth, and hence the partials, are undefined at the center
+            if not si.is_valid() or si.uv[0] == 0:
+                continue
+            u, v = float(si.uv[0]), float(si.uv[1])
+            assert dr.allclose(si.dp_du, (position(u + h, v) -
+                                          position(u - h, v)) / (2 * h), atol=1e-3)
+            assert dr.allclose(si.dp_dv, (position(u, v + h) -
+                                          position(u, v - h)) / (2 * h), atol=1e-3)

--- a/src/shapes/tests/test_disk.py
+++ b/src/shapes/tests/test_disk.py
@@ -60,7 +60,8 @@ def test03_ray_intersect(variant_scalar_rgb):
                         ray = mi.Ray3f(o=[x, y, -10], d=[0, 0, 1],
                                     time=0.0, wavelengths=[])
 
-                        si = s.ray_intersect(ray, mi.RayFlags.All | mi.RayFlags.dNSdUV, True)
+                        si = s.ray_intersect(
+                            ray, mi.RayFlags.Default | mi.RayFlags.NormalPartials, True)
                         ray_u = mi.Ray3f(ray)
                         ray_v = mi.Ray3f(ray)
                         eps = 1e-4
@@ -190,7 +191,7 @@ def test07_differentiable_surface_interaction_ray_forward_follow_shape(variants_
     dr.enable_grad(theta)
     params['to_world'] = mi.Transform4f().scale(1 + theta)
     params.update()
-    si = shape.ray_intersect(ray, mi.RayFlags.All | mi.RayFlags.DetachShape)
+    si = shape.ray_intersect(ray, mi.RayFlags.Default | mi.RayFlags.DetachShape)
 
     dr.forward(theta)
 
@@ -208,7 +209,7 @@ def test07_differentiable_surface_interaction_ray_forward_follow_shape(variants_
     dr.enable_grad(theta)
     params['to_world'] = mi.Transform4f().scale(1 + theta)
     params.update()
-    si = shape.ray_intersect(ray, mi.RayFlags.All)
+    si = shape.ray_intersect(ray, mi.RayFlags.Default)
 
     dr.forward(theta)
 
@@ -232,7 +233,7 @@ def test07_differentiable_surface_interaction_ray_forward_follow_shape(variants_
     dr.enable_grad(theta)
     params['to_world'] = mi.Transform4f().translate([theta, 0.0, 0.0])
     params.update()
-    si = shape.ray_intersect(ray, mi.RayFlags.All | mi.RayFlags.FollowShape)
+    si = shape.ray_intersect(ray, mi.RayFlags.Default | mi.RayFlags.FollowShape)
 
     dr.forward(theta, dr.ADFlag.ClearNone)
 
@@ -250,7 +251,7 @@ def test07_differentiable_surface_interaction_ray_forward_follow_shape(variants_
     dr.enable_grad(theta)
     params['to_world'] = mi.Transform4f().rotate([0, 0, 1], 90 * theta)
     params.update()
-    si = shape.ray_intersect(ray, mi.RayFlags.All | mi.RayFlags.FollowShape)
+    si = shape.ray_intersect(ray, mi.RayFlags.Default | mi.RayFlags.FollowShape)
 
     dr.forward(theta)
 
@@ -268,7 +269,7 @@ def test07_differentiable_surface_interaction_ray_forward_follow_shape(variants_
     dr.enable_grad(theta)
     params['to_world'] = mi.Transform4f().rotate([0, 0, 1], 90 * theta)
     params.update()
-    si = shape.ray_intersect(ray, mi.RayFlags.All)
+    si = shape.ray_intersect(ray, mi.RayFlags.Default)
 
     dr.forward(theta)
 
@@ -447,7 +448,7 @@ def test18_position_partials(variant_scalar_rgb):
     for x in dr.linspace(Float, -1.5, 1.5, 5):
         for y in dr.linspace(Float, -1.5, 1.5, 5):
             ray = mi.Ray3f(mi.Point3f(x, y, 5), mi.Vector3f(0, 0, -1))
-            si = scene.ray_intersect(ray, mi.RayFlags.All, True)
+            si = scene.ray_intersect(ray, mi.RayFlags.Default, True)
             # The azimuth, and hence the partials, are undefined at the center
             if not si.is_valid() or si.uv[0] == 0:
                 continue

--- a/src/shapes/tests/test_ellipsoidsmesh.py
+++ b/src/shapes/tests/test_ellipsoidsmesh.py
@@ -36,12 +36,12 @@ def test01_backface_culling_contract(variants_all_rgb):
     ray = mi.Ray3f(o=mi.Point3f([0, 0, 0]), d=mi.Vector3f([0, 0, -1]))
     _assert_invalid(scene.ray_test(ray))
     _assert_invalid(scene.ray_intersect_preliminary(ray).is_valid())
-    _assert_invalid(scene.ray_intersect(ray, mi.RayFlags.All, True).is_valid())
+    _assert_invalid(scene.ray_intersect(ray, mi.RayFlags.Default, True).is_valid())
 
     ray = mi.Ray3f(o=mi.Point3f([0, 0, 2]), d=mi.Vector3f([0, 0, -1]))
     _assert_valid(scene.ray_test(ray))
     _assert_valid(scene.ray_intersect_preliminary(ray).is_valid())
-    _assert_valid(scene.ray_intersect(ray, mi.RayFlags.All, True).is_valid())
+    _assert_valid(scene.ray_intersect(ray, mi.RayFlags.Default, True).is_valid())
 
 
 @fresolver_append_path
@@ -77,4 +77,4 @@ def test02_mixed_mesh_backfaces_remain_double_sided(variants_all_rgb):
     ray = mi.Ray3f(o=mi.Point3f([3, 0, -2]), d=mi.Vector3f([0, 0, 1]))
     _assert_valid(scene.ray_test(ray))
     _assert_valid(scene.ray_intersect_preliminary(ray).is_valid())
-    _assert_valid(scene.ray_intersect(ray, mi.RayFlags.All, True).is_valid())
+    _assert_valid(scene.ray_intersect(ray, mi.RayFlags.Default, True).is_valid())

--- a/src/shapes/tests/test_instance.py
+++ b/src/shapes/tests/test_instance.py
@@ -66,8 +66,9 @@ def test01_ray_intersect(variant_scalar_rgb, shape):
             assert si_found == si_found_inst
 
             if si_found:
-                si = s.ray_intersect(ray, mi.RayFlags.All | mi.RayFlags.dNSdUV, coherent=True, active=True)
-                si_inst = s_inst.ray_intersect(ray, mi.RayFlags.All | mi.RayFlags.dNSdUV, coherent=True, active=True)
+                flags = mi.RayFlags.Default | mi.RayFlags.NormalPartials
+                si = s.ray_intersect(ray, flags, coherent=True, active=True)
+                si_inst = s_inst.ray_intersect(ray, flags, coherent=True, active=True)
 
                 assert si.prim_index == si_inst.prim_index
                 assert si.instance is None
@@ -113,7 +114,7 @@ def test02_ray_intersect_transform(variant_scalar_rgb, shape):
                 assert si_found == si_found_inst
 
                 if si_found:
-                    flags = mi.RayFlags.All | mi.RayFlags.dNSdUV
+                    flags = mi.RayFlags.Default | mi.RayFlags.NormalPartials
                     si = s.ray_intersect(ray, flags, coherent=True, active=True)
                     si_inst = s_inst.ray_intersect(ray, flags, coherent=True, active=True)
 
@@ -281,7 +282,7 @@ def test05_normal_partials_non_similarity(variant_scalar_rgb):
                      'group': {'type': 'ref', 'id': 'group'},
                      'to_world': to_world}
     })
-    flags = mi.RayFlags.All | mi.RayFlags.dNSdUV
+    flags = mi.RayFlags.Default | mi.RayFlags.NormalPartials
 
     hits = 0
     for x in dr.linspace(ScalarF, -0.9, 0.9, 8):

--- a/src/shapes/tests/test_instance.py
+++ b/src/shapes/tests/test_instance.py
@@ -112,25 +112,25 @@ def test02_ray_intersect_transform(variant_scalar_rgb, shape):
 
                 assert si_found == si_found_inst
 
-                for dn_flags in [mi.RayFlags.dNGdUV, mi.RayFlags.dNSdUV]:
-                    if si_found:
-                        si = s.ray_intersect(ray, mi.RayFlags.All | dn_flags, coherent=True, active=True)
-                        si_inst = s_inst.ray_intersect(ray, mi.RayFlags.All | dn_flags, coherent=True, active=True)
+                if si_found:
+                    flags = mi.RayFlags.All | mi.RayFlags.dNSdUV
+                    si = s.ray_intersect(ray, flags, coherent=True, active=True)
+                    si_inst = s_inst.ray_intersect(ray, flags, coherent=True, active=True)
 
-                        assert si.prim_index == si_inst.prim_index
-                        assert si.instance is None
-                        assert si_inst.instance is not None
-                        assert dr.allclose(si.t, si_inst.t, atol=2e-2)
-                        assert dr.allclose(si.time, si_inst.time, atol=2e-2)
-                        assert dr.allclose(si.p, si_inst.p, atol=2e-2)
-                        assert dr.allclose(si.dp_du, si_inst.dp_du, atol=2e-2)
-                        assert dr.allclose(si.dp_dv, si_inst.dp_dv, atol=2e-2)
-                        assert dr.allclose(si.uv, si_inst.uv, atol=2e-2)
-                        assert dr.allclose(si.wi, si_inst.wi, atol=2e-2)
+                    assert si.prim_index == si_inst.prim_index
+                    assert si.instance is None
+                    assert si_inst.instance is not None
+                    assert dr.allclose(si.t, si_inst.t, atol=2e-2)
+                    assert dr.allclose(si.time, si_inst.time, atol=2e-2)
+                    assert dr.allclose(si.p, si_inst.p, atol=2e-2)
+                    assert dr.allclose(si.dp_du, si_inst.dp_du, atol=2e-2)
+                    assert dr.allclose(si.dp_dv, si_inst.dp_dv, atol=2e-2)
+                    assert dr.allclose(si.uv, si_inst.uv, atol=2e-2)
+                    assert dr.allclose(si.wi, si_inst.wi, atol=2e-2)
 
-                        if dr.norm(si.dn_du) > 0.0 and dr.norm(si.dn_dv) > 0.0:
-                            assert dr.allclose(si.dn_du, si_inst.dn_du, atol=2e-2)
-                            assert dr.allclose(si.dn_dv, si_inst.dn_dv, atol=2e-2)
+                    if dr.norm(si.dn_du) > 0.0 and dr.norm(si.dn_dv) > 0.0:
+                        assert dr.allclose(si.dn_du, si_inst.dn_du, atol=2e-2)
+                        assert dr.allclose(si.dn_dv, si_inst.dn_dv, atol=2e-2)
 
 
 @pytest.mark.parametrize('width', [1, 10])
@@ -262,3 +262,35 @@ def test04_single_child_group_recovery(variants_vec_backends_once_rgb, shape):
             assert dr.allclose(si.t, si_inst.t, atol=2e-2)
             assert dr.allclose(si.p, si_inst.p, atol=2e-2)
             assert dr.allclose(si.n, si_inst.n, atol=2e-2)
+
+
+def test05_normal_partials_non_similarity(variant_scalar_rgb):
+    """The instance transform must not assume that it is a similarity"""
+    from drjit.scalar import ArrayXf as ScalarF
+    from mitsuba import ScalarTransform4f as T
+    from mitsuba.scalar_rgb.test.util import curved_triangle, check_normal_partials
+
+    to_world = T().rotate([0.6, 0.8, 0.0], 37).scale([1.0, 2.0, 3.0])
+    assert not to_world.is_similarity()
+
+    mesh, normal_field = curved_triangle()
+    scene = mi.load_dict({
+        'type': 'scene',
+        'group': {'type': 'shapegroup', 'shape': mesh},
+        'instance': {'type': 'instance',
+                     'group': {'type': 'ref', 'id': 'group'},
+                     'to_world': to_world}
+    })
+    flags = mi.RayFlags.All | mi.RayFlags.dNSdUV
+
+    hits = 0
+    for x in dr.linspace(ScalarF, -0.9, 0.9, 8):
+        for y in dr.linspace(ScalarF, -0.9, 0.9, 8):
+            ray = mi.Ray3f(mi.Point3f(x, y, 8), mi.Vector3f(0, 0, -1))
+            si = scene.ray_intersect(ray, flags, True)
+            if not si.is_valid():
+                continue
+            hits += 1
+            check_normal_partials(si, normal_field, to_world)
+
+    assert hits > 5, hits

--- a/src/shapes/tests/test_linearcurve.py
+++ b/src/shapes/tests/test_linearcurve.py
@@ -100,7 +100,7 @@ def test04_ray_intersect(variant_scalar_rgb):
                     ray = mi.Ray3f(o=[x, y, -10], d=[0, 0, 1],
                                 time=0.0, wavelengths=[])
 
-                    si = s.ray_intersect(ray, mi.RayFlags.All | mi.RayFlags.dNSdUV, True)
+                    si = s.ray_intersect(ray, mi.RayFlags.Default, True)
                     ray_u = mi.Ray3f(ray)
                     ray_v = mi.Ray3f(ray)
                     eps = 1e-4
@@ -111,14 +111,10 @@ def test04_ray_intersect(variant_scalar_rgb):
 
                     if si_u.is_valid():
                         dp_du = (si_u.p - si.p) / eps
-                        dn_du = (si_u.n - si.n) / eps
                         assert dr.allclose(dp_du, si.dp_du, atol=2e-2)
-                        assert dr.allclose(dn_du, si.dn_du, atol=2e-2)
                     if si_v.is_valid():
                         dp_dv = (si_v.p - si.p) / eps
-                        dn_dv = (si_v.n - si.n) / eps
                         assert dr.allclose(dp_dv, si.dp_dv, atol=2e-2)
-                        assert dr.allclose(dn_dv, si.dn_dv, atol=2e-2)
 
 
 @fresolver_append_path

--- a/src/shapes/tests/test_rectangle.py
+++ b/src/shapes/tests/test_rectangle.py
@@ -242,7 +242,7 @@ def test08_differentiable_surface_interaction_ray_forward_follow_shape(variants_
     dr.enable_grad(theta)
     params['to_world'] = mi.Transform4f().scale(1 + theta)
     params.update()
-    si = scene.ray_intersect(ray, mi.RayFlags.All | mi.RayFlags.DetachShape, False)
+    si = scene.ray_intersect(ray, mi.RayFlags.Default | mi.RayFlags.DetachShape, False)
 
     dr.forward(theta)
 
@@ -260,7 +260,7 @@ def test08_differentiable_surface_interaction_ray_forward_follow_shape(variants_
     dr.enable_grad(theta)
     params['to_world'] = mi.Transform4f().scale([1 + theta, 1 + 2 * theta, 1])
     params.update()
-    si = scene.ray_intersect(ray, mi.RayFlags.All, False)
+    si = scene.ray_intersect(ray, mi.RayFlags.Default, False)
 
     dr.forward(theta)
 
@@ -281,7 +281,7 @@ def test08_differentiable_surface_interaction_ray_forward_follow_shape(variants_
     dr.enable_grad(theta)
     params['to_world'] = mi.Transform4f().translate([theta, 0.0, 0.0])
     params.update()
-    si = scene.ray_intersect(ray, mi.RayFlags.All | mi.RayFlags.FollowShape, False)
+    si = scene.ray_intersect(ray, mi.RayFlags.Default | mi.RayFlags.FollowShape, False)
 
     dr.forward(theta, dr.ADFlag.ClearNone)
 
@@ -299,7 +299,7 @@ def test08_differentiable_surface_interaction_ray_forward_follow_shape(variants_
     dr.enable_grad(theta)
     params['to_world'] = mi.Transform4f().rotate([0, 0, 1], 90 * theta)
     params.update()
-    si = scene.ray_intersect(ray, mi.RayFlags.All | mi.RayFlags.FollowShape, False)
+    si = scene.ray_intersect(ray, mi.RayFlags.Default | mi.RayFlags.FollowShape, False)
 
     dr.forward(theta)
 
@@ -316,7 +316,7 @@ def test08_differentiable_surface_interaction_ray_forward_follow_shape(variants_
     dr.enable_grad(theta)
     params['to_world'] = mi.Transform4f().rotate([0, 0, 1], 90 * theta)
     params.update()
-    si = scene.ray_intersect(ray, mi.RayFlags.All, False)
+    si = scene.ray_intersect(ray, mi.RayFlags.Default, False)
 
     dr.forward(theta)
 
@@ -492,7 +492,7 @@ def test18_inv_transpose(variants_all_ad_rgb):
     dr.enable_grad(params['shape.to_world'])
     params.update()
 
-    si = scene.ray_intersect(mi.Ray3f([0, 0, 2], [0, 0, -1]), mi.RayFlags.All, False)
+    si = scene.ray_intersect(mi.Ray3f([0, 0, 2], [0, 0, -1]), mi.RayFlags.Default, False)
     dr.backward(si.t)
     assert dr.allclose(
         dr.grad(params['shape.to_world']).matrix,

--- a/src/shapes/tests/test_sdfgrid.py
+++ b/src/shapes/tests/test_sdfgrid.py
@@ -102,7 +102,7 @@ def test04_ray_intersect(variants_all_ad_rgb):
                 assert si_found == (x >= 0 and x <= 1 and y >= 0 and y<= 1)
 
                 if si_found[0]:
-                    si = s.ray_intersect(ray, mi.RayFlags.All, True)
+                    si = s.ray_intersect(ray, mi.RayFlags.Default, True)
 
                     assert dr.allclose(si.t, 2 + y)
                     assert dr.allclose(si.n, mi.Normal3f(0, 1 / dr.sqrt(2), 1 / dr.sqrt(2)))
@@ -165,7 +165,7 @@ def test05_ray_intersect_instancing(variants_all_ad_rgb):
                 assert si_found == (x >= 0 and x <= 1 and y >= 0 and y<= 1)
 
                 if si_found[0]:
-                    si = s.ray_intersect(ray, mi.RayFlags.All, True)
+                    si = s.ray_intersect(ray, mi.RayFlags.Default, True)
 
                     assert dr.allclose(si.t, 2 + y)
                     assert dr.allclose(si.n, np.array([0, 1 / np.sqrt(2), 1 / np.sqrt(2)]))
@@ -207,7 +207,7 @@ def test07_differentiable_surface_interaction_ray_forward_follow_shape(variants_
     params['sdf.to_world'] = mi.Transform4f().translate(mi.Vector3f(theta))
     params.update()
     pi = scene.ray_intersect_preliminary(ray)
-    si = pi.compute_surface_interaction(ray, mi.RayFlags.All | mi.RayFlags.DetachShape)
+    si = pi.compute_surface_interaction(ray, mi.RayFlags.Default | mi.RayFlags.DetachShape)
 
     dr.forward(theta)
 
@@ -226,7 +226,7 @@ def test07_differentiable_surface_interaction_ray_forward_follow_shape(variants_
     params['sdf.to_world'] = dr.detach(params['sdf.to_world'])
     params.update()
     pi = scene.ray_intersect_preliminary(ray)
-    si = pi.compute_surface_interaction(ray, mi.RayFlags.All | mi.RayFlags.DetachShape)
+    si = pi.compute_surface_interaction(ray, mi.RayFlags.Default | mi.RayFlags.DetachShape)
 
     dr.forward(theta)
 
@@ -247,7 +247,7 @@ def test07_differentiable_surface_interaction_ray_forward_follow_shape(variants_
     params['sdf.to_world'] = mi.Transform4f().translate([0, theta, 0])
     params.update()
     pi = scene.ray_intersect_preliminary(ray)
-    si = pi.compute_surface_interaction(ray, mi.RayFlags.All)
+    si = pi.compute_surface_interaction(ray, mi.RayFlags.Default)
 
     dr.forward(theta)
 
@@ -271,7 +271,7 @@ def test07_differentiable_surface_interaction_ray_forward_follow_shape(variants_
 
     ray = mi.Ray3f(mi.Vector3f(0.5, 0.5, 2), mi.Vector3f(0, 0, -1))
     pi = scene.ray_intersect_preliminary(ray)
-    si = pi.compute_surface_interaction(ray, mi.RayFlags.All)
+    si = pi.compute_surface_interaction(ray, mi.RayFlags.Default)
 
     dr.forward(theta)
 
@@ -292,7 +292,7 @@ def test07_differentiable_surface_interaction_ray_forward_follow_shape(variants_
 
     ray = mi.Ray3f(mi.Vector3f(0.5, 0.5, 2), mi.Vector3f(0, 0, -1))
     pi = scene.ray_intersect_preliminary(ray)
-    si = pi.compute_surface_interaction(ray, mi.RayFlags.All | mi.RayFlags.FollowShape)
+    si = pi.compute_surface_interaction(ray, mi.RayFlags.Default | mi.RayFlags.FollowShape)
 
     dr.forward(theta)
 
@@ -315,7 +315,7 @@ def test07_differentiable_surface_interaction_ray_forward_follow_shape(variants_
 
     ray = mi.Ray3f(mi.Vector3f(0.5, 0.5, 2), mi.Vector3f(0, 0, -1))
     pi = scene.ray_intersect_preliminary(ray)
-    si = pi.compute_surface_interaction(ray, mi.RayFlags.All | mi.RayFlags.FollowShape)
+    si = pi.compute_surface_interaction(ray, mi.RayFlags.Default | mi.RayFlags.FollowShape)
 
     dr.forward(theta)
 
@@ -357,7 +357,7 @@ def test08_load_tensor(variants_all_ad_rgb):
                 assert si_found == (x >= 0 and x <= 1 and y >= 0 and y<= 1)
 
                 if si_found[0]:
-                    si = s.ray_intersect(ray, mi.RayFlags.All, True)
+                    si = s.ray_intersect(ray, mi.RayFlags.Default, True)
 
                     assert dr.allclose(si.t, 2 + y)
                     assert dr.allclose(si.n, np.array([0, 1 / np.sqrt(2), 1 / np.sqrt(2)]))

--- a/src/shapes/tests/test_sphere.py
+++ b/src/shapes/tests/test_sphere.py
@@ -496,3 +496,29 @@ def test20_eval_param_consistency(variants_vec_rgb, r):
     assert dr.allclose(si_ray.p, ps.p)
     assert dr.allclose(si_param.uv, ps.uv)
     assert dr.allclose(si_ray.uv, ps.uv)
+
+
+def test21_normal_partials(variant_scalar_rgb):
+    import numpy as np
+    from mitsuba.scalar_rgb.test.util import check_normal_partials
+
+    scene = mi.load_dict({'type': 'scene',
+                          'shape': {'type': 'sphere', 'radius': 0.8}})
+    flags = mi.RayFlags.All | mi.RayFlags.dNSdUV
+
+    def normal_field(u, v):
+        phi, theta = 2 * np.pi * u, np.pi * v
+        return np.array([np.sin(theta) * np.cos(phi),
+                         np.sin(theta) * np.sin(phi), np.cos(theta)])
+
+    hits = 0
+    for x in dr.linspace(Float, -0.5, 0.5, 6):
+        for y in dr.linspace(Float, -0.5, 0.5, 6):
+            ray = mi.Ray3f(mi.Point3f(x, y, 5), mi.Vector3f(0, 0, -1))
+            si = scene.ray_intersect(ray, flags, True)
+            if not si.is_valid():
+                continue
+            hits += 1
+            check_normal_partials(si, normal_field)
+
+    assert hits > 10, hits

--- a/src/shapes/tests/test_sphere.py
+++ b/src/shapes/tests/test_sphere.py
@@ -232,7 +232,7 @@ def test08_differentiable_surface_interaction_ray_forward_follow_shape(variants_
     dr.enable_grad(theta)
     params['to_world'] = mi.Transform4f().scale(1 + theta)
     params.update()
-    si = shape.ray_intersect(ray, mi.RayFlags.All | mi.RayFlags.DetachShape)
+    si = shape.ray_intersect(ray, mi.RayFlags.Default | mi.RayFlags.DetachShape)
 
     dr.forward(theta)
 
@@ -250,7 +250,7 @@ def test08_differentiable_surface_interaction_ray_forward_follow_shape(variants_
     dr.enable_grad(theta)
     params['to_world'] = mi.Transform4f().scale(1 + theta)
     params.update()
-    si = shape.ray_intersect(ray, mi.RayFlags.All)
+    si = shape.ray_intersect(ray, mi.RayFlags.Default)
 
     dr.forward(theta)
 
@@ -268,7 +268,7 @@ def test08_differentiable_surface_interaction_ray_forward_follow_shape(variants_
     dr.enable_grad(theta)
     params['to_world'] = mi.Transform4f().translate([theta, 0.0, 0.0])
     params.update()
-    si = shape.ray_intersect(ray, mi.RayFlags.All | mi.RayFlags.FollowShape)
+    si = shape.ray_intersect(ray, mi.RayFlags.Default | mi.RayFlags.FollowShape)
 
     dr.forward(theta)
 
@@ -286,7 +286,7 @@ def test08_differentiable_surface_interaction_ray_forward_follow_shape(variants_
     dr.enable_grad(theta)
     params['to_world'] = mi.Transform4f().rotate([0, 1, 0], 90 * theta)
     params.update()
-    si = shape.ray_intersect(ray, mi.RayFlags.All | mi.RayFlags.FollowShape)
+    si = shape.ray_intersect(ray, mi.RayFlags.Default | mi.RayFlags.FollowShape)
 
     dr.forward(theta)
 
@@ -304,7 +304,7 @@ def test08_differentiable_surface_interaction_ray_forward_follow_shape(variants_
     dr.enable_grad(theta)
     params['to_world'] = mi.Transform4f().rotate([1, 0, 0], 90 * theta)
     params.update()
-    si = shape.ray_intersect(ray, mi.RayFlags.All)
+    si = shape.ray_intersect(ray, mi.RayFlags.Default)
 
     dr.forward(theta)
 
@@ -504,7 +504,7 @@ def test21_normal_partials(variant_scalar_rgb):
 
     scene = mi.load_dict({'type': 'scene',
                           'shape': {'type': 'sphere', 'radius': 0.8}})
-    flags = mi.RayFlags.All | mi.RayFlags.dNSdUV
+    flags = mi.RayFlags.Default | mi.RayFlags.NormalPartials
 
     def normal_field(u, v):
         phi, theta = 2 * np.pi * u, np.pi * v


### PR DESCRIPTION
This PR contains a large simplification/fix pass over the various implementations of `Shape::compute_surface_interaction()`. It also simplifies the `RayFlags` enumeration, and removes redundant per-shape code handling `FollowShape`/`DetachShape`.

### `526a9a4d` — Mesh: fix computation of ``dp_du``/``dp_dv``

For a mesh without vertex texture coordinates, ``si.uv`` holds barycentric coordinates. This commit makes the reported ``dp_du`` and ``dp_dv`` tangents compatible with this convention.

### `e478ac5f` — Tweaks to shading frame generation

This commit inlines and refactors the computation of the shading frame in ``finalize_surface_interaction()``. It now uses a symbolic ``if`` statement to accelerate the default case where ``si.dp_du`` is valid.

The shading frame and ``wi`` are now only defined when the caller requests them. The ``sdfgrid`` plugin previously left ``sh_frame.n`` zero-initialized for other queries and ``instance`` left it in object space, both of which produce a meaningless ``si.wi``.

The instance plugin also no longer transforms and re-orthogonalizes the tangent, which disagreed with the transformation applied to ``dp_du`` under non-similarity transforms.

The commit also adds ``Transform::is_similarity()``, used by the sphere.

### `49abd0e3` — Mesh: detach the geometric normal when ``RayFlags::DetachShape`` is set

(The ``Mesh::compute_surface_interaction()`` implementation previously re-gathered positions to compute ``si.n``, which broke the expected behavior)

### `79110c1c` — Fix the shading normal partials of meshes and instances

The ``SurfaceInteraction::dn_du`` and ``dn_dv`` fields were incorrect in two places.

- The mesh expressed them wrt. barycentric coordinates while ``dp_du``/``dp_dv`` used texture coordinates. This caused incorrect projective sampling steps on meshes with texture coordinates. Both sets of fields now consistently use the UV parameterization whenever available. The mesh partials now also correctly follow ``flip_normals``, which previously only affected the normal.

- The instance plugin divides the partials by the length of the transformed shading normal prior to renormalization. The implementation previously did this incorrectly by mapping the normal through an attached transformation and measuring its length, which caused a partial derivative wrt. the instance transform that the
  normal does not have.

This commit deletes ``RayFlags::dNGdUV`` (derivative wrt. the geometric normal), which isn't used anywhere. It also removes a special case for collapsed triangles, which no part of Mitsuba actually depended on.

### `c9aaa81a` — Disk: fix UV parameterization inconsistencies

The shape uses ``si.uv = (r, phi/2pi)``. Two parts of the plugin were incompatible:

- ``dp_dv`` lacked a factor of ``2*pi*r``.

- ``eval_parameterization()`` used ``square_to_uniform_disk_concentric()`` instead of a polar map.

This commit fixes both and updates the tests.

### `ddcb08fe` — Reduce the number of ``RayFlags``

The ``compute_surface_interaction()`` implementations of various shapes are surprisingly complex, partly because they permit fine-grained selection of individual fields. Some entries (e.g., ``UV``, ``dPdUV``, ``ShadingFrame`` were never used individually).

This commit reduces ``RayFlags`` to

- ``Minimal`` (distance, position and geometric normal),
- ``Shading`` (+UV coordinates, position partials, and the shading frame),
- ``NormalPartials`` (formerly ``dNSdUV``)

A default alias (named ``Default``) is set to ``Shading``. The value ``All`` is deprecated (it never computed all fields..).

### `212f26ef` — Simplification pass over shape differentiation modes

Every shape implemented handling of ``FollowShape``/``DetachShape`` in a different way, which added up to a fairly large amount of redundant code.

This commit introduces ``SurfaceInteraction::attach_motion()``, which reattaches a suitably computed differentiable intersection using a ray-plane intersection based on the available differential geometry. This removes steps like a custom Möller-Trumbore intersection for triangle meshes, and curve-related code for b-spline curves.

The also fixes the linear curve primitive by filling ``dp_du``/``dp_dv`` and replaces a few uses of ``dr::detach<true>()`` by ``dr::detach()`` (they are equivalent).
