### PR TITLE
Fix AOV splatting in the AD integrator forward/backward passes

### DIFF
--- a/src/python/python/ad/integrators/common.py
+++ b/src/python/python/ad/integrators/common.py
@@ -607,7 +607,7 @@ class RBIntegrator(ADIntegrator):
                 value=δL * weight,
                 weight=1.0,
                 alpha=dr.select(valid_2, mi.Float(1), mi.Float(0)),
-                aovs=[δaov * weight for δaov in δaovs],
+                aovs=δaovs,
                 wavelengths=ray.wavelengths
             )
 
@@ -739,7 +739,7 @@ class RBIntegrator(ADIntegrator):
                     value=L * weight,
                     weight=1.0,
                     alpha=1.0,
-                    aovs=[aov * weight for aov in aovs]
+                    aovs=aovs
                 )
 
                 δL = dr.grad(L)
@@ -1001,7 +1001,7 @@ class PSIntegrator(ADIntegrator):
                 value=L * weight,
                 weight=1.0,
                 alpha=dr.select(valid, mi.Float(1), mi.Float(0)),
-                aovs=[aov * weight for aov in aovs],
+                aovs=aovs,
                 wavelengths=ray.wavelengths
             )
 


### PR DESCRIPTION
An AOV should not be scaled by the sensor importance. Furthermore, multiplying a `Float` AOV by the `Spectrum` sensor weight promotes it to a `Color3f`, which then sits in the channel list handed to `block.put`, and `put` only accepts `Floats`, which results in a `TypeError` aka crash.

Fix:

Do not multiply `δaov` with `weight`.

## Checklist

- [x] My code follows the [style guidelines](https://mitsuba.readthedocs.io/en/latest/src/developer_guide.html#coding-style) of this project
- [x] My changes generate no new warnings
- [x] My code also compiles for `cuda_*` and `llvm_*` variants. If you can't test this, please leave below
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 3 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba/blob/master/LICENSE)