### PR TITLE
Fix regular spectrum docstring

### DIFF
--- a/src/spectra/regular.cpp
+++ b/src/spectra/regular.cpp
@@ -32,7 +32,7 @@ Regular spectrum (:monosp:`regular`)
  * - range
    - |string|
    - Spectral emission range.
-   - |exposed|, |differentiable|
+   - |exposed|
 
 This spectrum returns linearly interpolated reflectance or emission values from *regularly*
 placed samples.
@@ -42,8 +42,9 @@ placed samples.
         :name: regular
 
         <spectrum type="regular">
-            <string name="range" value="400, 700">
-            <string name="values" value="0.1, 0.2">
+            <float name="wavelength_min" value="400"/>
+            <float name="wavelength_max" value="700"/>
+            <string name="values" value="0.1, 0.2"/>
         </spectrum>
 
     .. code-tab:: python


### PR DESCRIPTION
<!-- Please add the labels (e.g. bug fix, feature, ..) corresponding to this PR -->

## Description

Fixes the docstring in regular.cpp

The range parameter is listed as differentiable, but traverse() registers it as ParamFlags::NonDifferentiable, and ContinuousDistribution::range() returns a ScalarVector2f, so it cannot carry a gradient under any variant.

Also fixed the xml code tab to match the python code tab. 

## Testing

<!-- Please describe the tests that you added to verify your changes. -->

## Checklist

<!-- Please make sure to complete this checklist before requesting a review. -->

- [x] I have made corresponding changes to the documentation
- [x] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 3 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba/blob/master/LICENSE)