### PR TITLE
Fixes for Bsplinecurve

### DIFF
--- a/src/render/metal_accel.mm
+++ b/src/render/metal_accel.mm
@@ -433,7 +433,9 @@ build_impl(const std::vector<BlasEntry> &blases,
                                                           ? MTLCurveBasisBSpline
                                                           : MTLCurveBasisLinear;
                         gd.curveType                = MTLCurveTypeRound;
-                        gd.curveEndCaps             = MTLCurveEndCapsSphere;
+                        gd.curveEndCaps             = bspline
+                                                          ? MTLCurveEndCapsNone
+                                                          : MTLCurveEndCapsSphere;
                         gd.opaque                   = YES;
                         [geoms addObject: gd];
 

--- a/src/shapes/bsplinecurve.cpp
+++ b/src/shapes/bsplinecurve.cpp
@@ -277,6 +277,7 @@ public:
         m_indices = dr::load<UInt32Storage>(indices.get(), segment_count);
         m_curves_prim_idx = dr::load<UInt32Storage>(curves_1st_prim_idx.get(),
                                                     curve_1st_idx.size() + 1);
+        m_segment_count = dr::opaque<Float>((ScalarFloat) segment_count);
 
         std::unique_ptr<InputFloat[]> positions =
             std::make_unique<InputFloat[]>(m_control_point_count * 3);
@@ -345,6 +346,7 @@ public:
             recompute_bbox();
             mark_dirty();
         }
+        m_segment_count = dr::opaque<Float>((ScalarFloat) dr::width(m_indices));
         Base::parameters_changed();
     }
 
@@ -362,10 +364,10 @@ public:
 
         // Convert global v to segment-local v
         Float v_global = uv.y();
-        size_t segment_count = dr::width(m_indices);
-        UInt32 segment_idx = dr::floor2int<UInt32>(v_global * segment_count);
-        segment_idx = dr::clip(segment_idx, 0, (uint32_t) segment_count - 1); // In case v_global == 1
-        Float v_local = v_global * segment_count - segment_idx;
+        UInt32 segment_idx = dr::floor2int<UInt32>(v_global * m_segment_count);
+        // In case v_global == 1
+        segment_idx = dr::minimum(segment_idx, UInt32(m_segment_count) - 1u);
+        Float v_local = v_global * m_segment_count - segment_idx;
 
         pi.prim_uv.x() = v_local;
         pi.prim_uv.y() = 0;
@@ -437,7 +439,7 @@ public:
             ss.prim_index =
                 dr::select(use_first, first_segment_idx, last_segment_idx);
             ss.uv = Point2f(local_uv.x(),
-                            (local_uv.y() + ss.prim_index) / dr::width(m_indices));
+                            (local_uv.y() + ss.prim_index) / m_segment_count);
 
             // map UV parameterization to point on surface
             Point3f c;
@@ -543,8 +545,7 @@ public:
         );
         curve_idx -= 1;
 
-        size_t segment_count = dr::width(m_indices);
-        Float local_v = ss.uv.y() * segment_count - ss.prim_index;
+        Float local_v = ss.uv.y() * m_segment_count - ss.prim_index;
 
         sample_perimeter.x() = dr::select(
             local_v < 0.5f,
@@ -599,9 +600,8 @@ public:
         } else {
             Point2f uv = dr::detach(si.uv);
 
-            size_t segment_count = dr::width(m_indices);
-            UInt32 segment_id = dr::floor2int<UInt32>(uv.y() * segment_count);
-            Float v_local = uv.y() * segment_count - segment_id;
+            UInt32 segment_id = dr::floor2int<UInt32>(uv.y() * m_segment_count);
+            Float v_local = uv.y() * m_segment_count - segment_id;
 
             Point3f C;
             Vector3f Cv, Cvv, Cvvv;
@@ -647,15 +647,15 @@ public:
             UInt32 last_segment_idx =
                 dr::gather<UInt32>(m_curves_prim_idx, curve_idx + 1, active) - 1;
 
-            size_t segment_count = dr::width(m_indices);
-            Float local_v = si.uv.y() * segment_count - si.prim_index;
+            Float local_v = si.uv.y() * m_segment_count - si.prim_index;
             Float curve_v = Float(local_v + si.prim_index - first_segment_idx) /
                             Float(last_segment_idx - first_segment_idx + 1);
 
             Mask use_first = curve_v < 0.5f;
             local_v = dr::select(use_first, 0.f, 1.f);
             ss.prim_index = dr::select(use_first, first_segment_idx, last_segment_idx);
-            ss.uv = Point2f(si.uv.x(), (local_v + ss.prim_index) / segment_count);
+            ss.uv = Point2f(si.uv.x(),
+                            (local_v + ss.prim_index) / m_segment_count);
 
             // Map UV parameterization to point on surface
             Point3f c;
@@ -690,9 +690,9 @@ public:
                            (uint32_t) DiscontinuityFlags::PerimeterType,
                            (uint32_t) DiscontinuityFlags::Empty);
         } else if (has_flag(flags, DiscontinuityFlags::InteriorType)) {
-            size_t segment_count = dr::width(m_indices);
-            UInt32 segment_id = dr::floor2int<UInt32>(si.uv.y() * segment_count);
-            Float v_local = si.uv.y() * segment_count - segment_id;
+            UInt32 segment_id =
+                dr::floor2int<UInt32>(si.uv.y() * m_segment_count);
+            Float v_local = si.uv.y() * m_segment_count - segment_id;
 
             Point3f c;
             Vector3f dc_dv, dc_dvv, dc_dvvv;
@@ -830,7 +830,7 @@ public:
         si.prim_index =
             dr::select(use_first, first_segment_idx, last_segment_idx);
         si.uv = Point2f(local_uv.x(),
-                        (local_uv.y() + si.prim_index) / dr::width(m_indices));
+                        (local_uv.y() + si.prim_index) / m_segment_count);
 
         uint32_t flags = (uint32_t) DiscontinuityFlags::PerimeterType;
         Mask perimeter = active & (sample1 == +DiscontinuityFlags::PerimeterType);
@@ -925,7 +925,7 @@ public:
             if (!follow_shape) {
                 // Let the curve parameter follow the sliding of the
                 // interaction point across the moving surface
-                Float v_global = (v_local + prim_idx) / dr::width(m_indices);
+                Float v_global = (v_local + prim_idx) / m_segment_count;
                 Vector3f dp_dv;
                 std::tie(std::ignore, dp_dv, std::ignore, std::ignore,
                          std::ignore, std::ignore, std::ignore) =
@@ -936,7 +936,7 @@ public:
                                dr::squared_norm(dp_dv);
                 v_global = dr::replace_grad(v_global, v_global + v_diff);
                 v_local  = dr::replace_grad(
-                    v_local, v_global * dr::width(m_indices) - prim_idx);
+                    v_local, v_global * m_segment_count - prim_idx);
 
                 // Recompute the center line with the correct motion
                 std::tie(c, dc_dv, dc_dvv, std::ignore, radius, dr_dv,
@@ -971,7 +971,7 @@ public:
             if constexpr (IsDiff)
                 u_att = dr::replace_grad(u, u_att);
 
-            Float v = (v_local + prim_idx) / dr::width(m_indices);
+            Float v = (v_local + prim_idx) / m_segment_count;
 
             si.uv = Point2f(u_att, v);
 
@@ -1121,9 +1121,9 @@ private:
         // Finally, these are then used in the Weingarten equations to get the
         // normal's partials.
         Float v_global = uv.y();
-        size_t segment_count = dr::width(m_indices);
-        UInt32 segment_idx = dr::floor2int<UInt32>(v_global * segment_count);
-        Float v_local = v_global * segment_count - segment_idx;
+        UInt32 segment_idx = dr::floor2int<UInt32>(v_global * m_segment_count);
+        segment_idx = dr::minimum(segment_idx, UInt32(m_segment_count) - 1u);
+        Float v_local = v_global * m_segment_count - segment_idx;
 
         Point3f c;
         Vector3f dc_dv, dc_dvv, dc_dvvv;
@@ -1183,8 +1183,8 @@ private:
         dp_du *= dr::TwoPi<Float>;
         dp_duv *= dr::TwoPi<Float>;
         dp_duu *= dr::square(dr::TwoPi<Float>);
-        ScalarFloat ratio = (ScalarFloat) dr::width(m_indices),
-                    ratio2 = ratio * ratio;
+        Float ratio = m_segment_count,
+              ratio2 = ratio * ratio;
         dp_dv  *= ratio;
         dp_duv *= ratio;
         dp_dvv *= ratio2;
@@ -1232,9 +1232,13 @@ private:
     mutable UInt32Storage m_indices;
     mutable FloatStorage m_control_points;
 
+    /// Needs to be opaque to not get baked into the kernel
+    mutable Float m_segment_count;
+
     static constexpr float silhouette_offset = 5e-3f;
 
-    MI_TRAVERSE_CB(Base, m_curves_prim_idx, m_indices, m_control_points)
+    MI_TRAVERSE_CB(Base, m_curves_prim_idx, m_indices, m_control_points,
+                   m_segment_count)
 };
 
 MI_EXPORT_PLUGIN(BSplineCurve);


### PR DESCRIPTION
Fixes some bugs which caused problems with the Bsplinecurve. 

* Clamp the segment index in partials(). 
* Use no caps when using metal, similar to all other backends. 
* Make the segment count opaque, in order to not run into out of bounds issues when the curve count changed when using function freezing.

- [x] My code follows the [style guidelines](https://mitsuba.readthedocs.io/en/latest/src/developer_guide.html#coding-style) of this project
- [x] My changes generate no new warnings
- [x] My code also compiles for `cuda_*` and `llvm_*` variants. If you can't test this, please leave below
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 3 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba/blob/master/LICENSE)