### PR TITLE
Enable traversal of Bounding Boxes

### DIFF
--- a/include/mitsuba/core/bbox.h
+++ b/include/mitsuba/core/bbox.h
@@ -347,6 +347,8 @@ template <typename Point_> struct BoundingBox {
 
     Point min; /// Component-wise minimum
     Point max; /// Component-wise maximum
+
+    DRJIT_TRAVERSE(BoundingBox, min, max);
 };
 
 /// Compute the bounding box of an interleaved position buffer.
@@ -425,8 +427,8 @@ BoundingBox<Type> reduce_bbox(const StoredFloat &data, uint32_t count) {
 }
 
 /// Print a string representation of the bounding box
-template <typename Point>
-std::ostream &operator<<(std::ostream &os, const BoundingBox<Point> &bbox) {
+template <typename Stream, typename Point>
+Stream &operator<<(Stream &os, const BoundingBox<Point> &bbox) {
     os << "BoundingBox" << type_suffix<Point>();
     if (dr::all(!bbox.valid()))
         os << "[invalid]";

--- a/src/core/python/bbox_v.cpp
+++ b/src/core/python/bbox_v.cpp
@@ -8,6 +8,7 @@
 template <typename BBox, typename Ray> auto bind_bbox(nb::module_ &m, const char *name) {
         using Point = typename BBox::Point;
         using Float = typename BBox::Value;
+        using Mask  = typename BBox::Mask;
 
         MI_PY_CHECK_ALIAS(BBox, name) {
             auto bbox = nb::class_<BBox>(m, name, D(BoundingBox))
@@ -71,6 +72,8 @@ template <typename BBox, typename Ray> auto bind_bbox(nb::module_ &m, const char
                 .def_rw("min", &BBox::min)
                 .def_rw("max", &BBox::max)
                 .def_repr(BBox);
+
+            MI_PY_DRJIT_STRUCT(bbox, BBox, min, max);
 
             if constexpr (dr::size_v<Point> == 3) {
                 bbox.def("ray_intersect",

--- a/src/core/tests/test_bbox.py
+++ b/src/core/tests/test_bbox.py
@@ -137,3 +137,16 @@ def test06_ray_intersect_vec(variant_scalar_rgb):
 
     from mitsuba.test.util import check_vectorization
     check_vectorization(kernel, arg_dims = [3, 3, 3])
+
+def test07_traverse(variants_vec_rgb):
+    min = mi.Vector3f(dr.linspace(mi.Float, -5, 0, num=10))
+    max = min + 5
+    bboxes = mi.BoundingBox3f(min, max)
+    dr.eval(bboxes)
+
+    idx = dr.full(mi.UInt32, 9, shape=10)
+    res = dr.gather(mi.BoundingBox3f, bboxes, idx)
+
+    target = mi.BoundingBox3f(mi.Vector3f(0), mi.Vector3f(5))
+    assert dr.allclose(res.min, target.min)
+    assert dr.allclose(res.max, target.max)


### PR DESCRIPTION
## Description

This commit allows traversal of bounding boxes.

## Testing

Added a test with a gather from a buffer of bounding boxes

## Checklist

- [x] My code follows the [style guidelines](https://mitsuba.readthedocs.io/en/latest/src/developer_guide.html#coding-style) of this project
- [x] My changes generate no new warnings
- [x] My code also compiles for `cuda_*` and `llvm_*` variants. If you can't test this, please leave below
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 3 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba/blob/master/LICENSE)