### PR TITLE
Release GIL in wait_for_tasks

### DIFF
--- a/src/core/python/thread.cpp
+++ b/src/core/python/thread.cpp
@@ -20,5 +20,6 @@ MI_PY_EXPORT(Thread) {
        .def_static("set_file_resolver", &set_file_resolver)
        .def_static("thread", &Thread::thread,
            nb::rv_policy::reference)
-       .def_static("wait_for_tasks", &Thread::wait_for_tasks);
+       .def_static("wait_for_tasks", &Thread::wait_for_tasks,
+           nb::call_guard<nb::gil_scoped_release>(), D(Thread, wait_for_tasks));
 }

--- a/src/core/tests/test_bitmap.py
+++ b/src/core/tests/test_bitmap.py
@@ -439,3 +439,14 @@ def test_check_weight_division(variant_scalar_rgb):
     assert np.all(x[0, 0, :] == (2, 0, 0, 0))
     assert np.all(x[1, 0, :] == (1, 0, 0, 0))
     assert np.all(x[2, 0, :] == (2, 0, 0, 0))
+
+
+def test_write_async(variant_scalar_rgb, tmpdir, np_rng):
+    ref = np.float32(np_rng.random((10, 10, 3)))
+    b = mi.Bitmap(ref)
+    tmp_file = os.path.join(str(tmpdir), "out_async.exr")
+    b.write_async(tmp_file)
+    mi.Thread.wait_for_tasks()
+    b2 = mi.Bitmap(tmp_file)
+    os.remove(tmp_file)
+    assert np.allclose(np.array(b2), ref)


### PR DESCRIPTION
The `wait_for_tasks` function allows users to explicitly wait for asynchronous Bitmap writes to complete (or other tasks, but I think right now we only use this for `write_async`). The Python bindings of this were missing a GIL release to prevent deadlocks. This PR fixes this and adds a simple unit test (prior to the fix this test would hang).