### PR TITLE
New directed edge data structure

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -38,6 +38,10 @@ Mitsuba 3.10.0
     ``write_ply()`` or ``write_serialized()`` therefore carries the flip, and
     reloading it does not require the scene description to repeat it.
 
+  - The directed edge adjacency data structure moved into a standalone
+    ``mi.DirectedEdge`` class that a mesh builds on demand. The new class
+    produces a richer representation while also improving build efficiency.
+
   ⚠️ **WARNING** ⚠️: This is an **API-breaking change**. Code that constructs
   meshes or touches mesh scene parameters must be updated as follows.
 
@@ -144,6 +148,7 @@ Mitsuba 3.10.0
     ``has_vertex_normals()``                     ``has_normals()``
     ``recompute_vertex_normals()``               ``recompute_normals()``
     ``mesh.merge(other)``                        ``mi.Mesh.merge(shapes)``
+    ``build_directed_edges()``                   ``directed_edges()``
     ``mesh.has_flipped_normals()``               *removed, see above*
     ============================================ ==============================
 

--- a/include/mitsuba/python/docstr.h
+++ b/include/mitsuba/python/docstr.h
@@ -2983,6 +2983,324 @@ static const char *__doc_mitsuba_DefaultFormatter_set_has_log_level = R"doc(Shou
 
 static const char *__doc_mitsuba_DefaultFormatter_set_has_thread = R"doc(Should thread information be included? The default is yes.)doc";
 
+static const char *__doc_mitsuba_DirectedEdge =
+R"doc(Immutable half-edge adjacency for an indexed triangle mesh
+
+This class derives edge and vertex adjacency from a flat triangle
+index buffer ``F`` using the directed-edge representation of Campagna
+et al. [1]. It supports queries such as finding the triangle across an
+edge, traversing the triangles around a vertex, processing each mesh
+edge once, and identifying boundaries or malformed connectivity.
+
+The result is purely combinatorial and immutable. It stores neither
+vertex positions nor a copy of the index buffer.
+
+**Representation**
+
+``F`` stores the three vertex indices of each triangle consecutively
+and in winding order. Triangle ``f`` therefore contributes three half-
+edges ``e = 3*f + i``, where ``i`` is in ``{0, 1, 2}``. Their basic
+relationships are:
+
+```
+next(e)             = 3*f + (i + 1) % 3
+prev(e)             = 3*f + (i + 2) % 3
+face(e)             = e / 3
+corner(e)           = e % 3
+source(e)           = F[e]
+target(e)           = F[next(e)]
+opposing_vertex(e)  = F[prev(e)]
+```
+
+Hence, next() advances along the triangle's winding direction and
+prev() goes in the opposite direction; neither operation leaves the
+triangle.
+
+The structure provides four principal arrays:
+
+* E2E() maps each half-edge to the oppositely oriented half-edge of
+the adjacent triangle, or to Invalid when the result is ambiguous.
+
+* V2E() maps each vertex to a canonical outgoing half-edge, or to
+Invalid when no triangle with three distinct indices contains it.
+
+* valence() records how many triangles with three distinct indices
+contain each vertex.
+
+* flags() records per-vertex boundary and connectivity diagnostics.
+
+On a consistently oriented manifold triangle mesh, each interior edge
+is shared by two triangles, which contribute oppositely oriented half-
+edges. ``E2E`` pairs these half-edges. A boundary edge belongs to only
+one triangle, and its half-edge maps to Invalid.
+
+``V2E[v]`` provides a starting point for walking around vertex ``v``.
+For an interior vertex, any outgoing half-edge would work; ``V2E[v]``
+contains the smallest one for deterministic results. At a boundary
+vertex, ``V2E[v] = next(b)``, where ``b`` is the incoming boundary
+half-edge. Starting there, repeatedly applying ``e =
+next(opposite(e))`` visits the complete fan of faces. The walk stops
+at the other boundary edge, where ``opposite(e)`` is Invalid.
+
+The examples below use Python-style scalar pseudocode.
+
+**Example 1: querying the neighborhood of an edge**
+
+The following snippet obtains the two faces ``f0`` and ``f1`` that
+share an interior manifold edge (which is the case when ``o !=
+Invalid``).
+
+```
+python
+f0 = de.face(e)
+o  = de.opposite(e)  # Load E2E[e]
+f1 = de.face(o)
+```
+
+The two triangles share the edge endpoints ``v0`` and ``v1``. Each
+triangle also has one vertex opposite the shared edge, denoted by
+``c0`` and ``c1``. These are obtained as follows:
+
+```
+python
+v0 = F[e]
+v1 = F[de.next(e)]
+c0 = F[de.prev(e)]
+c1 = F[de.prev(o)]
+```
+
+This local neighborhood is useful when computing cotangent weights,
+curvature, etc.
+
+**Example 2: traversing the faces around a vertex**
+
+Starting at vertex_edge(), repeatedly crossing the current edge and
+advancing within the neighboring triangle walks around its source
+vertex:
+
+```
+start = de.vertex_edge(v)  # Load V2E[v]
+e, visited = start, 0
+
+while e != de.Invalid:
+    visit_face(de.face(e))
+    visited += 1
+
+    o = de.opposite(e)
+    if o == de.Invalid:
+        break
+
+    e = de.next(o)
+    if e == start:
+        break
+```
+
+A closed fan returns to ``start``. An open fan terminates at an
+unpaired edge. For a manifold vertex, ``visited`` equals
+``valence(v)``.
+
+Each visited half-edge starts at ``v``, so its target is one of
+``v``'s neighbors. For a closed fan, these targets include every
+neighbor. For an open fan, the incoming boundary edge is not visited
+because it points toward ``v``. The missing neighbor is
+``F[de.prev(start)]``.
+
+These neighborhoods are commonly used by Laplacian and curvature
+operators.
+
+**Robustness**
+
+The implementation only pairs half-edges when the result is
+unambiguous. Whenever ``o = E2E[e]`` is not Invalid, the following
+invariants hold:
+
+```
+E2E[o]     == e
+F[o]       == F[next(e)]
+F[next(o)] == F[e]
+```
+
+These invariants remain true in the presence of boundaries and
+malformed topology.
+
+**Boundaries and edge defects**
+
+On a well-formed mesh, every edge belongs to at most two triangles. An
+interior edge is shared by two triangles with oppositely oriented
+half-edges, which ``E2E`` pairs up. A boundary edge belongs to a
+single triangle, and its half-edge maps to Invalid. Both endpoints of
+such an edge receive the VertexFlags::Boundary flag. Triangles with
+repeated vertex indices are ignored throughout (see below).
+
+Malformed input deviates from this picture in two ways. In both cases
+there is no valid way to pair the involved half-edges, so all of them
+remain unpaired and read as boundaries. The endpoints of the affected
+edge receive VertexFlags::Boundary and a flag identifying the defect:
+
+- When the two half-edges of a shared edge are oriented the same way,
+one triangle is wound backwards relative to the other. The endpoints
+receive VertexFlags::InconsistentOrientation.
+
+- When three or more triangles share an edge (think of a fin attached
+to the edge of a box), no pair is preferable to the others. The
+endpoints receive VertexFlags::NonManifoldEdge.
+
+The following table summarizes the classification:
+
+```
+faces  winding    E2E entries  flags at both endpoints
+-------------------------------------------------------
+1      -          Invalid      Boundary
+2      opposite   paired       none
+2      same       Invalid      Boundary | InconsistentOrientation
+>= 3   any        Invalid      Boundary | NonManifoldEdge
+```
+
+A vertex accumulates the flags of all edges that touch it, so several
+bits may be set at once. Test them individually using ``has_flag()``
+rather than comparing the complete bitmask for equality. The remaining
+flag, VertexFlags::NonManifoldVertex, is not part of the edge
+classification and is explained next.
+
+**Disconnected fans around a vertex**
+
+VertexFlags::NonManifoldVertex marks vertices where the walk of
+Example 2 reaches fewer faces than valence() reports. The typical case
+is a bowtie: two fans that touch only at their common apex. Every edge
+of such a configuration may pair normally, and those pairings are
+preserved. The defect is a property of the vertex, not of its edges.
+vertex_edge() selects a starting point in one of the fans, and the
+walk covers only that fan.
+
+To enumerate every face around a non-manifold vertex, scan ``F`` for
+half-edges with ``F[e] == v`` (again skipping triangles with repeated
+indices) instead of walking from vertex_edge().
+
+**Triangles with repeated indices**
+
+A triangle such as ``(a, a, b)`` has no area and is ignored as a
+whole: it keeps its slots in the half-edge numbering, but its three
+``E2E`` entries are Invalid, its half-edges never appear in V2E(), and
+it contributes no face counts or flags. The remaining triangles are
+paired as if it did not exist.
+
+One consequence is that ``E2E[e] == Invalid`` alone does not identify
+a boundary edge: code that scans all half-edges must first skip those
+of triangles with repeated indices.
+
+**Geometric and input limitations**
+
+This structure only examines vertex indices. It cannot detect zero-
+area geometry caused by collinear vertices or distinct indices that
+refer to the same position, nor can it detect self-intersections. The
+constructor also does not validate index bounds: every entry of ``F``
+must be smaller than ``vertex_count``, and violations cause undefined
+behavior.
+
+[1] S. Campagna, L. Kobbelt, and H.-P. Seidel, "Directed Edges: A
+Scalable Representation for Triangle Meshes", Journal of Graphics
+Tools 3(4), 1998.)doc";
+
+static const char *__doc_mitsuba_DirectedEdge_2 = R"doc()doc";
+
+static const char *__doc_mitsuba_DirectedEdge_3 = R"doc()doc";
+
+static const char *__doc_mitsuba_DirectedEdge_4 = R"doc()doc";
+
+static const char *__doc_mitsuba_DirectedEdge_5 = R"doc()doc";
+
+static const char *__doc_mitsuba_DirectedEdge_6 = R"doc()doc";
+
+static const char *__doc_mitsuba_DirectedEdge_DirectedEdge =
+R"doc(Build the adjacency structure of a triangle mesh
+
+The caller must ensure that ``F[i] < vertex_count`` holds for all
+provided indices. Violations cause undefined behavior.
+
+Parameter ``F``:
+    A flat index buffer holding the three vertex indices of each
+    triangle face, in winding order. Its size must be a multiple of 3.
+
+Parameter ``vertex_count``:
+    The number of mesh vertices.
+
+Parameter ``name``:
+    An optional name identifying the mesh in log messages.)doc";
+
+static const char *__doc_mitsuba_DirectedEdge_E2E = R"doc(Per-half-edge buffer of opposites or Invalid entries)doc";
+
+static const char *__doc_mitsuba_DirectedEdge_V2E = R"doc(Per-vertex buffer of canonical outgoing half-edges)doc";
+
+static const char *__doc_mitsuba_DirectedEdge_build_host = R"doc(Single-threaded builder used in scalar variants)doc";
+
+static const char *__doc_mitsuba_DirectedEdge_build_jit = R"doc(Data-parallel builder used in JIT variants)doc";
+
+static const char *__doc_mitsuba_DirectedEdge_class_name = R"doc()doc";
+
+static const char *__doc_mitsuba_DirectedEdge_corner = R"doc(Return the local corner index of the half-edge within its face)doc";
+
+static const char *__doc_mitsuba_DirectedEdge_face = R"doc(Return the index of the face containing the half-edge)doc";
+
+static const char *__doc_mitsuba_DirectedEdge_flag_count = R"doc(Number of vertices carrying the given single-bit flag)doc";
+
+static const char *__doc_mitsuba_DirectedEdge_flags = R"doc(Per-vertex buffer of VertexFlags bitmasks)doc";
+
+static const char *__doc_mitsuba_DirectedEdge_half_edge_count = R"doc(Number of half-edges, i.e. three times the face count)doc";
+
+static const char *__doc_mitsuba_DirectedEdge_m_E2E = R"doc()doc";
+
+static const char *__doc_mitsuba_DirectedEdge_m_V2E = R"doc()doc";
+
+static const char *__doc_mitsuba_DirectedEdge_m_flag_counts = R"doc(Number of vertices carrying each of the four VertexFlags)doc";
+
+static const char *__doc_mitsuba_DirectedEdge_m_flags = R"doc()doc";
+
+static const char *__doc_mitsuba_DirectedEdge_m_half_edge_count = R"doc()doc";
+
+static const char *__doc_mitsuba_DirectedEdge_m_name = R"doc()doc";
+
+static const char *__doc_mitsuba_DirectedEdge_m_valence = R"doc()doc";
+
+static const char *__doc_mitsuba_DirectedEdge_m_vertex_count = R"doc()doc";
+
+static const char *__doc_mitsuba_DirectedEdge_name = R"doc(Return the name passed to the constructor)doc";
+
+static const char *__doc_mitsuba_DirectedEdge_next = R"doc(Return the next half-edge within the same face)doc";
+
+static const char *__doc_mitsuba_DirectedEdge_opposite =
+R"doc(Return the half-edge opposite to ``e``, or Invalid
+
+This accessor loads ``E2E[e]``.)doc";
+
+static const char *__doc_mitsuba_DirectedEdge_prev = R"doc(Return the previous half-edge within the same face)doc";
+
+static const char *__doc_mitsuba_DirectedEdge_to_string = R"doc()doc";
+
+static const char *__doc_mitsuba_DirectedEdge_traverse_1_cb_ro = R"doc()doc";
+
+static const char *__doc_mitsuba_DirectedEdge_traverse_1_cb_rw = R"doc()doc";
+
+static const char *__doc_mitsuba_DirectedEdge_valence =
+R"doc(Return the valence of ``v``
+
+This is the number of faces containing ``v``. It excludes degenerate
+faces with a repeated vertex index.)doc";
+
+static const char *__doc_mitsuba_DirectedEdge_valence_2 = R"doc(Per-vertex buffer of valences, i.e. face counts)doc";
+
+static const char *__doc_mitsuba_DirectedEdge_vertex_count = R"doc(Number of vertices in the numbering used by the per-vertex outputs)doc";
+
+static const char *__doc_mitsuba_DirectedEdge_vertex_edge =
+R"doc(Return the canonical half-edge starting at ``v``, or Invalid
+
+This accessor loads ``V2E[v]``.
+
+This is the smallest half-edge at ``v`` whose predecessor is unpaired,
+or the smallest one overall when no such half-edge exists. It is the
+entry point of the vertex walk described in the class documentation.)doc";
+
+static const char *__doc_mitsuba_DirectedEdge_vertex_flags = R"doc(Return the bitmask of VertexFlags associated with vertex ``v``)doc";
+
 static const char *__doc_mitsuba_DirectionSample = R"doc()doc";
 
 static const char *__doc_mitsuba_DirectionSample_2 =
@@ -5897,21 +6215,14 @@ static const char *__doc_mitsuba_Mesh_bsdf_index =
 R"doc(Return the per-face BSDF index (size face_count()). An empty buffer
 stands for zeros, see has_face_bsdfs().)doc";
 
-static const char *__doc_mitsuba_Mesh_build_directed_edges =
-R"doc(Build directed edge data structure to efficiently access adjacent
-edges.
-
-This is an implementation of the technique described in:
-``https://www.graphics.rwth-aachen.de/media/papers/directed.pdf``.)doc";
-
 static const char *__doc_mitsuba_Mesh_build_indirect_silhouette_distribution =
 R"doc(Precompute the set of edges that could contribute to the indirect
 discontinuous integral.
 
 This method filters out any concave edges or flat surfaces.
 
-Internally, this method relies on the directed edge data structure. A
-call to build_directed_edges before a call to this method is therefore
+Internally, this method relies on the half-edge adjacency structure. A
+call to directed_edges() before a call to this method is therefore
 necessary.)doc";
 
 static const char *__doc_mitsuba_Mesh_build_parameterization =
@@ -5946,6 +6257,19 @@ R"doc(Compute MikkTSpace shading tangents from the field views as a ``(V,
 static const char *__doc_mitsuba_Mesh_describe = R"doc()doc";
 
 static const char *__doc_mitsuba_Mesh_differential_motion = R"doc()doc";
+
+static const char *__doc_mitsuba_Mesh_directed_edges =
+R"doc(Return the half-edge adjacency of the mesh, building it on demand
+
+The structure is built from geometric_faces(), so that the two sides
+of an attribute seam are adjacent instead of reading as mesh
+boundaries. It survives position, normal and material edits, and is
+discarded when the index buffer, the position index map, or the
+position count changes.
+
+This function performs no synchronization, which is fine in the
+expected usage (JIT variants), where a single thread orchestrates the
+parallel computation.)doc";
 
 static const char *__doc_mitsuba_Mesh_drop_views = R"doc(Release the field views and make the packed state authoritative)doc";
 
@@ -6112,7 +6436,7 @@ R"doc(Return an ``(F, 3)`` tensor encoding the geometric topology
 
 This function returns faces() re-indexed into surface position space,
 i.e., the geometric topology of the mesh without UV/normal-related
-seams. It is used by features like build_directed_edges() and the mesh
+seams. It is used by features like directed_edges() and the mesh
 Laplacian in ``largesteps.py``.)doc";
 
 static const char *__doc_mitsuba_Mesh_has_attribute = R"doc()doc";
@@ -6146,8 +6470,6 @@ static const char *__doc_mitsuba_Mesh_is_vertex_attribute =
 R"doc(Does the attribute ``name`` live on the vertices rather than the
 faces?)doc";
 
-static const char *__doc_mitsuba_Mesh_m_E2E = R"doc(Directed edges data structures to support neighbor queries)doc";
-
 static const char *__doc_mitsuba_Mesh_m_area_pmf = R"doc()doc";
 
 static const char *__doc_mitsuba_Mesh_m_bbox = R"doc(Bounding box of the mesh positions)doc";
@@ -6155,6 +6477,8 @@ static const char *__doc_mitsuba_Mesh_m_bbox = R"doc(Bounding box of the mesh po
 static const char *__doc_mitsuba_Mesh_m_bsdf_index = R"doc()doc";
 
 static const char *__doc_mitsuba_Mesh_m_built = R"doc(Set by the first successful build; construction is one-shot)doc";
+
+static const char *__doc_mitsuba_Mesh_m_dedge = R"doc(Half-edge adjacency, null until directed_edges() builds it)doc";
 
 static const char *__doc_mitsuba_Mesh_m_face_count = R"doc()doc";
 
@@ -6271,9 +6595,10 @@ static const char *__doc_mitsuba_Mesh_opposite_dedge =
 R"doc(Returns the opposite edge index associated with directed edge
 ``index``
 
-If the directed edge data structure is not initialized, the return
-value is undefined. Ensure that build_directed_edges() is called
-before this method.)doc";
+The function returns ``DirectedEdge::Invalid`` when the adjacency
+structure has not been built. It deliberately does not build it, so
+that a vectorized call over a set of meshes of which only some carry
+the structure remains well defined. Call directed_edges() first.)doc";
 
 static const char *__doc_mitsuba_Mesh_pack =
 R"doc(Compile the field views into the packed records
@@ -6287,7 +6612,7 @@ single pass, and ends in refresh().
 
 The ``flip_normals`` flag turns the surface inside out as the records
 are written, which from_fields() uses to bake the property of the same
-name.)doc";
+name. See validate_impl() for ``updating``.)doc";
 
 static const char *__doc_mitsuba_Mesh_packed_face = R"doc(Returns the packed face record of triangle ``index``)doc";
 
@@ -6424,6 +6749,13 @@ By default, this function cheaply checks tensor ranks and shapes of
 the mesh state for consistency. When ``check_bounds`` is set, the
 function also verifies that every index is in range. This is
 relatively expensive because it requires several device reductions.)doc";
+
+static const char *__doc_mitsuba_Mesh_validate_impl =
+R"doc(Implementation of validate()
+
+When ``updating`` is set, the mesh is checking a parameters_changed()
+batch, and shape mismatches also report how to rewrite the offending
+field.)doc";
 
 static const char *__doc_mitsuba_Mesh_vertex_count = R"doc(Return the total number of vertices)doc";
 
@@ -12171,6 +12503,16 @@ static const char *__doc_mitsuba_Vector_operator_assign = R"doc()doc";
 
 static const char *__doc_mitsuba_Vector_operator_assign_2 = R"doc()doc";
 
+static const char *__doc_mitsuba_VertexFlags = R"doc(Per-vertex boundary and defect flags reported by DirectedEdge)doc";
+
+static const char *__doc_mitsuba_VertexFlags_Boundary = R"doc(An edge incident to the vertex is unpaired)doc";
+
+static const char *__doc_mitsuba_VertexFlags_InconsistentOrientation = R"doc(The vertex is an endpoint of an edge whose two faces wind the same way)doc";
+
+static const char *__doc_mitsuba_VertexFlags_NonManifoldEdge = R"doc(The vertex is an endpoint of an edge with more than two faces)doc";
+
+static const char *__doc_mitsuba_VertexFlags_NonManifoldVertex = R"doc(The faces around the vertex form more than one ring (e.g. a bowtie))doc";
+
 static const char *__doc_mitsuba_Volume = R"doc()doc";
 
 static const char *__doc_mitsuba_Volume_2 = R"doc(Abstract base class for 3D volumes.)doc";
@@ -13100,6 +13442,10 @@ static const char *__doc_mitsuba_has_flag_17 = R"doc()doc";
 
 static const char *__doc_mitsuba_has_flag_18 = R"doc()doc";
 
+static const char *__doc_mitsuba_has_flag_19 = R"doc()doc";
+
+static const char *__doc_mitsuba_has_flag_20 = R"doc()doc";
+
 static const char *__doc_mitsuba_hash = R"doc()doc";
 
 static const char *__doc_mitsuba_hash_2 = R"doc()doc";
@@ -13539,6 +13885,8 @@ static const char *__doc_mitsuba_operator_add_9 = R"doc()doc";
 
 static const char *__doc_mitsuba_operator_add_10 = R"doc()doc";
 
+static const char *__doc_mitsuba_operator_add_11 = R"doc()doc";
+
 static const char *__doc_mitsuba_operator_band = R"doc()doc";
 
 static const char *__doc_mitsuba_operator_band_2 = R"doc()doc";
@@ -13593,6 +13941,12 @@ static const char *__doc_mitsuba_operator_band_26 = R"doc()doc";
 
 static const char *__doc_mitsuba_operator_band_27 = R"doc()doc";
 
+static const char *__doc_mitsuba_operator_band_28 = R"doc()doc";
+
+static const char *__doc_mitsuba_operator_band_29 = R"doc()doc";
+
+static const char *__doc_mitsuba_operator_band_30 = R"doc()doc";
+
 static const char *__doc_mitsuba_operator_bnot = R"doc()doc";
 
 static const char *__doc_mitsuba_operator_bnot_2 = R"doc()doc";
@@ -13610,6 +13964,8 @@ static const char *__doc_mitsuba_operator_bnot_7 = R"doc()doc";
 static const char *__doc_mitsuba_operator_bnot_8 = R"doc()doc";
 
 static const char *__doc_mitsuba_operator_bnot_9 = R"doc()doc";
+
+static const char *__doc_mitsuba_operator_bnot_10 = R"doc()doc";
 
 static const char *__doc_mitsuba_operator_bor = R"doc()doc";
 
@@ -13665,6 +14021,12 @@ static const char *__doc_mitsuba_operator_bor_26 = R"doc()doc";
 
 static const char *__doc_mitsuba_operator_bor_27 = R"doc()doc";
 
+static const char *__doc_mitsuba_operator_bor_28 = R"doc()doc";
+
+static const char *__doc_mitsuba_operator_bor_29 = R"doc()doc";
+
+static const char *__doc_mitsuba_operator_bor_30 = R"doc()doc";
+
 static const char *__doc_mitsuba_operator_iand = R"doc()doc";
 
 static const char *__doc_mitsuba_operator_iand_2 = R"doc()doc";
@@ -13683,6 +14045,8 @@ static const char *__doc_mitsuba_operator_iand_8 = R"doc()doc";
 
 static const char *__doc_mitsuba_operator_iand_9 = R"doc()doc";
 
+static const char *__doc_mitsuba_operator_iand_10 = R"doc()doc";
+
 static const char *__doc_mitsuba_operator_ior = R"doc()doc";
 
 static const char *__doc_mitsuba_operator_ior_2 = R"doc()doc";
@@ -13700,6 +14064,8 @@ static const char *__doc_mitsuba_operator_ior_7 = R"doc()doc";
 static const char *__doc_mitsuba_operator_ior_8 = R"doc()doc";
 
 static const char *__doc_mitsuba_operator_ior_9 = R"doc()doc";
+
+static const char *__doc_mitsuba_operator_ior_10 = R"doc()doc";
 
 static const char *__doc_mitsuba_operator_lshift = R"doc(Print a string representation of the bounding box)doc";
 

--- a/include/mitsuba/render/dedge.h
+++ b/include/mitsuba/render/dedge.h
@@ -1,0 +1,373 @@
+#pragma once
+
+#include <mitsuba/core/object.h>
+#include <mitsuba/render/fwd.h>
+#include <drjit/dynamic.h>
+
+NAMESPACE_BEGIN(mitsuba)
+
+/// Per-vertex boundary and defect flags reported by \ref DirectedEdge
+enum class VertexFlags : uint32_t {
+    /// An edge incident to the vertex is unpaired
+    Boundary = 0x1,
+
+    /// The vertex is an endpoint of an edge with more than two faces
+    NonManifoldEdge = 0x2,
+
+    /// The faces around the vertex form more than one ring (e.g. a bowtie)
+    NonManifoldVertex = 0x4,
+
+    /// The vertex is an endpoint of an edge whose two faces wind the same way
+    InconsistentOrientation = 0x8
+};
+
+MI_DECLARE_ENUM_OPERATORS(VertexFlags)
+
+/**
+ * \brief Immutable half-edge adjacency for an indexed triangle mesh
+ *
+ * This class derives edge and vertex adjacency from a flat triangle index
+ * buffer ``F`` using the directed-edge representation of Campagna et al. [1].
+ * It supports queries such as finding the triangle across an edge, traversing
+ * the triangles around a vertex, processing each mesh edge once, and
+ * identifying boundaries or malformed connectivity.
+ *
+ * The result is purely combinatorial and immutable. It stores neither vertex
+ * positions nor a copy of the index buffer.
+ *
+ * **Representation**
+ *
+ * ``F`` stores the three vertex indices of each triangle consecutively and in
+ * winding order. Triangle ``f`` therefore contributes three half-edges
+ * ``e = 3*f + i``, where ``i`` is in ``{0, 1, 2}``. Their basic relationships
+ * are:
+ *
+ * ```
+ * next(e)             = 3*f + (i + 1) % 3
+ * prev(e)             = 3*f + (i + 2) % 3
+ * face(e)             = e / 3
+ * corner(e)           = e % 3
+ * source(e)           = F[e]
+ * target(e)           = F[next(e)]
+ * opposing_vertex(e)  = F[prev(e)]
+ * ```
+ *
+ * Hence, \ref next() advances along the triangle's winding direction and
+ * \ref prev() goes in the opposite direction; neither operation leaves the
+ * triangle.
+ *
+ * The structure provides four principal arrays:
+ *
+ * * \ref E2E() maps each half-edge to the oppositely oriented half-edge of
+ *   the adjacent triangle, or to \ref Invalid when the result is ambiguous.
+ *
+ * * \ref V2E() maps each vertex to a canonical outgoing half-edge, or to
+ *   \ref Invalid when no triangle with three distinct indices contains it.
+ *
+ * * \ref valence() records how many triangles with three distinct indices
+ *   contain each vertex.
+ *
+ * * \ref flags() records per-vertex boundary and connectivity diagnostics.
+ *
+ * On a consistently oriented manifold triangle mesh, each interior edge is
+ * shared by two triangles, which contribute oppositely oriented half-edges.
+ * ``E2E`` pairs these half-edges. A boundary edge belongs to only one triangle,
+ * and its half-edge maps to \ref Invalid.
+ *
+ * ``V2E[v]`` provides a starting point for walking around vertex ``v``. For
+ * an interior vertex, any outgoing half-edge would work; ``V2E[v]`` contains
+ * the smallest one for deterministic results. At a boundary vertex,
+ * ``V2E[v] = next(b)``, where ``b`` is the incoming boundary half-edge.
+ * Starting there, repeatedly applying ``e = next(opposite(e))`` visits the
+ * complete fan of faces. The walk stops at the other boundary edge, where
+ * ``opposite(e)`` is \ref Invalid.
+ *
+ * The examples below use Python-style scalar pseudocode.
+ *
+ * **Example 1: querying the neighborhood of an edge**
+ *
+ * The following snippet obtains the two faces ``f0`` and ``f1`` that share
+ * an interior manifold edge (which is the case when ``o != Invalid``).
+ *
+ * ```python
+ * f0 = de.face(e)
+ * o  = de.opposite(e)  # Load E2E[e]
+ * f1 = de.face(o)
+ * ```
+ *
+ * The two triangles share the edge endpoints ``v0`` and ``v1``. Each triangle
+ * also has one vertex opposite the shared edge, denoted by ``c0`` and ``c1``.
+ * These are obtained as follows:
+ *
+ * ```python
+ * v0 = F[e]
+ * v1 = F[de.next(e)]
+ * c0 = F[de.prev(e)]
+ * c1 = F[de.prev(o)]
+ * ```
+ *
+ * This local neighborhood is useful when computing cotangent weights,
+ * curvature, etc.
+ *
+ * **Example 2: traversing the faces around a vertex**
+ *
+ * Starting at \ref vertex_edge(), repeatedly crossing the current edge
+ * and advancing within the neighboring triangle walks around its source
+ * vertex:
+ *
+ * ```
+ * start = de.vertex_edge(v)  # Load V2E[v]
+ * e, visited = start, 0
+ *
+ * while e != de.Invalid:
+ *     visit_face(de.face(e))
+ *     visited += 1
+ *
+ *     o = de.opposite(e)
+ *     if o == de.Invalid:
+ *         break
+ *
+ *     e = de.next(o)
+ *     if e == start:
+ *         break
+ * ```
+ *
+ * A closed fan returns to ``start``. An open fan terminates at an unpaired
+ * edge. For a manifold vertex, ``visited`` equals ``valence(v)``.
+ *
+ * Each visited half-edge starts at ``v``, so its target is one of ``v``'s
+ * neighbors. For a closed fan, these targets include every neighbor. For an
+ * open fan, the incoming boundary edge is not visited because it points toward
+ * ``v``. The missing neighbor is ``F[de.prev(start)]``.
+ *
+ * These neighborhoods are commonly used by Laplacian and curvature operators.
+ *
+ * **Robustness**
+ *
+ * The implementation only pairs half-edges when the result is unambiguous.
+ * Whenever ``o = E2E[e]`` is not \ref Invalid, the following invariants hold:
+ *
+ * ```
+ * E2E[o]     == e
+ * F[o]       == F[next(e)]
+ * F[next(o)] == F[e]
+ * ```
+ *
+ * These invariants remain true in the presence of boundaries and malformed
+ * topology.
+ *
+ * **Boundaries and edge defects**
+ *
+ * On a well-formed mesh, every edge belongs to at most two triangles. An
+ * interior edge is shared by two triangles with oppositely oriented
+ * half-edges, which ``E2E`` pairs up. A boundary edge belongs to a single
+ * triangle, and its half-edge maps to \ref Invalid. Both endpoints of such
+ * an edge receive the \ref VertexFlags::Boundary flag. Triangles with
+ * repeated vertex indices are ignored throughout (see below).
+ *
+ * Malformed input deviates from this picture in two ways. In both cases
+ * there is no valid way to pair the involved half-edges, so all of them
+ * remain unpaired and read as boundaries. The endpoints of the affected
+ * edge receive \ref VertexFlags::Boundary and a flag identifying the
+ * defect:
+ *
+ * - When the two half-edges of a shared edge are oriented the same way,
+ *   one triangle is wound backwards relative to the other. The endpoints
+ *   receive \ref VertexFlags::InconsistentOrientation.
+ *
+ * - When three or more triangles share an edge (think of a fin attached to
+ *   the edge of a box), no pair is preferable to the others. The endpoints
+ *   receive \ref VertexFlags::NonManifoldEdge.
+ *
+ * The following table summarizes the classification:
+ *
+ * ```
+ * faces  winding    E2E entries  flags at both endpoints
+ * -------------------------------------------------------
+ * 1      -          Invalid      Boundary
+ * 2      opposite   paired       none
+ * 2      same       Invalid      Boundary | InconsistentOrientation
+ * >= 3   any        Invalid      Boundary | NonManifoldEdge
+ * ```
+ *
+ * A vertex accumulates the flags of all edges that touch it, so several
+ * bits may be set at once. Test them individually using ``has_flag()``
+ * rather than comparing the complete bitmask for equality. The remaining
+ * flag, \ref VertexFlags::NonManifoldVertex, is not part of the edge
+ * classification and is explained next.
+ *
+ * **Disconnected fans around a vertex**
+ *
+ * \ref VertexFlags::NonManifoldVertex marks vertices where the walk of
+ * Example 2 reaches fewer faces than \ref valence() reports. The
+ * typical case is a bowtie: two fans that touch only at their common apex.
+ * Every edge of such a configuration may pair normally, and those pairings
+ * are preserved. The defect is a property of the vertex, not of its edges.
+ * \ref vertex_edge() selects a starting point in one of the fans, and the
+ * walk covers only that fan.
+ *
+ * To enumerate every face around a non-manifold vertex, scan ``F`` for
+ * half-edges with ``F[e] == v`` (again skipping triangles with repeated
+ * indices) instead of walking from \ref vertex_edge().
+ *
+ * **Triangles with repeated indices**
+ *
+ * A triangle such as ``(a, a, b)`` has no area and is ignored as a whole:
+ * it keeps its slots in the half-edge numbering, but its three ``E2E``
+ * entries are \ref Invalid, its half-edges never appear in \ref V2E(), and
+ * it contributes no face counts or flags. The remaining triangles are
+ * paired as if it did not exist.
+ *
+ * One consequence is that ``E2E[e] == Invalid`` alone does not identify a
+ * boundary edge: code that scans all half-edges must first skip those of
+ * triangles with repeated indices.
+ *
+ * **Geometric and input limitations**
+ *
+ * This structure only examines vertex indices. It cannot detect zero-area
+ * geometry caused by collinear vertices or distinct indices that refer to the
+ * same position, nor can it detect self-intersections. The constructor also
+ * does not validate index bounds: every entry of ``F`` must be smaller than
+ * ``vertex_count``, and violations cause undefined behavior.
+ *
+ * [1] S. Campagna, L. Kobbelt, and H.-P. Seidel, "Directed Edges: A Scalable
+ * Representation for Triangle Meshes", Journal of Graphics Tools 3(4), 1998.
+ */
+template <typename Float, typename Spectrum>
+class MI_EXPORT_LIB DirectedEdge : public Object {
+public:
+    MI_IMPORT_CORE_TYPES()
+
+    using IndexBuffer = DynamicBuffer<UInt32>;
+
+    /// Sentinel denoting a half-edge that does not exist
+    static constexpr uint32_t Invalid = (uint32_t) -1;
+
+    /**
+     * \brief Build the adjacency structure of a triangle mesh
+     *
+     * The caller must ensure that ``F[i] < vertex_count`` holds for all
+     * provided indices. Violations cause undefined behavior.
+     *
+     * \param F
+     *     A flat index buffer holding the three vertex indices of each
+     *     triangle face, in winding order. Its size must be a multiple of 3.
+     *
+     * \param vertex_count
+     *     The number of mesh vertices.
+     *
+     * \param name
+     *     An optional name identifying the mesh in log messages.
+     */
+    DirectedEdge(const IndexBuffer &F, uint32_t vertex_count,
+                 std::string_view name = "");
+
+    /// Return the next half-edge within the same face
+    template <typename Index> static Index next(const Index &e) {
+        return dr::select(e % 3u == 2u, e - 2u, e + 1u);
+    }
+
+    /// Return the previous half-edge within the same face
+    template <typename Index> static Index prev(const Index &e) {
+        return dr::select(e % 3u == 0u, e + 2u, e - 1u);
+    }
+
+    /// Return the index of the face containing the half-edge
+    template <typename Index> static Index face(const Index &e) {
+        return e / 3u;
+    }
+
+    /// Return the local corner index of the half-edge within its face
+    template <typename Index> static Index corner(const Index &e) {
+        return e % 3u;
+    }
+
+    /// Number of half-edges, i.e. three times the face count
+    uint32_t half_edge_count() const { return m_half_edge_count; }
+
+    /// Number of vertices in the numbering used by the per-vertex outputs
+    uint32_t vertex_count() const { return m_vertex_count; }
+
+    /// Return the name passed to the constructor
+    const std::string &name() const { return m_name; }
+
+    /**
+     * \brief Return the half-edge opposite to \c e, or \ref Invalid
+     *
+     * This accessor loads ``E2E[e]``.
+     */
+    MI_INLINE UInt32 opposite(UInt32 e, Mask active = true) const {
+        return dr::gather<UInt32>(m_E2E, e, active);
+    }
+
+    /**
+     * \brief Return the canonical half-edge starting at \c v, or \ref Invalid
+     *
+     * This accessor loads ``V2E[v]``.
+     *
+     * This is the smallest half-edge at \c v whose predecessor is unpaired, or
+     * the smallest one overall when no such half-edge exists. It is the entry
+     * point of the vertex walk described in the class documentation.
+     */
+    MI_INLINE UInt32 vertex_edge(UInt32 v, Mask active = true) const {
+        return dr::gather<UInt32>(m_V2E, v, active);
+    }
+
+    /**
+     * \brief Return the valence of \c v
+     *
+     * This is the number of faces containing \c v. It excludes degenerate
+     * faces with a repeated vertex index.
+     */
+    MI_INLINE UInt32 valence(UInt32 v, Mask active = true) const {
+        return dr::gather<UInt32>(m_valence, v, active);
+    }
+
+    /// Return the bitmask of \ref VertexFlags associated with vertex \c v
+    MI_INLINE UInt32 vertex_flags(UInt32 v, Mask active = true) const {
+        return dr::gather<UInt32>(m_flags, v, active);
+    }
+
+    /// Per-half-edge buffer of opposites or \ref Invalid entries
+    const IndexBuffer &E2E() const { return m_E2E; }
+
+    /// Per-vertex buffer of canonical outgoing half-edges
+    const IndexBuffer &V2E() const { return m_V2E; }
+
+    /// Per-vertex buffer of valences, i.e. face counts
+    const IndexBuffer &valence() const { return m_valence; }
+
+    /// Per-vertex buffer of \ref VertexFlags bitmasks
+    const IndexBuffer &flags() const { return m_flags; }
+
+    /// Number of vertices carrying the given single-bit flag
+    uint32_t flag_count(VertexFlags flag) const {
+        return m_flag_counts[dr::log2i((uint32_t) flag)];
+    }
+
+    std::string to_string() const override;
+
+    MI_DECLARE_CLASS(DirectedEdge)
+
+protected:
+    /// Single-threaded builder used in scalar variants
+    void build_host(const IndexBuffer &F);
+
+    /// Data-parallel builder used in JIT variants
+    void build_jit(const IndexBuffer &F);
+
+protected:
+    uint32_t m_vertex_count = 0;
+    uint32_t m_half_edge_count = 0;
+    std::string m_name;
+
+    IndexBuffer m_E2E, m_V2E, m_valence, m_flags;
+
+    /// Number of vertices carrying each of the four \ref VertexFlags
+    uint32_t m_flag_counts[4] { 0, 0, 0, 0 };
+
+    MI_TRAVERSE_CB(Object, m_E2E, m_V2E, m_valence, m_flags)
+};
+
+MI_EXTERN_CLASS(DirectedEdge)
+NAMESPACE_END(mitsuba)

--- a/include/mitsuba/render/fwd.h
+++ b/include/mitsuba/render/fwd.h
@@ -9,6 +9,7 @@ NAMESPACE_BEGIN(mitsuba)
 struct BSDFContext;
 struct ShapeIR;
 template <typename Float, typename Spectrum> class BSDF;
+template <typename Float, typename Spectrum> class DirectedEdge;
 template <typename Float, typename Spectrum> class OptixDenoiser;
 template <typename Float, typename Spectrum> class Emitter;
 template <typename Float, typename Spectrum> class Endpoint;
@@ -119,6 +120,7 @@ template <typename Float_, typename Spectrum_> struct RenderAliases {
     using ShapeGroup             = mitsuba::ShapeGroup<Float, Spectrum>;
     using ShapeKDTree            = mitsuba::ShapeKDTree<Float, Spectrum>;
     using Mesh                   = mitsuba::Mesh<Float, Spectrum>;
+    using DirectedEdge           = mitsuba::DirectedEdge<Float, Spectrum>;
     using Integrator             = mitsuba::Integrator<Float, Spectrum>;
     using SamplingIntegrator     = mitsuba::SamplingIntegrator<Float, Spectrum>;
     using MonteCarloIntegrator   = mitsuba::MonteCarloIntegrator<Float, Spectrum>;

--- a/include/mitsuba/render/mesh.h
+++ b/include/mitsuba/render/mesh.h
@@ -4,6 +4,7 @@
 #include <mitsuba/render/shape.h>
 #include <mitsuba/render/srgb.h>
 #include <mitsuba/render/mesh_utils.h>
+#include <mitsuba/render/dedge.h>
 #include <mitsuba/core/filesystem.h>
 #include <mitsuba/core/string.h>
 #include <mitsuba/core/struct.h>
@@ -164,7 +165,7 @@ NAMESPACE_BEGIN(mitsuba)
 template <typename Float, typename Spectrum>
 class MI_EXPORT_LIB Mesh : public Shape<Float, Spectrum> {
 public:
-    MI_IMPORT_TYPES(BSDF)
+    MI_IMPORT_TYPES(BSDF, DirectedEdge)
     MI_IMPORT_BASE(Shape, m_to_world, mark_dirty, m_emitter, m_sensor, m_bsdf,
                    m_interior_medium, m_exterior_medium, m_is_instance,
                    m_discontinuity_types, m_shape_type, m_initialized,
@@ -415,7 +416,7 @@ public:
      *
      * This function returns \ref faces() re-indexed into surface position space,
      * i.e., the geometric topology of the mesh without UV/normal-related
-     * seams. It is used by features like \ref build_directed_edges() and the
+     * seams. It is used by features like \ref directed_edges() and the
      * mesh Laplacian in ``largesteps.py``.
      */
     TensorXu32 geometric_faces() const;
@@ -578,14 +579,15 @@ public:
     /**
      * Returns the opposite edge index associated with directed edge \c index
      *
-     * If the directed edge data structure is not initialized, the return
-     * value is undefined. Ensure that \ref build_directed_edges() is
-     * called before this method.
+     * The function returns \c DirectedEdge::Invalid when the adjacency
+     * structure has not been built. It deliberately does not build it, so that
+     * a vectorized call over a set of meshes of which only some carry the
+     * structure remains well defined. Call \ref directed_edges() first.
      */
     MI_INLINE UInt32 opposite_dedge(UInt32 index, Mask active = true) const {
-        if (m_E2E.size() == 0)
-            return UInt32((uint32_t) -1);
-        return dr::gather<UInt32>(m_E2E, index, active);
+        if (!m_dedge)
+            return UInt32(DirectedEdge::Invalid);
+        return m_dedge->opposite(index, active);
     }
 
     Point3f barycentric_coordinates(const SurfaceInteraction3f &si,
@@ -691,14 +693,26 @@ public:
      */
     void transform(const AffineTransform4f &t);
 
-    /**
-     * \brief Build directed edge data structure to efficiently access adjacent
-     * edges.
+    /** \brief Return a data structure describing the half-edge adjacency
      *
-     * This is an implementation of the technique described in:
-     * <tt>https://www.graphics.rwth-aachen.de/media/papers/directed.pdf</tt>.
+     * This function returns a \ref DirectedEdge data structure that enables
+     * geometric queries such as finding the triangle across an edge or
+     * traversing faces surrounding a vertex.
+     *
+     * The data structure is built on demand and uses the geometric
+     * connectivity specified by \ref geometric_faces() so that attribute
+     * discontinuities do not introduce artificial geometric boundaries.
+     *
+     * The result is immutable and invariant to changes in mesh positions,
+     * normals and materials. The \ref Mesh class automatically deletes the
+     * cached instance when the index buffer, the position index map, or the
+     * position count changes.
+     *
+     * The on-demand construction not lock a mutex to protect from concurrent
+     * calls to this function. This matches the expected usage (JIT variants),
+     * where a single thread orchestrates the parallel computation.
      */
-    void build_directed_edges();
+    const DirectedEdge *directed_edges() const;
 
     /**
      * \brief Check the field views for consistency
@@ -971,8 +985,8 @@ protected:
      *
      * This method filters out any concave edges or flat surfaces.
      *
-     * Internally, this method relies on the directed edge data structure. A
-     * call to \ref build_directed_edges before a call to this method is
+     * Internally, this method relies on the half-edge adjacency structure. A
+     * call to \ref directed_edges() before a call to this method is
      * therefore necessary.
      */
     void build_indirect_silhouette_distribution();
@@ -1225,8 +1239,8 @@ protected:
     IndexBuffer m_bsdf_index;
     TensorXf32 m_tangents;
 
-    /// Directed edges data structures to support neighbor queries
-    mutable IndexBuffer m_E2E;
+    /// Half-edge adjacency, null until \ref directed_edges() builds it
+    mutable ref<DirectedEdge> m_dedge;
 
     /// Sampling density of silhouette (\ref build_indirect_silhouette_distribution)
     DiscreteDistribution<Float> m_sil_dedge_pmf;
@@ -1255,7 +1269,7 @@ protected:
     MI_DECLARE_TRAVERSE_CB(m_packed_vertices, m_packed_faces,
                            m_positions, m_normals, m_texcoords,
                            m_position_index, m_normal_index,
-                           m_E2E, m_sil_dedge_pmf, m_mesh_attributes,
+                           m_dedge, m_sil_dedge_pmf, m_mesh_attributes,
                            m_area_pmf, m_parameterization)
 };
 

--- a/src/python/main_v.cpp
+++ b/src/python/main_v.cpp
@@ -93,6 +93,7 @@ MI_PY_DECLARE(Interaction);
 MI_PY_DECLARE(SurfaceInteraction);
 MI_PY_DECLARE(MediumInteraction);
 MI_PY_DECLARE(PreliminaryIntersection);
+MI_PY_DECLARE(DirectedEdge);
 MI_PY_DECLARE(Medium);
 MI_PY_DECLARE(mueller);
 MI_PY_DECLARE(MicrofacetDistribution);
@@ -196,6 +197,7 @@ NB_MODULE(MI_VARIANT_NAME, m) {
 
     MI_PY_IMPORT(Scene);
     MI_PY_IMPORT(Shape);
+    MI_PY_IMPORT(DirectedEdge);
     MI_PY_IMPORT(Medium);
     MI_PY_IMPORT(Endpoint);
     MI_PY_IMPORT(Emitter);

--- a/src/render/CMakeLists.txt
+++ b/src/render/CMakeLists.txt
@@ -73,6 +73,7 @@ add_library(mitsuba-render OBJECT
   ${INC_DIR}/records.h
 
   bsdf.cpp         ${INC_DIR}/bsdf.h
+  dedge.cpp ${INC_DIR}/dedge.h
   emitter.cpp      ${INC_DIR}/emitter.h
   endpoint.cpp     ${INC_DIR}/endpoint.h
   film.cpp         ${INC_DIR}/film.h

--- a/src/render/dedge.cpp
+++ b/src/render/dedge.cpp
@@ -1,0 +1,333 @@
+#include <mitsuba/core/logger.h>
+#include <mitsuba/render/dedge.h>
+#include <drjit/while_loop.h>
+#include <algorithm>
+#include <array>
+#include <vector>
+
+NAMESPACE_BEGIN(mitsuba)
+
+MI_VARIANT
+DirectedEdge<Float, Spectrum>::DirectedEdge(const IndexBuffer &F,
+                                            uint32_t vertex_count,
+                                            std::string_view name)
+    : m_vertex_count(vertex_count),
+      m_half_edge_count((uint32_t) F.size()), m_name(name) {
+    if (m_half_edge_count % 3 != 0)
+        Throw("DirectedEdge(): 'F' holds %u entries, which is not a multiple "
+              "of 3!", m_half_edge_count);
+
+    if (m_half_edge_count == 0 || m_vertex_count == 0)
+        Throw("DirectedEdge(): the mesh must have at least one face and one "
+              "vertex!");
+
+    if constexpr (dr::is_jit_v<Float>)
+        build_jit(F);
+    else
+        build_host(F);
+
+    // Tally flags
+    if constexpr (dr::is_jit_v<Float>) {
+        UInt32 counts = dr::zeros<UInt32>(4);
+        for (uint32_t i = 0; i < 4; ++i)
+            dr::scatter_reduce(ReduceOp::Add, counts, UInt32(1), UInt32(i),
+                               has_flag(m_flags, (VertexFlags) (1u << i)));
+        const IndexBuffer &host_counts = dr::migrate(counts, JitBackend::None);
+        dr::sync_thread();
+        for (uint32_t i = 0; i < 4; ++i)
+            m_flag_counts[i] = host_counts.data()[i];
+    } else {
+        for (uint32_t i = 0; i < 4; ++i)
+            m_flag_counts[i] = dr::count(has_flag(m_flags, (VertexFlags) (1u << i)))[0];
+    }
+
+    if (m_flag_counts[1] || m_flag_counts[2] || m_flag_counts[3])
+        Log(Warn,
+            "DirectedEdge(%s): mesh has %u vertices on non-manifold edges, %u "
+            "non-manifold vertices, and %u vertices on inconsistently wound "
+            "edges. Edges with non-manifold incidence or inconsistent face "
+            "winding are left unpaired and treated as boundaries.",
+            m_name.empty() ? std::string() : "\"" + m_name + "\"",
+            m_flag_counts[1], m_flag_counts[2], m_flag_counts[3]);
+}
+
+MI_VARIANT void DirectedEdge<Float, Spectrum>::build_host(const IndexBuffer &buffer) {
+    if constexpr (dr::is_jit_v<Float>) {
+        DRJIT_MARK_USED(buffer);
+    } else {
+        const uint32_t *F = buffer.data();
+        uint32_t D = m_half_edge_count,
+                 V = m_vertex_count;
+
+        std::vector<uint32_t> E2E(D, Invalid),
+                              V2E(V, Invalid),
+                              V2E_any(V, Invalid),
+                              valence(V, 0),
+                              flags(V, 0);
+
+        // Collect the half-edges of non-degenerate faces as {lower endpoint,
+        // upper endpoint, half-edge} and sort, which groups those sharing an
+        // undirected edge
+        std::vector<std::array<uint32_t, 3>> edges;
+        edges.reserve(D);
+        for (uint32_t f = 0; f < D / 3; ++f) {
+            const uint32_t *v = F + 3 * f;
+            if (v[0] == v[1] || v[1] == v[2] || v[0] == v[2])
+                continue; // A face with a repeated index has no area
+            for (uint32_t i = 0; i < 3; ++i)
+                edges.push_back({ std::min(v[i], v[(i + 1) % 3]),
+                                  std::max(v[i], v[(i + 1) % 3]), 3 * f + i });
+        }
+        std::sort(edges.begin(), edges.end());
+
+        // Pair each run of equal keys, but only where the answer is unambiguous
+        for (size_t i = 0, n = edges.size(); i < n; ) {
+            auto [a, b, e] = edges[i];
+
+            size_t j = i + 1;
+            while (j < n && edges[j][0] == a && edges[j][1] == b)
+                ++j;
+
+            if (j - i == 2) {
+                uint32_t g = edges[i + 1][2];
+                if (F[e] != F[g]) {
+                    E2E[e] = g;
+                    E2E[g] = e;
+                } else {
+                    flags[a] |= (uint32_t) VertexFlags::InconsistentOrientation;
+                    flags[b] |= (uint32_t) VertexFlags::InconsistentOrientation;
+                }
+            } else if (j - i > 2) {
+                flags[a] |= (uint32_t) VertexFlags::NonManifoldEdge;
+                flags[b] |= (uint32_t) VertexFlags::NonManifoldEdge;
+            }
+
+            i = j;
+        }
+
+        // A half-edge starts a ring exactly when its predecessor is unpaired,
+        // which turns the canonical start into a minimum over the whole star
+        for (const auto &edge : edges) {
+            uint32_t e = edge[2], a = F[e], b = F[next(e)];
+
+            valence[a]++;
+            V2E_any[a] = std::min(V2E_any[a], e);
+
+            if (E2E[e] == Invalid) {
+                flags[a] |= (uint32_t) VertexFlags::Boundary;
+                flags[b] |= (uint32_t) VertexFlags::Boundary;
+            }
+
+            if (E2E[prev(e)] == Invalid)
+                V2E[a] = std::min(V2E[a], e);
+        }
+
+        for (uint32_t v = 0; v < V; ++v)
+            if (V2E[v] == Invalid)
+                V2E[v] = V2E_any[v];
+
+        // Walk each ring forward. It cannot cycle without returning to its
+        // start (see build_jit()), so no iteration cap is needed.
+        for (uint32_t v = 0; v < V; ++v) {
+            uint32_t start = V2E[v];
+            if (start == Invalid)
+                continue;
+
+            uint32_t e = start, count = 1;
+            while (true) {
+                uint32_t opp = E2E[e];
+                if (opp == Invalid || next(opp) == start)
+                    break;
+                e = next(opp);
+                count++;
+            }
+
+            if (count != valence[v])
+                flags[v] |= (uint32_t) VertexFlags::NonManifoldVertex;
+        }
+
+        m_E2E     = dr::load<IndexBuffer>(E2E.data(), D);
+        m_V2E     = dr::load<IndexBuffer>(V2E.data(), V);
+        m_valence = dr::load<IndexBuffer>(valence.data(), V);
+        m_flags   = dr::load<IndexBuffer>(flags.data(), V);
+    }
+}
+
+MI_VARIANT void DirectedEdge<Float, Spectrum>::build_jit(const IndexBuffer &F) {
+    if constexpr (!dr::is_jit_v<Float>) {
+        DRJIT_MARK_USED(F);
+    } else {
+        uint32_t D = m_half_edge_count,
+                 V = m_vertex_count;
+
+        // Endpoints of every half-edge, plus the opposite corner of its face
+        UInt32 e     = dr::arange<UInt32>(D),
+               src   = dr::gather<UInt32>(F, e),
+               dst   = dr::gather<UInt32>(F, next(e)),
+               third = dr::gather<UInt32>(F, prev(e));
+
+        // Identify non-degenerate faces and drop others
+        Mask alive = (src != dst) && (dst != third) && (src != third);
+
+        m_valence = dr::zeros<UInt32>(V);
+        dr::scatter_reduce(ReduceOp::Add, m_valence, UInt32(1), src, alive);
+
+        // Construction begins with a pairing step that finds all half-edges
+        // sharing an undirected edge. For this, each half-edge inserts itself
+        // into a linked list at its lower-valence endpoint (ties broken by
+        // index). Both halves of an undirected edge pick the same one, so that
+        // walking a single list reveals all half-edges of that undirected
+        // edge. Preferring low valence keeps the lists short and avoids
+        // quadratic runtime cost in meshes with high-valence vertices.
+        UInt32 valence_src = dr::gather<UInt32>(m_valence, src),
+               valence_dst = dr::gather<UInt32>(m_valence, dst);
+
+        Mask src_first = (valence_src < valence_dst) ||
+                         ((valence_src == valence_dst) && (src < dst));
+
+        UInt32 owner = dr::select(src_first, src, dst),
+               other = dr::select(src_first, dst, src);
+
+        // The list at one vertex may contain half-edges from multiple
+        // undirected edges. The list traversal done later tells them apart via
+        // 'key', which stores the 'other' endpoint plus a bit recording
+        // whether the half-edge points toward 'owner' or away from it.
+        UInt32 key = (other << 1) | UInt32(src_first);
+
+        // Build the lists. Following these lines, 'head[v]' holds the most
+        // recently inserted half-edge of vertex 'v', and 'link[e]' points to
+        // the successor of half-edge 'e'.
+        UInt32 head = dr::full<UInt32>(Invalid, V),
+               link = dr::scatter_exch(head, e, owner, alive);
+
+        dr::eval(key, link, head);
+
+        // Every half-edge now walks its owner's list and classifies itself by
+        // counting the entries sharing its undirected edge and recording an
+        // opposed partner when it sees one. Both halves of a pair walk the
+        // same list and each writes only its own slot. As a consequence,
+        // E2E[E2E[e]] == e holds by construction.
+        struct ScanState {
+            UInt32 it;      // Current position in the list, Invalid at the end
+            UInt32 matches; // Entries seen on the same undirected edge
+            UInt32 partner; // Opposed half-edge, or Invalid if none seen yet
+            DRJIT_STRUCT(ScanState, it, matches, partner)
+        };
+
+        ScanState s{ dr::select(alive, dr::gather<UInt32>(head, owner, alive),
+                                UInt32(Invalid)),
+                     dr::zeros<UInt32>(D), dr::full<UInt32>(Invalid, D) };
+
+        dr::tie(s) = dr::while_loop(
+            dr::make_tuple(s),
+            [](const ScanState &s) { return s.it != Invalid; },
+            [&](ScanState &s) {
+                Mask valid = s.it != Invalid;
+                UInt32 k   = dr::gather<UInt32>(key, s.it, valid);
+
+                // Two half-edges share an undirected edge when they agree on
+                // the other endpoint. They are opposed when the top bit differs.
+                Mask match   = (k >> 1) == (key >> 1),
+                     opposed = k == (key ^ 1u);
+
+                s.matches += UInt32(match);
+                s.partner  = dr::select(opposed, s.it, s.partner);
+
+                // Advance and stop early when there are more than 2 matches
+                s.it = dr::select(s.matches > 2u, UInt32(Invalid),
+                                  dr::gather<UInt32>(link, s.it, valid));
+            });
+
+        // A half-edge always matches itself, and does so in its own direction,
+        // so a group of two holds at most one opposed half-edge
+        Mask paired       = (s.matches == 2u) && (s.partner != Invalid),
+             inconsistent = (s.matches == 2u) && (s.partner == Invalid),
+             non_manifold = s.matches > 2u;
+
+        m_E2E = dr::select(paired, s.partner, UInt32(Invalid));
+
+        auto bit = [](VertexFlags f, const Mask &mask) {
+            return dr::select(mask, UInt32((uint32_t) f), UInt32(0));
+        };
+
+        Mask unpaired = alive && !paired;
+
+        // Both endpoints of a half-edge inherit its defects
+        UInt32 defects = bit(VertexFlags::NonManifoldEdge, non_manifold) |
+                         bit(VertexFlags::InconsistentOrientation, inconsistent) |
+                         bit(VertexFlags::Boundary, unpaired);
+
+        m_flags = dr::zeros<UInt32>(V);
+        dr::scatter_reduce(ReduceOp::Or, m_flags, defects, src, unpaired);
+        dr::scatter_reduce(ReduceOp::Or, m_flags, defects, dst, unpaired);
+
+        // Now that E2E and the flags are ready, the next step computes V2E,
+        // the half-edge at which the walk around each vertex begins. The walk
+        // covers an open fan fully only when it begins at a half-edge with an
+        // unpaired predecessor, and 'is_start' marks these candidates. 'Min'
+        // reductions then find, per vertex, the smallest marked half-edge
+        // (V2E_start) and the smallest one overall (V2E_any), the latter
+        // serving as a fallback for closed fans. Vertices reached by neither
+        // reduction keep the Invalid sentinel.
+        Mask is_start = alive && (dr::gather<UInt32>(m_E2E, prev(e)) == Invalid);
+
+        UInt32 V2E_start = dr::full<UInt32>(Invalid, V),
+               V2E_any   = dr::full<UInt32>(Invalid, V);
+
+        dr::scatter_reduce(ReduceOp::Min, V2E_start, e, src, is_start);
+        dr::scatter_reduce(ReduceOp::Min, V2E_any, e, src, alive);
+
+        m_V2E = dr::select(V2E_start != Invalid, V2E_start, V2E_any);
+
+        // The last remaining output is the 'NonManifoldVertex' flag, which
+        // marks vertices whose faces form more than one fan. The loop below
+        // walks around each vertex and counts the number of faces, which
+        // matches the valence in the manifold case. Each half-edge has a
+        // unique successor next(E2E[e]) and a unique predecessor
+        // E2E[prev(e)], so the half-edges of a mesh link up into disjoint
+        // chains and rings. A walk of such a structure either ends at an
+        // unpaired edge or returns to its starting point, so no iteration
+        // cap is needed.
+        struct WalkState {
+            UInt32 e;     // Current half-edge of the walk
+            UInt32 count; // Number of faces visited so far
+            Mask active;  // Whether the walk is still in progress
+            DRJIT_STRUCT(WalkState, e, count, active)
+        };
+
+        Mask visits = m_V2E != Invalid;
+        WalkState w{ m_V2E, UInt32(visits), visits };
+
+        dr::tie(w) = dr::while_loop(
+            dr::make_tuple(w),
+            [](const WalkState &w) { return w.active; },
+            [this](WalkState &w) {
+                UInt32 opp = dr::gather<UInt32>(m_E2E, w.e, w.active),
+                       nxt = next(opp);
+
+                Mask step = w.active && (opp != Invalid) && (nxt != m_V2E);
+
+                w.count += UInt32(step);
+                w.e      = dr::select(step, nxt, w.e);
+                w.active = step;
+            });
+
+        m_flags |= bit(VertexFlags::NonManifoldVertex,
+                       w.count != m_valence);
+
+        dr::eval(m_E2E, m_V2E, m_valence, m_flags);
+    }
+}
+
+MI_VARIANT std::string DirectedEdge<Float, Spectrum>::to_string() const {
+    return tfm::format(
+        "DirectedEdge[%sfaces=%u, vertices=%u, boundary=%u, "
+        "non_manifold_edge=%u, non_manifold_vertex=%u, "
+        "inconsistent_orientation=%u]",
+        m_name.empty() ? std::string() : tfm::format("name=\"%s\", ", m_name),
+        m_half_edge_count / 3, m_vertex_count, m_flag_counts[0],
+        m_flag_counts[1], m_flag_counts[2], m_flag_counts[3]);
+}
+
+MI_INSTANTIATE_CLASS(DirectedEdge)
+NAMESPACE_END(mitsuba)

--- a/src/render/mesh.cpp
+++ b/src/render/mesh.cpp
@@ -575,7 +575,7 @@ void Mesh<Float, Spectrum>::pack(bool regenerate_normals, bool flip_normals,
         size_t covered = m_normal_index.empty() ? m_normal_count
                                                 : m_normal_index.size();
         if (covered != V) {
-            // 'm_normal_index' no longer has the right following a topology change
+            // 'm_normal_index' no longer has the right size following a topology change
             m_normal_index = m_position_index;
             m_normal_count = (ScalarSize) P;
             m_normal_rep   = m_position_rep;
@@ -596,6 +596,12 @@ void Mesh<Float, Spectrum>::pack(bool regenerate_normals, bool flip_normals,
     }
 
     validate_impl(/* check_bounds */ false, updating);
+
+    // The directed edge data structure depends on the position count.
+    if (m_dedge && m_dedge->vertex_count() != P) {
+        m_dedge = nullptr;
+        m_sil_dedge_pmf = DiscreteDistribution<Float>();
+    }
 
     m_face_count     = (ScalarSize) m_faces.shape(0);
     m_position_count = (ScalarSize) P;
@@ -795,9 +801,8 @@ void Mesh<Float, Spectrum>::refresh(const ScalarBoundingBox3f *bbox) {
         build_parameterization();
 
     if constexpr (dr::is_jit_v<Float>) {
-        if (parameters_grad_enabled()) {
-            if (m_E2E.empty())
-                build_directed_edges();
+        if (parameters_grad_enabled() && m_face_count > 0) {
+            directed_edges();
             build_indirect_silhouette_distribution();
         }
     }
@@ -859,8 +864,11 @@ MI_VARIANT void Mesh<Float, Spectrum>::parameters_changed(const std::vector<std:
             Throw("parameters_changed(): mesh \"%s\": writing 'normal_index' "
                   "requires writing 'normals' in the same batch.", m_filename);
 
-        if (topology)
-            m_E2E = IndexBuffer();
+        if (topology) {
+            m_dedge = nullptr;
+            // Derived from the pairing, so it cannot outlive it
+            m_sil_dedge_pmf = DiscreteDistribution<Float>();
+        }
 
         // The inverse index maps follow the maps they were built from
         if (has("position_index"))
@@ -1207,7 +1215,7 @@ MI_VARIANT void Mesh<Float, Spectrum>::flip_winding() {
         });
 
     // Invalidate directed edge data structure
-    m_E2E = IndexBuffer();
+    m_dedge = nullptr;
     m_sil_dedge_pmf = DiscreteDistribution<Float>();
 }
 
@@ -1368,197 +1376,15 @@ MI_VARIANT void Mesh<Float, Spectrum>::build_pmf() {
     m_area_pmf = DiscreteDistribution<Float>(std::move(area));
 }
 
-constexpr static uint32_t INVALID_DEDGE = (uint32_t) -1;
+MI_VARIANT const typename Mesh<Float, Spectrum>::DirectedEdge *
+Mesh<Float, Spectrum>::directed_edges() const {
+    // Unsynchronized, which is fine in the expected usage (JIT variants),
+    // where a single thread orchestrates the parallel computation
+    if (!m_dedge)
+        m_dedge = new DirectedEdge(geometric_faces().array(), m_position_count,
+                                   m_filename);
 
-MI_VARIANT void Mesh<Float, Spectrum>::build_directed_edges() {
-    std::lock_guard<std::mutex> lock(m_mutex);
-
-    if (m_face_count == 0)
-        Throw("Cannot create directed edges for an empty mesh: %s", to_string());
-
-    // Half-edges are paired on the geometric topology: vertices map to their
-    // surface point, so the two sides of an attribute seam connect instead of
-    // reading as mesh boundaries.
-    IndexBuffer gfaces = geometric_faces().array();
-
-    if constexpr (!dr::is_jit_v<Float>) {
-        const IndexBuffer &faces = dr::migrate(gfaces, JitBackend::None);
-        if constexpr (dr::is_array_v<Float>)
-            dr::sync_thread();
-
-        // To make this algorithm parallel in scalar variants, we'd need to
-        // have a scalar compare-and-swap operation in Dr.Jit
-
-        std::vector<ScalarIndex> V2E(m_position_count, INVALID_DEDGE);
-        std::vector<ScalarIndex> E2E(m_face_count * 3, INVALID_DEDGE);
-
-        // For an edge e1 = (v1, v2), tmp is defined as:
-        //     tmp[e1].first  = v2,
-        //     tmp[e1].second = (next edge e_k that also starts from v1) or INVALID_DEDGE
-        std::vector<std::pair<ScalarIndex, ScalarIndex>> tmp(m_face_count * 3);
-
-        // 1. Fill `tmp` and `V2E`
-        const ScalarIndex *face_data = faces.data();
-        for (ScalarIndex f = 0; f < m_face_count; f++) {
-            ScalarPoint3u triangle_indices =
-                dr::load<ScalarPoint3u>(face_data + 3 * f);
-            for (ScalarIndex i = 0; i < 3; i++) {
-                ScalarIndex idx_cur = triangle_indices[i],
-                            idx_nxt = triangle_indices[(i + 1) % 3],
-                            edge_id = 3 * f + i;
-                if (idx_cur == idx_nxt)
-                    continue;
-
-                tmp[edge_id] = std::make_pair(idx_nxt, INVALID_DEDGE);
-                if (V2E[idx_cur] != INVALID_DEDGE) {
-                    ScalarIndex last_edge_idx = V2E[idx_cur];
-
-                    while (tmp[last_edge_idx].second != INVALID_DEDGE)
-                        last_edge_idx = tmp[last_edge_idx].second;
-
-                    if (tmp[last_edge_idx].second == INVALID_DEDGE)
-                        tmp[last_edge_idx].second = edge_id;
-                } else {
-                    V2E[idx_cur] = edge_id;
-                }
-            }
-        }
-
-        // 2. Manifold check & assign `E2E`
-        std::vector<bool> non_manifold(m_position_count, false);
-        for (ScalarIndex f = 0; f < m_face_count; f++) {
-            ScalarPoint3u tri = dr::load<ScalarPoint3u>(face_data + 3 * f);
-            for (ScalarIndex i = 0; i < 3; i++) {
-                ScalarIndex idx_cur = tri[i],
-                            idx_nxt = tri[(i + 1) % 3],
-                            edge_id = 3 * f + i;
-                if (idx_cur == idx_nxt)
-                    continue;
-
-                ScalarIndex it = V2E[idx_nxt], edge_id_opp = INVALID_DEDGE;
-                while (it != INVALID_DEDGE) {
-                    if (tmp[it].first == idx_cur) {
-                        if (edge_id_opp == INVALID_DEDGE) {
-                            edge_id_opp = it;
-                        } else {
-                            non_manifold[idx_cur] = true;
-                            non_manifold[idx_nxt] = true;
-                            edge_id_opp           = INVALID_DEDGE;
-                            break;
-                        }
-                    }
-                    it = tmp[it].second;
-                }
-
-                if (edge_id_opp != INVALID_DEDGE && edge_id < edge_id_opp) {
-                    E2E[edge_id] = edge_id_opp;
-                    E2E[edge_id_opp] = edge_id;
-                }
-            }
-        }
-
-        // 3. Log
-        ScalarIndex non_manifold_count = 0;
-        for (ScalarIndex i = 0; i < m_position_count; i++)
-            non_manifold_count += non_manifold[i] ? 1 : 0;
-
-        if (non_manifold_count > 0)
-            Log(Warn,
-                "Mesh::build_directed_edges(): there are %d non-manifold vertices in the "
-                "following mesh: %s",
-                non_manifold_count, to_string());
-
-        m_E2E = dr::load<IndexBuffer>(E2E.data(), m_face_count * 3);
-    } else {
-        UInt32 V2E = dr::full<UInt32>(INVALID_DEDGE, m_position_count);
-
-        // For an edge e1 = (v1, v2), tmp is defined as:
-        // tmp[0][e1] = v2,
-        // tmp[1][e1] = (next edge e_k that also starts from v1) or INVALID_DEDGE
-        Vector2u tmp = dr::zeros<Vector2u>(m_face_count * 3);
-
-        //// 1. Fill `tmp` and `V2E`
-        UInt32 v1 = gfaces;
-        UInt32 face_idx = dr::repeat(dr::arange<UInt32>(m_face_count), 3);
-        UInt32 v2_idx = face_idx * 3 + ((dr::arange<UInt32>(m_face_count * 3) + 1) % 3);
-        UInt32 v2 = dr::gather<UInt32>(gfaces, v2_idx);
-        Bool invalid_edges = (v1 == v2);
-        UInt32 edge_id = dr::arange<UInt32>(m_face_count * 3);
-
-        tmp[0] = v2;
-        tmp[1] = dr::full<UInt32>(INVALID_DEDGE, v2.size());
-
-        auto [old, swapped] =
-            dr::scatter_cas(V2E, UInt32(INVALID_DEDGE), edge_id, v1, !invalid_edges);
-
-        struct LoopState {
-            UInt32 next_edge_id;
-            Mask active;
-            DRJIT_STRUCT(LoopState, next_edge_id, active)
-        };
-        UInt32 next_edge_id = old;
-        LoopState ls{ next_edge_id, (!swapped) & (!invalid_edges) };
-        dr::tie(ls) = dr::while_loop(
-            dr::make_tuple(ls),
-            [](const LoopState &ls) { return ls.active; },
-            [&tmp, &edge_id](LoopState &ls) {
-                auto [old, swapped] =
-                    dr::scatter_cas(tmp[1], UInt32(INVALID_DEDGE), edge_id, ls.next_edge_id);
-                ls.next_edge_id = old;
-                ls.active &= !swapped;
-            }
-        );
-
-        // 2. Manifold check & assign `E2E`
-        UInt32 it = dr::gather<UInt32>(V2E, v2);
-        UInt32 edge_id_opp = INVALID_DEDGE;
-        Bool non_manifold = dr::full<Bool>(false, m_position_count);
-        struct LoopState2 {
-            UInt32 it;
-            UInt32 edge_id_opp;
-            Mask active;
-            DRJIT_STRUCT(LoopState2, it, edge_id_opp, active)
-        };
-        LoopState2 ls2{ it, edge_id_opp, !invalid_edges};
-        dr::tie(ls2) = dr::while_loop(
-            dr::make_tuple(ls2),
-            [](const LoopState2 &ls) { return ls.active; },
-            [&tmp, &v1, &v2, &non_manifold](LoopState2 &ls) {
-                Bool found_edge = (dr::gather<UInt32>(tmp[0], ls.it) == v1);
-                Bool invalid_opp = (ls.edge_id_opp == INVALID_DEDGE);
-
-                // Set opposite edge
-                ls.edge_id_opp[found_edge & invalid_opp] = ls.it;
-
-                // Opposite edge was already set, must be non-manifold.
-                // Several edges may target the same vertex, but they all
-                // store the same value, so the writes can race harmlessly.
-                dr::scatter<Bool>(non_manifold, Bool(true), v1, found_edge & !invalid_opp, ReduceMode::NoConflicts);
-                dr::scatter<Bool>(non_manifold, Bool(true), v2, found_edge & !invalid_opp, ReduceMode::NoConflicts);
-                ls.edge_id_opp[found_edge & (!invalid_opp)] = INVALID_DEDGE;
-                ls.active[found_edge & (!invalid_opp)] = false;
-
-                // Move to next edge of vertex
-                ls.it = dr::gather<UInt32>(tmp[1], ls.it);
-                ls.active &= (ls.it != INVALID_DEDGE);
-            }
-        );
-        edge_id_opp = ls2.edge_id_opp;
-
-        Bool success = (edge_id_opp != INVALID_DEDGE) & (edge_id < edge_id_opp);
-        m_E2E = dr::full<UInt32>(INVALID_DEDGE, m_face_count * 3);
-        dr::scatter<UInt32>(m_E2E, edge_id_opp, edge_id, success, ReduceMode::NoConflicts);
-        dr::scatter<UInt32>(m_E2E, edge_id, edge_id_opp, success, ReduceMode::NoConflicts);
-        dr::eval(m_E2E, non_manifold);
-
-        // 3. Log
-        size_t non_manifold_count = dr::count(non_manifold)[0];
-        if (non_manifold_count > 0)
-            Log(Warn,
-                "Mesh::build_directed_edges(): there are %d non-manifold vertices in the "
-                "following mesh: %s",
-                non_manifold_count, to_string());
-    }
+    return m_dedge.get();
 }
 
 /**
@@ -1579,9 +1405,13 @@ MI_INLINE Index pick_vertex(const dr::Array<dr::uint32_array_t<Index>, 3> &vec, 
 
 MI_VARIANT void
 Mesh<Float, Spectrum>::build_indirect_silhouette_distribution() {
+    if (!m_dedge)
+        Throw("Mesh::build_indirect_silhouette_distribution(): mesh \"%s\" "
+              "has no half-edge adjacency.", m_filename);
+
     UInt32 dedge = dr::arange<UInt32>(m_face_count * 3),
            dedge_oppo = opposite_dedge(dedge);
-    Mask boundary = (dedge_oppo == INVALID_DEDGE);
+    Mask boundary = (dedge_oppo == DirectedEdge::Invalid);
     // One edge can be represented by two dedge indices, we use the smaller index
     Mask valid = (dedge_oppo > dedge) & !boundary;
 
@@ -1929,7 +1759,7 @@ Mesh<Float, Spectrum>::sample_silhouette(const Point3f &sample_,
                                          Mask active) const {
     MI_MASK_ARGUMENT(active);
 
-    if (!has_flag(flags, DiscontinuityFlags::PerimeterType) || m_E2E.empty())
+    if (!has_flag(flags, DiscontinuityFlags::PerimeterType) || !m_dedge)
         return dr::zeros<SilhouetteSample3f>();
 
     SilhouetteSample3f ss = dr::zeros<SilhouetteSample3f>();
@@ -1964,7 +1794,7 @@ Mesh<Float, Spectrum>::sample_silhouette(const Point3f &sample_,
 
     UInt32 dedge_oppo = opposite_dedge(dedge, active);
     UInt32 face_idx_oppo = dr::idiv(dedge_oppo, 3u);
-    Mask has_opposite = (dedge_oppo != INVALID_DEDGE) & active;
+    Mask has_opposite = (dedge_oppo != DirectedEdge::Invalid) & active;
     Normal3f n_oppo = face_normal(face_idx_oppo, has_opposite);
 
     bool is_lune = has_flag(flags, DiscontinuityFlags::DirectionLune);
@@ -2027,7 +1857,7 @@ MI_VARIANT typename Mesh<Float, Spectrum>::Point3f
 Mesh<Float, Spectrum>::invert_silhouette_sample(const SilhouetteSample3f &ss,
                                                 Mask active_) const {
     // Do not trace this function if it's not differentiated
-    if (m_E2E.empty())
+    if (!m_dedge)
         return dr::zeros<Point3f>();
 
     // Safely ignore invalid boundary segments
@@ -2044,7 +1874,7 @@ Mesh<Float, Spectrum>::invert_silhouette_sample(const SilhouetteSample3f &ss,
     dr::masked(dedge_curr, swap) = dedge_oppo;
     dr::masked(dedge_oppo, swap) = dedge_curr_tmp;
 
-    Mask has_opposite = (dedge_oppo != INVALID_DEDGE) && active;
+    Mask has_opposite = (dedge_oppo != DirectedEdge::Invalid) && active;
     Normal3f n_curr = face_normal(dr::idiv(dedge_curr, 3u), active),
              n_oppo = face_normal(dr::idiv(dedge_oppo, 3u), has_opposite);
 
@@ -2130,9 +1960,9 @@ Mesh<Float, Spectrum>::primitive_silhouette_projection(const Point3f &viewpoint,
     // the nearest edge, instead we randomly sample a point on any silhouette edge.
     // This ensures that the triangle corners do not receive minimal samples.
 
-    // Directed edge data structure was not prepared,
-    // e.g. due to the shape not being differentiated.
-    if (m_E2E.size() == 0)
+    // Half-edge adjacency was not prepared, e.g. due to the shape not
+    // being differentiated.
+    if (!m_dedge)
         return dr::zeros<SilhouetteSample3f>();
 
     Vector3u fi = face_indices(si.prim_index, active);
@@ -2143,7 +1973,7 @@ Mesh<Float, Spectrum>::primitive_silhouette_projection(const Point3f &viewpoint,
     Vector3u dedge_oppo(opposite_dedge(si.prim_index * 3u     , active),
                         opposite_dedge(si.prim_index * 3u + 1u, active),
                         opposite_dedge(si.prim_index * 3u + 2u, active));
-    dr::mask_t<Vector3u> boundary = (dedge_oppo == INVALID_DEDGE) && active;
+    dr::mask_t<Vector3u> boundary = (dedge_oppo == DirectedEdge::Invalid) && active;
     Vector3u prim_idx =
         dr::select(boundary, si.prim_index, dr::idiv(dedge_oppo, 3u));
     Normal3f normal_0 = face_normal(prim_idx[0], active && !boundary[0]),
@@ -2249,14 +2079,18 @@ auto Mesh<Float, Spectrum>::precompute_silhouette(
 
         const FloatBuffer &vertices = dr::migrate(m_packed_vertices, JitBackend::None);
         const IndexBuffer &faces = dr::migrate(m_packed_faces, JitBackend::None);
-        const IndexBuffer &E2E   = dr::migrate(m_E2E, JitBackend::None);
+        // A mesh without adjacency reads as an open surface below, which
+        // matches what the JIT branch does
+        IndexBuffer no_adjacency;
+        const IndexBuffer &E2E = dr::migrate(
+            m_dedge ? m_dedge->E2E() : no_adjacency, JitBackend::None);
 
         if constexpr (dr::is_array_v<Float>)
             dr::sync_thread();
 
         const InputFloat *V          = vertices.data();
         const size_t vstride         = MeshVertexStride;
-        const ScalarIndex *E2E_data  = E2E.data();
+        const ScalarIndex *E2E_data  = E2E.empty() ? nullptr : E2E.data();
         const ScalarIndex *face_data = faces.data();
 
         ScalarIndex prim_count = 0u;
@@ -2280,10 +2114,11 @@ auto Mesh<Float, Spectrum>::precompute_silhouette(
                                   const Vec3f &dir1,
                                   const Vec3f &dir2) -> void {
                 ScalarIndex dedge_oppo =
-                    dr::load<ScalarIndex>(E2E_data + dedge_curr);
+                    E2E_data ? dr::load<ScalarIndex>(E2E_data + dedge_curr)
+                             : DirectedEdge::Invalid;
                 bool valid = false;
 
-                if (dedge_oppo == INVALID_DEDGE) {
+                if (dedge_oppo == DirectedEdge::Invalid) {
                     valid = true;
                 } else if (dedge_oppo > dedge_curr) {
                     ScalarIndex face_index_oppo = dr::idiv(dedge_oppo, 3u);
@@ -2340,7 +2175,7 @@ auto Mesh<Float, Spectrum>::precompute_silhouette(
         Float weight = unit_angle(to_p0, to_p1);
 
         UInt32 dedge_oppo = opposite_dedge(dedge_curr);
-        Mask has_opposite = (dedge_oppo != INVALID_DEDGE);
+        Mask has_opposite = (dedge_oppo != DirectedEdge::Invalid);
 
         UInt32 face_idx_oppo = dr::idiv(dedge_oppo, 3u);
         Normal3f n_oppo = face_normal(face_idx_oppo, has_opposite);

--- a/src/render/python/CMakeLists.txt
+++ b/src/render/python/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(RENDER_PY_V_SRC
   ${CMAKE_CURRENT_SOURCE_DIR}/bsdf_v.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/dedge_v.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/emitter_v.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/endpoint_v.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/film_v.cpp

--- a/src/render/python/dedge_v.cpp
+++ b/src/render/python/dedge_v.cpp
@@ -1,0 +1,50 @@
+#include <nanobind/nanobind.h> // Needs to be first, to get `ref<T>` caster
+#include <nanobind/stl/string.h>
+#include <nanobind/stl/string_view.h>
+#include <mitsuba/core/spectrum.h>
+#include <mitsuba/render/dedge.h>
+#include <mitsuba/python/python.h>
+#include <drjit/python.h>
+
+MI_PY_EXPORT(DirectedEdge) {
+    MI_PY_IMPORT_TYPES(DirectedEdge)
+
+    auto cls = MI_PY_CLASS(DirectedEdge, Object);
+    cls.attr("Invalid") = DirectedEdge::Invalid;
+
+    cls.def(nb::init<const DynamicBuffer<UInt32> &, uint32_t,
+                     std::string_view>(),
+            "F"_a, "vertex_count"_a, "name"_a = "",
+            D(DirectedEdge, DirectedEdge))
+
+       .def_static("next", [](const UInt32 &e) { return DirectedEdge::next(e); },
+                   "e"_a, D(DirectedEdge, next))
+       .def_static("prev", [](const UInt32 &e) { return DirectedEdge::prev(e); },
+                   "e"_a, D(DirectedEdge, prev))
+       .def_static("face", [](const UInt32 &e) { return DirectedEdge::face(e); },
+                   "e"_a, D(DirectedEdge, face))
+       .def_static("corner", [](const UInt32 &e) { return DirectedEdge::corner(e); },
+                   "e"_a, D(DirectedEdge, corner))
+
+       .def_method(DirectedEdge, half_edge_count)
+       .def_method(DirectedEdge, vertex_count)
+       .def_method(DirectedEdge, name)
+
+       .def("opposite", &DirectedEdge::opposite, "e"_a, "active"_a = true,
+            D(DirectedEdge, opposite))
+       .def("vertex_edge", &DirectedEdge::vertex_edge,
+            "v"_a, "active"_a = true, D(DirectedEdge, vertex_edge))
+       .def("valence",
+            nb::overload_cast<UInt32, Mask>(&DirectedEdge::valence, nb::const_),
+            "v"_a, "active"_a = true, D(DirectedEdge, valence))
+       .def("vertex_flags", &DirectedEdge::vertex_flags,
+            "v"_a, "active"_a = true, D(DirectedEdge, vertex_flags))
+
+       .def_method(DirectedEdge, E2E)
+       .def_method(DirectedEdge, V2E)
+       .def("valence", nb::overload_cast<>(&DirectedEdge::valence, nb::const_),
+            D(DirectedEdge, valence, 2))
+       .def_method(DirectedEdge, flags)
+       .def("flag_count", &DirectedEdge::flag_count, "flag"_a,
+            D(DirectedEdge, flag_count));
+}

--- a/src/render/python/shape.cpp
+++ b/src/render/python/shape.cpp
@@ -1,5 +1,6 @@
 #include <mitsuba/render/shape.h>
 #include <mitsuba/render/mesh_utils.h>
+#include <mitsuba/render/dedge.h>
 #include <mitsuba/core/properties.h>
 #include <mitsuba/python/python.h>
 
@@ -11,6 +12,13 @@ MI_PY_EXPORT(DiscontinuityFlags) {
         .def_value(Layout, Texcoords)
         .def_value(Layout, Tangents)
         .def_value(Layout, FaceBSDFs);
+
+    nb::enum_<VertexFlags>(m, "VertexFlags", nb::is_arithmetic(),
+                           D(VertexFlags))
+        .def_value(VertexFlags, Boundary)
+        .def_value(VertexFlags, NonManifoldEdge)
+        .def_value(VertexFlags, NonManifoldVertex)
+        .def_value(VertexFlags, InconsistentOrientation);
 
     auto disc_flags = nb::enum_<DiscontinuityFlags>(m, "DiscontinuityFlags", nb::is_arithmetic(), D(DiscontinuityFlags))
         .def_value(DiscontinuityFlags, Empty)

--- a/src/render/python/shape_v.cpp
+++ b/src/render/python/shape_v.cpp
@@ -568,8 +568,8 @@ MI_PY_EXPORT(Shape) {
         .def("recompute_normals", &Mesh::recompute_normals,
              D(Mesh, recompute_normals))
         .def("transform", &Mesh::transform, "t"_a, D(Mesh, transform))
-        .def("build_directed_edges", &Mesh::build_directed_edges,
-             D(Mesh, build_directed_edges))
+        .def("directed_edges", &Mesh::directed_edges,
+             nb::rv_policy::reference_internal, D(Mesh, directed_edges))
 
         .def("from_corners", &mesh_from_corners<Mesh>,
              "positions"_a, "corner_vertex"_a,

--- a/src/render/tests/test_dedge.py
+++ b/src/render/tests/test_dedge.py
@@ -1,0 +1,477 @@
+"""
+Tests of the DirectedEdge half-edge adjacency structure: golden values on
+hand-checkable meshes, the guarantees of its contract on generated geometry up
+to a few million faces, agreement between the scalar and the data-parallel
+builder, and its lifetime inside a Mesh.
+"""
+
+import numpy as np
+import pytest
+import drjit as dr
+import mitsuba as mi
+
+from mitsuba.scalar_rgb.test.util import fresolver_append_path
+
+I = 0xffffffff
+
+# Fixtures: faces, vertex count, E2E, V2E, and the four flag sets
+FIXTURES = {
+    # Two triangles sharing one edge, open elsewhere
+    'T1': ([(0, 1, 2), (2, 1, 3)], 4,
+           [I, 3, I, 1, I, I], [0, 1, 3, 5],
+           {0, 1, 2, 3}, set(), set(), set()),
+
+    # Open fan
+    'T2': ([(0, 1, 2), (0, 2, 3), (0, 3, 4)], 5,
+           [I, I, 3, 2, I, 6, 5, I, I], [6, 1, 2, 5, 8],
+           {0, 1, 2, 3, 4}, set(), set(), set()),
+
+    # Closed tetrahedron: fully paired, no flags
+    'T3': ([(0, 2, 1), (0, 1, 3), (0, 3, 2), (1, 2, 3)], 4,
+           [8, 9, 3, 2, 11, 6, 5, 10, 0, 1, 7, 4], [0, 2, 1, 5],
+           set(), set(), set(), set()),
+
+    # Non-manifold fin: three faces on one edge
+    'T4': ([(0, 1, 2), (0, 1, 3), (1, 0, 4)], 5,
+           [I] * 9, [0, 1, 2, 5, 8],
+           {0, 1, 2, 3, 4}, {0, 1}, {0, 1}, set()),
+
+    # Bowtie: E2E stays fully valid, only the ring at the apex is split
+    'T5': ([(0, 1, 2), (0, 2, 3), (0, 3, 1),
+            (0, 4, 5), (0, 5, 6), (0, 6, 4)], 7,
+           [8, I, 3, 2, I, 6, 5, I, 0, 17, I, 12, 11, I, 15, 14, I, 9],
+           [0, 8, 2, 5, 17, 11, 14],
+           {1, 2, 3, 4, 5, 6}, set(), {0}, set()),
+
+    # Inconsistent winding
+    'T6': ([(0, 1, 2), (0, 1, 3)], 4,
+           [I] * 6, [0, 1, 2, 5],
+           {0, 1, 2, 3}, set(), {0, 1}, {0, 1}),
+
+    # Degenerate face plus isolated vertex
+    'T7': ([(0, 1, 2), (3, 3, 4)], 6,
+           [I] * 6, [0, 1, 2, I, I, I],
+           {0, 1, 2}, set(), set(), set()),
+
+    # One closed and one open fan at vertex 0. V2E[0] = 12 lies in the OPEN
+    # fan, although the smallest half-edge at vertex 0 lies in the closed one
+    'T8': ([(0, 1, 2), (0, 2, 3), (0, 3, 1), (0, 4, 5), (0, 5, 6)], 7,
+           [8, I, 3, 2, I, 6, 5, I, 0, I, I, 12, 11, I, I],
+           [12, 8, 2, 5, 10, 11, 14],
+           {0, 1, 2, 3, 4, 5, 6}, set(), {0}, set()),
+
+    # Nothing but degenerate faces: every vertex is isolated
+    'T9': ([(0, 0, 0), (1, 1, 2)], 4,
+           [I] * 6, [I] * 4,
+           set(), set(), set(), set()),
+
+    # The same face twice. All three edges carry two half-edges that agree on
+    # their direction, so none of them pairs.
+    'T10': ([(0, 1, 2), (0, 1, 2)], 3,
+            [I] * 6, [0, 1, 2],
+            {0, 1, 2}, set(), {0, 1, 2}, {0, 1, 2}),
+
+    # Two open fans at vertex 0, whose ring starts are 3 and 9. V2E[0] is the
+    # smaller of the two, and the walk from it covers only its own fan.
+    'T11': ([(0, 1, 2), (0, 2, 3), (0, 4, 5), (0, 5, 6)], 7,
+            [I, I, 3, 2, I, I, I, I, 9, 8, I, I],
+            [3, 1, 2, 5, 7, 8, 11],
+            {0, 1, 2, 3, 4, 5, 6}, set(), {0}, set()),
+}
+
+
+def build(F, vertex_count, module=None):
+    return (module or mi).DirectedEdge(
+        np.array(F, np.uint32).ravel(), vertex_count)
+
+
+def flag_set(dedge, flag):
+    flags = np.array(dedge.flags())
+    return set(np.flatnonzero(flags & int(flag)).tolist())
+
+
+def grid_mesh(n):
+    """An open square patch: ``2 * (n - 1)**2`` triangles, ``4 * (n - 1)``
+    boundary vertices"""
+    i, j = np.meshgrid(np.arange(n - 1), np.arange(n - 1), indexing='ij')
+    return quads(i * n + j, i * n + j + 1, (i + 1) * n + j + 1,
+                 (i + 1) * n + j), n * n
+
+
+def torus_mesh(n):
+    """A closed torus: ``2 * n**2`` triangles, no boundary and no defects"""
+    i, j = np.meshgrid(np.arange(n), np.arange(n), indexing='ij')
+    idx = lambda a, b: (a % n) * n + (b % n)
+    return quads(idx(i, j), idx(i, j + 1), idx(i + 1, j + 1),
+                 idx(i + 1, j)), n * n
+
+
+def cylinder_mesh(n):
+    """An open tube: ``2 * n * (n - 1)`` triangles and two boundary loops"""
+    i, j = np.meshgrid(np.arange(n - 1), np.arange(n), indexing='ij')
+    idx = lambda a, b: a * n + (b % n)
+    return quads(idx(i, j), idx(i, j + 1), idx(i + 1, j + 1),
+                 idx(i + 1, j)), n * n
+
+
+def quads(a, b, c, d):
+    """Split a grid of quads into a consistently wound triangle index buffer"""
+    a, b, c, d = (x.ravel().astype(np.uint32) for x in (a, b, c, d))
+    faces = np.empty((2 * len(a), 3), np.uint32)
+    faces[0::2] = np.stack([a, b, c], 1)
+    faces[1::2] = np.stack([a, c, d], 1)
+    return faces.ravel()
+
+
+MESHES = { 'grid': grid_mesh, 'torus': torus_mesh, 'cylinder': cylinder_mesh }
+
+
+def check_topology(dedge, faces, vertex_count):
+    """Assert every guarantee of the class except the ring walk, which needs a
+    loop over the vertices. Vectorized, so it also runs on large meshes."""
+    E2E = np.array(dedge.E2E())
+    V2E = np.array(dedge.V2E())
+    valence = np.array(dedge.valence())
+    flags = np.array(dedge.flags())
+
+    faces = np.asarray(faces, np.uint32).reshape(-1, 3)
+    D = 3 * len(faces)
+    src = faces.ravel()
+    dst = faces[:, [1, 2, 0]].ravel()
+    e = np.arange(D, dtype=np.uint32)
+    prv = np.where(e % 3 == 0, e + 2, e - 1)
+
+    degenerate = ((faces[:, 0] == faces[:, 1]) | (faces[:, 1] == faces[:, 2]) |
+                  (faces[:, 0] == faces[:, 2]))
+    alive = ~np.repeat(degenerate, 3)
+
+    paired = E2E != I
+    assert np.all(E2E[paired] < D)
+
+    # Involution, reversal, irreflexivity, non-degeneracy
+    assert np.all(E2E[E2E[paired]] == e[paired])
+    assert np.all(src[E2E[paired]] == dst[paired])
+    assert np.all(dst[E2E[paired]] == src[paired])
+    assert np.all(E2E[paired] != e[paired])
+    assert not np.any(paired & ~alive)
+
+    assert np.array_equal(valence,
+                          np.bincount(src[alive], minlength=vertex_count))
+
+    # Canonical start: the smallest half-edge with an unpaired predecessor,
+    # falling back to the smallest one at the vertex
+    def smallest(mask):
+        out = np.full(vertex_count, I, np.uint32)
+        np.minimum.at(out, src[mask], e[mask])
+        return out
+
+    ring_start = smallest(alive & (E2E[prv] == I))
+    assert np.array_equal(V2E, np.where(ring_start != I, ring_start,
+                                        smallest(alive)))
+
+    # Boundary is defined over the whole star, not over one ring
+    boundary = np.zeros(vertex_count, bool)
+    unpaired = alive & ~paired
+    boundary[src[unpaired]] = True
+    boundary[dst[unpaired]] = True
+    assert np.array_equal(boundary,
+                          (flags & int(mi.VertexFlags.Boundary)) != 0)
+
+
+def check_invariants(dedge, faces, vertex_count):
+    """Assert the guarantees documented on the DirectedEdge class"""
+    check_topology(dedge, faces, vertex_count)
+
+    E2E = np.array(dedge.E2E())
+    V2E = np.array(dedge.V2E())
+    valence = np.array(dedge.valence())
+    flags = np.array(dedge.flags())
+
+    faces = np.asarray(faces, np.uint32).reshape(-1, 3)
+    src = faces.ravel()
+    e = np.arange(3 * len(faces), dtype=np.uint32)
+    nxt = np.where(e % 3 == 2, e - 2, e + 1)
+
+    degenerate = ((faces[:, 0] == faces[:, 1]) | (faces[:, 1] == faces[:, 2]) |
+                  (faces[:, 0] == faces[:, 2]))
+    alive = ~np.repeat(degenerate, 3)
+
+    # Ring closure: the walk stays in the star, never repeats, and covers the
+    # star exactly when the vertex is not flagged as non-manifold
+    for v in range(vertex_count):
+        star = e[alive & (src == v)]
+        if len(star) == 0:
+            assert V2E[v] == I
+            continue
+
+        visited, cur = [], V2E[v]
+        while True:
+            assert cur in star and cur not in visited
+            visited.append(cur)
+            if E2E[cur] == I:
+                break
+            cur = nxt[E2E[cur]]
+            if cur == V2E[v]:
+                break
+
+        assert ((len(visited) != valence[v]) ==
+                bool(flags[v] & int(mi.VertexFlags.NonManifoldVertex)))
+
+
+@pytest.mark.parametrize("name", list(FIXTURES))
+def test01_fixtures(variants_all_rgb, name):
+    """Golden values on small meshes covering every branch of the
+    classification: closed, open, non-manifold edge, non-manifold vertex,
+    inconsistent winding and degenerate faces."""
+    faces, V, E2E, V2E, boundary, nm_edge, nm_vertex, inconsistent = \
+        FIXTURES[name]
+    dedge = build(faces, V)
+
+    assert dedge.half_edge_count() == 3 * len(faces)
+    assert dedge.vertex_count() == V
+    assert list(dedge.E2E()) == E2E
+    assert list(dedge.V2E()) == V2E
+    assert flag_set(dedge, mi.VertexFlags.Boundary) == boundary
+    assert flag_set(dedge, mi.VertexFlags.NonManifoldEdge) == nm_edge
+    assert flag_set(dedge, mi.VertexFlags.NonManifoldVertex) == nm_vertex
+    assert flag_set(dedge, mi.VertexFlags.InconsistentOrientation) == \
+        inconsistent
+
+    for flag, expected in [(mi.VertexFlags.Boundary, boundary),
+                           (mi.VertexFlags.NonManifoldEdge, nm_edge),
+                           (mi.VertexFlags.NonManifoldVertex, nm_vertex),
+                           (mi.VertexFlags.InconsistentOrientation,
+                            inconsistent)]:
+        assert dedge.flag_count(flag) == len(expected)
+
+
+@pytest.mark.parametrize("name", list(FIXTURES))
+def test02_invariants(variants_all_rgb, name):
+    """The contract of the class, asserted exhaustively on the fixtures."""
+    faces, V = FIXTURES[name][:2]
+    check_invariants(build(faces, V), faces, V)
+
+
+@fresolver_append_path
+@pytest.mark.parametrize("filename", ["cbox_smallbox", "rectangle_uv",
+                                      "triangle"])
+def test03_invariants_ply(variants_all_rgb, filename):
+    """The same invariants on real geometry."""
+    mesh = mi.load_dict({
+        "type": "ply",
+        "filename": f"resources/data/tests/ply/{filename}.ply",
+    })
+    faces = np.array(mesh.geometric_faces())
+    dedge = build(faces, mesh.position_count())
+    check_invariants(dedge, faces, mesh.position_count())
+
+
+def test04_pathological_topology(variants_all_rgb):
+    """Two inputs on which a naive grouping degrades to quadratic work. They
+    would not fail on a regression, they would hang."""
+    # A closed fan of N triangles. Half-edges join the list of their
+    # endpoint with fewer incident faces, so the 2N edges of the shared
+    # center vertex spread over the outer vertices.
+    N = 20000
+    i = np.arange(1, N + 1, dtype=np.uint32)
+    j = np.where(i == N, 1, i + 1).astype(np.uint32)
+    faces = np.stack([np.zeros(N, np.uint32), i, j], 1).ravel()
+
+    dedge = build(faces, N + 1)
+    E2E = np.array(dedge.E2E())
+    paired = E2E != I
+
+    assert np.all(E2E[E2E[paired]] == np.arange(len(E2E))[paired])
+    assert np.array(dedge.valence())[0] == N
+    # Every spoke is shared; only the rim is a boundary, and it closes
+    assert np.count_nonzero(paired) == 2 * N
+    assert dedge.flag_count(mi.VertexFlags.Boundary) == N
+    assert dedge.flag_count(mi.VertexFlags.NonManifoldVertex) == 0
+
+    # A 'book': N faces on the single edge (0, 1). Every entry of that list
+    # matches, so the scan has to give up once the classification is settled.
+    N = 20000
+    i = np.arange(2, N + 2, dtype=np.uint32)
+    faces = np.stack([np.zeros(N, np.uint32), np.ones(N, np.uint32), i],
+                     1).ravel()
+
+    dedge = build(faces, N + 2)
+    assert list(np.unique(np.array(dedge.E2E()))) == [I]
+    assert dedge.flag_count(mi.VertexFlags.NonManifoldEdge) == 2
+
+
+@pytest.mark.parametrize("mesh", ["grid", "torus", "cylinder"])
+def test05_builders_agree(variants_vec_rgb, mesh):
+    """The data-parallel builder of the JIT variants and the scalar one group
+    equal keys by unrelated mechanisms, a comparison sort against atomically
+    threaded lists, so this checks the grouping design rather than its
+    transcription. It also pins that the list order, which races by design,
+    does not reach the output."""
+    import mitsuba.scalar_rgb as mi_s
+
+    faces, V = MESHES[mesh](120)
+    fast = build(faces, V)
+    ref = build(faces, V, mi_s)
+
+    for a, b in [(fast.E2E(), ref.E2E()), (fast.V2E(), ref.V2E()),
+                 (fast.valence(), ref.valence()),
+                 (fast.flags(), ref.flags())]:
+        assert np.array_equal(np.array(a), np.array(b))
+
+
+@pytest.mark.parametrize("mesh", ["grid", "torus", "cylinder", "doubled"])
+def test06_large_meshes(variants_vec_rgb, mesh):
+    """Over a million faces of generated geometry, in four topologies whose
+    boundary and defect counts are known exactly. The torus pins that pairing
+    is complete, since a builder returning nothing would also satisfy the
+    involution."""
+    n, V = 800, 800 * 800
+    if mesh == "doubled":
+        # Every face of the torus twice, so every edge carries four half-edges
+        faces = np.tile(torus_mesh(n)[0], 2)
+    else:
+        faces = MESHES[mesh](n)[0]
+    assert len(faces) // 3 > 10**6
+
+    dedge = build(faces, V)
+    check_topology(dedge, faces, V)
+
+    # Boundary, non-manifold edge, non-manifold vertex, inconsistent winding
+    expected = { 'grid':     (4 * (n - 1), 0, 0, 0),
+                 'torus':    (0,           0, 0, 0),
+                 'cylinder': (2 * n,       0, 0, 0),
+                 'doubled':  (V,           V, V, 0) }[mesh]
+
+    for flag, count in zip([mi.VertexFlags.Boundary,
+                            mi.VertexFlags.NonManifoldEdge,
+                            mi.VertexFlags.NonManifoldVertex,
+                            mi.VertexFlags.InconsistentOrientation], expected):
+        assert dedge.flag_count(flag) == count
+
+
+def test07_invalid_input(variants_all_rgb):
+    """A mesh always has at least one face and one vertex, so degenerate input
+    is rejected rather than silently accepted."""
+    with pytest.raises(RuntimeError, match="not a multiple of 3"):
+        mi.DirectedEdge(np.array([0, 1], np.uint32), 2)
+
+    with pytest.raises(RuntimeError, match="at least one face"):
+        build([], 3)
+
+    with pytest.raises(RuntimeError, match="at least one face"):
+        build([(0, 1, 2)], 0)
+
+
+def test08_defects_are_reported(variants_all_rgb, capfd):
+    """Broken input yields a sound but degraded structure, and says so."""
+    faces, V = FIXTURES['T4'][:2]
+    build(faces, V)
+    assert "non-manifold" in capfd.readouterr().out
+
+    faces, V = FIXTURES['T3'][:2]
+    build(faces, V)
+    assert "non-manifold" not in capfd.readouterr().out
+
+
+def test09_accessors(variants_all_rgb):
+    """The indexed accessors agree with the raw buffers."""
+    faces, V, E2E, V2E = FIXTURES['T5'][:4]
+    dedge = build(faces, V)
+    valence = np.array(dedge.valence())
+
+    for i in range(len(E2E)):
+        assert dr.all(dedge.opposite(mi.UInt32(i)) == E2E[i])
+    for v in range(V):
+        assert dr.all(dedge.vertex_edge(mi.UInt32(v)) == V2E[v])
+        assert dr.all(dedge.valence(mi.UInt32(v)) == int(valence[v]))
+        # The apex carries the split ring, every other vertex the boundary
+        expected = (mi.VertexFlags.NonManifoldVertex if v == 0
+                    else mi.VertexFlags.Boundary)
+        assert dr.all(dedge.vertex_flags(mi.UInt32(v)) == int(expected))
+
+    # The half-edges of a face are consecutive and wind with it
+    assert dr.all(mi.DirectedEdge.next(mi.UInt32(0)) == 1)
+    assert dr.all(mi.DirectedEdge.next(mi.UInt32(2)) == 0)
+    assert dr.all(mi.DirectedEdge.prev(mi.UInt32(0)) == 2)
+    assert dr.all(mi.DirectedEdge.prev(mi.UInt32(4)) == 3)
+    assert dr.all(mi.DirectedEdge.face(mi.UInt32(2)) == 0)
+    assert dr.all(mi.DirectedEdge.face(mi.UInt32(3)) == 1)
+    assert dr.all(mi.DirectedEdge.corner(mi.UInt32(2)) == 2)
+    assert dr.all(mi.DirectedEdge.corner(mi.UInt32(3)) == 0)
+
+
+def test10_mesh_lifetime(variants_all_rgb):
+    """The structure is built on demand, survives position-value edits, and is
+    discarded when the position count or topology changes."""
+    mesh = mi.Mesh("quad", faces=[[0, 1, 2], [0, 2, 3]],
+                   positions=np.float32([[0, 0, 0], [1, 0, 0],
+                                         [1, 1, 0], [0, 1, 0]]))
+
+    # Before construction the JIT-facing accessor must not build anything
+    assert dr.all(mesh.opposite_dedge(mi.UInt32(2)) == I)
+
+    dedge = mesh.directed_edges()
+    assert list(dedge.E2E()) == [I, I, 3, 2, I, I]
+    assert mesh.directed_edges() is dedge
+    assert dr.all(mesh.opposite_dedge(mi.UInt32(2)) == 3)
+
+    params = mi.traverse(mesh)
+    params['positions'] = mi.TensorXf(np.float32([[0, 0, 0], [2, 0, 0],
+                                                  [2, 2, 0], [0, 2, 0]]))
+    params.update()
+    assert mesh.directed_edges() is dedge
+
+    params['positions'] = mi.TensorXf(np.float32([
+        [0, 0, 0], [2, 0, 0], [2, 2, 0], [0, 2, 0], [3, 3, 0]
+    ]))
+    params.update()
+    assert mesh.position_count() == 5
+    assert dr.all(mesh.opposite_dedge(mi.UInt32(2)) == I)
+
+    resized_dedge = mesh.directed_edges()
+    assert resized_dedge is not dedge
+    assert resized_dedge.vertex_count() == 5
+    assert list(resized_dedge.V2E()) == [3, 1, 2, 5, I]
+
+    params['faces'] = mi.TensorXu(np.uint32([[0, 1, 2], [2, 1, 3]]))
+    params.update()
+    assert dr.all(mesh.opposite_dedge(mi.UInt32(2)) == I)
+    assert list(mesh.directed_edges().E2E()) == [I, 3, I, 1, I, I]
+
+
+@fresolver_append_path
+def test11_seamed_mesh(variants_all_rgb):
+    """Pairing runs on the geometric topology, so a closed mesh whose faces are
+    separate UV islands has no unpaired half-edge."""
+    positions = np.float32([[0, 0, 0], [1, 0, 0], [0, 1, 0], [0, 0, 1]])
+    tris = [(0, 2, 1), (0, 1, 3), (0, 3, 2), (1, 2, 3)]
+    uv = np.float32([(10 * f + i, f) for f in range(4) for i in range(3)])
+
+    mesh = mi.Mesh("tet")
+    mesh.from_corners(positions=positions,
+                      corner_vertex=np.uint32(tris).ravel(), texcoords=uv)
+    assert mesh.vertex_count() == 12 and mesh.position_count() == 4
+
+    dedge = mesh.directed_edges()
+    assert dedge.vertex_count() == 4
+    assert I not in list(dedge.E2E())
+    assert dedge.flag_count(mi.VertexFlags.Boundary) == 0
+
+
+def test12_frozen(variants_vec_rgb):
+    """The structure participates in Dr.Jit's object traversal, so a frozen
+    function that gathers through it sees its buffers as dependencies."""
+    mesh = mi.Mesh("quad", faces=[[0, 1, 2], [0, 2, 3]],
+                   positions=np.float32([[0, 0, 0], [1, 0, 0],
+                                         [1, 1, 0], [0, 1, 0]]))
+    mesh.directed_edges()
+
+    @dr.freeze
+    def func(m, e):
+        return m.opposite_dedge(e)
+
+    index = dr.arange(mi.UInt32, 6)
+    expected = mi.UInt32([I, I, 3, 2, I, I])
+    for _ in range(3):
+        assert dr.all(func(mi.MeshPtr(mesh), index) == expected)
+    assert func.n_recordings == 1

--- a/src/render/tests/test_mesh_query.py
+++ b/src/render/tests/test_mesh_query.py
@@ -1,7 +1,7 @@
 """
-Tests of mesh silhouette sampling, the MeshPtr pointer type and its
-vectorized calls, and the directed edge structure on closed, open and
-non-manifold geometry.
+Tests of mesh silhouette sampling, and of the MeshPtr pointer type and its
+vectorized calls. The half-edge adjacency itself is covered by
+test_dedge.py.
 """
 
 import numpy as np
@@ -145,7 +145,7 @@ def test04_primitive_silhouette_projection(variants_vec_rgb):
         "type": "ply",
         "filename": "resources/data/tests/ply/rectangle_uv.ply",
     })
-    mesh.build_directed_edges()
+    mesh.directed_edges()
 
     u = dr.linspace(mi.Float, 1e-6, 1 - 1e-6, 10)
     uv = mi.Point2f(dr.meshgrid(u, u))
@@ -216,7 +216,7 @@ def test06_mesh_ptr_and_vcalls(variants_vec_rgb):
             assert sh.shape_type() == mi.ShapeType.Mesh
             assert dr.all(dr.gather(mi.MeshPtr, shapes, i) == as_mesh)
             assert as_mesh[0] == shapes[i] and as_mesh[0] == sh
-            sh.build_directed_edges()
+            sh.directed_edges()
         else:
             assert dr.all(dr.reinterpret_array(mi.UInt32, as_mesh) == 0)
             assert as_mesh[0] is None
@@ -278,8 +278,8 @@ def test06_mesh_ptr_and_vcalls(variants_vec_rgb):
 
 @fresolver_append_path
 def test07_vcalls_partial_dedges(variants_vec_rgb):
-    """Vcalls involving only meshes with an initialized E2E structure work
-    even when other meshes lack one."""
+    """A vcall over a mix of meshes with and without half-edge adjacency is
+    well defined: the ones that lack it report every edge as a boundary."""
     scene = mi.load_dict({
         "type": "scene",
         "mesh1": {
@@ -292,63 +292,10 @@ def test07_vcalls_partial_dedges(variants_vec_rgb):
         },
     })
 
-    # The second mesh will *not* have a valid E2E data structure
-    mesh_ptr = dr.gather(mi.MeshPtr, scene.shapes_dr(), dr.zeros(mi.UInt32, 3))
-    mesh_ptr[0].build_directed_edges()
+    # Only the first mesh gets the structure, and the accessor must not build
+    # one for the second
+    scene.shapes()[0].directed_edges()
 
+    mesh_ptr = dr.gather(mi.MeshPtr, scene.shapes_dr(), mi.UInt32([0, 1, 0]))
     result = mesh_ptr.opposite_dedge(mi.UInt32([2, 3, 2]))
-    assert dr.all(result == mi.UInt32([3, 2, 3]))
-
-
-# -------------------------------------------------------------------
-# Directed edges
-# -------------------------------------------------------------------
-
-def test08_directed_edges(variants_all_rgb, capfd):
-    """Half-edge pairing runs on the geometric topology, so a tetrahedron
-    whose faces are separate UV islands still reads as a closed surface.
-    Boundary edges of an open surface have no opposite, and three faces
-    meeting at one edge are reported as non-manifold."""
-    def opposite(m):
-        return [int(np.ravel(m.opposite_dedge(mi.UInt32(e)))[0])
-                for e in range(3 * m.face_count())]
-
-    # A closed tetrahedron, with each face in its own UV island
-    positions = np.float32([[0, 0, 0], [1, 0, 0], [0, 1, 0], [0, 0, 1]])
-    tris = [(0, 2, 1), (0, 1, 3), (0, 3, 2), (1, 2, 3)]
-    uv = np.float32([(10 * f + i, f) for f in range(4) for i in range(3)])
-
-    m = mi.Mesh("tet")
-    m.from_corners(positions=positions,
-                   corner_vertex=np.uint32(tris).ravel(), texcoords=uv)
-    assert m.vertex_count() == 12 and m.position_count() == 4
-
-    m.build_directed_edges()
-    assert INVALID_DEDGE not in opposite(m)
-
-    # Two triangles of an open quad: the shared diagonal is traversed as
-    # (2, 0) in face 0 (dedge 2) and as (0, 2) in face 1 (dedge 3), while
-    # every other edge is a boundary
-    m = mi.Mesh("quad", faces=[[0, 1, 2], [0, 2, 3]],
-                positions=np.float32([[0, 0, 0], [1, 0, 0],
-                                      [1, 1, 0], [0, 1, 0]]))
-    m.build_directed_edges()
-    assert opposite(m) == [INVALID_DEDGE, INVALID_DEDGE, 3,
-                           2, INVALID_DEDGE, INVALID_DEDGE]
-
-    # A topology edit through the parameter map invalidates the pairing;
-    # rebuilding pairs the new shared diagonal
-    params = mi.traverse(m)
-    params['faces'] = np.uint32([[0, 1, 2], [2, 1, 3]])
-    params.update()
-    assert opposite(m) == [INVALID_DEDGE] * 6
-    m.build_directed_edges()
-    assert opposite(m) == [INVALID_DEDGE, 3, INVALID_DEDGE,
-                           1, INVALID_DEDGE, INVALID_DEDGE]
-
-    # Three triangles sharing one edge
-    m = mi.Mesh("nm", faces=[[0, 1, 2], [1, 0, 3], [0, 1, 4]],
-                positions=np.float32([[0, 0, 0], [1, 0, 0], [0.5, 1, 0],
-                                      [0.5, -1, 0], [0.5, 0, 1]]))
-    m.build_directed_edges()
-    assert "non-manifold" in capfd.readouterr().out
+    assert dr.all(result == mi.UInt32([3, INVALID_DEDGE, 3]))


### PR DESCRIPTION
This commit moves the half-edge adjacency data structure from ``Mesh`` into a standalone class (``mitsuba::DirectedEdge``). The implementation was rewritten to improve performance and address corner cases when dealing with non-manifold input.

Besides the ``E2E`` pairing it now also exposes the per-vertex entry points (``V2E``) and face valences. It detects and correctly annotates non-manifold edges, vertices, and inconsistently wound faces.

The new implementation provides a parallel builder for JIT variants, and a single-threaded scalar reference implementation used by the test suite.

The new builder is ~1.3x (LLVM) to ~1.4x (CUDA) faster than the previous implementation, while also computing a richer representation (V2E, face valences, and per-vertex flags). Meshes with high-valence vertices previously triggered quadratic runtime; a fan of 100K triangles sharing one vertex now builds 15x (CUDA) to ~700x (LLVM) faster.