### PR TITLE
Add eval scope guard to build_pmf in mesh.cpp

### DIFF
--- a/src/render/mesh.cpp
+++ b/src/render/mesh.cpp
@@ -1360,6 +1360,8 @@ MI_VARIANT void Mesh<Float, Spectrum>::build_pmf() {
     if (m_face_count == 0)
         Throw("Cannot create sampling table for an empty mesh: %s", to_string());
 
+    dr::scoped_eval_scope<Float> guard;
+
     DynamicBuffer<Float> area = interleaved<1, DynamicBuffer<Float>>(
         m_face_count, [&](const UInt32 &f) {
             Vector3u fi = face_indices(f);


### PR DESCRIPTION
`build_pmf` may be invoked during symbolic vcalls (e.g., `sample_position` calls it) and it therefore also needs the new eval scope guard.