### PR TITLE
Automatic discovery of external Python plugin packages

### DIFF
--- a/docs/src/developer_guide.rst
+++ b/docs/src/developer_guide.rst
@@ -109,4 +109,5 @@ Going further
     developer_guide/documentation
     developer_guide/variants_cpp
     developer_guide/writing_plugin
+    developer_guide/distributing_plugins
     developer_guide/testing

--- a/docs/src/developer_guide/distributing_plugins.rst
+++ b/docs/src/developer_guide/distributing_plugins.rst
@@ -1,0 +1,92 @@
+.. _sec-distributing-plugins:
+
+Distributing Python plugins
+===========================
+
+This section describes how to *redistribute* Python plugins that extend
+Mitsuba. By packaging them as described below, users can run ``pip install``
+on their device to make the plugin available to Mitsuba.
+
+A minimal package
+-----------------
+
+Create a new folder holding your Python extensions along with a file
+``pyproject.toml`` providing metadata about the package.
+
+.. code-block:: toml
+
+    # pyproject.toml
+    [project]
+    name = "mitsuba-myplugin"
+    version = "0.1.0"
+    dependencies = ["mitsuba>=3.10,<4"]
+
+    [project.entry-points.mitsuba]
+    myplugin = "mitsuba_myplugin"
+
+In this case ``mitsuba-myplugin`` is the name of the package on PyPI,
+``myplugin`` is an arbitrary key, and ``mitsuba_myplugin`` is the installed
+module name. The ``project.entry-points.mitsuba`` entry point allows Mitsuba
+to automatically find this module when the package is installed.
+
+The second file is the module itself. It looks exactly like the code from the
+:ref:`custom plugin tutorial <sec-other-tutos>`: it defines its classes and
+registers them at module scope.
+
+.. code-block:: python
+
+    # mitsuba_myplugin/__init__.py
+    import mitsuba as mi
+
+    class MyBSDF(mi.BSDF):
+        def __init__(self, props):
+            super().__init__(props)
+        # ... sample(), eval() and pdf() as in the tutorial ...
+
+    mi.register_bsdf('mybsdf', lambda props: MyBSDF(props))
+
+Mitsuba imports this module the first time a variant becomes active and reloads
+it after every subsequent variant change. Reloading is needed because
+``mi.BSDF`` refers to a different class in each variant, and because
+:py:func:`mitsuba.register_bsdf` and its siblings (see the :ref:`API reference
+<sec-api>`) only apply to the variant that is active at the time of the call.
+
+After a user installs this package via ``pip install`` (e.g., from
+[PyPI](https://pypi.org/), the plugin can be used:
+
+.. code-block:: python
+
+    import mitsuba as mi
+    mi.set_variant('cuda_ad_rgb')
+
+    scene = mi.load_dict({
+        'type': 'scene',
+        'sphere': {'type': 'sphere', 'bsdf': {'type': 'mybsdf'}}
+    })
+
+A package that spreads its plugins over several files should declare one entry
+point per file, since reloading a package does not reload its submodules:
+
+.. code-block:: toml
+
+    [project.entry-points.mitsuba]
+    myplugin_bsdf = "mitsuba_myplugin.bsdf"
+    myplugin_integrator = "mitsuba_myplugin.integrator"
+
+Introspection
+-------------
+
+Plugin code may need to adapt to the Mitsuba build that loaded it. The
+following are available at module scope:
+
+- ``mi.MI_VERSION`` and :py:class:`mitsuba.Version` for comparisons such as
+  ``mi.Version(mi.MI_VERSION) < mi.Version('3.10.0')``, e.g. to work around an
+  incompatibility in a specific release.
+- ``mi.variant()`` and the flags ``mi.is_jit``, ``mi.is_ad``, ``mi.is_cuda``,
+  ``mi.is_spectral``, etc. described in :ref:`sec-variants-introspection`.
+- ``mi.MI_ENABLE_EMBREE``, ``mi.MI_ENABLE_CUDA`` and ``mi.MI_ENABLE_METAL``
+  report what the installed binary supports.
+
+If a plugin module fails to import, Mitsuba emits a warning that identifies the
+responsible entry point and continues loading the others. Setting the
+environment variable ``MI_DISABLE_AUTOLOAD`` skips the search entirely.

--- a/docs/src/key_topics/variants.rst
+++ b/docs/src/key_topics/variants.rst
@@ -310,3 +310,60 @@ support double precision, hence ray-tracing operations will run in reduced
 including ray tracing is to render on the CPU (``scalar`` or ``llvm``) and
 disable Embree in CMake. Also note that double precision arithmetic runs with
 greatly reduced throughput (1/64th of FP32) on recent NVIDIA GPUs.
+
+
+.. _sec-variants-introspection:
+
+Inspecting the active variant
+-----------------------------
+
+Code that must work across several variants can query the name of the active
+one using :py:func:`mitsuba.variant`. Matching on that string is awkward, so
+Mitsuba additionally exposes a set of boolean flags that describe each part of
+the name individually. They become available once a variant is active and
+change value whenever a different one is selected.
+
+.. list-table::
+    :widths: 25 75
+    :header-rows: 1
+
+    * - Flag
+      - Meaning
+    * - ``mi.is_scalar``
+      - The backend evaluates one sample at a time (``scalar``)
+    * - ``mi.is_llvm``
+      - The backend vectorizes onto the CPU via LLVM (``llvm``)
+    * - ``mi.is_cuda``
+      - The backend targets an NVIDIA GPU (``cuda``)
+    * - ``mi.is_metal``
+      - The backend targets a Metal device (``metal``)
+    * - ``mi.is_jit``
+      - Any of the three tracing backends above is in use
+    * - ``mi.is_ad``
+      - Automatic differentiation is enabled (``_ad``)
+    * - ``mi.is_monochromatic``
+      - Color is a single luminance value (``mono``)
+    * - ``mi.is_rgb``
+      - Color is a red, green and blue triplet (``rgb``)
+    * - ``mi.is_spectral``
+      - Color is a set of sampled wavelengths (``spectral``)
+    * - ``mi.is_polarized``
+      - The polarization state of light is tracked (``_polarized``)
+
+A typical use is to select an implementation strategy that only makes sense on
+some backends:
+
+.. code-block:: python
+
+    import mitsuba as mi
+    mi.set_variant('cuda_ad_rgb')
+
+    if mi.is_jit:
+        # Wavefront backends can afford a large precomputed table
+        table = build_table(1024)
+    else:
+        table = build_table(16)
+
+Note that ``mi.is_scalar`` and ``mi.is_jit`` are complements of each other, and
+that exactly one of the four color flags is true at any time. The precision of
+a variant is not covered by a flag, since ``mi.Float`` reports it directly.

--- a/docs/src/others_tutorials.rst
+++ b/docs/src/others_tutorials.rst
@@ -1,3 +1,5 @@
+.. _sec-other-tutos:
+
 .. image:: ../../resources/data/docs/images/banners/banner_02.jpg
     :width: 100%
     :align: center

--- a/include/mitsuba/core/util.h
+++ b/include/mitsuba/core/util.h
@@ -62,6 +62,10 @@ struct Version {
         : major_version(major), minor_version(minor), patch_version(patch) { }
 
     Version(std::string_view value) {
+        // Ignore the ".dev*" suffix of a pre-release
+        size_t pos = value.rfind(".dev");
+        if (pos != std::string_view::npos)
+            value = value.substr(0, pos);
         auto list = string::tokenize(value, " .");
         if (list.size() != 3)
             Throw("Version number must consist of three period-separated parts!");

--- a/src/core/python/misc.cpp
+++ b/src/core/python/misc.cpp
@@ -1,6 +1,7 @@
 #include <mitsuba/core/util.h>
 #include <mitsuba/python/python.h>
 #include <nanobind/stl/string.h>
+#include <nanobind/stl/string_view.h>
 
 MI_PY_EXPORT(misc) {
     auto misc = m.def_submodule("misc", "Miscellaneous utility routines");

--- a/src/python/__init__.py
+++ b/src/python/__init__.py
@@ -136,6 +136,9 @@ def set_variant(*args: str) -> None:
                                 'mitsuba.python.ad.loaders'):
                 _importlib.reload(_importlib.import_module(module_name))
 
+        # Modules of external plugin packages are (re)imported the same way
+        detail.load_plugins()
+
         # Invoke user-provided callbacks once the modules above have reloaded
         for callback in list(detail._variant_callbacks):
             callback(old_variant, _variant)

--- a/src/python/detail.py
+++ b/src/python/detail.py
@@ -1,29 +1,90 @@
 """Mitsuba detail module - internal implementation details."""
 
+import os
 import typing
 
-# Callables that ``mitsuba.set_variant()`` invokes after a variant change
-_variant_callbacks = set()
+# Callables that ``mitsuba.set_variant()`` invokes after a variant change. This
+# is a dict rather than a set so that callbacks run in registration order.
+_variant_callbacks = dict()
+
+# Modules provided by external plugin packages, or ``None`` before the search
+_plugin_modules = None
 
 
 def add_variant_callback(callback: typing.Callable[[typing.Optional[str], str], None]) -> None:
     """
     Register a callable that runs each time the Mitsuba variant changes. It
     receives the arguments ``old_variant: Optional[str], new_variant: str``.
-    The callbacks form a set, registering the same callable several times has
-    no further effect.
+    Registering the same callable several times has no further effect.
     """
-    _variant_callbacks.add(callback)
+    _variant_callbacks.setdefault(callback, None)
 
 
 def remove_variant_callback(callback: typing.Callable[[typing.Optional[str], str], None]) -> None:
     """Remove the given callable from the set of variant change callbacks."""
-    _variant_callbacks.discard(callback)
+    _variant_callbacks.pop(callback, None)
 
 
 def clear_variant_callbacks() -> None:
     """Remove all variant change callbacks."""
     _variant_callbacks.clear()
+
+
+def load_plugins() -> None:
+    """
+    Import or reload the modules of external Mitsuba plugin packages.
+
+    Any installed distribution can extend Mitsuba by declaring entry points
+    in the ``mitsuba`` group that name modules containing plugin code:
+
+    .. code-block:: toml
+
+        [project.entry-points.mitsuba]
+        my_bsdf = "my_plugins.bsdf"
+
+    Such a module defines its classes and calls ``mitsuba.register_bsdf()``
+    and friends at module scope, just like a script would. Mitsuba imports it
+    the first time a variant becomes active and reloads it after every
+    subsequent variant change, since plugin registration applies to one
+    variant at a time.
+
+    Setting the environment variable ``MI_DISABLE_AUTOLOAD`` skips the search.
+    """
+    global _plugin_modules
+
+    import importlib
+    import traceback
+    import warnings
+
+    if _plugin_modules is not None:
+        for module in _plugin_modules:
+            try:
+                importlib.reload(module)
+            except Exception:
+                warnings.warn('Could not reload the Mitsuba plugin module '
+                              '"%s":\n%s' % (module.__name__,
+                                             traceback.format_exc()),
+                              stacklevel=2)
+        return
+
+    # Assign first: a plugin module that sets a variant must not recurse here
+    _plugin_modules = []
+
+    if os.environ.get('MI_DISABLE_AUTOLOAD'):
+        return
+
+    import importlib.metadata
+
+    # Distributions are enumerated in filesystem order, sort for determinism
+    for ep in sorted(importlib.metadata.entry_points(group='mitsuba'),
+                     key=lambda ep: ep.name):
+        try:
+            _plugin_modules.append(importlib.import_module(ep.value))
+        except Exception:
+            warnings.warn('Could not load the Mitsuba plugin "%s" provided by '
+                          'the module "%s":\n%s'
+                          % (ep.name, ep.value, traceback.format_exc()),
+                          stacklevel=2)
 
 
 class TransformWrapper:

--- a/src/python/main_v.cpp
+++ b/src/python/main_v.cpp
@@ -166,11 +166,20 @@ NB_MODULE(MI_VARIANT_NAME, m) {
 
     MI_PY_IMPORT(DrJit);
 
-    // TODO: Add documentation
+    // Properties of the color representation used by this variant
     m.attr("is_monochromatic") = is_monochromatic_v<Spectrum>;
     m.attr("is_rgb") = is_rgb_v<Spectrum>;
     m.attr("is_spectral") = is_spectral_v<Spectrum>;
     m.attr("is_polarized") = is_polarized_v<Spectrum>;
+
+    // Properties of the computational backend used by this variant
+    constexpr JitBackend Backend = dr::backend_v<Float>;
+    m.attr("is_scalar") = !dr::is_jit_v<Float>;
+    m.attr("is_llvm") = Backend == JitBackend::LLVM;
+    m.attr("is_cuda") = Backend == JitBackend::CUDA;
+    m.attr("is_metal") = Backend == JitBackend::Metal;
+    m.attr("is_jit") = dr::is_jit_v<Float>;
+    m.attr("is_ad") = dr::is_diff_v<Float>;
 
     MI_PY_IMPORT(Object);
     MI_PY_IMPORT(Ray);


### PR DESCRIPTION
This commit adds a new discovery mechanism so that users can make Python plugins available to Mitsuba by installing a package, without importing anything by hand.

Python plugins must call ``mi.register_bsdf()`` or one of its siblings once per variant. Until now, this meant importing the providing module before loading a scene that refers to the plugin.

With this change, a package announces itself to Mitsuba by declaring an entry point in the ``mitsuba`` group:

```toml
# pyproject.toml
[project]
name = "mitsuba-myplugin"
version = "0.1.0"
dependencies = ["mitsuba>=3.10,<4"]

[project.entry-points.mitsuba]
myplugin = "mitsuba_myplugin"
```

The module named by the entry point looks exactly like the tutorial code. It defines its classes and registers them at module scope:

```python
# mitsuba_myplugin/__init__.py
import mitsuba as mi

class MyBSDF(mi.BSDF):
    def __init__(self, props):
        super().__init__(props)
    # ... sample(), eval() and pdf() ...

mi.register_bsdf('mybsdf', lambda props: MyBSDF(props))
```

Mitsuba imports this module the first time a variant becomes active and reloads it after every subsequent variant change, in the same way that the built-in AD integrators are reloaded. After ``pip install mitsuba-myplugin``, this is all a user needs:

```python
import mitsuba as mi
mi.set_variant('cuda_ad_rgb')

scene = mi.load_dict({
    'type': 'scene',
    'sphere': {'type': 'sphere', 'bsdf': {'type': 'mybsdf'}}
})
```

Import failures produce a warning rather than an exception, and the environment variable ``MI_DISABLE_AUTOLOAD`` disables the search. A new section in the developer guide documents the feature.

Other changes: the variant modules now expose ``mi.is_scalar``, ``mi.is_llvm``, ``mi.is_cuda``, ``mi.is_metal``, ``mi.is_jit`` and ``mi.is_ad``. ``mi.Version`` accepts pre-release version strings such as ``3.10.0.dev1``. Variant callbacks now run in registration order.