### PR TITLE
Resolve instancing at the scene level

### DIFF
--- a/include/mitsuba/core/object.h
+++ b/include/mitsuba/core/object.h
@@ -8,6 +8,8 @@
 #include <string>
 #include <string_view>
 #include <stdexcept>
+#include <cstdlib>
+#include <cstring>
 #include <drjit/traversable_base.h>
 
 NAMESPACE_BEGIN(mitsuba)
@@ -288,14 +290,39 @@ template <typename Derived>
 class JitObject : public Object {
 public:
     /// Return the identifier of this instance
-    std::string_view id() const override { return m_id; }
+    std::string_view id() const override {
+        const char *p = id_ptr();
+        return p ? std::string_view(p) : std::string_view();
+    }
 
     /// Set the identifier of this instance
-    void set_id(std::string_view id) override { m_id = id; }
+    void set_id(std::string_view id) override {
+        uintptr_t flag = m_state & 1;
+        delete[] id_ptr();
+        char *p = nullptr;
+        if (!id.empty()) {
+            p = new char[id.size() + 1];
+            memcpy(p, id.data(), id.size());
+            p[id.size()] = '\0';
+        }
+        m_state = (uintptr_t) p | flag;
+    }
+
+    /// Withdraw this instance from the JIT registry. This can be useful when
+    /// an instance should not be reached by traced function calls.
+    void unregister() {
+        if constexpr (dr::is_jit_v<typename Derived::UInt32>) {
+            if (!(m_state & 1)) {
+                jit_registry_remove(this);
+                m_state |= 1;
+            }
+        }
+    }
 
 protected:
     /// Constructor with ID and optional ObjectType
-    JitObject(std::string_view id, ObjectType type = ObjectType::Unknown) : m_id(id) {
+    JitObject(std::string_view id, ObjectType type = ObjectType::Unknown) {
+        JitObject::set_id(id);
         if constexpr (dr::is_jit_v<typename Derived::UInt32>) {
             const char *domain = type == ObjectType::Unknown
                                      ? Derived::Domain
@@ -318,13 +345,22 @@ protected:
 
     /// Deregister from JIT registry on destruction
     ~JitObject() {
-        if constexpr (dr::is_jit_v<typename Derived::UInt32>)
-            jit_registry_remove(this);
+        if constexpr (dr::is_jit_v<typename Derived::UInt32>) {
+            if (!(m_state & 1))
+                jit_registry_remove(this);
+        }
+        delete[] id_ptr();
     }
 
 private:
-    /// Stores the identifier of this instance
-    std::string m_id;
+    const char *id_ptr() const {
+        return (const char *) (m_state & ~(uintptr_t) 1);
+    }
+
+    /// Combined storage for two pieces of information:
+    /// - Is the instance registered with Dr.Jit (lowest bit)
+    /// - A heap-allocated identifier string returned by ``id()``
+    uintptr_t m_state = 0;
 };
 
 

--- a/include/mitsuba/python/docstr.h
+++ b/include/mitsuba/python/docstr.h
@@ -4672,8 +4672,6 @@ static const char *__doc_mitsuba_InstanceEntry = R"doc(One flattened TLAS/IAS in
 
 static const char *__doc_mitsuba_InstanceEntry_blas_index = R"doc(Index into ``SceneIR.blases``.)doc";
 
-static const char *__doc_mitsuba_InstanceEntry_owner_registry_id = R"doc(JIT registry ID of the ShapeGroup, or ``SCENE_IR_NO_OWNER``.)doc";
-
 static const char *__doc_mitsuba_InstanceEntry_to_world = R"doc(Column-major 3x4 affine, identity for a top-level BLAS.)doc";
 
 static const char *__doc_mitsuba_Integrator =
@@ -6492,11 +6490,13 @@ static const char *__doc_mitsuba_MetalAccel_fields = R"doc()doc";
 
 static const char *__doc_mitsuba_MetalAccel_fields_2 = R"doc()doc";
 
-static const char *__doc_mitsuba_MetalAccel_geom_shape_offsets =
-R"doc(Per-instance recovery tables resolving ``pi.shape`` from a hit's
-(instance_id, geometry_id), built in scene_metal.inl.)doc";
+static const char *__doc_mitsuba_MetalAccel_geom_shape_table =
+R"doc(Recovery table indexed by TLAS userID + geometry ID, resolving a hit
+into ``pi.shape`` (see scene_metal.inl))doc";
 
-static const char *__doc_mitsuba_MetalAccel_geom_shape_table = R"doc()doc";
+static const char *__doc_mitsuba_MetalAccel_has_instances =
+R"doc(Layout of ``geom_shape_table``: (shape id, instance index) pairs when
+true, plain shape ids otherwise)doc";
 
 static const char *__doc_mitsuba_MetalAccel_init = R"doc()doc";
 
@@ -7493,8 +7493,8 @@ This data structure is used as return type for the
 stores whether the shape is intersected by a given ray, and cache
 preliminary information about the intersection if that is the case.
 
-If the intersection is deemed relevant, detailed intersection information can later be
-obtained via the  `compute_surface_interaction()` method.)doc";
+If the intersection is deemed relevant, detailed intersection information
+can later be obtained via `Scene.compute_surface_interaction()`.)doc";
 
 static const char *__doc_mitsuba_PreliminaryIntersection_2 =
 R"doc(Stores preliminary information related to a ray intersection
@@ -7504,8 +7504,8 @@ This data structure is used as return type for the
 stores whether the shape is intersected by a given ray, and cache
 preliminary information about the intersection if that is the case.
 
-If the intersection is deemed relevant, detailed intersection information can later be
-obtained via the  `compute_surface_interaction()` method.)doc";
+If the intersection is deemed relevant, detailed intersection information
+can later be obtained via `Scene.compute_surface_interaction()`.)doc";
 
 static const char *__doc_mitsuba_PreliminaryIntersection_3 = R"doc()doc";
 
@@ -7515,22 +7515,11 @@ static const char *__doc_mitsuba_PreliminaryIntersection_PreliminaryIntersection
 
 static const char *__doc_mitsuba_PreliminaryIntersection_PreliminaryIntersection_3 = R"doc()doc";
 
-static const char *__doc_mitsuba_PreliminaryIntersection_compute_surface_interaction =
-R"doc(Compute and return detailed information related to a surface interaction
-
-Args:
-    ray: Ray associated with the ray intersection
-
-    ray_flags: Flags specifying which information should be computed
-
-Returns:
-    A data structure containing the detailed information)doc";
-
 static const char *__doc_mitsuba_PreliminaryIntersection_fields = R"doc()doc";
 
 static const char *__doc_mitsuba_PreliminaryIntersection_fields_2 = R"doc()doc";
 
-static const char *__doc_mitsuba_PreliminaryIntersection_instance = R"doc(Stores a pointer to the parent instance (if applicable))doc";
+static const char *__doc_mitsuba_PreliminaryIntersection_instance_index = R"doc(Instance index. The value 0 encodes that the shape is not instanced.)doc";
 
 static const char *__doc_mitsuba_PreliminaryIntersection_is_valid = R"doc(Is the current interaction valid?)doc";
 
@@ -7546,9 +7535,7 @@ static const char *__doc_mitsuba_PreliminaryIntersection_prim_index = R"doc(Prim
 
 static const char *__doc_mitsuba_PreliminaryIntersection_prim_uv = R"doc(2D coordinates on the primitive surface parameterization)doc";
 
-static const char *__doc_mitsuba_PreliminaryIntersection_shape = R"doc(Pointer to the associated shape)doc";
-
-static const char *__doc_mitsuba_PreliminaryIntersection_shape_index = R"doc(Shape index, e.g. the shape ID in shapegroup (if applicable))doc";
+static const char *__doc_mitsuba_PreliminaryIntersection_shape = R"doc(Pointer to the associated shape (the leaf shape for instanced hits))doc";
 
 static const char *__doc_mitsuba_PreliminaryIntersection_t = R"doc(Distance traveled along the ray. Invalid lanes are set to infinity.)doc";
 
@@ -8904,6 +8891,25 @@ static const char *__doc_mitsuba_Scene_class_name = R"doc()doc";
 
 static const char *__doc_mitsuba_Scene_clear_shapes_dirty = R"doc(Unmarks all shapes as dirty)doc";
 
+static const char *__doc_mitsuba_Scene_compute_surface_interaction =
+R"doc(Expand a preliminary intersection into a detailed surface interaction
+
+This function turns a `PreliminaryIntersection3f` into a
+`SurfaceInteraction3f`, which provides a richer description of the
+intersection's differentiable geometry.
+
+Args:
+    ray: Ray associated with the preliminary ray intersection ``pi``
+
+    pi: Preliminary intersection to be expanded
+
+    ray_flags: An integer combining flag bits from `RayFlags` (merged
+        using binary or).
+
+Returns:
+    A detailed surface interaction record. Its ``is_valid()`` method
+    should be queried to check if an intersection was actually found.)doc";
+
 static const char *__doc_mitsuba_Scene_emitters = R"doc(Return the list of emitters)doc";
 
 static const char *__doc_mitsuba_Scene_emitters_2 = R"doc(Return the list of emitters (const version))doc";
@@ -8940,6 +8946,11 @@ Args:
 Returns:
     The incident radiance and discrete or solid angle density of the
     sample.)doc";
+
+static const char *__doc_mitsuba_Scene_instance =
+R"doc(Return the ``instance`` shape with the given index. Like ``shapes()``,
+this is a host-side lookup; it maps values read back from
+``pi.instance_index`` to the underlying shape object.)doc";
 
 static const char *__doc_mitsuba_Scene_integrator = R"doc(Return the scene's `Integrator`)doc";
 
@@ -10970,7 +10981,7 @@ static const char *__doc_mitsuba_SurfaceInteraction_has_n_partials = R"doc()doc"
 
 static const char *__doc_mitsuba_SurfaceInteraction_has_uv_partials = R"doc()doc";
 
-static const char *__doc_mitsuba_SurfaceInteraction_instance = R"doc(Stores a pointer to the parent instance (if applicable))doc";
+static const char *__doc_mitsuba_SurfaceInteraction_instance_index = R"doc(Instance index. The value 0 encodes that the shape is not instanced.)doc";
 
 static const char *__doc_mitsuba_SurfaceInteraction_is_medium_transition = R"doc(Does the surface mark a transition between two media?)doc";
 

--- a/include/mitsuba/render/accel_embree.h
+++ b/include/mitsuba/render/accel_embree.h
@@ -48,23 +48,41 @@ struct EmbreeAccel {
 
     // --- Declarative traversal ---
     DRJIT_TRAVERSE(EmbreeAccel, accel_handle, func_handle,
-                   occlude_handle, shapes_registry_ids)
+                   occlude_handle)
 
-    /// Native Embree scene, lifetime tied to ``accel_handle`` in JIT variants.
+    /// Native Embree scene, lifetime tied to ``accel_handle`` in JIT variants
     RTCSceneTy *accel = nullptr;
-    std::vector<int> geometries;
+
+    /// Geometry IDs currently attached to ``accel`` (detached on rebuild)
+    std::vector<unsigned int> geometries;
+
+    /// Whether this scene was created while another scene renders (see init())
     bool is_nested_scene = false;
-    /// One nested Embree scene per ShapeGroup, shared by its Instances.
+
+    /// One nested Embree scene per ShapeGroup, shared by its Instances
     tsl::robin_map<const void *, RTCSceneTy *, PointerHasher> group_scenes;
-    /// Width-specialized Embree entry points.
+
+    /// Width-specialized Embree closest-hit entry point
     void *func_ptr = nullptr;
+
+    /// Width-specialized Embree any-hit (shadow ray) entry point
     void *occlude_func_ptr = nullptr;
 
-    /// Freeze-visible handles and shape recovery table.
+    /// Freeze-visible handle owning ``accel``
     UInt64 accel_handle;
+
+    /// Freeze-visible handle wrapping ``func_ptr``
     UInt64 func_handle;
+
+    /// Freeze-visible handle wrapping ``occlude_func_ptr``
     UInt64 occlude_handle;
-    DynamicBuffer<UInt32> shapes_registry_ids;
+
+    /// Number of instances.
+    /// The Embree backends reserve the geometry IDs [0, instance_count) for
+    /// instances, so that a hit's ``instID`` can be directly interpreted as the
+    /// instance index. Non-instanced geometry follows at ``instance_count``
+    /// plus its registry ID (LLVM mode) or sequentially (scalar mode)
+    uint32_t instance_count = 0;
 };
 
 NAMESPACE_END(mitsuba)

--- a/include/mitsuba/render/accel_metal.h
+++ b/include/mitsuba/render/accel_metal.h
@@ -43,9 +43,8 @@ struct MetalAccel {
         const Scene<Float, Spectrum> *scene, const Ray3f &ray,
         Mask active) const;
 
-    // --- Declarative traversal (scene handle + recovery tables) ---
-    DRJIT_TRAVERSE(MetalAccel, accel_handle, geom_shape_offsets,
-                   geom_shape_table)
+    // --- Declarative traversal (scene handle + recovery table) ---
+    DRJIT_TRAVERSE(MetalAccel, accel_handle, geom_shape_table)
 
     /// Opaque handle owning the Metal objects (TLAS/BLAS/buffers/library)
     MetalAccelData *accel = nullptr;
@@ -53,10 +52,12 @@ struct MetalAccel {
     uint32_t scene_index = 0;
     /// Handle variable representing the Metal scene for @dr.freeze
     UInt64 accel_handle;
-    /// Per-instance recovery tables resolving ``pi.shape`` from a hit's
-    /// (instance_id, geometry_id), built in scene_metal.inl.
-    DynamicBuffer<UInt32> geom_shape_offsets;
+    /// Recovery table indexed by TLAS userID + geometry ID, resolving a hit
+    /// into ``pi.shape`` (see scene_metal.inl)
     DynamicBuffer<UInt32> geom_shape_table;
+    /// Layout of ``geom_shape_table``: (shape id, instance index) pairs when
+    /// true, plain shape ids otherwise
+    bool has_instances = false;
 
 private:
     /// Trace ``ray``, writing eight result variable indices to ``out``. With

--- a/include/mitsuba/render/interaction.h
+++ b/include/mitsuba/render/interaction.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <mitsuba/core/frame.h>
-#include <mitsuba/core/profiler.h>
 #include <mitsuba/core/ray.h>
 #include <mitsuba/core/spectrum.h>
 #include <mitsuba/render/fwd.h>
@@ -255,8 +254,8 @@ struct SurfaceInteraction : Interaction<Float_, Spectrum_> {
     /// Primitive index, e.g. the triangle ID (if applicable)
     Index prim_index;
 
-    /// Stores a pointer to the parent instance (if applicable)
-    ShapePtr instance = nullptr;
+    /// Instance index. The value 0 encodes that the shape is not instanced.
+    Index instance_index = 0;
 
     // =============================================================
 
@@ -285,25 +284,19 @@ struct SurfaceInteraction : Interaction<Float_, Spectrum_> {
      */
     void zero_(size_t size = 1) override {
         Interaction<Float_, Spectrum_>::zero_(size);
-        uv            = dr::zeros<Point2f>(size);
-        sh_frame      = dr::zeros<Frame3f>(size);
-        frame_flipped = dr::zeros<Bool>(size);
-        dp_du         = dr::zeros<Vector3f>(size);
-        dp_dv         = dr::zeros<Vector3f>(size);
-        dn_du         = dr::zeros<Vector3f>(size);
-        dn_dv         = dr::zeros<Vector3f>(size);
-        duv_dx        = dr::zeros<Vector2f>(size);
-        duv_dy        = dr::zeros<Vector2f>(size);
-        wi            = dr::zeros<Vector3f>(size);
-        prim_index    = dr::zeros<Index>(size);
-
-        if constexpr (dr::is_jit_v<Float_>) {
-            shape       = dr::zeros<ShapePtr>(size);
-            instance    = dr::zeros<ShapePtr>(size);
-        } else {
-            shape       = nullptr;
-            instance    = nullptr;
-        }
+        uv             = dr::zeros<Point2f>(size);
+        sh_frame       = dr::zeros<Frame3f>(size);
+        frame_flipped  = dr::zeros<Bool>(size);
+        dp_du          = dr::zeros<Vector3f>(size);
+        dp_dv          = dr::zeros<Vector3f>(size);
+        dn_du          = dr::zeros<Vector3f>(size);
+        dn_dv          = dr::zeros<Vector3f>(size);
+        duv_dx         = dr::zeros<Vector2f>(size);
+        duv_dy         = dr::zeros<Vector2f>(size);
+        wi             = dr::zeros<Vector3f>(size);
+        prim_index     = dr::zeros<Index>(size);
+        instance_index = dr::zeros<Index>(size);
+        shape          = dr::zeros<ShapePtr>(size);
     }
 
     /// Convert a local shading-space vector into world space
@@ -504,8 +497,7 @@ struct SurfaceInteraction : Interaction<Float_, Spectrum_> {
     }
 
     /**
-     * Attach the motion of this interaction under the requested
-     * differentiation mode
+     * Attach the motion of this interaction under the requested differentiation mode
      *
      * This function exists for use within implementations of
      * `Shape.compute_surface_interaction()`. It reads ``t``, ``p`` and ``n`` and
@@ -564,8 +556,8 @@ struct SurfaceInteraction : Interaction<Float_, Spectrum_> {
         dr::masked(t, !active) = dr::Infinity<Float>;
         active &= is_valid();
 
-        dr::masked(shape, !active)    = nullptr;
-        dr::masked(instance, !active) = nullptr;
+        dr::masked(shape, !active)          = nullptr;
+        dr::masked(instance_index, !active) = 0u;
 
         time        = ray.time;
         wavelengths = ray.wavelengths;
@@ -615,7 +607,7 @@ struct SurfaceInteraction : Interaction<Float_, Spectrum_> {
 
     DRJIT_STRUCT(SurfaceInteraction, t, time, wavelengths, p, n, shape, uv,
                  sh_frame, frame_flipped, dp_du, dp_dv, dn_du, dn_dv, duv_dx,
-                 duv_dy, wi, prim_index, instance)
+                 duv_dy, wi, prim_index, instance_index)
 };
 
 // -----------------------------------------------------------------------------
@@ -675,12 +667,7 @@ struct MediumInteraction : Interaction<Float_, Spectrum_> {
         sigma_t             = dr::zeros<UnpolarizedSpectrum>(size);
         combined_extinction = dr::zeros<UnpolarizedSpectrum>(size);
         mint                = dr::zeros<Float>(size);
-
-        if constexpr (dr::is_jit_v<Float_>) {
-            medium      = dr::zeros<MediumPtr>(size);
-        } else {
-            medium      = nullptr;
-        }
+        medium              = dr::zeros<MediumPtr>(size);
     }
 
     /// Convert a local shading-space (defined by `wi`) vector into world space
@@ -710,8 +697,8 @@ struct MediumInteraction : Interaction<Float_, Spectrum_> {
  * stores whether the shape is intersected by a given ray, and cache
  * preliminary information about the intersection if that is the case.
  *
- * If the intersection is deemed relevant, detailed intersection information can later be
- * obtained via the  `compute_surface_interaction()` method.
+ * If the intersection is deemed relevant, detailed intersection information
+ * can later be obtained via `Scene.compute_surface_interaction()`.
  */
 template <typename Float_, typename Shape_>
 struct PreliminaryIntersection {
@@ -748,14 +735,11 @@ struct PreliminaryIntersection {
     /// Primitive index, e.g. the triangle ID (if applicable)
     Index prim_index;
 
-    /// Shape index, e.g. the shape ID in shapegroup (if applicable)
-    Index shape_index;
+    /// Instance index. The value 0 encodes that the shape is not instanced.
+    Index instance_index = 0;
 
-    /// Pointer to the associated shape
+    /// Pointer to the associated shape (the leaf shape for instanced hits)
     ShapePtr shape = nullptr;
-
-    /// Stores a pointer to the parent instance (if applicable)
-    ShapePtr instance = nullptr;
 
     // =============================================================
 
@@ -769,19 +753,12 @@ struct PreliminaryIntersection {
      * ``valid`` and sets ``t`` to infinity for invalid intersection records.
      */
     void zero_(size_t size = 1) {
-        valid       = dr::zeros<Mask>(size);
-        t           = dr::full<Float>(dr::Infinity<Float>, size);
-        prim_uv     = dr::zeros<Point2f>(size);
-        prim_index  = dr::zeros<Index>(size);
-        shape_index = dr::zeros<Index>(size);
-
-        if constexpr (dr::is_jit_v<Float_>) {
-            shape       = dr::zeros<ShapePtr>(size);
-            instance    = dr::zeros<ShapePtr>(size);
-        } else {
-            shape       = nullptr;
-            instance    = nullptr;
-        }
+        valid          = dr::zeros<Mask>(size);
+        t              = dr::full<Float>(dr::Infinity<Float>, size);
+        prim_uv        = dr::zeros<Point2f>(size);
+        prim_index     = dr::zeros<Index>(size);
+        instance_index = dr::zeros<Index>(size);
+        shape          = dr::zeros<ShapePtr>(size);
     }
 
     /// Is the current interaction valid?
@@ -789,49 +766,10 @@ struct PreliminaryIntersection {
         return valid;
     }
 
-    /**
-     * Compute and return detailed information related to a surface interaction
-     *
-     * Args:
-     *     ray: Ray associated with the ray intersection
-     *
-     *     ray_flags: Flags specifying which information should be computed
-     *
-     * Returns:
-     *     A data structure containing the detailed information
-     */
-    auto compute_surface_interaction(const Ray3f &ray,
-                                     uint32_t ray_flags = +RayFlags::Default,
-                                     Mask active = true) {
-        if constexpr (!std::is_same_v<Shape_, Shape<Float, Spectrum>>) {
-            Throw("PreliminaryIntersection::compute_surface_interaction(): not implemented!");
-        } else {
-            using SurfaceInteraction3f = SurfaceInteraction<Float, Spectrum>;
-            using ShapePtr = typename SurfaceInteraction3f::ShapePtr;
-
-            active &= is_valid();
-            if (dr::none_or<false>(active)) {
-                SurfaceInteraction3f si = dr::zeros<SurfaceInteraction3f>();
-                si.wi = -ray.d;
-                si.wavelengths = ray.wavelengths;
-                return si;
-            }
-
-            ScopedPhase sp(ProfilerPhase::CreateSurfaceInteraction);
-
-            ShapePtr target = dr::select(instance == nullptr, shape, instance);
-            SurfaceInteraction3f si =
-                target->compute_surface_interaction(ray, *this, ray_flags, 0u, active);
-            si.finalize_surface_interaction(*this, ray, ray_flags, active);
-
-            return si;
-        }
-    }
-
     // =============================================================
 
     DRJIT_STRUCT(PreliminaryIntersection, valid, t, prim_uv, prim_index,
-                 shape_index, shape, instance);
+                 instance_index, shape);
 };
 
 // -----------------------------------------------------------------------------
@@ -878,7 +816,7 @@ std::ostream &operator<<(std::ostream &os, const SurfaceInteraction<Float, Spect
 
         os << "  wi = " << string::indent(it.wi, 7) << "," << std::endl
            << "  prim_index = " << it.prim_index << "," << std::endl
-           << "  instance = " << string::indent(it.instance, 13) << std::endl
+           << "  instance_index = " << it.instance_index << std::endl
            << "]";
     }
     return os;
@@ -912,9 +850,8 @@ std::ostream &operator<<(std::ostream &os, const PreliminaryIntersection<Float, 
            << "  t = " << pi.t << "," << std::endl
            << "  prim_uv = " << pi.prim_uv << "," << std::endl
            << "  prim_index = " << pi.prim_index << "," << std::endl
-           << "  shape_index = " << pi.shape_index << "," << std::endl
+           << "  instance_index = " << pi.instance_index << "," << std::endl
            << "  shape = " << string::indent(pi.shape, 6) << "," << std::endl
-           << "  instance = " << string::indent(pi.instance, 6) << "," << std::endl
            << "]";
     }
     return os;

--- a/include/mitsuba/render/kdtree.h
+++ b/include/mitsuba/render/kdtree.h
@@ -2385,20 +2385,18 @@ protected:
             pi.valid = hit;
             pi.t = dr::select(hit, ScalarFloat(0), dr::Infinity<ScalarFloat>);
         } else {
-            uint32_t inst_index = (uint32_t) -1;
             if (shape->is_mesh()) {
                 std::tie(pi.valid, pi.t, pi.prim_uv) =
                     mesh->ray_intersect_triangle_scalar(prim_index, ray);
             } else {
-                std::tie(pi.valid, pi.t, pi.prim_uv, inst_index, prim_index) =
+                std::tie(pi.valid, pi.t, pi.prim_uv, std::ignore, prim_index) =
                     shape->ray_intersect_preliminary_scalar(ray);
             }
             pi.prim_index = prim_index;
-
-            bool hit_inst  = (inst_index != (uint32_t) -1);
-            pi.shape       = hit_inst ? (const Shape *) (size_t) shape_index : shape; // shape_index for LLVM + kdtree
-            pi.instance    = hit_inst ? shape : nullptr;
-            pi.shape_index = hit_inst ? inst_index : shape_index;
+            pi.shape      = shape;
+            // Repurposed to convey the top-level shape index (the kd-tree
+            // does not support instancing)
+            pi.instance_index = shape_index;
         }
 
         return pi;

--- a/include/mitsuba/render/mesh.h
+++ b/include/mitsuba/render/mesh.h
@@ -909,7 +909,6 @@ public:
     SurfaceInteraction3f compute_surface_interaction(const Ray3f &ray,
                                                      const PreliminaryIntersection3f &pi,
                                                      uint32_t ray_flags,
-                                                     uint32_t recursion_depth = 0,
                                                      Mask active = true) const override;
 
     Mask has_attribute(std::string_view name, Mask active = true) const override;

--- a/include/mitsuba/render/optix/common.h
+++ b/include/mitsuba/render/optix/common.h
@@ -59,8 +59,6 @@ set_preliminary_intersection_to_payload(float t,
     optixSetPayload_2(__float_as_int(prim_uv[1]));
     optixSetPayload_3(prim_index);
     optixSetPayload_4(shape_registry_id);
-
-    // Instance index is initialized to 0 when there is no instancing in the scene
     if (optixGetPayload_5() > 0)
         optixSetPayload_5(optixGetInstanceId());
 }

--- a/include/mitsuba/render/scene.h
+++ b/include/mitsuba/render/scene.h
@@ -236,6 +236,32 @@ public:
                                        Mask active = true) const;
 
     /**
+     * Expand a preliminary intersection into a detailed surface interaction
+     *
+     * This function turns a `PreliminaryIntersection3f` into a
+     * `SurfaceInteraction3f`, which provides a richer description of the
+     * intersection's differentiable geometry.
+     *
+     * Args:
+     *     ray: Ray associated with the preliminary ray intersection ``pi``
+     *
+     *     pi: Preliminary intersection to be expanded
+     *
+     *     ray_flags: An integer combining flag bits from `RayFlags` (merged
+     *         using binary or).
+     *
+     * Returns:
+     *     A detailed surface interaction record. Its ``is_valid()`` method
+     *     should be queried to check if an intersection was actually found.
+     */
+    SurfaceInteraction3f compute_surface_interaction(
+        const Ray3f &ray, const PreliminaryIntersection3f &pi,
+        uint32_t ray_flags = +RayFlags::Default, Mask active = true) const;
+
+    /// Return the ``instance`` shape with the given index.
+    const Shape *instance(size_t index) const { return m_instances[index]; }
+
+    /**
      * Intersect a ray with the shapes comprising the scene and return a
      * boolean specifying whether or not an intersection was found.
      *
@@ -747,6 +773,9 @@ protected:
     /// Unmarks all shapes as dirty
     void clear_shapes_dirty();
 
+    /// Repack the per-instance transform records (see below)
+    void update_instance_transforms();
+
     using ShapeKDTree = mitsuba::ShapeKDTree<Float, Spectrum>;
 
     /// Updates the discrete distribution used to select an emitter
@@ -792,6 +821,21 @@ protected:
     /// Enable/disable automatic BVH compaction criterion in compact_accel().
     bool m_compact_accel_auto;
 
+    /// Instances in order of appearance in ``m_shapes``.
+    /// `PreliminaryIntersection3f.instance_index` references this array biased
+    /// by one, since 0 marks non-instanced intersections.
+    std::vector<const Shape *> m_instances;
+
+    /// Flattened sequence of instance ``to_world`` matrices (12 floats each)
+    DynamicBuffer<Float> m_instance_transforms;
+
+    /// Instancing-aware expansion of a preliminary intersection (see
+    /// ``compute_surface_interaction()``, which forwards here when the
+    /// record may reference instanced geometry)
+    SurfaceInteraction3f compute_surface_interaction_instanced(
+        const Ray3f &ray, const PreliminaryIntersection3f &pi,
+        uint32_t ray_flags, Mask active) const;
+
     // The Accel class needs to access the scene's protected members.
     friend SceneAccel<Float, Spectrum>;
 
@@ -799,7 +843,8 @@ protected:
                            m_shapes_dr, m_shapegroups, m_sensors, m_sensors_dr,
                            m_children, m_integrator, m_environment,
                            m_emitter_pmf, m_emitter_distr, m_silhouette_shapes,
-                           m_silhouette_shapes_dr, m_silhouette_distr)
+                           m_silhouette_shapes_dr, m_silhouette_distr,
+                           m_instance_transforms)
 };
 
 // See interaction.h

--- a/include/mitsuba/render/scene_ir.h
+++ b/include/mitsuba/render/scene_ir.h
@@ -114,9 +114,6 @@ static constexpr size_t NumGeometryKinds = (size_t) ShapeIR::Kind::Instance;
 //  Whole-scene descriptor
 // ---------------------------------------------------------------------------
 
-/// ``InstanceEntry.owner_registry_id`` for a top-level BLAS.
-static constexpr uint32_t SCENE_IR_NO_OWNER = (uint32_t) -1;
-
 /// One bottom-level acceleration structure holding same-kind geometry.
 struct BlasEntry {
     ShapeIR::Kind        kind;
@@ -132,8 +129,8 @@ struct InstanceEntry {
     float    to_world[12] = { 1.f, 0.f, 0.f, 0.f, 1.f, 0.f,
                               0.f, 0.f, 1.f, 0.f, 0.f, 0.f };
 
-    /// JIT registry ID of the ShapeGroup, or ``SCENE_IR_NO_OWNER``.
-    uint32_t owner_registry_id = SCENE_IR_NO_OWNER;
+    /// Index + 1 of the owning ``instance``, or 0 for a top-level BLAS.
+    uint32_t instance_index = 0;
 };
 
 /// Scene description consumed by acceleration-structure builders.

--- a/include/mitsuba/render/shape.h
+++ b/include/mitsuba/render/shape.h
@@ -551,7 +551,6 @@ public:
     virtual SurfaceInteraction3f compute_surface_interaction(const Ray3f &ray,
                                                              const PreliminaryIntersection3f &pi,
                                                              uint32_t ray_flags = +RayFlags::Default,
-                                                             uint32_t recursion_depth = 0,
                                                              Mask active = true) const;
 
     /**
@@ -805,6 +804,12 @@ public:
     /// Is this shape an instance?
     bool is_instance() const { return shape_type() == +ShapeType::Instance; };
 
+    /// Return the object-to-world transformation
+    AffineTransform4f to_world() const { return m_to_world.value(); }
+
+    /// Return the object-to-world transformation (scalar form)
+    const ScalarAffineTransform4f &scalar_to_world() const { return m_to_world.scalar(); }
+
     /// Does the surface of this shape mark a medium transition?
     bool is_medium_transition() const { return m_interior_medium.get() != nullptr ||
                                                m_exterior_medium.get() != nullptr; }
@@ -1017,7 +1022,7 @@ NAMESPACE_END(mitsuba)
         const Ray3f &ray, ScalarIndex prim_index, Mask active) const override {             \
         MI_MASK_ARGUMENT(active);                                                           \
         PreliminaryIntersection3f pi = dr::zeros<PreliminaryIntersection3f>();              \
-        std::tie(pi.valid, pi.t, pi.prim_uv, pi.shape_index, pi.prim_index) =               \
+        std::tie(pi.valid, pi.t, pi.prim_uv, std::ignore, pi.prim_index) =                  \
             ray_intersect_preliminary_impl<Float>(ray, prim_index, active);                 \
         pi.shape = this;                                                                    \
         return pi;                                                                          \

--- a/include/mitsuba/render/shapegroup.h
+++ b/include/mitsuba/render/shapegroup.h
@@ -28,12 +28,6 @@ public:
     bool ray_test_scalar(const ScalarRay3f &ray) const override;
 #endif
 
-    SurfaceInteraction3f compute_surface_interaction(const Ray3f &ray,
-                                                     const PreliminaryIntersection3f &pi,
-                                                     uint32_t ray_flags,
-                                                     uint32_t recursion_depth,
-                                                     Mask active) const override;
-
     ScalarSize primitive_count() const override;
 
     ScalarBoundingBox3f bbox() const override{ return m_bbox; }
@@ -64,10 +58,6 @@ private:
     ScalarBoundingBox3f m_bbox;
     std::vector<ref<Base>> m_shapes;
 
-#if defined(MI_ENABLE_LLVM) || defined(MI_ENABLE_CUDA) || defined(MI_ENABLE_METAL)
-    DynamicBuffer<UInt32> m_shapes_registry_ids;
-#endif
-
 #if !defined(MI_ENABLE_EMBREE)
     ref<ShapeKDTree> m_kdtree;
 #endif
@@ -80,11 +70,7 @@ private:
     mutable bool m_parameters_grad_enabled_cache = false;
     mutable bool m_parameters_grad_enabled_dirty = true;
 
-#if defined(MI_ENABLE_LLVM) || defined(MI_ENABLE_CUDA) || defined(MI_ENABLE_METAL)
-    MI_DECLARE_TRAVERSE_CB(m_shapes, m_shapes_registry_ids, m_accel_handles)
-#else
     MI_DECLARE_TRAVERSE_CB(m_shapes, m_accel_handles)
-#endif
 };
 
 MI_EXTERN_CLASS(ShapeGroup)

--- a/src/emitters/envmap.cpp
+++ b/src/emitters/envmap.cpp
@@ -189,7 +189,6 @@ public:
         TensorXf tensor(bitmap_2->data(), { (size_t) m_res.y(), (size_t) sw,
                                             (size_t) PixelWidth });
         m_texture = Tex(tensor, /* use_accel = */ true,
-                        /* migrate = */ dr::is_jit_v<Float>,
                         dr::FilterMode::Linear, dr::WrapMode::Clamp);
 
         m_scale = props.get<ScalarFloat>("scale", 1.f);
@@ -242,8 +241,7 @@ public:
 
                 m_texture.set_tensor(
                     TensorXf(corrected, { (size_t) m_res.y(), (size_t) sw,
-                                          (size_t) PixelWidth }),
-                    /* migrate */ true);
+                                          (size_t) PixelWidth }));
             } else {
                 refresh_halo((ScalarFloat *) tensor.array().data(), m_res);
                 m_texture.update_inplace();

--- a/src/emitters/timed_sunsky.cpp
+++ b/src/emitters/timed_sunsky.cpp
@@ -419,7 +419,7 @@ private:
         Float turb_idx_f = dr::clip(m_turbidity - 1.f, 0.f, TURBIDITY_LVLS - 1.f);
         TensorXf res = dr::take_interp(sampling_weights_data, turb_idx_f, 1);
 
-        return new SamplingTexture(res, true, true, dr::FilterMode::Linear, dr::WrapMode::Clamp);
+        return new SamplingTexture(res, true, dr::FilterMode::Linear, dr::WrapMode::Clamp);
     }
 
     template<typename Dataset>
@@ -482,7 +482,7 @@ private:
 
             TensorXf temp(sampling_weigths, { MPDF_ELEVATION_COUNT, 1 });
 
-            sky_weight_tex = new SamplingTexture(temp, true, true, dr::FilterMode::Linear, dr::WrapMode::Clamp);
+            sky_weight_tex = new SamplingTexture(temp, true, dr::FilterMode::Linear, dr::WrapMode::Clamp);
         }
 
         // Sun irradiance
@@ -497,7 +497,7 @@ private:
             TensorXf temp(sun_irrad_data,
                           { MPDF_ELEVATION_COUNT, CHANNEL_COUNT });
 
-            sun_irrad_tex = new SunIrradTexture(temp, true, true, dr::FilterMode::Linear, dr::WrapMode::Clamp);
+            sun_irrad_tex = new SunIrradTexture(temp, true, dr::FilterMode::Linear, dr::WrapMode::Clamp);
         }
 
         return std::make_pair(sky_weight_tex, sun_irrad_tex);

--- a/src/integrators/aov.cpp
+++ b/src/integrators/aov.cpp
@@ -286,9 +286,9 @@ public:
 
                 case AOVType::ShapeIndex:
                     if constexpr (!dr::is_jit_v<Float>) {
-                        ShapePtr target = si.instance;
-                        if (!target)
-                            target = si.shape;
+                        ShapePtr target = si.instance_index != 0
+                            ? scene->instance(si.instance_index - 1)
+                            : si.shape;
 
                         auto it = m_shape_to_idx.find(target);
                         if (it == m_shape_to_idx.end())

--- a/src/integrators/direct.cpp
+++ b/src/integrators/direct.cpp
@@ -135,8 +135,8 @@ public:
                 Ray3f ray_skip = si.spawn_ray(ray.d);
                 PreliminaryIntersection3f pi =
                     Base::skip_area_emitters(scene, ray_skip, true, skip_emitters);
-                SurfaceInteraction3f si_after_skip = pi.compute_surface_interaction(
-                        ray, +RayFlags::Default, skip_emitters);
+                SurfaceInteraction3f si_after_skip = scene->compute_surface_interaction(
+                        ray, pi, +RayFlags::Default, skip_emitters);
                 dr::masked(si, skip_emitters) = si_after_skip;
             }
         } else {

--- a/src/integrators/path.cpp
+++ b/src/integrators/path.cpp
@@ -180,8 +180,8 @@ public:
                                  ls.active;
 
             if (dr::any_or<true>(skip_emitters)) {
-                SurfaceInteraction3f si = ls.pi.compute_surface_interaction(
-                    ls.ray, +RayFlags::Minimal, skip_emitters);
+                SurfaceInteraction3f si = scene->compute_surface_interaction(
+                    ls.ray, ls.pi, +RayFlags::Minimal, skip_emitters);
                 Ray3f skip_ray = si.spawn_ray(ls.ray.d);
                 PreliminaryIntersection3f pi_after_skip =
                     Base::skip_area_emitters(scene, skip_ray, true, skip_emitters);
@@ -197,8 +197,8 @@ public:
             // 'active' flag, so there is no need to pass it to every function
 
             // Fill out all information of the interaction
-            SurfaceInteraction3f si =
-                ls.pi.compute_surface_interaction(ls.ray, +RayFlags::Default);
+            SurfaceInteraction3f si = scene->compute_surface_interaction(
+                ls.ray, ls.pi, +RayFlags::Default);
 
             // ---------------------- Direct emission ----------------------
 

--- a/src/integrators/ptracer.cpp
+++ b/src/integrators/ptracer.cpp
@@ -250,7 +250,8 @@ public:
             [](const LoopState& ls) { return ls.active; },
             [this, scene, sensor, block, sample_scale](LoopState& ls) {
 
-            SurfaceInteraction3f si = ls.pi.compute_surface_interaction(ls.ray, +RayFlags::Default);
+            SurfaceInteraction3f si = scene->compute_surface_interaction(
+                ls.ray, ls.pi, +RayFlags::Default);
 
             BSDFPtr bsdf = si.bsdf(ls.ray);
 

--- a/src/integrators/volpath.cpp
+++ b/src/integrators/volpath.cpp
@@ -317,7 +317,7 @@ public:
                         PreliminaryIntersection3f pi =
                             Base::skip_area_emitters(scene, skip_ray, true, skip_emitters);
                         SurfaceInteraction3f si_after_skip =
-                            pi.compute_surface_interaction(skip_ray, +RayFlags::Default, skip_emitters);
+                            scene->compute_surface_interaction(skip_ray, pi, +RayFlags::Default, skip_emitters);
                         dr::masked(si, skip_emitters) = si_after_skip;
                     }
                 }

--- a/src/integrators/volpathmis.cpp
+++ b/src/integrators/volpathmis.cpp
@@ -374,7 +374,7 @@ public:
                         PreliminaryIntersection3f pi =
                             Base::skip_area_emitters(scene, skip_ray, true, skip_emitters);
                         SurfaceInteraction3f si_after_skip =
-                            pi.compute_surface_interaction(skip_ray, +RayFlags::Default, skip_emitters);
+                            scene->compute_surface_interaction(skip_ray, pi, +RayFlags::Default, skip_emitters);
                         dr::masked(si, skip_emitters) = si_after_skip;
                     }
                 }

--- a/src/python/python/ad/integrators/direct_projective.py
+++ b/src/python/python/ad/integrators/direct_projective.py
@@ -330,8 +330,8 @@ class DirectProjectiveIntegrator(PSIntegrator):
 
             # The ray origin is wrong, but this is fine if we only need the primal
             # radiance
-            si_fg = pi_fg.compute_surface_interaction(
-                dummy_ray, mi.RayFlags.Default, active)
+            si_fg = scene.compute_surface_interaction(
+                dummy_ray, pi_fg, mi.RayFlags.Default, active)
 
             # We know the incident direction is valid since this is the
             # foreground interaction. Overwrite the incident direction to avoid
@@ -361,8 +361,8 @@ class DirectProjectiveIntegrator(PSIntegrator):
 
             # The ray origin is wrong, but this is fine if we only need the primal
             # radiance
-            si_fg = pi_fg.compute_surface_interaction(
-                dummy_ray, mi.RayFlags.Default, active)
+            si_fg = scene.compute_surface_interaction(
+                dummy_ray, pi_fg, mi.RayFlags.Default, active)
 
             # If smooth normals are used, it is possible that the computed
             # shading normal near visibility silhouette points to the wrong side

--- a/src/python/python/ad/integrators/prb.py
+++ b/src/python/python/ad/integrators/prb.py
@@ -113,7 +113,7 @@ class PRBIntegrator(RBIntegrator):
         if dr.hint(self.hide_emitters, mode='scalar'):
             # Did we hit an area emitter? If so, skip all area emitters along this ray
             skip_emitters = pi.is_valid() & (pi.shape.emitter() != None) & active
-            si_skip = pi.compute_surface_interaction(ray, mi.RayFlags.Minimal, skip_emitters)
+            si_skip = scene.compute_surface_interaction(ray, pi, mi.RayFlags.Minimal, skip_emitters)
             ray_skip = si_skip.spawn_ray(ray.d)
             pi_after_skip = self.skip_area_emitters(scene, ray_skip, True, skip_emitters)
             pi[skip_emitters] = pi_after_skip
@@ -127,14 +127,13 @@ class PRBIntegrator(RBIntegrator):
             # from differentiable shape parameters (position, normals, etc.)
             # In primal mode, this is just an ordinary ray tracing operation.
             with dr.resume_grad(when=not primal):
-                si = pi.compute_surface_interaction(ray, ray_flags=mi.RayFlags.Default)
+                si = scene.compute_surface_interaction(ray, pi, ray_flags=mi.RayFlags.Default)
 
                 # Recompute an attached si.wi to account for motion of the
                 # previous surface interaction
                 if (not primal) & mi.Bool(depth >= 1):
-                    si_prev_diff = pi_prev.compute_surface_interaction(
-                        ray_prev, ray_flags=mi.RayFlags.Minimal
-                    )
+                    si_prev_diff = scene.compute_surface_interaction(
+                        ray_prev, pi_prev, ray_flags=mi.RayFlags.Minimal)
                     si_prev = dr.replace_grad(si_prev, si_prev_diff)
                     si_detached = dr.detach(si) # Ignore motion of current point
                     wi_global = dr.normalize(si_prev.p - si_detached.p)
@@ -261,9 +260,9 @@ class PRBIntegrator(RBIntegrator):
             # ------------------ Differential phase only ------------------
 
             if dr.hint(not primal, mode='scalar'):
-                si_next = pi_next.compute_surface_interaction(ray_next,
-                                                              ray_flags=mi.RayFlags.Minimal,
-                                                              active=active_next)
+                si_next = scene.compute_surface_interaction(
+                    ray_next, pi_next, ray_flags=mi.RayFlags.Minimal,
+                    active=active_next)
 
                 with dr.resume_grad():
                     # If the current interaction point is moving, we need

--- a/src/python/python/ad/integrators/prb_basic.py
+++ b/src/python/python/ad/integrators/prb_basic.py
@@ -94,7 +94,7 @@ class BasicPRBIntegrator(RBIntegrator):
         if dr.hint(self.hide_emitters, mode='scalar'):
             # Did we hit an area emitter? If so, skip all area emitters along this ray
             skip_emitters = pi.is_valid() & (pi.shape.emitter() != None) & active
-            si_skip = pi.compute_surface_interaction(ray, mi.RayFlags.Minimal, skip_emitters)
+            si_skip = scene.compute_surface_interaction(ray, pi, mi.RayFlags.Minimal, skip_emitters)
             ray_skip = si_skip.spawn_ray(ray.d)
             pi_after_skip = self.skip_area_emitters(scene, ray_skip, True, skip_emitters)
             pi[skip_emitters] = pi_after_skip
@@ -108,12 +108,13 @@ class BasicPRBIntegrator(RBIntegrator):
             # from differentiable shape parameters (position, normals, etc.)
             # In primal mode, this is just an ordinary ray tracing operation.
             with dr.resume_grad(when=not primal):
-                si = pi.compute_surface_interaction(ray, ray_flags=mi.RayFlags.Default)
+                si = scene.compute_surface_interaction(ray, pi, ray_flags=mi.RayFlags.Default)
 
                 # Recompute an attached si.wi to account for motion of the
                 # previous surface interaction
                 if (not primal) & mi.Bool(depth >= 1):
-                    si_prev = pi_prev.compute_surface_interaction(ray_prev, ray_flags=mi.RayFlags.Default)
+                    si_prev = scene.compute_surface_interaction(
+                        ray_prev, pi_prev, ray_flags=mi.RayFlags.Default)
                     # We should not account for the current interaction's motion
                     si_detach = dr.detach(si)
                     wi_global = dr.normalize(si_prev.p - si_detach.p)
@@ -163,9 +164,9 @@ class BasicPRBIntegrator(RBIntegrator):
             # ------------------ Differential phase only ------------------
 
             if dr.hint(not primal, mode='scalar'):
-                si_next = pi_next.compute_surface_interaction(ray_next,
-                                                              ray_flags=mi.RayFlags.Default,
-                                                              active=active_next)
+                si_next = scene.compute_surface_interaction(
+                    ray_next, pi_next, ray_flags=mi.RayFlags.Default,
+                    active=active_next)
 
                 with dr.resume_grad():
                     # If the current interaction point is moving, we need

--- a/src/python/python/ad/integrators/prb_projective.py
+++ b/src/python/python/ad/integrators/prb_projective.py
@@ -195,18 +195,16 @@ class PathProjectiveIntegrator(PSIntegrator):
             # In primal mode, this is just an ordinary ray tracing operation.
             use_si_shade = ignore_ray & (depth == depth_init)
             with dr.resume_grad(when=not primal):
-                si = pi.compute_surface_interaction(ray,
+                si = scene.compute_surface_interaction(ray, pi,
                                                     ray_flags=mi.RayFlags.Default,
                                                     active=active_next & ~use_si_shade)
 
                 # Recompute an attached si.wi to account for motion of the
                 # previous surface interaction
                 if (not primal) & mi.Bool(depth >= 1):
-                    si_prev_diff = pi_prev.compute_surface_interaction(
-                        ray_prev,
-                        ray_flags=mi.RayFlags.Minimal,
-                        active=active_next & ~use_si_shade
-                    )
+                    si_prev_diff = scene.compute_surface_interaction(
+                        ray_prev, pi_prev, ray_flags=mi.RayFlags.Minimal,
+                        active=active_next & ~use_si_shade)
                     si_prev = dr.replace_grad(si_prev, si_prev_diff)
                     si_detached = dr.detach(si) # Ignore motion of current point
                     wi_global = dr.normalize(si_prev.p - si_detached.p)
@@ -380,9 +378,9 @@ class PathProjectiveIntegrator(PSIntegrator):
             # ------------------ Differential phase only ------------------
 
             if dr.hint(not primal, mode='scalar'):
-                si_next = pi_next.compute_surface_interaction(ray_next,
-                                                              ray_flags=mi.RayFlags.Minimal,
-                                                              active=active_next)
+                si_next = scene.compute_surface_interaction(
+                    ray_next, pi_next, ray_flags=mi.RayFlags.Minimal,
+                    active=active_next)
 
                 with dr.resume_grad():
                     # If the current interaction point is moving, we need
@@ -488,8 +486,8 @@ class PathProjectiveIntegrator(PSIntegrator):
 
         # The ray origin is wrong, but this is fine if we only need the primal
         # radiance
-        si_fg = pi_fg.compute_surface_interaction(
-            dummy_ray, mi.RayFlags.Default, active)
+        si_fg = scene.compute_surface_interaction(
+            dummy_ray, pi_fg, mi.RayFlags.Default, active)
 
         # If smooth normals are used, it is possible that the computed
         # shading normal near visibility silhouette points to the wrong side

--- a/src/python/python/ad/integrators/prbvolpath.py
+++ b/src/python/python/ad/integrators/prbvolpath.py
@@ -227,7 +227,8 @@ class PRBVolpathIntegrator(RBIntegrator):
 
                     ray_skip = si.spawn_ray(ray.d)
                     pi = self.skip_area_emitters(scene, ray_skip, True, skip_emitters)
-                    si_after_skip = pi.compute_surface_interaction(ray, mi.RayFlags.Default, skip_emitters)
+                    si_after_skip = scene.compute_surface_interaction(
+                        ray, pi, mi.RayFlags.Default, skip_emitters)
                     si[skip_emitters] = si_after_skip
 
                 # ----------------- Intersection with emitters -----------------

--- a/src/python/python/ad/projective.py
+++ b/src/python/python/ad/projective.py
@@ -739,8 +739,9 @@ class ProjectiveDetail():
             pi.prim_index = ss.prim_index
             pi.shape = ss.shape
             dummy_ray = dr.zeros(mi.Ray3f, dr.width(ss))
-            si_jump = pi.compute_surface_interaction(
-                dummy_ray, mi.RayFlags.Default | mi.RayFlags.NormalPartials,
+            si_jump = scene.compute_surface_interaction(
+                dummy_ray, pi,
+                mi.RayFlags.Default | mi.RayFlags.NormalPartials,
                 active=active)
 
             # Perform the jump operation

--- a/src/render/accel_cpu_common.h
+++ b/src/render/accel_cpu_common.h
@@ -29,14 +29,12 @@ build_registry_ids(const std::vector<ref<Shape<Float, Spectrum>>> &shapes) {
 }
 
 /**
- * Decode the closest-hit result of a CPU (LLVM) ray trace into
+ * Decode the closest-hit result of a kd-tree (LLVM) ray trace into
  * a `PreliminaryIntersection`.
  *
  * The trace writes ``out`` = { valid, t, u, v, prim_index, shape_index,
- * inst_index, hit_inst }. The owning `ShapePtr` comes from ``registry_ids``,
- * gathered by instance index for instanced hits and shape index for top-level
- * hits. Embree and the native kd-tree share this logic and only differ in
- * ``RayScalar`` precision.
+ * unused, unused }. The owning `ShapePtr` comes from ``registry_ids``,
+ * gathered by the top-level shape index.
  */
 template <typename Float, typename Spectrum, typename RayScalar>
 auto decode_cpu_llvm_pi(
@@ -50,16 +48,10 @@ auto decode_cpu_llvm_pi(
     pi.t           = Float(RayScalar::steal(out[1]));
     pi.prim_uv     = Vector2f(RayScalar::steal(out[2]), RayScalar::steal(out[3]));
     pi.prim_index  = UInt32::steal(out[4]);
-    pi.shape_index = UInt32::steal(out[5]);
-
-    UInt32 inst_index = UInt32::steal(out[6]);
-    Mask hit_inst = Mask::steal(out[7]);
-    UInt32 index = dr::select(hit_inst, inst_index, pi.shape_index);
-
-    ShapePtr shape = dr::gather<UInt32>(registry_ids, index, pi.valid);
-
-    pi.instance = shape & hit_inst;
-    pi.shape    = shape & !hit_inst;
+    pi.shape       = dr::gather<UInt32>(registry_ids, UInt32::steal(out[5]),
+                                        pi.valid);
+    UInt32::steal(out[6]);
+    Mask::steal(out[7]);
 
     return pi;
 }

--- a/src/render/integrator.cpp
+++ b/src/render/integrator.cpp
@@ -115,8 +115,8 @@ Integrator<Float, Spectrum>::skip_area_emitters(const Scene *scene,
         [&scene, coherent](LoopState &ls) {
             ls.pi = scene->ray_intersect_preliminary(ls.ray, coherent);
             ls.active &= ls.pi.is_valid() && (ls.pi.shape->emitter() != nullptr);
-            SurfaceInteraction3f si = ls.pi.compute_surface_interaction(
-                ls.ray, +RayFlags::Minimal, ls.active);
+            SurfaceInteraction3f si = scene->compute_surface_interaction(
+                ls.ray, ls.pi, +RayFlags::Minimal, ls.active);
             ls.ray = si.spawn_ray(ls.ray.d);
         });
 

--- a/src/render/mesh.cpp
+++ b/src/render/mesh.cpp
@@ -1755,7 +1755,7 @@ Mesh<Float, Spectrum>::eval_parameterization(const Point2f &uv,
         return dr::zeros<SurfaceInteraction3f>();
 
     SurfaceInteraction3f si =
-        compute_surface_interaction(ray, pi, ray_flags, 0, active);
+        compute_surface_interaction(ray, pi, ray_flags, active);
     si.finalize_surface_interaction(pi, ray, ray_flags, active);
 
     return si;
@@ -2277,15 +2277,10 @@ MI_VARIANT typename Mesh<Float, Spectrum>::SurfaceInteraction3f
 Mesh<Float, Spectrum>::compute_surface_interaction(const Ray3f &ray,
                                                    const PreliminaryIntersection3f &pi,
                                                    uint32_t ray_flags,
-                                                   uint32_t recursion_depth,
                                                    Mask active) const {
     MI_MASK_ARGUMENT(active);
 
     SurfaceInteraction3f si = dr::zeros<SurfaceInteraction3f>();
-
-    // Early exit when tracing isn't necessary
-    if (!m_is_instance && recursion_depth > 0)
-        return si;
 
     constexpr bool IsDiff = dr::is_diff_v<Float>;
     bool detach  = IsDiff && has_flag(ray_flags, RayFlags::DetachShape),
@@ -2466,7 +2461,7 @@ Mesh<Float, Spectrum>::compute_surface_interaction(const Ray3f &ray,
 
     si.prim_index = pi.prim_index;
     si.shape    = this;
-    si.instance = nullptr;
+    si.instance_index = 0;
 
     return si;
 }

--- a/src/render/metal/accel.h
+++ b/src/render/metal/accel.h
@@ -20,11 +20,14 @@ NAMESPACE_BEGIN(mitsuba)
 struct MetalAccelData;
 
 /// Build the lowered scene's acceleration structures (same-kind BLASes plus the
-/// flattened TLAS instances) and register them with Dr.Jit. ``compact`` shrinks
-/// the BLASes after building. Returns the owning `MetalAccelData` and the
-/// scene's JIT variable index (caller-owned), to pass to jit_metal_ray_trace().
+/// flattened TLAS instances) and register them with Dr.Jit. ``user_ids``
+/// supplies each TLAS entry's userID (see scene_metal.inl). ``compact``
+/// shrinks the BLASes after building. Returns the owning `MetalAccelData` and
+/// the scene's JIT variable index (caller-owned), to pass to
+/// jit_metal_ray_trace().
 extern MI_EXPORT_LIB std::pair<MetalAccelData *, uint32_t>
-build_metal_accel(const SceneIR &sd, bool compact);
+build_metal_accel(const SceneIR &sd, const std::vector<uint32_t> &user_ids,
+                  bool compact);
 
 /// Release a scene built with `build_metal_accel()`: drop the JIT variable
 /// reference and free the Metal objects (deferred until no kernel/recording

--- a/src/render/metal_accel.mm
+++ b/src/render/metal_accel.mm
@@ -217,7 +217,8 @@ static void compact_blases(id<MTLDevice> device, id<MTLCommandQueue> queue,
 /// scene variable.
 static std::pair<MetalAccelData *, uint32_t>
 build_impl(const std::vector<BlasEntry> &blases,
-           const std::vector<InstanceEntry> &instances, bool compact) {
+           const std::vector<InstanceEntry> &instances,
+           const std::vector<uint32_t> &user_ids, bool compact) {
     @autoreleasepool {
         id<MTLDevice> device = (__bridge id<MTLDevice>) jit_metal_context();
         id<MTLCommandQueue> queue =
@@ -545,10 +546,9 @@ build_impl(const std::vector<BlasEntry> &blases,
         // ------------------------------------------------------------------
         // Build the TLAS over all instances
         // ------------------------------------------------------------------
-        // userID is recovered on the device as pi.instance: the owning
-        // Instance's registry id, or 0 (a null shape) for a top-level shape,
-        // matching the OptiX backend. [[instance_id]] stays the raw instance
-        // index the IFT lookup table is keyed by.
+        // userID is the entry's base index into the shape recovery table
+        // (see scene_metal.inl). [[instance_id]] is the raw TLAS entry index
+        // the IFT lookup table is keyed by.
         size_t n_inst = instances.size();
         BufferAllocation inst_alloc(
             n_inst * sizeof(MTLAccelerationStructureUserIDInstanceDescriptor),
@@ -574,10 +574,7 @@ build_impl(const std::vector<BlasEntry> &blases,
             d.mask                            = 0xFFu;
             d.intersectionFunctionTableOffset = blas_ift_base[inst.blas_index];
             d.accelerationStructureIndex      = inst.blas_index;
-            d.userID                          =
-                inst.owner_registry_id == SCENE_IR_NO_OWNER
-                    ? 0u
-                    : inst.owner_registry_id;
+            d.userID                          = user_ids[i];
         }
 
         NSMutableArray<id<MTLAccelerationStructure>> *blas_array =
@@ -678,8 +675,9 @@ build_impl(const std::vector<BlasEntry> &blases,
 }
 
 std::pair<MetalAccelData *, uint32_t>
-build_metal_accel(const SceneIR &sd, bool compact) {
-    return build_impl(sd.blases, sd.instances, compact);
+build_metal_accel(const SceneIR &sd, const std::vector<uint32_t> &user_ids,
+                  bool compact) {
+    return build_impl(sd.blases, sd.instances, user_ids, compact);
 }
 
 void release_metal_accel(MetalAccelData *accel, uint32_t scene_index) {

--- a/src/render/optix/accel.cpp
+++ b/src/render/optix/accel.cpp
@@ -377,15 +377,9 @@ void prepare_ias(const SceneIR &sd,
                              ? OPTIX_INSTANCE_FLAG_NONE
                              : OPTIX_INSTANCE_FLAG_DISABLE_TRIANGLE_FACE_CULLING;
 
-        // instanceId is recovered on the device as pi.instance: the owning
-        // Instance's registry id for an instanced hit, or 0 (null) for a
-        // top-level shape.
-        uint32_t instance_id = inst.owner_registry_id == SCENE_IR_NO_OWNER
-                                   ? 0u
-                                   : inst.owner_registry_id;
+        uint32_t instance_id = inst.instance_index;
 
-        // to_world is column-major 3x4 (to_world[col*3 + row]). OptiX wants
-        // row-major 3x4.
+        // to_world is col-major 3x4. OptiX wants row-major 3x4.
         float t[12];
         for (int row = 0; row < 3; ++row)
             for (int col = 0; col < 4; ++col)

--- a/src/render/python/interaction_v.cpp
+++ b/src/render/python/interaction_v.cpp
@@ -51,7 +51,7 @@ MI_PY_EXPORT(SurfaceInteraction) {
         .def_field(SurfaceInteraction3f, duv_dy,        D(SurfaceInteraction, duv_dy))
         .def_field(SurfaceInteraction3f, wi,            D(SurfaceInteraction, wi))
         .def_field(SurfaceInteraction3f, prim_index,    D(SurfaceInteraction, prim_index))
-        .def_field(SurfaceInteraction3f, instance,      "instance"_a.none(), D(SurfaceInteraction, instance))
+        .def_field(SurfaceInteraction3f, instance_index, D(SurfaceInteraction, instance_index))
 
         // Methods
         .def(nb::init<>(), D(SurfaceInteraction, SurfaceInteraction))
@@ -94,7 +94,7 @@ MI_PY_EXPORT(SurfaceInteraction) {
 
     MI_PY_DRJIT_STRUCT(si, SurfaceInteraction3f, t, time, wavelengths, p, n,
                        shape, uv, sh_frame, frame_flipped, dp_du, dp_dv, dn_du,
-                       dn_dv, duv_dx, duv_dy, wi, prim_index, instance)
+                       dn_dv, duv_dx, duv_dy, wi, prim_index, instance_index)
 }
 
 MI_PY_EXPORT(MediumInteraction) {
@@ -138,25 +138,16 @@ MI_PY_EXPORT(PreliminaryIntersection) {
         .def_field(PreliminaryIntersection3f, t,           D(PreliminaryIntersection, t))
         .def_field(PreliminaryIntersection3f, prim_uv,     D(PreliminaryIntersection, prim_uv))
         .def_field(PreliminaryIntersection3f, prim_index,  D(PreliminaryIntersection, prim_index))
-        .def_field(PreliminaryIntersection3f, shape_index, D(PreliminaryIntersection, shape_index))
+        .def_field(PreliminaryIntersection3f, instance_index, D(PreliminaryIntersection, instance_index))
         .def_field(PreliminaryIntersection3f, shape,       D(PreliminaryIntersection, shape))
-        .def_field(PreliminaryIntersection3f, instance,    D(PreliminaryIntersection, instance))
 
         // Methods
         .def(nb::init<>(), D(PreliminaryIntersection, PreliminaryIntersection))
         .def(nb::init<const PreliminaryIntersection3f &>(), "Copy constructor")
         .def("is_valid", &PreliminaryIntersection3f::is_valid, D(PreliminaryIntersection, is_valid))
-        .def("compute_surface_interaction",
-           // GCC 13.2.0 miscompiles the bindings below unless its wrapped in a lambda
-           [](PreliminaryIntersection3f& pi, const Ray3f &&ray, uint32_t ray_flags, Mask active) {
-               return pi.compute_surface_interaction(
-                       std::forward<const Ray3f&>(ray), ray_flags, active);
-           },
-           D(PreliminaryIntersection, compute_surface_interaction),
-           "ray"_a, "ray_flags"_a = +RayFlags::Default, "active"_a = true)
         .def("zero_", &PreliminaryIntersection3f::zero_, D(PreliminaryIntersection, zero))
         .def_repr(PreliminaryIntersection3f);
 
     MI_PY_DRJIT_STRUCT(pi, PreliminaryIntersection3f, valid, t, prim_uv,
-                       prim_index, shape_index, shape, instance);
+                       prim_index, instance_index, shape);
 }

--- a/src/render/python/scene_v.cpp
+++ b/src/render/python/scene_v.cpp
@@ -65,6 +65,12 @@ MI_PY_EXPORT(Scene) {
              nb::overload_cast<const Ray3f &, uint32_t, Mask, bool, UInt32, uint32_t, Mask>(&Scene::ray_intersect, nb::const_),
              "ray"_a, "ray_flags"_a, "coherent"_a, "reorder"_a = false,
              "reorder_hint"_a = 0, "reorder_hint_bits"_a = 0, "active"_a = true, D(Scene, ray_intersect, 3))
+        .def("compute_surface_interaction",
+             &Scene::compute_surface_interaction, "ray"_a, "pi"_a,
+             "ray_flags"_a = +RayFlags::Default, "active"_a = true,
+             D(Scene, compute_surface_interaction))
+        .def("instance", &Scene::instance, "index"_a,
+             nb::rv_policy::reference_internal, D(Scene, instance))
         .def("ray_test",
              nb::overload_cast<const Ray3f &, Mask>(&Scene::ray_test, nb::const_),
              "ray"_a, "active"_a = true, D(Scene, ray_test))

--- a/src/render/python/shape_v.cpp
+++ b/src/render/python/shape_v.cpp
@@ -121,7 +121,7 @@ template <typename Ptr, typename Cls> void bind_shape_generic(Cls &cls) {
                const PreliminaryIntersection3f &pi, uint32_t ray_flags,
                Mask active) {
                 SurfaceInteraction3f si = shape->compute_surface_interaction(
-                    ray, pi, ray_flags, 0, active);
+                    ray, pi, ray_flags, active);
                 si.finalize_surface_interaction(pi, ray, ray_flags, active);
                 return si;
             },

--- a/src/render/scene.cpp
+++ b/src/render/scene.cpp
@@ -53,6 +53,8 @@ MI_VARIANT Scene<Float, Spectrum>::Scene(const Properties &props)
             } else {
                 m_bbox.expand(shape->bbox());
                 m_shapes.push_back(shape);
+                if (shape->is_instance())
+                    m_instances.push_back(shape);
             }
             if (mesh)
                 mesh->set_scene(this);
@@ -93,6 +95,7 @@ MI_VARIANT Scene<Float, Spectrum>::Scene(const Properties &props)
 
     m_accel.init(this, props);
     clear_shapes_dirty();
+    update_instance_transforms();
 
     if (!m_emitters.empty()) {
         // Inform environment emitters etc. about the scene bounds
@@ -100,8 +103,28 @@ MI_VARIANT Scene<Float, Spectrum>::Scene(const Properties &props)
             emitter->set_scene(this);
     }
 
-    m_shapes_dr = dr::load<DynamicBuffer<ShapePtr>>(
-        m_shapes.data(), m_shapes.size());
+    if constexpr (dr::is_jit_v<Float>) {
+        // Mitsuba resolves 1-level instancing directly within the scene
+        // class. Traced calls don't need to ever reach 'instance' and
+        // 'shapegroup' shapes, so we just deregister them from the JIT here.
+        std::unique_ptr<uint32_t[]> ids(new uint32_t[m_shapes.size()]);
+        for (size_t i = 0; i < m_shapes.size(); ++i) {
+            Shape *shape = m_shapes[i];
+            uint32_t index = 0;
+            if (shape->is_instance())
+                shape->unregister();
+            else
+                index = jit_registry_id(shape);
+            ids[i] = index;
+        }
+        for (ShapeGroup *group : m_shapegroups)
+            group->unregister();
+        m_shapes_dr = dr::reinterpret_array<DynamicBuffer<ShapePtr>>(
+            dr::load<DynamicBuffer<UInt32>>(ids.get(), m_shapes.size()));
+    } else {
+        m_shapes_dr = dr::load<DynamicBuffer<ShapePtr>>(
+            m_shapes.data(), m_shapes.size());
+    }
 
     m_emitters_dr = dr::load<DynamicBuffer<EmitterPtr>>(
         m_emitters.data(), m_emitters.size());
@@ -195,6 +218,209 @@ MI_VARIANT Scene<Float, Spectrum>::~Scene() {
 
 // -----------------------------------------------------------------------
 
+/// Stash the 3x4 affine part of a transformation into a flat list
+template <typename Value, typename Transform>
+static void pack_matrix(Value *rec, const Transform &t) {
+    for (size_t col = 0; col < 4; ++col)
+        for (size_t row = 0; row < 3; ++row)
+            rec[col * 3 + row] = t.matrix(row, col);
+}
+
+/// Reassemble a transformation from a flat column-major 3x4 list
+template <typename AffineTransform4f, typename Rec>
+static AffineTransform4f unpack_matrix(const Rec &rec) {
+    using Matrix = typename AffineTransform4f::Matrix;
+    return AffineTransform4f(Matrix(
+        rec[0], rec[3], rec[6], rec[9],
+        rec[1], rec[4], rec[7], rec[10],
+        rec[2], rec[5], rec[8], rec[11],
+        0.f,    0.f,    0.f,    1.f));
+}
+
+MI_VARIANT void Scene<Float, Spectrum>::update_instance_transforms() {
+    // An empty record buffer marks an instance-free scene (the instance list
+    // itself is fixed at construction time)
+    if (m_instances.empty())
+        return;
+
+    // Pack the primal transform data on the host
+    size_t n = m_instances.size();
+    std::unique_ptr<ScalarFloat[]> data(new ScalarFloat[12 * n]);
+    for (size_t i = 0; i < n; ++i)
+        pack_matrix(data.get() + 12 * i, m_instances[i]->scalar_to_world());
+    m_instance_transforms =
+        dr::load<DynamicBuffer<Float>>(data.get(), 12 * n);
+
+    // Overlay the records of differentiated instances so that gradients
+    // flow from the packed buffer back to each instance's ``to_world``.
+    if constexpr (dr::is_diff_v<Float>) {
+        for (size_t i = 0; i < n; ++i) {
+            AffineTransform4f t = m_instances[i]->to_world();
+            if (!dr::grad_enabled(t))
+                continue;
+            dr::Array<Float, 12> rec;
+            pack_matrix(rec.data(), t);
+            dr::scatter(m_instance_transforms, rec, UInt32((uint32_t) i),
+                        true, ReduceMode::NoConflicts);
+        }
+    }
+}
+
+MI_VARIANT typename Scene<Float, Spectrum>::SurfaceInteraction3f
+Scene<Float, Spectrum>::compute_surface_interaction(
+    const Ray3f &ray, const PreliminaryIntersection3f &pi, uint32_t ray_flags,
+    Mask active) const {
+    active &= pi.is_valid();
+    if (dr::none_or<false>(active)) {
+        SurfaceInteraction3f si = dr::zeros<SurfaceInteraction3f>();
+        si.wi = -ray.d;
+        si.wavelengths = ray.wavelengths;
+        return si;
+    }
+
+    ScopedPhase sp(ProfilerPhase::CreateSurfaceInteraction);
+
+    // Instance-free scenes only need the plain leaf-shape call
+    if (m_instance_transforms.size() == 0) {
+        SurfaceInteraction3f si = pi.shape->compute_surface_interaction(
+            ray, pi, ray_flags, active);
+        si.finalize_surface_interaction(pi, ray, ray_flags, active);
+        return si;
+    }
+
+    return compute_surface_interaction_instanced(ray, pi, ray_flags, active);
+}
+
+MI_VARIANT typename Scene<Float, Spectrum>::SurfaceInteraction3f
+Scene<Float, Spectrum>::compute_surface_interaction_instanced(
+    const Ray3f &ray, const PreliminaryIntersection3f &pi, uint32_t ray_flags,
+    Mask active) const {
+    Mask has_inst = active && (pi.instance_index != 0u);
+
+    bool detach_shape = has_flag(ray_flags, RayFlags::DetachShape),
+         follow_shape = has_flag(ray_flags, RayFlags::FollowShape),
+         grad_enabled = dr::grad_enabled(m_instance_transforms);
+
+    // Move instanced lanes' rays into the local frame of their shape
+    // group. Both parameterizations share the same distance value ``t``
+    // because the direction is not re-normalized.
+    auto [ray_l_o, ray_l_d] = dr::if_stmt(
+        std::make_tuple(ray.o, ray.d, pi.instance_index),
+        has_inst,
+
+        [this, detach_shape](const Point3f &o, const Vector3f &d,
+                             const UInt32 &index) {
+            AffineTransform4f to_object =
+                unpack_matrix<AffineTransform4f>(
+                    dr::gather<dr::Array<Float, 12>>(m_instance_transforms,
+                                                     index - 1u)).inverse();
+
+            if constexpr (dr::is_diff_v<Float>) {
+                if (detach_shape)
+                    to_object = dr::detach(to_object);
+            }
+
+            return std::make_pair(Point3f(to_object * o),
+                                  Vector3f(to_object * d));
+        },
+
+        [](const Point3f &o, const Vector3f &d,
+           const UInt32 &) { return std::make_pair(o, d); },
+
+        "Scene::compute_surface_interaction_instanced() [ray transform]");
+
+    Ray3f ray_l = ray;
+    ray_l.o = ray_l_o;
+    ray_l.d = ray_l_d;
+
+    SurfaceInteraction3f si =
+        pi.shape->compute_surface_interaction(ray_l, pi, ray_flags, active);
+
+    si = dr::if_stmt(
+        std::make_tuple(si, ray, pi.instance_index),
+        has_inst,
+
+        [this, ray_flags, detach_shape, follow_shape, grad_enabled](
+            SurfaceInteraction3f si, const Ray3f &ray,
+            const UInt32 &index) {
+            AffineTransform4f to_world =
+                unpack_matrix<AffineTransform4f>(
+                    dr::gather<dr::Array<Float, 12>>(m_instance_transforms, index - 1u));
+            if constexpr (dr::is_diff_v<Float>) {
+                if (detach_shape)
+                    to_world = dr::detach(to_world);
+            }
+
+            AffineTransform4f to_world_d = dr::detach(to_world);
+
+            // Hit point `si.p` is only attached to the surface motion
+            si.p = to_world * si.p;
+            si.n = dr::normalize(to_world_d * si.n);
+
+            if (likely(has_flag(ray_flags, RayFlags::Shading))) {
+                // Transforming a normal applies the inverse transpose,
+                // which does not preserve its length. Differentiating the
+                // re-normalization projects the transformed partials back
+                // onto the tangent plane.
+                Normal3f n = to_world_d * si.sh_frame.n;
+                Float inv_len = dr::rcp(dr::norm(n));
+                n *= inv_len;
+                si.sh_frame.n = n;
+
+                if (has_flag(ray_flags, RayFlags::NormalPartials)) {
+                    Vector3f dn_du = to_world_d * Normal3f(si.dn_du) * inv_len,
+                             dn_dv = to_world_d * Normal3f(si.dn_dv) * inv_len;
+
+                    si.dn_du = dr::fnmadd(n, dr::dot(n, dn_du), dn_du);
+                    si.dn_dv = dr::fnmadd(n, dr::dot(n, dn_dv), dn_dv);
+                }
+
+                // A tangent direction supplied by the nested shape
+                // transforms along; finalize_surface_interaction()
+                // orthonormalizes it against the transformed normal and
+                // derives the bitangent. A mirroring instance transform
+                // flips the orientation of the nested parameterization.
+                si.sh_frame.s = to_world_d * si.sh_frame.s;
+                si.frame_flipped ^=
+                    dr::det(Matrix3f(to_world_d.matrix)) < 0.f;
+
+                si.dp_du = to_world * si.dp_du;
+                si.dp_dv = to_world * si.dp_dv;
+            }
+
+            if constexpr (dr::is_diff_v<Float>) {
+                if (follow_shape && grad_enabled) {
+                    // Recompute si.t in a differential manner as the
+                    // distance between the ray origin and the hit point
+                    // following the moving surface.
+                    si.t = dr::sqrt(dr::squared_norm(si.p - ray.o) /
+                                    dr::squared_norm(ray.d));
+                } else if (!follow_shape && grad_enabled) {
+                    // Differential recomputation of the intersection of
+                    // the ray with the moving plane tangent to the hit
+                    // point. In this scenario, it is important that
+                    // `si.p` stays along the ray as the surface moves.
+                    si.t = (dr::dot(si.n, si.p) - dr::dot(si.n, ray.o)) /
+                            dr::dot(si.n, ray.d);
+                    si.p = ray(si.t);
+                }
+            }
+
+            return si;
+        },
+
+        [](SurfaceInteraction3f si, const Ray3f &,
+           const UInt32 &) { return si; },
+
+        "Scene::compute_surface_interaction_instanced() [world transform]");
+
+    si.instance_index = pi.instance_index;
+
+    si.finalize_surface_interaction(pi, ray, ray_flags, active);
+    return si;
+}
+
+
 MI_VARIANT typename Scene<Float, Spectrum>::SurfaceInteraction3f
 Scene<Float, Spectrum>::ray_intersect(const Ray3f &ray, uint32_t ray_flags,
                                       Mask coherent, bool reorder,
@@ -211,7 +437,7 @@ Scene<Float, Spectrum>::ray_intersect(const Ray3f &ray, uint32_t ray_flags,
     // SurfaceInteraction. This composition is backend-independent.
     PreliminaryIntersection3f pi = m_accel.ray_intersect_preliminary(
         this, ray, coherent, reorder, reorder_hint, reorder_hint_bits, active);
-    return pi.compute_surface_interaction(ray, ray_flags, active);
+    return compute_surface_interaction(ray, pi, ray_flags, active);
 }
 
 MI_VARIANT typename Scene<Float, Spectrum>::PreliminaryIntersection3f
@@ -547,6 +773,7 @@ MI_VARIANT void Scene<Float, Spectrum>::parameters_changed(const std::vector<std
     if (accel_is_dirty) {
         m_accel.rebuild(this);
         clear_shapes_dirty();
+        update_instance_transforms();
 
         m_bbox = {};
         for (auto &s : m_shapes)

--- a/src/render/scene_embree.inl
+++ b/src/render/scene_embree.inl
@@ -149,6 +149,7 @@ embree_make_geometry(RTCDevice device, const Shape<Float, Spectrum> *shape,
                 rtcSetGeometryIntersectFilterFunction(geom, embree_backface_cull);
                 rtcSetGeometryOccludedFilterFunction(geom, embree_backface_cull);
             }
+            rtcSetGeometryUserData(geom, (void *) shape);
             rtcCommitGeometry(geom);
             return geom;
         }
@@ -165,6 +166,7 @@ embree_make_geometry(RTCDevice device, const Shape<Float, Spectrum> *shape,
             rtcSetSharedGeometryBuffer(geom, RTC_BUFFER_TYPE_INDEX, 0,
                                        RTC_FORMAT_UINT, g.seg_ptr, 0,
                                        sizeof(uint32_t), g.seg_count);
+            rtcSetGeometryUserData(geom, (void *) shape);
             rtcCommitGeometry(geom);
             return geom;
         }
@@ -183,6 +185,8 @@ embree_make_geometry(RTCDevice device, const Shape<Float, Spectrum> *shape,
                 M[col * 4 + 3] = (col == 3) ? 1.f : 0.f;
             }
             rtcSetGeometryTransform(inst, 0, RTC_FORMAT_FLOAT4X4_COLUMN_MAJOR, M);
+            // Scalar-mode hits resolve nested geometry through the group
+            rtcSetGeometryUserData(inst, (void *) g.group_id);
             rtcCommitGeometry(inst);
             return inst;
         }
@@ -231,9 +235,6 @@ void EmbreeAccel<Float, Spectrum>::init(Scene<Float, Spectrum> *scene,
 
     Log(Info, "Embree ready. (took %s)",
         util::time_string((float) timer.value()));
-
-    if constexpr (dr::is_llvm_v<Float>)
-        shapes_registry_ids = build_registry_ids<Float, Spectrum>(scene->m_shapes);
 }
 
 template <typename Float, typename Spectrum>
@@ -242,7 +243,7 @@ void EmbreeAccel<Float, Spectrum>::rebuild(
     if constexpr (dr::is_llvm_v<Float>)
         dr::sync_thread();
 
-    for (int geo : geometries)
+    for (unsigned int geo : geometries)
         rtcDetachGeometry(accel, geo);
     geometries.clear();
 
@@ -259,7 +260,13 @@ void EmbreeAccel<Float, Spectrum>::rebuild(
         for (const ref<Shape> &child : group->shapes()) {
             RTCGeometry cg = embree_make_geometry<Float, Spectrum>(
                 embree_device, child.get(), group_scenes);
-            rtcAttachGeometry(nested, cg);
+            if constexpr (dr::is_llvm_v<Float>)
+                // The child's registry id doubles as its geometry ID, so a
+                // nested hit directly reports the child shape
+                rtcAttachGeometryByID(nested, cg,
+                                      jit_registry_id(child.get()));
+            else
+                rtcAttachGeometry(nested, cg);
             rtcReleaseGeometry(cg);
         }
         // Publish the uncommitted nested scene for top-level Instances.
@@ -267,10 +274,27 @@ void EmbreeAccel<Float, Spectrum>::rebuild(
         nested_scenes.push_back(nested);
     }
 
+    // Attach top-level geometry using the explicit ID scheme described in
+    // accel_embree.h
+    instance_count = 0;
+    for (Shape *shape : scene->m_shapes)
+        instance_count += shape->is_instance() ? 1 : 0;
+
+    uint32_t instance_index = 0, scalar_id = instance_count;
     for (Shape *shape : scene->m_shapes) {
         RTCGeometry geom = embree_make_geometry<Float, Spectrum>(
             embree_device, shape, group_scenes);
-        geometries.push_back(rtcAttachGeometry(accel, geom));
+        unsigned int id;
+        if (shape->is_instance()) {
+            id = instance_index++;
+        } else {
+            if constexpr (dr::is_llvm_v<Float>)
+                id = instance_count + jit_registry_id(shape);
+            else
+                id = scalar_id++;
+        }
+        rtcAttachGeometryByID(accel, geom, id);
+        geometries.push_back(id);
         rtcReleaseGeometry(geom);
     }
 
@@ -400,27 +424,27 @@ EmbreeAccel<Float, Spectrum>::ray_intersect_preliminary(
         rtcIntersect1(accel, &context, &rh);
 
         if (rh.hit.geomID != RTC_INVALID_GEOMETRY_ID) {
-            uint32_t shape_index = rh.hit.geomID;
-            uint32_t prim_index  = rh.hit.primID;
+            uint32_t geom_id = rh.hit.geomID;
 
             // We get level 0 because we only support one level of instancing
             uint32_t inst_index = rh.hit.instID[0];
 
-            // If the hit is not on an instance
-            bool hit_instance = inst_index != RTC_INVALID_GEOMETRY_ID;
-            uint32_t index = hit_instance ? inst_index : shape_index;
-
-            ShapePtr shape = scene->m_shapes[index];
-            if (hit_instance)
-                pi.instance = shape;
-            else
-                pi.shape = shape;
+            if (inst_index != RTC_INVALID_GEOMETRY_ID) {
+                // Instanced hit: the top-level ID is the instance index, and
+                // the nested geometry ID identifies the leaf child within the
+                // shape group (positional attachment order)
+                const auto *group = (const ShapeGroup<Float, Spectrum> *)
+                    rtcGetGeometryUserData(rtcGetGeometry(accel, inst_index));
+                pi.shape = group->shapes()[geom_id].get();
+                pi.instance_index = inst_index + 1;
+            } else {
+                pi.shape = (const Shape *) rtcGetGeometryUserData(
+                    rtcGetGeometry(accel, geom_id));
+            }
 
             pi.valid = true;
-            pi.shape_index = shape_index;
-
             pi.t = rh.ray.tfar;
-            pi.prim_index = prim_index;
+            pi.prim_index = rh.hit.primID;
             pi.prim_uv = Point2f(rh.hit.u, rh.hit.v);
         }
 
@@ -436,8 +460,33 @@ EmbreeAccel<Float, Spectrum>::ray_intersect_preliminary(
                                   0, out);
 
         // Embree traces in float32, so the hit fields are stolen as ``Single``.
-        return decode_cpu_llvm_pi<Float, Spectrum, Single>(out,
-                                                           shapes_registry_ids);
+        PreliminaryIntersection3f pi;
+        pi.valid      = Mask::steal(out[0]);
+        pi.t          = Float(Single::steal(out[1]));
+        pi.prim_uv    = Vector2f(Single::steal(out[2]), Single::steal(out[3]));
+        pi.prim_index = UInt32::steal(out[4]);
+
+        UInt32 geom_id    = UInt32::steal(out[5]),
+               inst_index = UInt32::steal(out[6]);
+        Mask hit_inst = Mask::steal(out[7]);
+
+        // Undo the geometry ID encoding (see accel_embree.h). The shape
+        // pointer of missed lanes must be masked (stale IDs would index
+        // dispatch tables out of bounds). ``inst_index`` is -1 unless the
+        // lane has an instanced hit; adding 1 therefore needs no mask.
+        if (instance_count > 0) {
+            UInt32 shape_id =
+                dr::select(hit_inst, geom_id, geom_id - instance_count);
+            pi.shape = dr::reinterpret_array<ShapePtr, UInt32>(
+                dr::select(pi.valid, shape_id, 0u));
+            pi.instance_index = inst_index + 1u;
+        } else {
+            pi.shape = dr::reinterpret_array<ShapePtr, UInt32>(
+                dr::select(pi.valid, geom_id, 0u));
+            pi.instance_index = dr::zeros<UInt32>();
+        }
+
+        return pi;
     } else {
         DRJIT_MARK_USED(ray);
         DRJIT_MARK_USED(coherent);

--- a/src/render/scene_ir.cpp
+++ b/src/render/scene_ir.cpp
@@ -76,12 +76,16 @@ SceneIR SceneIRBuilder<Float, Spectrum>::build(Scene<Float, Spectrum> *scene) {
         sd.instances.push_back(e);
     }
     // ...then, per Instance shape, one instance per BLAS of its ShapeGroup.
+    // ``inst_shapes`` preserves the order of appearance in the scene's shape
+    // list, so the running index below matches the numbering used by
+    // Scene::update_instance_transforms().
+    uint32_t instance_index = 0;
     for (const ShapeIR &inst : inst_shapes) {
-        uint32_t owner = jit_registry_id(inst.ctx);
+        ++instance_index;
         for (uint32_t bi : sd.group_blases[group_index.at(inst.group_id)]) {
             InstanceEntry e;
             e.blas_index = bi;
-            e.owner_registry_id = owner;
+            e.instance_index = instance_index;
             for (int k = 0; k < 12; ++k)
                 e.to_world[k] = inst.to_world[k];
             sd.instances.push_back(e);

--- a/src/render/scene_metal.inl
+++ b/src/render/scene_metal.inl
@@ -14,19 +14,25 @@
 
 NAMESPACE_BEGIN(mitsuba)
 
-/// Build the raw recovery tables that resolve \c pi.shape from a Metal hit.
-/// The trace reports raw instance and geometry indices. The offset table maps
-/// the pair into the shape-id table.
-static void build_recovery_table_data(const SceneIR &sd,
-                                      std::vector<uint32_t> &offsets,
+/// Build the recovery table that resolves a Metal hit into \c pi.shape. The
+/// record index is the TLAS entry's userID (returned via \c user_ids) plus
+/// the hit's geometry ID. Records are (shape id, instance index) pairs when
+/// the scene contains instances, plain shape ids otherwise.
+static void build_recovery_table_data(const SceneIR &sd, bool has_instances,
+                                      std::vector<uint32_t> &user_ids,
                                       std::vector<uint32_t> &table) {
-    offsets.clear();
+    user_ids.clear();
     table.clear();
-    offsets.reserve(sd.instances.size());
+    user_ids.reserve(sd.instances.size());
+    uint32_t cursor = 0;
     for (const InstanceEntry &inst : sd.instances) {
-        offsets.push_back((uint32_t) table.size());
-        for (const ShapeIR &g : sd.blases[inst.blas_index].geoms)
+        user_ids.push_back(cursor);
+        for (const ShapeIR &g : sd.blases[inst.blas_index].geoms) {
             table.push_back(jit_registry_id(g.ctx));
+            if (has_instances)
+                table.push_back(inst.instance_index);
+            cursor++;
+        }
     }
 }
 
@@ -44,16 +50,18 @@ void MetalAccel<Float, Spectrum>::init(Scene<Float, Spectrum> *scene,
         return;
     }
 
-    std::vector<uint32_t> offsets, table;
-    build_recovery_table_data(sd, offsets, table);
+    has_instances = false;
+    for (const InstanceEntry &inst : sd.instances)
+        has_instances |= inst.instance_index != 0;
+
+    std::vector<uint32_t> user_ids, table;
+    build_recovery_table_data(sd, has_instances, user_ids, table);
     using UInt32 = dr::uint32_array_t<Float>;
-    geom_shape_offsets =
-        dr::load<DynamicBuffer<UInt32>>(offsets.data(), offsets.size());
     geom_shape_table =
         dr::load<DynamicBuffer<UInt32>>(table.data(), table.size());
 
     std::tie(accel, scene_index) =
-        build_metal_accel(sd, scene->compact_accel());
+        build_metal_accel(sd, user_ids, scene->compact_accel());
 
     accel_handle = UInt64::steal(jit_metal_scene_owner_handle(scene_index));
 }
@@ -128,22 +136,23 @@ MetalAccel<Float, Spectrum>::ray_intersect_preliminary(
                             Float(Single::steal(out[3])));
     pi.prim_index = UInt32::steal(out[5]);
 
-    UInt32 instance_id = UInt32::steal(out[4]);
+    UInt32::steal(out[4]); // raw TLAS entry index, unused
     UInt32 geometry_id = UInt32::steal(out[6]);
+    UInt32 user_id     = UInt32::steal(out[7]);
 
-    // The hit shape's registry id is the (instance, geometry) entry of the
-    // recovery table, so pi.shape names the actual child for every hit. The
-    // gathers are masked, so missed lanes read 0 (a null shape).
-    UInt32 off      = dr::gather<UInt32>(geom_shape_offsets, instance_id, valid);
-    UInt32 shape_id = dr::gather<UInt32>(geom_shape_table, off + geometry_id,
-                                         valid);
-    pi.shape = dr::reinterpret_array<ShapePtr, UInt32>(shape_id);
-
-    // userID is the owning Instance's registry id, or 0 (a null shape) for a
-    // top-level hit. Missed lanes read 0 too. Consecutive TLAS instances of one
-    // ShapeGroup (one per BLAS) share a userID, which is correct.
-    UInt32 user_id = dr::select(valid, UInt32::steal(out[7]), dr::zeros<UInt32>());
-    pi.instance = dr::reinterpret_array<ShapePtr, UInt32>(user_id);
+    // Recover the hit shape (and instance index, if instanced) from the
+    // record at userID + geometry ID. The masked gather leaves missed lanes
+    // with a null shape.
+    UInt32 index = user_id + geometry_id;
+    if (has_instances) {
+        dr::Array<UInt32, 2> rec =
+            dr::gather<dr::Array<UInt32, 2>>(geom_shape_table, index, valid);
+        pi.shape = dr::reinterpret_array<ShapePtr, UInt32>(rec[0]);
+        pi.instance_index = rec[1];
+    } else {
+        UInt32 shape_id = dr::gather<UInt32>(geom_shape_table, index, valid);
+        pi.shape = dr::reinterpret_array<ShapePtr, UInt32>(shape_id);
+    }
 
     return pi;
 }

--- a/src/render/scene_native.inl
+++ b/src/render/scene_native.inl
@@ -17,9 +17,6 @@ void NativeAccel<Float, Spectrum>::init(Scene<Float, Spectrum> *scene,
     accel = new ShapeKDTree<Float, Spectrum>(props);
     accel->inc_ref();
 
-    if constexpr (dr::is_llvm_v<Float>)
-        shapes_registry_ids = build_registry_ids<Float, Spectrum>(scene->m_shapes);
-
     rebuild(scene);
 }
 
@@ -31,10 +28,19 @@ void NativeAccel<Float, Spectrum>::rebuild(
         dr::sync_thread();
 
     accel->clear();
-    for (Shape *shape : scene->m_shapes)
+    for (Shape *shape : scene->m_shapes) {
+        if (shape->is_instance())
+            Throw("The native kd-tree acceleration structure does not "
+                  "support instancing. Rebuild Mitsuba with Embree enabled "
+                  "to render scenes containing 'instance' shapes.");
         accel->add_shape(shape);
+    }
     ScopedPhase phase(ProfilerPhase::InitAccel);
     accel->build();
+
+    if constexpr (dr::is_llvm_v<Float>)
+        shapes_registry_ids =
+            build_registry_ids<Float, Spectrum>(scene->m_shapes);
 
     // The kd-tree is rebuilt in place, so initialize the handles only once.
     // The cleanup callback keeps it alive until pending ray-tracing kernels
@@ -149,15 +155,13 @@ void kdtree_trace_func_wrapper(const int *valid, void *ptr,
                 ScalarFloat& prim_v = ((ScalarFloat*) &args[offsetof(RayHit, v) * Width])[i];
                 uint32_t& prim_id = ((uint32_t*) &args[offsetof(RayHit, prim_id) * Width])[i];
                 uint32_t& geom_id = ((uint32_t*) &args[offsetof(RayHit, geom_id) * Width])[i];
-                uint32_t& inst_id = ((uint32_t*) &args[offsetof(RayHit, inst_id) * Width])[i];
 
+                // inst_id keeps the -1 ("not instanced") written by the trace
                 ray_maxt  = pi.t;
                 prim_u = pi.prim_uv[0];
                 prim_v = pi.prim_uv[1];
                 prim_id = pi.prim_index;
-                geom_id = pi.shape_index;
-                inst_id = pi.instance ? (uint32_t) (size_t) pi.shape
-                                      : (uint32_t) -1;
+                geom_id = pi.instance_index; // top-level shape index (see kdtree.h)
             }
         }
     }
@@ -175,7 +179,10 @@ NativeAccel<Float, Spectrum>::ray_intersect_preliminary(
     Mask active) const {
     if constexpr (!dr::is_array_v<Float>) {
         DRJIT_MARK_USED(coherent);
-        return accel->template ray_intersect_preliminary<false>(ray, active);
+        auto pi = accel->template ray_intersect_preliminary<false>(ray, active);
+        // The kd-tree repurposes this field internally (see kdtree.h)
+        pi.instance_index = 0;
+        return pi;
     } else {
         dr::Array<Float, 3> ray_o(ray.o), ray_d(ray.d);
 
@@ -187,8 +194,8 @@ NativeAccel<Float, Spectrum>::ray_intersect_preliminary(
 
         // The kd-tree traces in ``Float`` precision, so the hit fields are
         // stolen at that width.
-        return decode_cpu_llvm_pi<Float, Spectrum, Float>(out,
-                                                          shapes_registry_ids);
+        return decode_cpu_llvm_pi<Float, Spectrum, Float>(
+            out, shapes_registry_ids);
     }
 }
 
@@ -218,12 +225,13 @@ NativeAccel<Float, Spectrum>::ray_test(const Scene<Float, Spectrum> * /*scene*/,
 template <typename Float, typename Spectrum>
 typename NativeAccel<Float, Spectrum>::SurfaceInteraction3f
 NativeAccel<Float, Spectrum>::ray_intersect_naive(
-    const Scene<Float, Spectrum> * /*scene*/, const Ray3f &ray,
+    const Scene<Float, Spectrum> *scene, const Ray3f &ray,
     Mask active) const {
     PreliminaryIntersection3f pi =
         accel->template ray_intersect_naive<false>(ray, active);
 
-    return pi.compute_surface_interaction(ray, +RayFlags::Default, active);
+    return scene->compute_surface_interaction(ray, pi, +RayFlags::Default,
+                                              active);
 }
 
 NAMESPACE_END(mitsuba)

--- a/src/render/scene_optix.inl
+++ b/src/render/scene_optix.inl
@@ -741,10 +741,11 @@ OptixAccel<Float, Spectrum>::ray_intersect_preliminary(
     pi.prim_uv[1] = dr::reinterpret_array<Single, UInt32>(UInt32::steal(hitobject_out[3]));
     pi.prim_index = UInt32::steal(hitobject_out[4]);
     pi.shape      = dr::reinterpret_array<ShapePtr, UInt32>(UInt32::steal(shape_id_idx));
-    pi.instance   = has_instances ? ShapePtr::steal(hitobject_out[6]) : dr::zeros<ShapePtr>();
-
-    // This field is only used by embree, but we still need to initialize it for vcalls
-    pi.shape_index = dr::zeros<UInt32>();
+    // Missed/masked lanes carry a nop hit object, whose instance id query
+    // reports zero
+    pi.instance_index = has_instances
+        ? UInt32::steal(hitobject_out[6])
+        : dr::zeros<UInt32>();
 
     return pi;
 }

--- a/src/render/shape.cpp
+++ b/src/render/shape.cpp
@@ -1,5 +1,6 @@
 #include <mitsuba/core/properties.h>
 #include <mitsuba/render/mesh.h>
+#include <mitsuba/render/scene.h>
 #include <mitsuba/render/scene_ir.h>
 #include <mitsuba/render/emitter.h>
 #include <mitsuba/render/bsdf.h>
@@ -228,7 +229,6 @@ MI_VARIANT typename Shape<Float, Spectrum>::SurfaceInteraction3f
 Shape<Float, Spectrum>::compute_surface_interaction(const Ray3f & /*ray*/,
                                                     const PreliminaryIntersection3f &/*pi*/,
                                                     uint32_t /*ray_flags*/,
-                                                    uint32_t /*recursion_depth*/,
                                                     Mask /*active*/) const {
     NotImplementedError("compute_surface_interaction");
 }
@@ -236,8 +236,22 @@ Shape<Float, Spectrum>::compute_surface_interaction(const Ray3f & /*ray*/,
 MI_VARIANT typename Shape<Float, Spectrum>::SurfaceInteraction3f
 Shape<Float, Spectrum>::ray_intersect(const Ray3f &ray, uint32_t ray_flags, Mask active) const {
     MI_MASK_ARGUMENT(active);
-    auto pi = ray_intersect_preliminary(ray, 0, active);
-    return pi.compute_surface_interaction(ray, ray_flags, active);
+    PreliminaryIntersection3f pi = ray_intersect_preliminary(ray, 0, active);
+
+    active &= pi.is_valid();
+    if (dr::none_or<false>(active)) {
+        SurfaceInteraction3f si = dr::zeros<SurfaceInteraction3f>();
+        si.wi = -ray.d;
+        si.wavelengths = ray.wavelengths;
+        return si;
+    }
+
+    // Route through the ShapePtr so that JIT variants trace the call like
+    // any other hit expansion
+    SurfaceInteraction3f si =
+        pi.shape->compute_surface_interaction(ray, pi, ray_flags, active);
+    si.finalize_surface_interaction(pi, ray, ray_flags, active);
+    return si;
 }
 
 MI_VARIANT void

--- a/src/render/shapegroup.cpp
+++ b/src/render/shapegroup.cpp
@@ -52,17 +52,6 @@ MI_VARIANT ShapeGroup<Float, Spectrum>::ShapeGroup(const Properties &props)
     }
 #endif
 
-#if defined(MI_ENABLE_LLVM) || defined(MI_ENABLE_METAL)
-    if constexpr (dr::is_llvm_v<Float> || dr::is_metal_v<Float>) {
-        // Get shapes registry ids
-        std::unique_ptr<uint32_t[]> data(new uint32_t[m_shapes.size()]);
-        for (size_t i = 0; i < m_shapes.size(); i++)
-            data[i] = jit_registry_id(m_shapes[i]);
-        m_shapes_registry_ids =
-            dr::load<DynamicBuffer<UInt32>>(data.get(), m_shapes.size());
-    }
-#endif
-
     // Initialize gradient enabled cache
     m_parameters_grad_enabled_cache = false;
     for (auto s : m_shapes) {
@@ -101,37 +90,6 @@ MI_VARIANT void ShapeGroup<Float, Spectrum>::parameters_changed(const std::vecto
 }
 
 
-MI_VARIANT typename ShapeGroup<Float, Spectrum>::SurfaceInteraction3f
-ShapeGroup<Float, Spectrum>::compute_surface_interaction(const Ray3f &ray,
-                                                         const PreliminaryIntersection3f &pi,
-                                                         uint32_t ray_flags,
-                                                         uint32_t recursion_depth,
-                                                         Mask active) const {
-    MI_MASK_ARGUMENT(active);
-
-    if (recursion_depth > 0)
-        return dr::zeros<SurfaceInteraction3f>();
-
-    ShapePtr shape = pi.shape;
-
-    // OptiX and Metal recover the hit child shape directly: ``pi.shape`` is set
-    // per-geometry (from the SBT record / the Metal geom_shape table), so it
-    // already names the actual child. The scalar and LLVM/Embree backends instead
-    // resolve it from a within-group leaf index (``pi.shape_index``).
-    if constexpr (!dr::is_cuda_v<Float> && !dr::is_metal_v<Float>) {
-        if constexpr (!dr::is_array_v<Float>) {
-            Assert(pi.shape_index < m_shapes.size());
-            shape = m_shapes[pi.shape_index];
-        } else {
-#if defined(MI_ENABLE_LLVM)
-            shape = dr::gather<UInt32>(m_shapes_registry_ids, pi.shape_index, active);
-#endif
-        }
-    }
-
-    return shape->compute_surface_interaction(ray, pi, ray_flags, 1, active);
-}
-
 MI_VARIANT typename ShapeGroup<Float, Spectrum>::ScalarSize
 ShapeGroup<Float, Spectrum>::primitive_count() const {
 #if !defined(MI_ENABLE_EMBREE)
@@ -155,7 +113,9 @@ std::tuple<bool,
            typename ShapeGroup<Float, Spectrum>::ScalarUInt32>
 ShapeGroup<Float, Spectrum>::ray_intersect_preliminary_scalar(const ScalarRay3f &ray) const {
     auto pi = m_kdtree->template ray_intersect_scalar<false>(ray);
-    return { pi.valid, pi.t, pi.prim_uv, pi.shape_index, pi.prim_index };
+    // The kd-tree repurposes ``instance_index`` to report the index of the
+    // hit child shape (see kdtree.h)
+    return { pi.valid, pi.t, pi.prim_uv, pi.instance_index, pi.prim_index };
 }
 
 MI_VARIANT

--- a/src/render/tests/test_interaction.py
+++ b/src/render/tests/test_interaction.py
@@ -34,7 +34,7 @@ def test02_intersection_construction(variant_scalar_rgb):
     si.duv_dy = [26, 27]
     si.wi = [31, 32, 33]
     si.prim_index = 34
-    si.instance = None
+    si.instance_index = 0
     assert si.sh_frame == mi.Frame3f([9, 10, 11], [12, 13, 14], [15, 16, 17])
 
     assert repr(si).strip() == """SurfaceInteraction[
@@ -59,7 +59,7 @@ def test02_intersection_construction(variant_scalar_rgb):
   duv_dy=[26, 27],
   wi=[31, 32, 33],
   prim_index=34,
-  instance=0x0
+  instance_index=0
 ]"""
 
 

--- a/src/render/tests/test_mesh_ad.py
+++ b/src/render/tests/test_mesh_ad.py
@@ -37,19 +37,19 @@ def test01_attach_automatic(variants_all_ad_rgb):
     pi = scene.ray_intersect_preliminary(ray, coherent=True)
 
     # Not attached if not necessary
-    si = pi.compute_surface_interaction(ray)
+    si = scene.compute_surface_interaction(ray, pi)
     assert not dr.grad_enabled(si.t)
     assert not dr.grad_enabled(si.p)
 
     # Attached if the ray is attached
     dr.enable_grad(ray.o)
-    si = pi.compute_surface_interaction(ray)
+    si = scene.compute_surface_interaction(ray, pi)
     assert dr.grad_enabled(si.t)
     assert dr.grad_enabled(si.p)
     assert not dr.grad_enabled(si.n)  # face normal does not depend on the ray
 
     # Still attached to the ray under DetachShape
-    si = pi.compute_surface_interaction(ray,
+    si = scene.compute_surface_interaction(ray, pi,
                                         mi.RayFlags.Default |
                                         mi.RayFlags.DetachShape)
     assert dr.grad_enabled(si.p)
@@ -67,7 +67,7 @@ def test01_attach_automatic(variants_all_ad_rgb):
         assert shape.parameters_grad_enabled() == expected
 
     dr.disable_grad(ray.o)
-    si = pi.compute_surface_interaction(ray)
+    si = scene.compute_surface_interaction(ray, pi)
     assert dr.grad_enabled(si.t)
     assert dr.grad_enabled(si.p)
 
@@ -91,7 +91,7 @@ def test02_ray_derivatives(variants_all_ad_rgb):
             (ray.o.z, lambda si: si.t, -1),
             # Tilting the direction along x moves si.p by the flight distance
             (ray.d.x, lambda si: si.p, [10, 0, 0])]:
-        si = pi.compute_surface_interaction(ray)
+        si = scene.compute_surface_interaction(ray, pi)
         dr.forward(param)
         dr.assert_allclose(dr.grad(field(si)), expected)
 
@@ -99,7 +99,7 @@ def test02_ray_derivatives(variants_all_ad_rgb):
     for output, expected in [(lambda si: si.p.x, [1, 0, 0]),
                              (lambda si: si.t, [0, 0, -1])]:
         dr.set_grad(ray.o, 0.0)
-        si = pi.compute_surface_interaction(ray)
+        si = scene.compute_surface_interaction(ray, pi)
         dr.backward(output(si))
         dr.assert_allclose(dr.grad(ray.o), expected)
 
@@ -126,7 +126,7 @@ def test03_params_forward(variants_all_ad_rgb):
 
     # A translation along z moves si.t and si.p
     apply_transformation(lambda v: mi.Transform4f().translate(v))
-    si = pi.compute_surface_interaction(ray)
+    si = scene.compute_surface_interaction(ray, pi)
     dr.forward(diff_vector.z)
     dr.assert_allclose(dr.grad(si.t), 1)
     dr.assert_allclose(dr.grad(si.p), [0, 0, 1])
@@ -135,7 +135,7 @@ def test03_params_forward(variants_all_ad_rgb):
     # opposite direction
     for axis, uv_grad in [('x', [-0.5, 0]), ('y', [0, -0.5])]:
         apply_transformation(lambda v: mi.Transform4f().translate(v))
-        si = pi.compute_surface_interaction(ray)
+        si = scene.compute_surface_interaction(ray, pi)
         dr.forward(getattr(diff_vector, axis))
         dr.assert_allclose(dr.grad(si.uv), uv_grad, atol=1e-6)
 
@@ -145,7 +145,7 @@ def test03_params_forward(variants_all_ad_rgb):
     pi = scene.ray_intersect_preliminary(ray, coherent=True)
 
     apply_transformation(lambda v: mi.Transform4f().rotate([0, 0, 1], v.x))
-    si = pi.compute_surface_interaction(ray)
+    si = scene.compute_surface_interaction(ray, pi)
     dr.forward(diff_vector.x)
     du = 0.5 * dr.sin(2 * dr.pi / 360.0)
     dr.assert_allclose(dr.grad(si.uv), [-du, du], atol=1e-6)
@@ -174,7 +174,7 @@ def test04_params_backward(variants_all_ad_rgb):
         params.set_dirty(pos_key)
         params.set_dirty(uv_key)
         params.update()
-        return pi.compute_surface_interaction(ray)
+        return scene.compute_surface_interaction(ray, pi)
 
     # (output, expected positions gradient)
     pos_cases = [
@@ -254,12 +254,12 @@ def test05_follow_and_detach_shape(variants_all_ad_rgb):
     ]
     for flags, p_grad, uv_grad in cases:
         apply_translation()
-        si = pi.compute_surface_interaction(ray, flags)
+        si = scene.compute_surface_interaction(ray, pi, flags)
         dr.forward(diff_vector.x)
         dr.assert_allclose(dr.grad(si.p), p_grad, atol=1e-5)
 
         apply_translation()
-        si = pi.compute_surface_interaction(ray, flags)
+        si = scene.compute_surface_interaction(ray, pi, flags)
         dr.forward(diff_vector.x)
         dr.assert_allclose(dr.grad(si.uv), uv_grad, atol=1e-5)
 
@@ -267,7 +267,7 @@ def test05_follow_and_detach_shape(variants_all_ad_rgb):
     # what a rectangle that was never attached would have produced
     apply_translation()
     dr.enable_grad(ray.o)
-    si = pi.compute_surface_interaction(ray, mi.RayFlags.Default |
+    si = scene.compute_surface_interaction(ray, pi, mi.RayFlags.Default |
                                         mi.RayFlags.DetachShape)
     dr.forward(ray.o.x)
     dr.assert_allclose(dr.grad(si.p), [1, 0, 0], atol=1e-5)

--- a/src/render/tests/test_mesh_shading.py
+++ b/src/render/tests/test_mesh_shading.py
@@ -39,7 +39,7 @@ def probe(scene, xy, flags=mi.RayFlags.Default):
     dr.eval(pi)
     assert dr.all(pi.is_valid())
     return (int(np.array(pi.prim_index).ravel()[0]), rows(pi.prim_uv, 2).T,
-            pi.compute_surface_interaction(ray, flags), ray)
+            scene.compute_surface_interaction(ray, pi, flags), ray)
 
 
 # -------------------------------------------------------------------

--- a/src/render/tests/test_scene.py
+++ b/src/render/tests/test_scene.py
@@ -358,7 +358,7 @@ def test12_many_top_level_analytic_shapes(variants_vec_backends_once_rgb):
     assert dr.all(si.is_valid())
     dr.assert_allclose(si.p.x, cx, atol=1e-3)
     # Top-level hits carry no instance
-    assert dr.all(si.instance == dr.zeros(mi.ShapePtr))
+    assert dr.all(si.instance_index == 0)
     # The hit shape recovered for ray i must be exactly the i-th shape
     for i in range(n):
         got = dr.gather(mi.ShapePtr, si.shape, mi.UInt32(i))

--- a/src/shapes/bsplinecurve.cpp
+++ b/src/shapes/bsplinecurve.cpp
@@ -395,7 +395,7 @@ public:
         Ray3f ray(o, d, 0, Wavelength(0));
 
         SurfaceInteraction3f si =
-            compute_surface_interaction(ray, pi, ray_flags, 0, active);
+            compute_surface_interaction(ray, pi, ray_flags, active);
         si.finalize_surface_interaction(pi, ray, ray_flags, active);
 
         return si;
@@ -869,14 +869,9 @@ public:
     SurfaceInteraction3f compute_surface_interaction(const Ray3f &ray,
                                                      const PreliminaryIntersection3f &pi,
                                                      uint32_t ray_flags,
-                                                     uint32_t recursion_depth,
                                                      Mask active) const override {
         MI_MASK_ARGUMENT(active);
         constexpr bool IsDiff = dr::is_diff_v<Float>;
-
-        // Early exit when tracing isn't necessary
-        if (!m_is_instance && recursion_depth > 0)
-            return dr::zeros<SurfaceInteraction3f>();
 
         // Fields requirement dependencies
         bool shading      = has_flag(ray_flags, RayFlags::Shading);
@@ -997,7 +992,7 @@ public:
 
         si.prim_index = pi.prim_index;
         si.shape = this;
-        si.instance = nullptr;
+        si.instance_index = 0;
 
         return si;
     }

--- a/src/shapes/cylinder.cpp
+++ b/src/shapes/cylinder.cpp
@@ -307,7 +307,7 @@ public:
             return dr::zeros<SurfaceInteraction3f>();
 
         SurfaceInteraction3f si =
-            compute_surface_interaction(ray, pi, ray_flags, 0, active);
+            compute_surface_interaction(ray, pi, ray_flags, active);
         si.finalize_surface_interaction(pi, ray, ray_flags, active);
 
         return si;
@@ -673,13 +673,8 @@ public:
     SurfaceInteraction3f compute_surface_interaction(const Ray3f &ray,
                                                      const PreliminaryIntersection3f &pi,
                                                      uint32_t ray_flags,
-                                                     uint32_t recursion_depth,
                                                      Mask active) const override {
         MI_MASK_ARGUMENT(active);
-
-        // Early exit when tracing isn't necessary
-        if (!m_is_instance && recursion_depth > 0)
-            return dr::zeros<SurfaceInteraction3f>();
 
         bool detach_shape = has_flag(ray_flags, RayFlags::DetachShape);
 
@@ -740,7 +735,7 @@ public:
 
         si.prim_index = pi.prim_index;
         si.shape    = this;
-        si.instance = nullptr;
+        si.instance_index = 0;
 
         return si;
     }

--- a/src/shapes/disk.cpp
+++ b/src/shapes/disk.cpp
@@ -215,7 +215,7 @@ public:
             return dr::zeros<SurfaceInteraction3f>();
 
         SurfaceInteraction3f si =
-            compute_surface_interaction(ray, pi, ray_flags, 0, active);
+            compute_surface_interaction(ray, pi, ray_flags, active);
         si.finalize_surface_interaction(pi, ray, ray_flags, active);
 
         return si;
@@ -435,13 +435,8 @@ public:
     SurfaceInteraction3f compute_surface_interaction(const Ray3f &ray,
                                                      const PreliminaryIntersection3f &pi,
                                                      uint32_t ray_flags,
-                                                     uint32_t recursion_depth,
                                                      Mask active) const override {
         MI_MASK_ARGUMENT(active);
-
-        // Early exit when tracing isn't necessary
-        if (!m_is_instance && recursion_depth > 0)
-            return dr::zeros<SurfaceInteraction3f>();
 
         bool detach_shape = has_flag(ray_flags, RayFlags::DetachShape);
 
@@ -495,7 +490,7 @@ public:
 
         si.prim_index = pi.prim_index;
         si.shape    = this;
-        si.instance = nullptr;
+        si.instance_index = 0;
 
         return si;
     }

--- a/src/shapes/ellipsoids.cpp
+++ b/src/shapes/ellipsoids.cpp
@@ -376,13 +376,8 @@ public:
     SurfaceInteraction3f compute_surface_interaction(const Ray3f &ray,
                                                      const PreliminaryIntersection3f &pi,
                                                      uint32_t ray_flags,
-                                                     uint32_t recursion_depth,
                                                      Mask active) const override {
         MI_MASK_ARGUMENT(active);
-
-        // Early exit when tracing isn't necessary
-        if (!m_is_instance && recursion_depth > 0)
-            return dr::zeros<SurfaceInteraction3f>();
 
         bool detach_shape = has_flag(ray_flags, RayFlags::DetachShape);
         // If necessary, temporally suspend gradient tracking for all shape
@@ -417,7 +412,7 @@ public:
 
         si.prim_index = pi.prim_index;
         si.shape      = this;
-        si.instance   = nullptr;
+        si.instance_index = 0;
 
         return si;
     }

--- a/src/shapes/ellipsoidsmesh.cpp
+++ b/src/shapes/ellipsoidsmesh.cpp
@@ -291,9 +291,8 @@ public:
     SurfaceInteraction3f compute_surface_interaction(const Ray3f &ray,
                                                      const PreliminaryIntersection3f &pi,
                                                      uint32_t ray_flags,
-                                                     uint32_t recursion_depth,
                                                      Mask active) const override {
-        auto si = Base::compute_surface_interaction(ray, pi, ray_flags, recursion_depth, active);
+        auto si = Base::compute_surface_interaction(ray, pi, ray_flags, active);
 
         // Divide by the number of faces per Gaussians
         si.prim_index /= (uint32_t) m_shell_faces.size();

--- a/src/shapes/instance.cpp
+++ b/src/shapes/instance.cpp
@@ -81,7 +81,8 @@ public:
     }
 
     void traverse(TraversalCallback *cb) override {
-        cb->put("to_world", m_to_world, ParamFlags::NonDifferentiable);
+        cb->put("to_world", m_to_world,
+                ParamFlags::Differentiable | ParamFlags::Discontinuous);
     }
 
     void parameters_changed(const std::vector<std::string> &keys) override {
@@ -145,109 +146,6 @@ public:
     }
 
     MI_SHAPE_DEFINE_RAY_INTERSECT_METHODS()
-
-    SurfaceInteraction3f compute_surface_interaction(const Ray3f &ray,
-                                                     const PreliminaryIntersection3f &pi,
-                                                     uint32_t ray_flags,
-                                                     uint32_t recursion_depth,
-                                                     Mask active) const override {
-        MI_MASK_ARGUMENT(active);
-
-        const AffineTransform4f& to_world  = m_to_world.value();
-        AffineTransform4f to_object = to_world.inverse();
-
-        constexpr bool IsDiff = dr::is_diff_v<Float>;
-        bool grad_enabled = dr::grad_enabled(to_world);
-
-        if constexpr (IsDiff) {
-            if (grad_enabled && m_shapegroup->parameters_grad_enabled())
-                Throw("Cannot differentiate instance parameters and shapegroup "
-                      "internal parameters at the same time!");
-        }
-
-        // Nested instancing is not supported
-        if (recursion_depth > 0)
-            return dr::zeros<SurfaceInteraction3f>();
-
-        bool detach_shape = has_flag(ray_flags, RayFlags::DetachShape);
-        bool follow_shape = has_flag(ray_flags, RayFlags::FollowShape);
-
-        // If necessary, temporally suspend gradient tracking for all shape
-        // parameters to construct a surface interaction completely detach from
-        // the shape.
-        dr::suspend_grad<Float> scope(detach_shape, to_world, to_object);
-
-        SurfaceInteraction3f si;
-        {
-            // Temporally suspend gradient tracking when `to_world` need to be
-            // differentiated as the various terms of `si` will be recomputed
-            // to account for the motion of `si` already.
-            dr::suspend_grad<Float> scope2(grad_enabled);
-            si = m_shapegroup->compute_surface_interaction(
-                to_object * ray, pi, ray_flags,
-                recursion_depth, active);
-        }
-
-        // Hit point `si.p` is only attached to the surface motion
-        si.p = to_world * si.p;
-        si.n = dr::normalize(dr::detach(to_world) * si.n);
-
-        if (likely(has_flag(ray_flags, RayFlags::Shading))) {
-            AffineTransform4f to_world_d = dr::detach(to_world);
-
-            // Transforming a normal applies the inverse transpose, which does
-            // not preserve its length. Differentiating the re-normalization
-            // projects the transformed partials back onto the tangent plane.
-            Normal3f n = to_world_d * si.sh_frame.n;
-            Float inv_len = dr::rcp(dr::norm(n));
-            n *= inv_len;
-            si.sh_frame.n = n;
-
-            if (has_flag(ray_flags, RayFlags::NormalPartials)) {
-                Vector3f dn_du = to_world_d * Normal3f(si.dn_du) * inv_len,
-                         dn_dv = to_world_d * Normal3f(si.dn_dv) * inv_len;
-
-                si.dn_du = dr::fnmadd(n, dr::dot(n, dn_du), dn_du);
-                si.dn_dv = dr::fnmadd(n, dr::dot(n, dn_dv), dn_dv);
-            }
-
-            // A tangent direction supplied by the nested shape transforms
-            // along; finalize_surface_interaction() orthonormalizes it
-            // against the transformed normal and derives the bitangent. A
-            // mirroring instance transform flips the orientation of the
-            // nested parameterization.
-            si.sh_frame.s = to_world_d * si.sh_frame.s;
-            si.frame_flipped ^= dr::det(Matrix3f(to_world_d.matrix)) < 0.f;
-        }
-
-        if constexpr (IsDiff) {
-            if (follow_shape && grad_enabled) {
-                // Recompute si.t in a differential manner as the distance
-                // between the ray origin and the hit point following the moving
-                // surface.
-                si.t = dr::sqrt(dr::squared_norm(si.p - ray.o) / dr::squared_norm(ray.d));
-            } else if (!follow_shape && grad_enabled) {
-                // Differential recomputation of the intersection of the ray
-                // with the moving plane tangent to the hit point. In this
-                // scenario, it is important that `si.p` stays along the ray as
-                // the surface moves.
-                si.t = (dr::dot(si.n, si.p) - dr::dot(si.n, ray.o)) / dr::dot(si.n, ray.d);
-                si.p = ray(si.t);
-                // TODO what can we do about the normals? Take into account curvature?
-                // TODO si.uv should be attached but we don't know about the underlying parameterization
-            }
-        }
-
-        if (likely(has_flag(ray_flags, RayFlags::Shading))) {
-            si.dp_du = to_world * si.dp_du;
-            si.dp_dv = to_world * si.dp_dv;
-        }
-
-        si.prim_index = pi.prim_index;
-        si.instance = this;
-
-        return si;
-    }
 
     // =============================================================
 

--- a/src/shapes/linearcurve.cpp
+++ b/src/shapes/linearcurve.cpp
@@ -320,13 +320,8 @@ public:
     SurfaceInteraction3f compute_surface_interaction(const Ray3f &ray,
                                                      const PreliminaryIntersection3f &pi,
                                                      uint32_t ray_flags,
-                                                     uint32_t recursion_depth,
                                                      Mask active) const override {
         MI_MASK_ARGUMENT(active);
-
-        // Early exit when tracing isn't necessary
-        if (!m_is_instance && recursion_depth > 0)
-            return dr::zeros<SurfaceInteraction3f>();
 
         bool shading = has_flag(ray_flags, RayFlags::Shading);
 
@@ -420,7 +415,7 @@ public:
 
         si.prim_index = pi.prim_index;
         si.shape    = this;
-        si.instance = nullptr;
+        si.instance_index = 0;
 
         return si;
     }

--- a/src/shapes/rectangle.cpp
+++ b/src/shapes/rectangle.cpp
@@ -223,7 +223,7 @@ public:
         si.dp_dv     = m_frame.t;
         si.uv        = uv;
         si.shape    = this;
-        si.instance = nullptr;
+        si.instance_index = 0;
         si.t        = dr::select(active, 0, dr::Infinity<Float>);
 
         /// Zero-initialize remaining fields

--- a/src/shapes/sdfgrid.cpp
+++ b/src/shapes/sdfgrid.cpp
@@ -160,7 +160,7 @@ public:
                 InputTensorXf(vol_grid.data(), { (size_t) res.z(),
                                                  (size_t) res.y(),
                                                  (size_t) res.x(), 1 }),
-                true, true, dr::FilterMode::Linear, dr::WrapMode::Clamp);
+                true, dr::FilterMode::Linear, dr::WrapMode::Clamp);
         } else if (props.has_property("grid")) {
             const TensorXf& tensor = props.get_any<TensorXf>("grid");
             if (tensor.ndim() != 4)
@@ -171,7 +171,7 @@ public:
                       tensor.shape(3));
             m_grid_texture = InputTexture3f(
                 (const typename InputTexture3f::TensorXf &) tensor,
-                true, true, dr::FilterMode::Linear, dr::WrapMode::Clamp);
+                true, dr::FilterMode::Linear, dr::WrapMode::Clamp);
         } else {
             Throw("The SDF values must be specified with either the "
                   "\"filename\" or \"grid\" parameter!");
@@ -338,13 +338,9 @@ public:
     SurfaceInteraction3f
     compute_surface_interaction(const Ray3f &ray,
                                 const PreliminaryIntersection3f &pi,
-                                uint32_t ray_flags, uint32_t recursion_depth,
+                                uint32_t ray_flags,
                                 Mask active) const override {
         MI_MASK_ARGUMENT(active);
-
-        // Early exit when tracing isn't necessary
-        if (!m_is_instance && recursion_depth > 0)
-            return dr::zeros<SurfaceInteraction3f>();
 
         SurfaceInteraction3f si = dr::zeros<SurfaceInteraction3f>();
 
@@ -399,7 +395,7 @@ public:
 
         si.prim_index = pi.prim_index;
         si.shape    = this;
-        si.instance = nullptr;
+        si.instance_index = 0;
 
         return si;
     }

--- a/src/shapes/sphere.cpp
+++ b/src/shapes/sphere.cpp
@@ -353,7 +353,7 @@ public:
             return dr::zeros<SurfaceInteraction3f>();
 
         SurfaceInteraction3f si =
-            compute_surface_interaction(ray, pi, ray_flags, 0, active);
+            compute_surface_interaction(ray, pi, ray_flags, active);
         si.finalize_surface_interaction(pi, ray, ray_flags, active);
 
         return si;
@@ -627,13 +627,8 @@ public:
     SurfaceInteraction3f compute_surface_interaction(const Ray3f &ray,
                                                      const PreliminaryIntersection3f &pi,
                                                      uint32_t ray_flags,
-                                                     uint32_t recursion_depth,
                                                      Mask active) const override {
         MI_MASK_ARGUMENT(active);
-
-        // Early exit when tracing isn't necessary
-        if (!m_is_instance && recursion_depth > 0)
-            return dr::zeros<SurfaceInteraction3f>();
 
         bool shading      = has_flag(ray_flags, RayFlags::Shading);
         bool detach_shape = has_flag(ray_flags, RayFlags::DetachShape);
@@ -704,7 +699,7 @@ public:
 
         si.prim_index = pi.prim_index;
         si.shape    = this;
-        si.instance = nullptr;
+        si.instance_index = 0;
 
         return si;
     }

--- a/src/shapes/tests/test_bsplinecurve.py
+++ b/src/shapes/tests/test_bsplinecurve.py
@@ -170,7 +170,7 @@ def test07_differentiable_surface_interaction_ray_forward_follow_shape(variant_l
     )
     params.update()
     pi = scene.ray_intersect_preliminary(ray)
-    si = pi.compute_surface_interaction(ray, mi.RayFlags.Default | mi.RayFlags.DetachShape)
+    si = scene.compute_surface_interaction(ray, pi, mi.RayFlags.Default | mi.RayFlags.DetachShape)
 
     dr.forward(theta)
 
@@ -194,7 +194,7 @@ def test07_differentiable_surface_interaction_ray_forward_follow_shape(variant_l
     params.update()
 
     pi = scene.ray_intersect_preliminary(ray)
-    si = pi.compute_surface_interaction(ray, mi.RayFlags.Default)
+    si = scene.compute_surface_interaction(ray, pi, mi.RayFlags.Default)
 
     dr.forward(theta)
 
@@ -218,7 +218,7 @@ def test07_differentiable_surface_interaction_ray_forward_follow_shape(variant_l
     params.update()
 
     pi = scene.ray_intersect_preliminary(ray)
-    si = pi.compute_surface_interaction(ray, mi.RayFlags.Default | mi.RayFlags.FollowShape)
+    si = scene.compute_surface_interaction(ray, pi, mi.RayFlags.Default | mi.RayFlags.FollowShape)
 
     dr.forward(theta)
 
@@ -244,7 +244,7 @@ def test08_eval_parameterization(variants_vec_rgb):
     ray = mi.Ray3f(mi.Vector3f(x, y, 2), mi.Vector3f(0, 0, -1))
 
     pi = scene.ray_intersect_preliminary(ray)
-    si = pi.compute_surface_interaction(ray, mi.RayFlags.Default | mi.RayFlags.DetachShape)
+    si = scene.compute_surface_interaction(ray, pi, mi.RayFlags.Default | mi.RayFlags.DetachShape)
 
     curve = scene.shapes()[0]
     eval_param_si = curve.eval_parameterization(si.uv, active=si.is_valid())

--- a/src/shapes/tests/test_cylinder.py
+++ b/src/shapes/tests/test_cylinder.py
@@ -127,37 +127,37 @@ def test05_differentiable_surface_interaction_ray_forward(variants_all_ad_rgb):
     dr.enable_grad(ray.d)
 
     # If the ray origin is shifted along the x-axis, so does si.p
-    si = pi.compute_surface_interaction(ray)
+    si = shape.compute_surface_interaction(ray, pi)
     si.p *= 1.0
     dr.forward(ray.o.x)
     assert dr.allclose(dr.grad(si.p), [1, 0, 0])
 
     # If the ray origin is shifted along the z-axis, so does si.p
-    si = pi.compute_surface_interaction(ray)
+    si = shape.compute_surface_interaction(ray, pi)
     si.p *= 1.0
     dr.forward(ray.o.z)
     assert dr.allclose(dr.grad(si.p), [0, 0, 1])
 
     # If the ray origin is shifted along the y-axis, so does si.t
-    si = pi.compute_surface_interaction(ray)
+    si = shape.compute_surface_interaction(ray, pi)
     si.t *= 1.0
     dr.forward(ray.o.y)
     assert dr.allclose(dr.grad(si.t), -1.0)
 
     # If the ray direction is shifted along the x-axis, so does si.p
-    si = pi.compute_surface_interaction(ray)
+    si = shape.compute_surface_interaction(ray, pi)
     si.p *= 1.0
     dr.forward(ray.d.x)
     assert dr.allclose(dr.grad(si.p), [9, 0, 0])
 
     # If the ray origin is shifted tangent to the cylinder section, si.uv.x move by 1 / 2pi
-    si = pi.compute_surface_interaction(ray)
+    si = shape.compute_surface_interaction(ray, pi)
     si.uv *= 1.0
     dr.forward(ray.o.x)
     assert dr.allclose(dr.grad(si.uv), [1 / (2 * dr.pi), 0])
 
     # If the ray origin is shifted along the cylinder length, si.uv.y move by 1
-    si = pi.compute_surface_interaction(ray)
+    si = shape.compute_surface_interaction(ray, pi)
     si.uv *= 1.0
     dr.forward(ray.o.z)
     assert dr.allclose(dr.grad(si.uv), [0, 1])
@@ -172,13 +172,13 @@ def test06_differentiable_surface_interaction_ray_backward(variant_cuda_ad_rgb):
     dr.enable_grad(ray.o)
 
     # If si.p is shifted along the x-axis, so does the ray origin
-    si = pi.compute_surface_interaction(ray)
+    si = shape.compute_surface_interaction(ray, pi)
     dr.backward(si.p.x)
     assert dr.allclose(dr.grad(ray.o), [1, 0, 0])
 
     # If si.t is changed, so does the ray origin along the z-axis
     dr.set_grad(ray.o, 0.0)
-    si = pi.compute_surface_interaction(ray)
+    si = shape.compute_surface_interaction(ray, pi)
     dr.backward(si.t)
     assert dr.allclose(dr.grad(ray.o), [0, -1, 0])
 

--- a/src/shapes/tests/test_disk.py
+++ b/src/shapes/tests/test_disk.py
@@ -114,25 +114,25 @@ def test05_differentiable_surface_interaction_ray_forward(variants_all_ad_rgb):
     dr.enable_grad(ray.d)
 
     # If the ray origin is shifted along the x-axis, so does si.p
-    si = pi.compute_surface_interaction(ray)
+    si = shape.compute_surface_interaction(ray, pi)
     si.p *= 1.0
     dr.forward(ray.o.x)
     assert dr.allclose(dr.grad(si.p), [1, 0, 0])
 
     # If the ray origin is shifted along the y-axis, so does si.p
-    si = pi.compute_surface_interaction(ray)
+    si = shape.compute_surface_interaction(ray, pi)
     si.p *= 1.0
     dr.forward(ray.o.y)
     assert dr.allclose(dr.grad(si.p), [0, 1, 0])
 
     # If the ray origin is shifted along the z-axis, so does si.t
-    si = pi.compute_surface_interaction(ray)
+    si = shape.compute_surface_interaction(ray, pi)
     si.t *= 1.0
     dr.forward(ray.o.z)
     assert dr.allclose(dr.grad(si.t), -1)
 
     # If the ray direction is shifted along the x-axis, so does si.p
-    si = pi.compute_surface_interaction(ray)
+    si = shape.compute_surface_interaction(ray, pi)
     si.p *= 1.0
     dr.forward(ray.d.x)
     assert dr.allclose(dr.grad(si.p), [10, 0, 0])
@@ -167,13 +167,13 @@ def test06_differentiable_surface_interaction_ray_backward(variants_all_ad_rgb):
     dr.enable_grad(ray.o)
 
     # If si.p is shifted along the x-axis, so does the ray origin
-    si = pi.compute_surface_interaction(ray)
+    si = shape.compute_surface_interaction(ray, pi)
     dr.backward(si.p.x)
     assert dr.allclose(dr.grad(ray.o), [1, 0, 0])
 
     # If si.t is changed, so does the ray origin along the z-axis
     dr.set_grad(ray.o, 0.0)
-    si = pi.compute_surface_interaction(ray)
+    si = shape.compute_surface_interaction(ray, pi)
     dr.backward(si.t)
     assert dr.allclose(dr.grad(ray.o), [0, 0, -1])
 

--- a/src/shapes/tests/test_instance.py
+++ b/src/shapes/tests/test_instance.py
@@ -71,8 +71,8 @@ def test01_ray_intersect(variant_scalar_rgb, shape):
                 si_inst = s_inst.ray_intersect(ray, flags, coherent=True, active=True)
 
                 assert si.prim_index == si_inst.prim_index
-                assert si.instance is None
-                assert si_inst.instance is not None
+                assert si.instance_index == 0
+                assert si_inst.instance_index != 0
                 assert dr.allclose(si.t, si_inst.t, atol=2e-2)
                 assert dr.allclose(si.time, si_inst.time, atol=2e-2)
                 assert dr.allclose(si.p, si_inst.p, atol=2e-2)
@@ -119,8 +119,8 @@ def test02_ray_intersect_transform(variant_scalar_rgb, shape):
                     si_inst = s_inst.ray_intersect(ray, flags, coherent=True, active=True)
 
                     assert si.prim_index == si_inst.prim_index
-                    assert si.instance is None
-                    assert si_inst.instance is not None
+                    assert si.instance_index == 0
+                    assert si_inst.instance_index != 0
                     assert dr.allclose(si.t, si_inst.t, atol=2e-2)
                     assert dr.allclose(si.time, si_inst.time, atol=2e-2)
                     assert dr.allclose(si.p, si_inst.p, atol=2e-2)
@@ -187,43 +187,44 @@ def test03_ray_intersect_instance(variants_all_rgb, width):
 
     time = 0.0 if scalar_mode else [0.0] * width
 
+    def hit_instance_str(si):
+        slot = int(si.instance_index if scalar_mode else si.instance_index[0])
+        assert slot != 0
+        return str(scene.instance(slot - 1))
+
     ray = mi.Ray3f([-0.5, -0.5, -12], [0.0, 0.0, 1.0], time, [])
-    pi = scene.ray_intersect(ray)
-    assert dr.all(pi.is_valid())
-    instance_str = str(pi.instance) if scalar_mode else str(pi.instance[0])
+    si = scene.ray_intersect(ray)
+    assert dr.all(si.is_valid())
+    instance_str = hit_instance_str(si)
     assert '[0.5, 0, 0, -0.5]' in instance_str
     assert '[0, 0.5, 0, -0.5]' in instance_str
 
     ray = mi.Ray3f([-0.5, 0.5, -12], [0.0, 0.0, 1.0], time, [])
-    pi = scene.ray_intersect(ray)
-    assert dr.all(pi.is_valid())
-    instance_str = str(pi.instance) if scalar_mode else str(pi.instance[0])
+    si = scene.ray_intersect(ray)
+    assert dr.all(si.is_valid())
+    instance_str = hit_instance_str(si)
     assert '[0.5, 0, 0, -0.5]' in instance_str
     assert '[0, 0.5, 0, 0.5]' in instance_str
 
     ray = mi.Ray3f([0.5, -0.5, -12], [0.0, 0.0, 1.0], time, [])
-    pi = scene.ray_intersect(ray)
-    assert dr.all(pi.is_valid())
-    instance_str = str(pi.instance) if scalar_mode else str(pi.instance[0])
+    si = scene.ray_intersect(ray)
+    assert dr.all(si.is_valid())
+    instance_str = hit_instance_str(si)
     assert '[0.5, 0, 0, 0.5]' in instance_str
     assert '[0, 0.5, 0, -0.5]' in instance_str
 
     ray = mi.Ray3f([0.5, 0.5, -12], [0.0, 0.0, 1.0], time, [])
-    pi = scene.ray_intersect(ray)
+    si = scene.ray_intersect(ray)
 
-    assert dr.all(pi.is_valid())
-
-    if scalar_mode:
-        assert 'instance=0x0' in str(pi)
-    else:
-        assert ('instance=[' + '0x0, ' * (width - 1) + '0x0]') in str(pi)
+    assert dr.all(si.is_valid())
+    assert dr.all(si.instance_index == 0)
 
 
 @pytest.mark.parametrize("shape", shapes)
 def test04_single_child_group_recovery(variants_vec_backends_once_rgb, shape):
     """A ShapeGroup with exactly one child, instanced with a non-identity
-    transform, must recover ``si.shape`` (the child) and ``si.instance`` (the
-    Instance) correctly.
+    transform, must recover ``si.shape`` (the child) and ``si.instance_index``
+    (the record slot of the Instance) correctly.
 
     This exercises the GPU backends' per-geometry hit recovery: a one-child group
     resolves its hit shape from ``pi.shape`` exactly like a multi-child group. The
@@ -253,11 +254,10 @@ def test04_single_child_group_recovery(variants_vec_backends_once_rgb, shape):
             if dr.none(valid):
                 continue
 
-            # The instanced hit names the Instance as si.instance; the direct
-            # hit has none. The recovered child (si.shape) is never the Instance.
-            assert dr.all(~valid | (si_inst.instance != dr.zeros(mi.ShapePtr)))
-            assert dr.all(si.instance == dr.zeros(mi.ShapePtr))
-            assert dr.all(~valid | (si_inst.shape != si_inst.instance))
+            # The instanced hit reports the Instance's record slot; the
+            # direct hit has none.
+            assert dr.all(~valid | (si_inst.instance_index != 0))
+            assert dr.all(si.instance_index == 0)
 
             # The recovered child geometry must match the directly-placed shape.
             assert dr.allclose(si.t, si_inst.t, atol=2e-2)
@@ -298,3 +298,198 @@ def test05_normal_partials_non_similarity(variant_scalar_rgb):
                                   to_world)
 
     assert hits > 5, hits
+
+
+@pytest.mark.parametrize("api", ['scene', 'pi'])
+def test06_ad_gradients(variants_all_ad_rgb, api):
+    """Gradients propagate through instanced ray-tracing calls, both with
+    respect to the instance-to-world transform and with respect to parameters
+    of the instanced geometry. Both the scene-level and the preliminary
+    intersection entry points are checked."""
+
+    def make_scene():
+        return mi.load_dict({
+            'type': 'scene',
+            'group': {'type': 'shapegroup', 'shape': {'type': 'sphere'}},
+            'instance': {'type': 'instance',
+                         'group': {'type': 'ref', 'id': 'group'},
+                         'to_world': mi.ScalarTransform4f().translate([5, 0, 0])}
+        })
+
+    def intersect(scene, ray, ray_flags):
+        if api == 'scene':
+            return scene.ray_intersect(ray, ray_flags, True)
+        else:
+            pi = scene.ray_intersect_preliminary(ray)
+            return scene.compute_surface_interaction(ray, pi, ray_flags)
+
+    def grad(key, ray_flags, output):
+        """Differentiate 'output' with respect to a z-translation appended to
+        the transform parameter 'key'"""
+        scene = make_scene()
+        params = mi.traverse(scene)
+        theta = mi.Float(0.0)
+        dr.enable_grad(theta)
+        params[key] = mi.Transform4f(params[key]) @ \
+                      mi.Transform4f().translate([0, 0, theta])
+        params.update()
+
+        ray = mi.Ray3f(mi.Point3f(5, 0, -5), mi.Vector3f(0, 0, 1))
+        si = intersect(scene, ray, ray_flags)
+        dr.backward(si.p.z if output == 'p.z' else si.t,
+                    flags=dr.ADFlag.Default | dr.ADFlag.AllowNoGrad)
+        return dr.grad(theta)
+
+    follow = mi.RayFlags.Default | mi.RayFlags.FollowShape
+    detach = mi.RayFlags.Default | mi.RayFlags.DetachShape
+
+    # Instance transform: the hit point follows the moving instance
+    assert dr.allclose(grad('instance.to_world', follow, 'p.z'), 1.0)
+
+    # Instance transform, default mode: the hit point stays on the ray while
+    # the distance tracks the moving tangent plane
+    assert dr.allclose(grad('instance.to_world', mi.RayFlags.Default, 't'), 1.0)
+
+    # DetachShape severs the dependence entirely
+    assert dr.allclose(grad('instance.to_world', detach, 't'), 0.0)
+
+    # Group-internal shape parameters, reached through the instanced hit
+    assert dr.allclose(grad('group.shape.to_world', mi.RayFlags.Default, 't'), 1.0)
+
+
+@fresolver_append_path
+@pytest.mark.parametrize("api", ['scene', 'pi'])
+def test07_ad_gradients_vs_direct_mesh(variants_all_ad_rgb, api):
+    """Gradient reference test: a mesh under a non-similarity world transform
+    must produce the same position/distance derivatives whether the moving
+    transform is realized directly (differentiated through the mesh's vertex
+    positions) or through an instance (differentiated through the instance's
+    to_world parameter)."""
+    from mitsuba import ScalarTransform4f as T
+
+    to_world = T().translate([1.5, 0.5, -0.3]) @ T().rotate([0, 1, 0], 30) @ \
+               T().rotate([1, 0, 0], -20) @ T().scale([1.0, 2.0, 3.0])
+    mesh = {'type': 'obj',
+            'filename': 'resources/data/common/meshes/rectangle.obj'}
+
+    # A grid of rays that hits the transformed rectangle
+    x, y = dr.meshgrid(dr.linspace(mi.Float, -0.7, 0.7, 4),
+                       dr.linspace(mi.Float, -0.7, 0.7, 4))
+    p_world = mi.Transform4f(to_world) @ mi.Point3f(x, y, 0)
+    d = dr.normalize(mi.Vector3f(0.2, -0.1, -1.0))
+    ray = mi.Ray3f(p_world - 5 * d, d)
+
+    # World-space surface motion per unit of the appended local z-translation
+    v_world = mi.Transform4f(to_world) @ mi.Vector3f(0, 0, 1)
+
+    def intersect(scene, ray_flags):
+        if api == 'scene':
+            return scene.ray_intersect(ray, ray_flags, True)
+        else:
+            pi = scene.ray_intersect_preliminary(ray)
+            return scene.compute_surface_interaction(ray, pi, ray_flags)
+
+    def grad(instanced, ray_flags, output):
+        theta = mi.Float(0.0)
+        dr.enable_grad(theta)
+        if instanced:
+            scene = mi.load_dict({
+                'type': 'scene',
+                'group': {'type': 'shapegroup', 'shape': mesh},
+                'instance': {'type': 'instance',
+                             'group': {'type': 'ref', 'id': 'group'}}})
+            params = mi.traverse(scene)
+            params['instance.to_world'] = mi.Transform4f(to_world) @ \
+                mi.Transform4f().translate([0, 0, theta])
+            params.update()
+        else:
+            scene = mi.load_dict({
+                'type': 'scene', 'shape': dict(mesh, to_world=to_world)})
+            params = mi.traverse(scene)
+            key = 'shape.positions'
+            pos = dr.unravel(mi.Point3f, params[key].array)
+            params[key] = mi.TensorXf(dr.ravel(pos + v_world * theta),
+                                      dr.shape(params[key]))
+            params.update()
+
+        si = intersect(scene, ray_flags)
+        assert dr.all(si.is_valid())
+        dr.backward(dr.sum(si.t if output == 't' else si.p.z))
+        return dr.grad(theta)
+
+    follow = mi.RayFlags.Default | mi.RayFlags.FollowShape
+    for ray_flags in [mi.RayFlags.Default, follow]:
+        for output in ['t', 'p.z']:
+            g_direct = grad(False, ray_flags, output)
+            g_inst = grad(True, ray_flags, output)
+            assert dr.allclose(g_direct, g_inst, rtol=1e-4), \
+                (int(ray_flags), output, g_direct[0], g_inst[0])
+
+
+@fresolver_append_path
+def test08_ad_gradients_combined(variants_all_ad_rgb):
+    """Gradient reference test for simultaneous differentiation of the
+    instance-to-world transform and group-internal vertex positions. The
+    gradients of both parameters must match an equivalent non-instanced mesh
+    whose vertices realize the two motions directly."""
+    from mitsuba import ScalarTransform4f as T
+
+    to_world = T().translate([1.5, 0.5, -0.3]) @ T().rotate([0, 1, 0], 30) @ \
+               T().rotate([1, 0, 0], -20) @ T().scale([1.0, 2.0, 3.0])
+    mesh = {'type': 'obj',
+            'filename': 'resources/data/common/meshes/rectangle.obj'}
+
+    # A grid of rays that hits the transformed rectangle
+    x, y = dr.meshgrid(dr.linspace(mi.Float, -0.7, 0.7, 4),
+                       dr.linspace(mi.Float, -0.7, 0.7, 4))
+    p_world = mi.Transform4f(to_world) @ mi.Point3f(x, y, 0)
+    d = dr.normalize(mi.Vector3f(0.2, -0.1, -1.0))
+    ray = mi.Ray3f(p_world - 5 * d, d)
+
+    # World-space surface motions per unit of theta (a local z-translation
+    # appended to the instance transform) and per unit of phi (a local
+    # x-displacement of the group-internal vertices)
+    v_theta = mi.Transform4f(to_world) @ mi.Vector3f(0, 0, 1)
+    v_phi   = mi.Transform4f(to_world) @ mi.Vector3f(1, 0, 0)
+
+    def displace(params, key, direction, amount):
+        pos = dr.unravel(mi.Point3f, params[key].array)
+        params[key] = mi.TensorXf(dr.ravel(pos + direction * amount),
+                                  dr.shape(params[key]))
+
+    def grads(instanced, ray_flags, output):
+        theta, phi = mi.Float(0.0), mi.Float(0.0)
+        dr.enable_grad(theta, phi)
+        if instanced:
+            scene = mi.load_dict({
+                'type': 'scene',
+                'group': {'type': 'shapegroup', 'shape': mesh},
+                'instance': {'type': 'instance',
+                             'group': {'type': 'ref', 'id': 'group'}}})
+            params = mi.traverse(scene)
+            params['instance.to_world'] = mi.Transform4f(to_world) @ \
+                mi.Transform4f().translate([0, 0, theta])
+            displace(params, 'group.shape.positions', mi.Vector3f(1, 0, 0), phi)
+            params.update()
+        else:
+            scene = mi.load_dict({
+                'type': 'scene', 'shape': dict(mesh, to_world=to_world)})
+            params = mi.traverse(scene)
+            displace(params, 'shape.positions', v_theta, theta)
+            displace(params, 'shape.positions', v_phi, phi)
+            params.update()
+
+        si = scene.ray_intersect(ray, ray_flags, True)
+        assert dr.all(si.is_valid())
+        dr.backward(dr.sum(si.t if output == 't' else si.p.z))
+        return dr.grad(theta), dr.grad(phi)
+
+    follow = mi.RayFlags.Default | mi.RayFlags.FollowShape
+    for ray_flags in [mi.RayFlags.Default, follow]:
+        for output in ['t', 'p.z']:
+            gd_theta, gd_phi = grads(False, ray_flags, output)
+            gi_theta, gi_phi = grads(True, ray_flags, output)
+            assert dr.allclose(gd_theta, gi_theta, rtol=1e-4, atol=1e-5), \
+                ('theta', int(ray_flags), output, gd_theta[0], gi_theta[0])
+            assert dr.allclose(gd_phi, gi_phi, rtol=1e-4, atol=1e-5), \
+                ('phi', int(ray_flags), output, gd_phi[0], gi_phi[0])

--- a/src/shapes/tests/test_sdfgrid.py
+++ b/src/shapes/tests/test_sdfgrid.py
@@ -207,7 +207,7 @@ def test07_differentiable_surface_interaction_ray_forward_follow_shape(variants_
     params['sdf.to_world'] = mi.Transform4f().translate(mi.Vector3f(theta))
     params.update()
     pi = scene.ray_intersect_preliminary(ray)
-    si = pi.compute_surface_interaction(ray, mi.RayFlags.Default | mi.RayFlags.DetachShape)
+    si = scene.compute_surface_interaction(ray, pi, mi.RayFlags.Default | mi.RayFlags.DetachShape)
 
     dr.forward(theta)
 
@@ -226,7 +226,7 @@ def test07_differentiable_surface_interaction_ray_forward_follow_shape(variants_
     params['sdf.to_world'] = dr.detach(params['sdf.to_world'])
     params.update()
     pi = scene.ray_intersect_preliminary(ray)
-    si = pi.compute_surface_interaction(ray, mi.RayFlags.Default | mi.RayFlags.DetachShape)
+    si = scene.compute_surface_interaction(ray, pi, mi.RayFlags.Default | mi.RayFlags.DetachShape)
 
     dr.forward(theta)
 
@@ -247,7 +247,7 @@ def test07_differentiable_surface_interaction_ray_forward_follow_shape(variants_
     params['sdf.to_world'] = mi.Transform4f().translate([0, theta, 0])
     params.update()
     pi = scene.ray_intersect_preliminary(ray)
-    si = pi.compute_surface_interaction(ray, mi.RayFlags.Default)
+    si = scene.compute_surface_interaction(ray, pi, mi.RayFlags.Default)
 
     dr.forward(theta)
 
@@ -271,7 +271,7 @@ def test07_differentiable_surface_interaction_ray_forward_follow_shape(variants_
 
     ray = mi.Ray3f(mi.Vector3f(0.5, 0.5, 2), mi.Vector3f(0, 0, -1))
     pi = scene.ray_intersect_preliminary(ray)
-    si = pi.compute_surface_interaction(ray, mi.RayFlags.Default)
+    si = scene.compute_surface_interaction(ray, pi, mi.RayFlags.Default)
 
     dr.forward(theta)
 
@@ -292,7 +292,7 @@ def test07_differentiable_surface_interaction_ray_forward_follow_shape(variants_
 
     ray = mi.Ray3f(mi.Vector3f(0.5, 0.5, 2), mi.Vector3f(0, 0, -1))
     pi = scene.ray_intersect_preliminary(ray)
-    si = pi.compute_surface_interaction(ray, mi.RayFlags.Default | mi.RayFlags.FollowShape)
+    si = scene.compute_surface_interaction(ray, pi, mi.RayFlags.Default | mi.RayFlags.FollowShape)
 
     dr.forward(theta)
 
@@ -315,7 +315,7 @@ def test07_differentiable_surface_interaction_ray_forward_follow_shape(variants_
 
     ray = mi.Ray3f(mi.Vector3f(0.5, 0.5, 2), mi.Vector3f(0, 0, -1))
     pi = scene.ray_intersect_preliminary(ray)
-    si = pi.compute_surface_interaction(ray, mi.RayFlags.Default | mi.RayFlags.FollowShape)
+    si = scene.compute_surface_interaction(ray, pi, mi.RayFlags.Default | mi.RayFlags.FollowShape)
 
     dr.forward(theta)
 

--- a/src/shapes/tests/test_sphere.py
+++ b/src/shapes/tests/test_sphere.py
@@ -147,25 +147,25 @@ def test06_differentiable_surface_interaction_ray_forward(variants_all_ad_rgb):
     dr.enable_grad(ray.d)
 
     # If the ray origin is shifted along the x-axis, so does si.p
-    si = pi.compute_surface_interaction(ray)
+    si = shape.compute_surface_interaction(ray, pi)
     si.p *= 1.0
     dr.forward(ray.o.x)
     assert dr.allclose(dr.grad(si.p), [1, 0, 0])
 
     # If the ray origin is shifted along the z-axis, so does si.p
-    si = pi.compute_surface_interaction(ray)
+    si = shape.compute_surface_interaction(ray, pi)
     si.p *= 1.0
     dr.forward(ray.o.z)
     assert dr.allclose(dr.grad(si.p), [0, 0, 1])
 
     # If the ray origin is shifted along the y-axis, so does si.t
-    si = pi.compute_surface_interaction(ray)
+    si = shape.compute_surface_interaction(ray, pi)
     si.t *= 1.0
     dr.forward(ray.o.y)
     assert dr.allclose(dr.grad(si.t), -1)
 
     # If the ray direction is shifted along the x-axis, so does si.p
-    si = pi.compute_surface_interaction(ray)
+    si = shape.compute_surface_interaction(ray, pi)
     si.p *= 1.0
     dr.forward(ray.d.x)
     assert dr.allclose(dr.grad(si.p), [9, 0, 0])
@@ -208,13 +208,13 @@ def test07_differentiable_surface_interaction_ray_backward(variants_all_ad_rgb):
     dr.enable_grad(ray.o)
 
     # If si.p is shifted along the x-axis, so does the ray origin
-    si = pi.compute_surface_interaction(ray)
+    si = shape.compute_surface_interaction(ray, pi)
     dr.backward(si.p.x)
     assert dr.allclose(dr.grad(ray.o), [1, 0, 0])
 
     # If si.t is changed, so does the ray origin along the z-axis
     dr.set_grad(ray.o, 0.0)
-    si = pi.compute_surface_interaction(ray)
+    si = shape.compute_surface_interaction(ray, pi)
     dr.backward(si.t)
     assert dr.allclose(dr.grad(ray.o), [0, 0, -1])
 

--- a/src/textures/bitmap.cpp
+++ b/src/textures/bitmap.cpp
@@ -455,12 +455,12 @@ public:
         m_raw(raw),
         m_srgb(srgb) {
 
-        // Compute the mean without migrating texture data, i.e. avoid the
-        // m_texture.tensor() call that would trigger a migration. On CUDA we
-        // ideally keep the data solely as a GPU texture.
+        // Compute the mean from the input tensor, i.e. avoid the
+        // m_texture.tensor() call that would read the data back from the
+        // GPU texture.
         rebuild_internals(tensor, true, false);
 
-        m_texture = StoredTexture2f(std::forward<Tensor>(tensor), accel, accel,
+        m_texture = StoredTexture2f(std::forward<Tensor>(tensor), accel,
                                     filter_mode, wrap_mode, srgb);
     }
 

--- a/src/volumes/grid.cpp
+++ b/src/volumes/grid.cpp
@@ -262,14 +262,14 @@ public:
                     TensorXf(scaled_data.get(), { (size_t) res.z(),
                                                   (size_t) res.y(),
                                                   (size_t) res.x(), 4 }),
-                    m_accel, m_accel, filter_mode, wrap_mode);
+                    m_accel, filter_mode, wrap_mode);
             } else if (volume_grid) {
                 m_texture = Texture3f(
                     TensorXf(volume_grid->data(), { (size_t) res.z(),
                                                     (size_t) res.y(),
                                                     (size_t) res.x(),
                                                     channel_count }),
-                    m_accel, m_accel, filter_mode, wrap_mode);
+                    m_accel, filter_mode, wrap_mode);
                 m_max = volume_grid->max();
                 m_max_per_channel.resize(volume_grid->channel_count());
                 volume_grid->max_per_channel(m_max_per_channel.data());
@@ -280,7 +280,7 @@ public:
                                                 (size_t) res.y(),
                                                 (size_t) res.x(),
                                                 channel_count }),
-                    m_accel, m_accel, filter_mode, wrap_mode);
+                    m_accel, filter_mode, wrap_mode);
                 m_max = (float) dr::max_nested(dr::detach(m_texture.value()));
                 m_channel_count = channel_count;
             }


### PR DESCRIPTION
Instancing has previously had *terrible* performance in JIT builds of Mitsuba. Due to the way in which nested virtual calls interact with Dr.Jit, ``compute_surface_interaction()`` produced a trace that grew quadratically in the number of shapes.

This commit fixes the issue by making the scene aware of instances when tracing ray tracing operations, which reduces the call depth by 1 level. Architecturally, this change fits well because the scene is already aware of instances when it builds the TLAS/BLAS hierarchy.

The scene now holds a flat Nx12 array storing the 3x4 affine transformation of all instances and packet-loads its entries as needed. The transformations of intersections previously done within ``shapegroup.cpp``/``instance.cpp`` move to the scene level (executed conditionally inside a ``dr::if_stmt``). Everything is differentiable, both wrt. the intersected shape and the instance transform.

On architectural break is that
``PreliminaryInteraction::compute_surface_interaction()`` moves to ``Scene::compute_surface_interaction()``. Only the scene has all the necessary information to perform this operation.

Because ``instance`` and ``shapegroup`` serve no further use in traced calls, a new ``JitObject::unregister()`` method completely unregisters them, which makes tracing of shapes faster.

This commit breaks instancing in the legacy kd-tree in Mitsuba (which is not even covered by CI). My plan is to replace that code in an upcoming commit.