### PR TITLE
Remove remaining mention/use of obsolete ThreadEnvironment

### DIFF
--- a/src/python/main.cpp
+++ b/src/python/main.cpp
@@ -99,23 +99,18 @@ NB_MODULE(mitsuba_ext, m) {
     );
 
     m.def("set_log_level", [](mitsuba::LogLevel level) {
-        if (!mitsuba::logger()) {
-            Throw("No Logger instance is set on the current thread! This is likely due to "
-                  "set_log_level being called from a non-Mitsuba thread. You can manually set a "
-                  "thread's ThreadEnvironment (which includes the logger) using "
-                  "ScopedSetThreadEnvironment e.g.\n"
-                  "# Main thread\n"
-                  "env = mi.ThreadEnvironment()\n"
-                  "# Secondary thread\n"
-                  "with mi.ScopedSetThreadEnvironment(env):\n"
-                  "   mi.set_log_level(mi.LogLevel.Info)\n"
-                  "   mi.Log(mi.LogLevel.Info, 'Message')\n");
+        Logger *logger = mitsuba::logger();
+        if (!logger) {
+            Throw("Could not set log level, global Logger instance is null!");
         }
-
-        mitsuba::logger()->set_log_level(level);
+        logger->set_log_level(level);
     }, "Sets the log level.");
     m.def("log_level", []() {
-        return mitsuba::logger()->log_level();
+        Logger *logger = mitsuba::logger();
+        if (!logger) {
+            Throw("Could not get log level, global Logger instance is null!");
+        }
+        return logger->log_level();
     }, "Returns the current log level.");
 
     Thread::static_initialization();

--- a/src/python/python/polvis.py
+++ b/src/python/python/polvis.py
@@ -4,168 +4,166 @@ def polvis(fname, args):
     import mitsuba.scalar_rgb as mi
     mi.set_log_level(mi.LogLevel.Info)
 
-    te = mi.ThreadEnvironment()
-    with mi.ScopedSetThreadEnvironment(te):
-        try:
-            assert fname[-4:] == '.exr', "Needs to be a EXR image."
-            name = fname[:-4]
+    try:
+        assert fname[-4:] == '.exr', "Needs to be a EXR image."
+        name = fname[:-4]
 
-            # Load image and convert to NumPy array
-            img_in = mi.Bitmap(fname)
-            img_py = np.array(img_in, copy=False)
-            assert img_py.shape[2] == 16, "Needs to be a 16-channel image output by the `stokes` integrator."
+        # Load image and convert to NumPy array
+        img_in = mi.Bitmap(fname)
+        img_py = np.array(img_in, copy=False)
+        assert img_py.shape[2] == 16, "Needs to be a 16-channel image output by the `stokes` integrator."
 
-            if not args.scale is None:
-                # Apply a linear scale factor to the image before generating outputs.
-                img_py *= args.scale
+        if not args.scale is None:
+            # Apply a linear scale factor to the image before generating outputs.
+            img_py *= args.scale
 
-            if args.intensity:
-                # Write out just the S0 (intensity) channels
-                s0 = img_py[:, :, 4:7]
-                mi.Bitmap(s0).convert(mi.Bitmap.PixelFormat.RGB, mi.Struct.Type.UInt8, True).write("%s_intensity.png" % name)
+        if args.intensity:
+            # Write out just the S0 (intensity) channels
+            s0 = img_py[:, :, 4:7]
+            mi.Bitmap(s0).convert(mi.Bitmap.PixelFormat.RGB, mi.Struct.Type.UInt8, True).write("%s_intensity.png" % name)
 
-            if not args.polarizer is None:
-                # Write out intensity after applying a linear polarizer at a given angle to the image
+        if not args.polarizer is None:
+            # Write out intensity after applying a linear polarizer at a given angle to the image
 
-                # Create linear polarizer at right rotation
-                LP = mi.mueller.linear_polarizer(1.0)
-                angle = args.polarizer
-                LP = mi.mueller.rotated_element(np.radians(angle), LP)
-                LP = np.array(LP)
+            # Create linear polarizer at right rotation
+            LP = mi.mueller.linear_polarizer(1.0)
+            angle = args.polarizer
+            LP = mi.mueller.rotated_element(np.radians(angle), LP)
+            LP = np.array(LP)
 
-                # Extract Stokes vector for all channels
-                stokes_rgb = [img_py[:, :, 4::3], img_py[:, :, 5::3], img_py[:, :, 6::3]]
-                # Apply Mueller matrix to all pixels and extract intensity (S0) component
-                out = np.dstack([(img @ LP.T)[:, :, 0] for img in stokes_rgb])
+            # Extract Stokes vector for all channels
+            stokes_rgb = [img_py[:, :, 4::3], img_py[:, :, 5::3], img_py[:, :, 6::3]]
+            # Apply Mueller matrix to all pixels and extract intensity (S0) component
+            out = np.dstack([(img @ LP.T)[:, :, 0] for img in stokes_rgb])
 
-                mi.Bitmap(out).convert(mi.Bitmap.PixelFormat.RGB, mi.Struct.Type.UInt8, True).write("%s_polarizer_%.02f.png" % (name, angle))
+            mi.Bitmap(out).convert(mi.Bitmap.PixelFormat.RGB, mi.Struct.Type.UInt8, True).write("%s_polarizer_%.02f.png" % (name, angle))
 
-            # Extract Stokes vectors. Either one channel only (if `--channel` is specified), or else average all.
-            stokes = None
-            if not args.channel is None:
-                stokes = img_py[:, :, 4+args.channel::3]
-            else:
-                stokes_rgb = [img_py[:, :, 4::3], img_py[:, :, 5::3], img_py[:, :, 6::3]]
-                stokes = np.mean(stokes_rgb, axis=0)
+        # Extract Stokes vectors. Either one channel only (if `--channel` is specified), or else average all.
+        stokes = None
+        if not args.channel is None:
+            stokes = img_py[:, :, 4+args.channel::3]
+        else:
+            stokes_rgb = [img_py[:, :, 4::3], img_py[:, :, 5::3], img_py[:, :, 6::3]]
+            stokes = np.mean(stokes_rgb, axis=0)
 
-            # Create the various quantities that are used by false-color visualizations
-            s0   = stokes[:, :, 0]
-            s3   = stokes[:, :, 3]
-            s12  = np.sqrt(np.maximum(0.0, stokes[:, :, 1]**2 + stokes[:, :, 2]**2))
-            s123 = np.sqrt(np.maximum(0.0, stokes[:, :, 1]**2 + stokes[:, :, 2]**2 + stokes[:, :, 3]**2))
+        # Create the various quantities that are used by false-color visualizations
+        s0   = stokes[:, :, 0]
+        s3   = stokes[:, :, 3]
+        s12  = np.sqrt(np.maximum(0.0, stokes[:, :, 1]**2 + stokes[:, :, 2]**2))
+        s123 = np.sqrt(np.maximum(0.0, stokes[:, :, 1]**2 + stokes[:, :, 2]**2 + stokes[:, :, 3]**2))
 
-            dop    = np.divide(s123, s0, out=np.zeros_like(s0), where=s0!=0)
-            rdop_l = np.divide(s12, s123, out=np.zeros_like(s0), where=s123!=0)
-            rdop_c = np.divide(np.abs(s3), s123, out=np.zeros_like(s0), where=s123!=0) # The original paper does not have the abs(...) here, but that leads to negative values in the final false-color images.
+        dop    = np.divide(s123, s0, out=np.zeros_like(s0), where=s0!=0)
+        rdop_l = np.divide(s12, s123, out=np.zeros_like(s0), where=s123!=0)
+        rdop_c = np.divide(np.abs(s3), s123, out=np.zeros_like(s0), where=s123!=0) # The original paper does not have the abs(...) here, but that leads to negative values in the final false-color images.
 
-            black_white = np.dstack([s0, s0, s0])
+        black_white = np.dstack([s0, s0, s0])
 
-            if args.stokes or args.stokes_nrm:
-                # Write out false-color images of the raw Stokes vectors.
-                out_list = [s0]
-                for i in range(3):
-                    tmp = stokes[:, :, 1+i]
-                    if args.stokes_nrm:
-                        tmp = np.divide(tmp, s0, out=np.zeros_like(s0), where=s0!=0)
+        if args.stokes or args.stokes_nrm:
+            # Write out false-color images of the raw Stokes vectors.
+            out_list = [s0]
+            for i in range(3):
+                tmp = stokes[:, :, 1+i]
+                if args.stokes_nrm:
+                    tmp = np.divide(tmp, s0, out=np.zeros_like(s0), where=s0!=0)
 
-                    # Red channel: negative, green channel: positive, blue channel: unused
-                    out = np.dstack([np.maximum(0, -tmp),
-                                     np.maximum(0,  tmp),
-                                     np.zeros(s0.shape)])
-
-                    if args.direct_overlay or args.luminance_overlay:
-                        # Optionally overlay the false-color information on top of the original black and white image.
-                        # In this case, also normalize the Stokes components based on `S0`.
-                        alpha = dop[:, :, np.newaxis]
-                        if args.luminance_overlay:
-                            out *= s0[:, :, np.newaxis]
-                        out = out*alpha + black_white*(1 - alpha)
-
-                    out_list.append(out)
-
-                for idx, img in enumerate(out_list):
-                    mi.Bitmap(img).convert(mi.Bitmap.PixelFormat.RGB, mi.Struct.Type.UInt8, True).write("%s_s%d.png" % (name, idx))
-
-            if args.dop:
-                # Write out false-color image of degree of polarization.
-                # Uses the red channel only
-                z = np.zeros(s0.shape)
-                out = np.dstack([dop, z, z])
+                # Red channel: negative, green channel: positive, blue channel: unused
+                out = np.dstack([np.maximum(0, -tmp),
+                                    np.maximum(0,  tmp),
+                                    np.zeros(s0.shape)])
 
                 if args.direct_overlay or args.luminance_overlay:
                     # Optionally overlay the false-color information on top of the original black and white image.
+                    # In this case, also normalize the Stokes components based on `S0`.
                     alpha = dop[:, :, np.newaxis]
                     if args.luminance_overlay:
                         out *= s0[:, :, np.newaxis]
                     out = out*alpha + black_white*(1 - alpha)
 
-                mi.Bitmap(out).convert(mi.Bitmap.PixelFormat.RGB, mi.Struct.Type.UInt8, True).write("%s_dop.png" % (name))
+                out_list.append(out)
 
-            if args.top:
-                # Write out false-color image of the type of polarization (linear vs. circular)
+            for idx, img in enumerate(out_list):
+                mi.Bitmap(img).convert(mi.Bitmap.PixelFormat.RGB, mi.Struct.Type.UInt8, True).write("%s_s%d.png" % (name, idx))
 
-                # Cyan for linear polarization, yellow for circular polarization.
-                c_top = np.dstack([rdop_c, rdop_l + rdop_c, rdop_l])
-                out = c_top * dop[:, :, np.newaxis]
+        if args.dop:
+            # Write out false-color image of degree of polarization.
+            # Uses the red channel only
+            z = np.zeros(s0.shape)
+            out = np.dstack([dop, z, z])
 
-                if args.direct_overlay or args.luminance_overlay:
-                    # Optionally overlay the false-color information on top of the original black and white image.
-                    alpha = dop[:, :, np.newaxis]
-                    if args.luminance_overlay:
-                        out *= s0[:, :, np.newaxis]
-                    out = out*alpha + black_white*(1 - alpha)
+            if args.direct_overlay or args.luminance_overlay:
+                # Optionally overlay the false-color information on top of the original black and white image.
+                alpha = dop[:, :, np.newaxis]
+                if args.luminance_overlay:
+                    out *= s0[:, :, np.newaxis]
+                out = out*alpha + black_white*(1 - alpha)
 
-                mi.Bitmap(out).convert(mi.Bitmap.PixelFormat.RGB, mi.Struct.Type.UInt8, True).write("%s_top.png" % (name))
+            mi.Bitmap(out).convert(mi.Bitmap.PixelFormat.RGB, mi.Struct.Type.UInt8, True).write("%s_dop.png" % (name))
 
-            if args.lin:
-                # Write out false-color image for the oscillation plane of linear polarization.
+        if args.top:
+            # Write out false-color image of the type of polarization (linear vs. circular)
 
-                s1_nrm = np.divide(stokes[:, :, 1], s0, out=np.zeros_like(s0), where=s0!=0)
-                s2_nrm = np.divide(stokes[:, :, 2], s0, out=np.zeros_like(s0), where=s0!=0)
+            # Cyan for linear polarization, yellow for circular polarization.
+            c_top = np.dstack([rdop_c, rdop_l + rdop_c, rdop_l])
+            out = c_top * dop[:, :, np.newaxis]
 
-                # S1. Red: negative, green: positive
-                out_a = np.dstack([np.maximum(0, -s1_nrm),
-                                   np.maximum(0,  s1_nrm),
-                                   np.zeros(s0.shape)])
-                # S2: Blue: negative, yellow: positive
-                out_b = np.dstack([np.maximum(0,  s2_nrm),
-                                   np.maximum(0,  s2_nrm),
-                                   np.maximum(0, -s2_nrm)])
+            if args.direct_overlay or args.luminance_overlay:
+                # Optionally overlay the false-color information on top of the original black and white image.
+                alpha = dop[:, :, np.newaxis]
+                if args.luminance_overlay:
+                    out *= s0[:, :, np.newaxis]
+                out = out*alpha + black_white*(1 - alpha)
 
-                out = (out_a + out_b) * rdop_l[:, :, np.newaxis]
+            mi.Bitmap(out).convert(mi.Bitmap.PixelFormat.RGB, mi.Struct.Type.UInt8, True).write("%s_top.png" % (name))
 
-                if args.direct_overlay or args.luminance_overlay:
-                    # Optionally overlay the false-color information on top of the original black and white image.
-                    alpha = rdop_l[:, :, np.newaxis]
-                    if args.luminance_overlay:
-                        out *= s0[:, :, np.newaxis]
-                    out = out*alpha + black_white*(1 - alpha)
+        if args.lin:
+            # Write out false-color image for the oscillation plane of linear polarization.
 
-                mi.Bitmap(out).convert(mi.Bitmap.PixelFormat.RGB, mi.Struct.Type.UInt8, True).write("%s_lin.png" % (name))
+            s1_nrm = np.divide(stokes[:, :, 1], s0, out=np.zeros_like(s0), where=s0!=0)
+            s2_nrm = np.divide(stokes[:, :, 2], s0, out=np.zeros_like(s0), where=s0!=0)
 
-            if args.cir:
-                # Write out false-color image for the chirality of circular polarization.
+            # S1. Red: negative, green: positive
+            out_a = np.dstack([np.maximum(0, -s1_nrm),
+                                np.maximum(0,  s1_nrm),
+                                np.zeros(s0.shape)])
+            # S2: Blue: negative, yellow: positive
+            out_b = np.dstack([np.maximum(0,  s2_nrm),
+                                np.maximum(0,  s2_nrm),
+                                np.maximum(0, -s2_nrm)])
 
-                s3_nrm = np.divide(stokes[:, :, 3], s0, out=np.zeros_like(s0), where=s0!=0)
+            out = (out_a + out_b) * rdop_l[:, :, np.newaxis]
 
-                # Blue: right circular polarization, yellow: left circular polarization
-                cir = np.dstack([np.maximum(0, -s3_nrm),
-                                 np.maximum(0, -s3_nrm),
-                                 np.maximum(0,  s3_nrm)])
-                out = cir * rdop_c[:, :, np.newaxis]
+            if args.direct_overlay or args.luminance_overlay:
+                # Optionally overlay the false-color information on top of the original black and white image.
+                alpha = rdop_l[:, :, np.newaxis]
+                if args.luminance_overlay:
+                    out *= s0[:, :, np.newaxis]
+                out = out*alpha + black_white*(1 - alpha)
 
-                if args.direct_overlay or args.luminance_overlay:
-                    # Optionally overlay the false-color information on top of the original black and white image.
-                    alpha = rdop_c[:, :, np.newaxis]
-                    if args.luminance_overlay:
-                        out *= s0[:, :, np.newaxis]
-                    out = out*alpha + black_white*(1 - alpha)
+            mi.Bitmap(out).convert(mi.Bitmap.PixelFormat.RGB, mi.Struct.Type.UInt8, True).write("%s_lin.png" % (name))
 
-                mi.Bitmap(out).convert(mi.Bitmap.PixelFormat.RGB, mi.Struct.Type.UInt8, True).write("%s_cir.png" % (name))
+        if args.cir:
+            # Write out false-color image for the chirality of circular polarization.
 
-        except Exception as e:
-            sys.stderr.write('Could not apply polarization visualization to image "%s": %s!\n' %
-                (fname, str(e)))
+            s3_nrm = np.divide(stokes[:, :, 3], s0, out=np.zeros_like(s0), where=s0!=0)
+
+            # Blue: right circular polarization, yellow: left circular polarization
+            cir = np.dstack([np.maximum(0, -s3_nrm),
+                                np.maximum(0, -s3_nrm),
+                                np.maximum(0,  s3_nrm)])
+            out = cir * rdop_c[:, :, np.newaxis]
+
+            if args.direct_overlay or args.luminance_overlay:
+                # Optionally overlay the false-color information on top of the original black and white image.
+                alpha = rdop_c[:, :, np.newaxis]
+                if args.luminance_overlay:
+                    out *= s0[:, :, np.newaxis]
+                out = out*alpha + black_white*(1 - alpha)
+
+            mi.Bitmap(out).convert(mi.Bitmap.PixelFormat.RGB, mi.Struct.Type.UInt8, True).write("%s_cir.png" % (name))
+
+    except Exception as e:
+        sys.stderr.write('Could not apply polarization visualization to image "%s": %s!\n' %
+            (fname, str(e)))
 
 if __name__ == '__main__':
     import sys, os, argparse


### PR DESCRIPTION
Remove any use and mention of deprecated `ThreadEnvironment`. There was a leftover warning in `set_log_level`, and a use in the `polvis.py` helper script. 