### PR TITLE
Fix BoundingSphere3f Python bindings

### DIFF
--- a/include/mitsuba/core/bsphere.h
+++ b/include/mitsuba/core/bsphere.h
@@ -5,7 +5,7 @@
 NAMESPACE_BEGIN(mitsuba)
 
 /// Generic n-dimensional bounding sphere data structure
-template <typename Point_> struct BoundingSphere: drjit::TraversableBase {
+template <typename Point_> struct BoundingSphere {
     static constexpr size_t Size = Point_::Size;
     using Point                  = Point_;
     using Float                  = dr::value_t<Point>;
@@ -78,12 +78,12 @@ template <typename Point_> struct BoundingSphere: drjit::TraversableBase {
         );
     }
 
-    MI_TRAVERSE_CB(drjit::TraversableBase, center, radius)
+    DRJIT_TRAVERSE(BoundingSphere, center, radius)
 };
 
 /// Print a string representation of the bounding sphere
-template <typename Point>
-std::ostream &operator<<(std::ostream &os, const BoundingSphere<Point> &bsphere) {
+template <typename Stream, typename Point>
+Stream &operator<<(Stream &os, const BoundingSphere<Point> &bsphere) {
     os << "BoundingSphere" << type_suffix<Point>();
     if (dr::all(bsphere.empty()))
         os << "[empty]";

--- a/src/core/python/bsphere_v.cpp
+++ b/src/core/python/bsphere_v.cpp
@@ -8,9 +8,10 @@
 template <typename BSphere, typename Ray> auto bind_bsphere(nb::module_ &m, const char *name) {
         using Point = typename BSphere::Point;
         using Float = typename BSphere::Float;
+        using Mask  = typename BSphere::Mask;
 
         MI_PY_CHECK_ALIAS(BSphere, name) {
-        nb::class_<BSphere, drjit::TraversableBase>(m, name, D(BoundingSphere))
+        auto bsphere = nb::class_<BSphere>(m, name, D(BoundingSphere))
             .def(nb::init<>(), D(BoundingSphere, BoundingSphere))
             .def(nb::init<Point, Float>(), D(BoundingSphere, BoundingSphere, 2))
             .def(nb::init<const BSphere &>())
@@ -30,13 +31,33 @@ template <typename BSphere, typename Ray> auto bind_bsphere(nb::module_ &m, cons
             .def_rw("center", &BSphere::center)
             .def_rw("radius", &BSphere::radius)
             .def_repr(BSphere);
+
+        MI_PY_DRJIT_STRUCT(bsphere, BSphere, center, radius);
         }
+}
+
+// Add a `ray_intersect` overload to an existing bounding sphere binding.
+// This is used to allow intersecting a JIT array of rays against a scalar
+// bounding sphere.
+template <typename BSphere, typename Ray> void bind_bsphere_ray(const char *name) {
+    nb::handle h = nb::type<BSphere>();
+    if (!h)
+        Throw("bind_bsphere_ray(): '%s' has not been registered yet!", name);
+    nb::borrow<nb::class_<BSphere>>(h).def(
+        "ray_intersect",
+        [](const BSphere &self, const Ray &ray) { return self.ray_intersect(ray); },
+        D(BoundingSphere, ray_intersect), "ray"_a);
 }
 
 MI_PY_EXPORT(BoundingSphere) {
     MI_PY_IMPORT_TYPES()
+    using ScalarRay3f = Ray<ScalarPoint3f, scalar_spectrum_t<Spectrum>>;
 
     bind_bsphere<BoundingSphere3f, Ray3f>(m, "BoundingSphere3f");
 
-    bind_bsphere<ScalarBoundingSphere3f, Ray3f>(m, "ScalarBoundingSphere3f");
+    bind_bsphere<ScalarBoundingSphere3f, ScalarRay3f>(m, "ScalarBoundingSphere3f");
+
+    // Also accept this variant's (possibly vectorized) ray type for ray_intersect
+    if constexpr (!std::is_same_v<Ray3f, ScalarRay3f>)
+        bind_bsphere_ray<ScalarBoundingSphere3f, Ray3f>("ScalarBoundingSphere3f");
 }

--- a/src/core/tests/test_bsphere.py
+++ b/src/core/tests/test_bsphere.py
@@ -48,3 +48,11 @@ def test06_ray_intersect_vec(variant_scalar_rgb):
 
     from mitsuba.test.util import check_vectorization
     check_vectorization(kernel, arg_dims = [3, 3, 1])
+
+
+def test07_bounding_sphere(variant_scalar_rgb):
+    # Ensures returning a bounding sphere by value works.
+    bbox = mi.BoundingBox3f([-1, -1, -1], [1, 1, 1])
+    bsphere = bbox.bounding_sphere()
+    assert dr.all(bsphere.center == [0, 0, 0])
+    assert dr.allclose(bsphere.radius, dr.sqrt(3))


### PR DESCRIPTION
This fixes two issues with the BoundingSphere3f Python bindings:

1. Calling `bounding_sphere()` on a bounding box returns a bounding sphere by value. Because bounding sphere was inheriting from `drjit::TraversableBase`, this did not work and crashed. This PR makes bounding sphere mirror the patterns of bounding box to make it a proper value type.

2. Similar to #1948 for bounding boxes, this also fixes the binding of the `ray_intersect` function to not depend on import order.
