### PR TITLE
`PSIntegrator`: fix biased boundary gradients when `sample_border` is enabled

### DIFF
--- a/src/python/python/ad/integrators/common.py
+++ b/src/python/python/ad/integrators/common.py
@@ -1140,7 +1140,10 @@ class PSIntegrator(ADIntegrator):
         block.put(
             pos=sensor_ds.uv,
             wavelengths=wavelengths,
-            value=derivative * dr.rcp(mi.ScalarFloat(spp)),
+            # Boundary samples are not tied to pixels: normalize by their
+            # count and the pixel area, not by `spp`
+            value=derivative * (dr.prod(film.crop_size()) /
+                                mi.ScalarFloat(sampler.wavefront_size())),
             weight=0,
             alpha=1,
             active=active
@@ -1246,8 +1249,10 @@ class PSIntegrator(ADIntegrator):
                 scene, sensor, sample, sampler, preprocess=False)
             active = dr.any(value != 0)
 
-            # Account for the guiding sampling density and spp
-            value *= rcp_pdf_guiding * dr.rcp(spp)
+            # Account for the guiding density, the sample count and the
+            # pixel area
+            value *= rcp_pdf_guiding * (dr.prod(film.crop_size()) /
+                                        mi.ScalarFloat(sampler.wavefront_size()))
 
             # Splat the result to the film
             block = film.create_block(normalize=True)

--- a/src/python/python/ad/integrators/common.py
+++ b/src/python/python/ad/integrators/common.py
@@ -1138,7 +1138,7 @@ class PSIntegrator(ADIntegrator):
         block = film.create_block(normalize=True)
         block.set_coalesce(block.coalesce() and spp >= 4)
         block.put(
-            pos=sensor_ds.uv,
+            pos=sensor_ds.uv + mi.ScalarPoint2f(block.offset()),
             wavelengths=wavelengths,
             # Boundary samples are not tied to pixels: normalize by their
             # count and the pixel area, not by `spp`
@@ -1258,7 +1258,7 @@ class PSIntegrator(ADIntegrator):
             block = film.create_block(normalize=True)
             block.set_coalesce(block.coalesce() and spp >= 4)
             block.put(
-                pos=sensor_uv,
+                pos=sensor_uv + mi.ScalarPoint2f(block.offset()),
                 wavelengths=wavelengths,
                 value=value,
                 weight=0,

--- a/src/python/python/ad/projective.py
+++ b/src/python/python/ad/projective.py
@@ -175,7 +175,17 @@ class ProjectiveDetail():
             it = dr.zeros(mi.Interaction3f)
             it.p = ss.p
             ds, _ = sensor.sample_direction(it, mi.Point2f(0), active)
-            visible &= ds.pdf != 0
+            film = sensor.film()
+            if film.sample_border():
+                # The filter reaches past the crop window, so points just
+                # outside of it still contribute
+                border = film.rfilter().border_size()
+                size = mi.ScalarVector2f(film.crop_size())
+                in_front = (to_world.inverse() @ ss.p).z > 0
+                visible &= in_front & dr.all((ds.uv >= -border) &
+                                             (ds.uv <= size + border))
+            else:
+                visible &= ds.pdf != 0
 
             # Sample wavelengths
             wavelength_sample = 0


### PR DESCRIPTION
- **Fix boundary sample normalization.** Splats used `1 / spp`, but when the film samples its border the wavefront is `prod(crop_size + 2 * border) * spp`, overestimating the derivative. Use `prod(crop_size) / wavefront_size` instead, which reduces to `1 / spp` when no border is sampled.
- **Account for the filter border when culling.** Silhouette points outside of the crop window were discarded, although the filter reaches `border_size` pixels beyond it. Widening the frustum test reduces error against finite differences.
- **Splat boundary samples at the right pixel.** `sample_direction` returns `ds.uv` relative to the crop window, while `ImageBlock::put` subtracts the block's own offset, so with a non-zero `crop_offset` the derivatives landed `crop_offset` pixels away from the edge they belong to. Add the offset back, as the primal render and `ptracer` already do.
- [x] My code follows the [style guidelines](https://mitsuba.readthedocs.io/en/latest/src/developer_guide.html#coding-style) of this project
- [x] My changes generate no new warnings
- [x] My code also compiles for `cuda_*` and `llvm_*` variants. If you can't test this, please leave below
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 3 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba/blob/master/LICENSE)