### PR TITLE
Fix false positive in SceneParameters.__setitem__ equality check

### DIFF
--- a/src/python/python/util.py
+++ b/src/python/python/util.py
@@ -65,6 +65,7 @@ class SceneParameters(Mapping):
 
         try:
             if (_jit_id_hash(cur_value) == _jit_id_hash(value) and
+                dr.shape(cur_value) == dr.shape(value) and
                 dr.all(cur_value == value, axis=None)):
                 # Turn this into a no-op when the set value is identical to the new value
                 return


### PR DESCRIPTION
The `SceneParameters.__setitem__` call skips setting elements that haven't changed. In scalar mode, this test was not restrictive enough: For example, replacing a tensor `[[1, 1, 1]]` by `[[1, 1, 1], [1, 1, 1]]` would pass the JIT ID test (both IDs are the same in scalar mode), and also pass the equality test due to broadcasting. Technically this may even work fine in some cases (e.g., if a plugin then internally can broadcast), but will fail if the plugin enforces any kind of consistency checks (e.g., checks that two different parameters have the same shape).

This PR simply adds an additonal shape test to prevent broadcasting from giving a false positive here.