### PR TITLE
Optix APIs: Add the necessary API definitions for motion blur

### DIFF
--- a/include/mitsuba/render/optix_api.h
+++ b/include/mitsuba/render/optix_api.h
@@ -24,6 +24,7 @@ using OptixTransformFormat   = int;
 using OptixAccelPropertyType = int;
 using OptixProgramGroupKind  = int;
 using OptixPrimitiveType     = int;
+using OptixTraversableType   = int;
 using OptixDeviceContext     = void*;
 using OptixTask              = void*;
 using OptixDenoiserStructPtr = void*;
@@ -51,6 +52,7 @@ using OptixOpacityMicromapArrayIndexingMode       = int;
 #define OPTIX_INDICES_FORMAT_UNSIGNED_INT3 0x2103
 #define OPTIX_VERTEX_FORMAT_FLOAT3         0x2121
 #define OPTIX_SBT_RECORD_ALIGNMENT         16ull
+#define OPTIX_TRANSFORM_BYTE_ALIGNMENT     64ull
 #define OPTIX_SBT_RECORD_HEADER_SIZE       32
 
 #define OPTIX_COMPILE_DEFAULT_MAX_REGISTER_COUNT 0
@@ -99,6 +101,7 @@ using OptixOpacityMicromapArrayIndexingMode       = int;
 
 #define OPTIX_MODULE_COMPILE_STATE_COMPLETED 0x2364
 
+#define OPTIX_TRAVERSABLE_TYPE_SRT_MOTION_TRANSFORM 0x21C3
 
 // =====================================================
 //          Commonly used OptiX data structures
@@ -263,6 +266,21 @@ struct OptixInstance {
     unsigned int flags;
     OptixTraversableHandle traversableHandle;
     unsigned int pad[2];
+};
+
+struct OptixSRTData {
+    float sx, a, b, pvx;
+    float sy, c, pvy;
+    float sz, pvz;
+    float qx, qy, qz, qw;
+    float tx, ty, tz;
+};
+
+struct alignas(OPTIX_TRANSFORM_BYTE_ALIGNMENT) OptixSRTMotionTransform {
+    OptixTraversableHandle child;
+    OptixMotionOptions motionOptions;
+    unsigned int pad[3];
+    OptixSRTData srtData[2];
 };
 
 struct OptixPayloadType {
@@ -469,6 +487,8 @@ D(optixDenoiserInvoke, OptixDenoiserStructPtr, CUstream,
   unsigned int, unsigned int, CUdeviceptr, size_t);
 D(optixDenoiserComputeIntensity, OptixDenoiserStructPtr, CUstream,
   const OptixImage2D *, CUdeviceptr, CUdeviceptr, size_t);
+D(optixConvertPointerToTraversableHandle, OptixDeviceContext, CUdeviceptr,
+  OptixTraversableType, OptixTraversableHandle *);
 
 #undef D
 

--- a/src/render/optix_api.cpp
+++ b/src/render/optix_api.cpp
@@ -31,6 +31,7 @@ void optix_initialize() {
     L(optixTaskExecute);
     L(optixProgramGroupCreate);
     L(optixSbtRecordPackHeader);
+    L(optixConvertPointerToTraversableHandle);
 
     #undef L
 }


### PR DESCRIPTION
Adds the necessary API definitions to the optix header to implement motion blur. This can already be merged and reduces a bit the change set of the main PR