### PR TITLE
Add NVIDIA DLSS Ray Reconstruction denoiser

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,12 @@ option(MI_ENABLE_PYTHON "Build Python bindings for Mitsuba, Dr.Jit, and NanoGUI?
 # precision arithmetic.
 option(MI_ENABLE_EMBREE  "Use Embree for ray tracing operations?" ON)
 
+# The NVIDIA DLSS Ray Reconstruction denoiser can be used as an alternative to
+# the OptiX denoiser. It requires the headers of the DLSS SDK
+# (https://github.com/NVIDIA/DLSS) at compile time, which are located through
+# the 'DLSS_SDK_ROOT' variable, and a CUDA variant of Mitsuba.
+option(MI_ENABLE_DLSS "Enable the NVIDIA DLSS Ray Reconstruction denoiser?" OFF)
+
 # Use GCC/Clang address sanitizer?
 # NOTE: To use this in conjunction with Python plugin, you will need to call
 # On OSX:
@@ -317,6 +323,34 @@ if (MI_ENABLE_CUDA)
   add_definitions(-DMI_ENABLE_CUDA=1)
 endif()
 
+if (MI_ENABLE_DLSS)
+  if (NOT MI_ENABLE_CUDA)
+    message(WARNING "Mitsuba: MI_ENABLE_DLSS requires a CUDA variant, "
+                    "disabling DLSS support.")
+    set(MI_ENABLE_DLSS OFF)
+  else()
+    list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/src/cmake")
+    find_package(DLSS)
+    if (DLSS_FOUND)
+      include_directories(${DLSS_INCLUDE_DIR})
+      add_definitions(-DMI_ENABLE_DLSS=1)
+      message(STATUS "Mitsuba: using DLSS Ray Reconstruction for denoising.")
+      if (NOT DLSS_RR_LIBRARY)
+        message(WARNING "Mitsuba: could not find the DLSS Ray Reconstruction "
+                        "library in the SDK. It has to be placed next to the "
+                        "executable, or in the directory given by the "
+                        "MI_DLSS_LIBRARY_PATH environment variable, for DLSS "
+                        "to report itself as available at runtime.")
+      endif()
+    else()
+      message(WARNING "Mitsuba: could not find the DLSS SDK headers, set "
+                      "DLSS_SDK_ROOT to a checkout of "
+                      "https://github.com/NVIDIA/DLSS. Disabling DLSS support.")
+      set(MI_ENABLE_DLSS OFF)
+    endif()
+  endif()
+endif()
+
 if (MI_ENABLE_LLVM)
   add_definitions(-DMI_ENABLE_LLVM=1)
 endif()
@@ -595,6 +629,26 @@ install(
 )
 
 add_custom_target(copy-resources ALL DEPENDS ${MI_COPY_FILES})
+
+# DLSS Ray Reconstruction implementation library. Note that this is only copied
+# into the build tree, it is deliberately not part of 'install' since Mitsuba
+# does not redistribute it.
+if (MI_ENABLE_DLSS AND DLSS_RR_LIBRARY)
+  add_custom_command(
+    TARGET copy-resources POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+    "${DLSS_RR_LIBRARY}"
+    "${MI_BINARY_DIR}"
+  )
+  if (MI_ENABLE_PYTHON)
+    add_custom_command(
+      TARGET copy-resources POST_BUILD
+      COMMAND ${CMAKE_COMMAND} -E copy_if_different
+      "${DLSS_RR_LIBRARY}"
+      "${MI_BINARY_DIR}/python/mitsuba"
+    )
+  endif()
+endif()
 
 # IOR data
 file(GLOB IOR_FILES "${CMAKE_CURRENT_SOURCE_DIR}/resources/data/ior/*spd")

--- a/docs/api_from_stubs.py
+++ b/docs/api_from_stubs.py
@@ -89,7 +89,7 @@ RENDER_SECTIONS: dict[str, list[str]] = {
     'Emitters and sensors': ['Endpoint', r'Emitter\w*', r'Sensor\w*',
                              'ProjectiveCamera', r'\w+_projection'],
     'Films and image blocks': [r'Film\w*', 'ImageBlock', 'Spiral',
-                               'OptixDenoiser'],
+                               'OptixDenoiser', 'DLSSDenoiser'],
     'Integrators': ['render', r'\w*Integrator\w*', r'Sampler\w*'],
 }
 

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -166,6 +166,22 @@ Mitsuba 3.10.0
     ``mesh.has_flipped_normals()``               *removed, see above*
     ============================================ ==============================
 
+- **NVIDIA DLSS Ray Reconstruction denoiser**. The new ``mi.DLSSDenoiser``
+  class exposes DLSS Ray Reconstruction (DLSS-D) as an alternative to
+  ``mi.OptixDenoiser``. In contrast to the latter, it is a real-time denoiser
+  that is driven with a sequence of jittered 1-sample-per-pixel frames plus
+  screen-space motion vectors, and it can upscale the result. It requires a
+  CUDA variant, an RTX GPU, NVIDIA driver 590 or newer, and a build configured
+  with ``-DMI_ENABLE_DLSS=ON -DDLSS_SDK_ROOT=<path to the DLSS SDK>``. Only the
+  SDK headers are needed at compile time. At runtime, the NGX entry points are
+  resolved from the display driver, which in turn loads the Ray Reconstruction
+  library that ships with the SDK (``nvngx_dlssd.dll``, or
+  ``libnvidia-ngx-dlssd.so`` on Linux). The build copies that library next to
+  Mitsuba's own binaries, and Mitsuba passes that directory to the driver as a
+  search path, so that no manual step is needed; the ``MI_DLSS_LIBRARY_PATH``
+  environment variable overrides the directory. This mirrors how Blender's
+  Cycles renderer integrates DLSS.
+
 Mitsuba 3.9.1
 -------------
 *August 7, 2026*

--- a/include/mitsuba/python/docstr.h
+++ b/include/mitsuba/python/docstr.h
@@ -27,6 +27,10 @@ static const char *__doc_EmptySbtRecord = R"doc()doc";
 
 static const char *__doc_EmptySbtRecord_header = R"doc()doc";
 
+static const char *__doc_NVSDK_NGX_CUDADevice = R"doc()doc";
+
+static const char *__doc_NVSDK_NGX_Handle = R"doc()doc";
+
 static const char *__doc_OptixAccelBufferSizes = R"doc()doc";
 
 static const char *__doc_OptixAccelBufferSizes_outputSizeInBytes = R"doc()doc";
@@ -2733,6 +2737,258 @@ static const char *__doc_mitsuba_CornerMesh_record_count = R"doc(Number of corne
 static const char *__doc_mitsuba_CornerMesh_texcoords = R"doc(Texture coordinates (2 channels); optional)doc";
 
 static const char *__doc_mitsuba_CornerMesh_vertex_count = R"doc(Number of source vertices)doc";
+
+static const char *__doc_mitsuba_DLSSDenoiser =
+R"doc(Wrapper for the NVIDIA DLSS Ray Reconstruction denoiser
+
+DLSS Ray Reconstruction (also known as DLSS-D) is a real-time denoiser which
+additionally performs temporal antialiasing and optional upscaling. It is
+wrapped in this object such that it can work directly with Mitsuba types and
+its conventions.
+
+In contrast to `OptixDenoiser`, this denoiser is inherently temporal: it
+expects a sequence of independently rendered frames (typically a single
+sample per pixel each), the subpixel jitter that was applied to the camera of
+every frame, and screen-space motion vectors relating consecutive frames. It
+accumulates information across the frames that are passed to it, which means
+that the output of the very first frames of a sequence will be considerably
+noisier than that of later ones.
+
+The implementation is loaded from the NVIDIA display driver at runtime. It
+requires driver version 590 or newer, an RTX GPU, and the DLSS Ray
+Reconstruction library (``nvngx_dlssd.dll`` on Windows,
+``libnvidia-ngx-dlssd.so.*`` on Linux) to be installed in one of the
+directories which are searched by the NGX driver. Use `is_available()` to
+query whether all of these requirements are met before constructing an
+instance of this class. The environment variable ``MI_DLSS_LIBRARY_PATH``
+can be used to add a directory to that search path.)doc";
+
+static const char *__doc_mitsuba_DLSSDenoiser_2 = R"doc()doc";
+
+static const char *__doc_mitsuba_DLSSDenoiser_3 = R"doc()doc";
+
+static const char *__doc_mitsuba_DLSSDenoiser_4 = R"doc()doc";
+
+static const char *__doc_mitsuba_DLSSDenoiser_5 = R"doc()doc";
+
+static const char *__doc_mitsuba_DLSSDenoiser_6 = R"doc()doc";
+
+static const char *__doc_mitsuba_DLSSDenoiser_7 = R"doc()doc";
+
+static const char *__doc_mitsuba_DLSSDenoiser_CUDATexture = R"doc(A 2D CUDA array along with the texture and surface objects viewing it)doc";
+
+static const char *__doc_mitsuba_DLSSDenoiser_CUDATexture_array = R"doc()doc";
+
+static const char *__doc_mitsuba_DLSSDenoiser_CUDATexture_destroy = R"doc()doc";
+
+static const char *__doc_mitsuba_DLSSDenoiser_CUDATexture_download = R"doc(Copy `n_channels` interleaved floats per pixel to device memory)doc";
+
+static const char *__doc_mitsuba_DLSSDenoiser_CUDATexture_height = R"doc()doc";
+
+static const char *__doc_mitsuba_DLSSDenoiser_CUDATexture_init = R"doc()doc";
+
+static const char *__doc_mitsuba_DLSSDenoiser_CUDATexture_n_channels = R"doc()doc";
+
+static const char *__doc_mitsuba_DLSSDenoiser_CUDATexture_surface_handle = R"doc()doc";
+
+static const char *__doc_mitsuba_DLSSDenoiser_CUDATexture_surface_ptr = R"doc()doc";
+
+static const char *__doc_mitsuba_DLSSDenoiser_CUDATexture_texture_handle = R"doc()doc";
+
+static const char *__doc_mitsuba_DLSSDenoiser_CUDATexture_texture_ptr = R"doc(Pointers to the handles, in the form in which NGX expects them)doc";
+
+static const char *__doc_mitsuba_DLSSDenoiser_CUDATexture_upload = R"doc(Copy `n_channels` interleaved floats per pixel from device memory)doc";
+
+static const char *__doc_mitsuba_DLSSDenoiser_CUDATexture_width = R"doc()doc";
+
+static const char *__doc_mitsuba_DLSSDenoiser_DLSSDenoiser =
+R"doc(Constructs a DLSS denoiser
+
+Args:
+    input_size: Resolution of the noisy images that will be fed to the
+        denoiser.
+
+    output_size: Resolution of the denoised images produced by the
+        denoiser. When it is larger than ``input_size``, DLSS will
+        upscale the input.
+        This parameter is optional, by default it is equal to
+        ``input_size`` (i.e. no upscaling, DLAA mode).
+
+    quality: Quality/performance tradeoff of the upscaling step, one of
+        ``"high"``, ``"balanced"`` or ``"fast"``. This parameter has no
+        effect when ``output_size`` is equal to ``input_size``.
+        This parameter is optional, by default it is ``"high"``.
+
+Returns:
+    A callable object which will apply the DLSS denoiser.)doc";
+
+static const char *__doc_mitsuba_DLSSDenoiser_DLSSDenoiser_2 = R"doc()doc";
+
+static const char *__doc_mitsuba_DLSSDenoiser_class_name = R"doc()doc";
+
+static const char *__doc_mitsuba_DLSSDenoiser_is_available =
+R"doc(Check whether DLSS Ray Reconstruction can be used on this system
+
+This queries the NGX driver for the availability of the feature on the
+CUDA device which is currently active. It returns ``false`` when Mitsuba
+was compiled without DLSS support, when the driver is too old, when the
+GPU is unsupported, or when the DLSS Ray Reconstruction library could not
+be found.)doc";
+
+static const char *__doc_mitsuba_DLSSDenoiser_m_color = R"doc()doc";
+
+static const char *__doc_mitsuba_DLSSDenoiser_m_depth = R"doc()doc";
+
+static const char *__doc_mitsuba_DLSSDenoiser_m_device = R"doc()doc";
+
+static const char *__doc_mitsuba_DLSSDenoiser_m_diffuse_albedo = R"doc()doc";
+
+static const char *__doc_mitsuba_DLSSDenoiser_m_handle = R"doc()doc";
+
+static const char *__doc_mitsuba_DLSSDenoiser_m_input_size = R"doc()doc";
+
+static const char *__doc_mitsuba_DLSSDenoiser_m_motion = R"doc()doc";
+
+static const char *__doc_mitsuba_DLSSDenoiser_m_normal_roughness = R"doc()doc";
+
+static const char *__doc_mitsuba_DLSSDenoiser_m_output = R"doc()doc";
+
+static const char *__doc_mitsuba_DLSSDenoiser_m_output_size = R"doc()doc";
+
+static const char *__doc_mitsuba_DLSSDenoiser_m_quality = R"doc()doc";
+
+static const char *__doc_mitsuba_DLSSDenoiser_m_reset = R"doc(DLSS has no history for the first invocation, force a reset)doc";
+
+static const char *__doc_mitsuba_DLSSDenoiser_m_specular_albedo = R"doc()doc";
+
+static const char *__doc_mitsuba_DLSSDenoiser_m_specular_motion = R"doc()doc";
+
+static const char *__doc_mitsuba_DLSSDenoiser_operator_assign = R"doc()doc";
+
+static const char *__doc_mitsuba_DLSSDenoiser_operator_call =
+R"doc(Apply denoiser on inputs which are `TensorXf` objects.
+
+All input tensors must have the resolution which was passed to the
+constructor as ``input_size``.
+
+Args:
+    noisy: The noisy input. (tensor shape: (height, width, 3 | 4))
+
+    albedo: Diffuse albedo of the noisy rendering. Values are clamped to
+        the [0, 1] range. (tensor shape: (height, width, 3))
+
+    normals: Shading normals of the noisy rendering. They should be given
+        in the same coordinate frame which was used to compute the
+        ``flow`` and ``depth`` arguments (typically world space), and can
+        be transformed with the ``to_sensor`` argument.
+        (tensor shape: (height, width, 3))
+
+    depth: Linear camera-space depth of the noisy rendering, i.e. the
+        distance of the shading point to the plane of the sensor rather
+        than the distance to the sensor itself.
+        (tensor shape: (height, width, 1))
+
+    specular_albedo: Specular albedo of the noisy rendering. Leaving this
+        parameter unspecified degrades the quality of reflections.
+        This parameter is optional, by default it is zero.
+        (tensor shape: (height, width, 3))
+
+    roughness: Surface roughness of the noisy rendering.
+        This parameter is optional, by default it is zero.
+        (tensor shape: (height, width, 1))
+
+    flow: Screen-space motion vectors, in pixels of the input resolution,
+        pointing from the position of a pixel in the current frame to its
+        position in the previous frame.
+        This parameter is optional, by default it is zero, which will
+        produce ghosting whenever the camera or the scene moves.
+        (tensor shape: (height, width, 2))
+
+    specular_flow: Screen-space motion vectors of the virtual image seen
+        in specular surfaces, in the same units as ``flow``.
+        This parameter is optional, by default it is zero.
+        (tensor shape: (height, width, 2))
+
+    to_sensor: An `AffineTransform4f` which is applied to the ``normals``
+        parameter before denoising.
+        This parameter is optional, by default no transformation is
+        applied.
+
+    jitter: The subpixel offset which was applied to the camera when
+        rendering the noisy input, in pixels and relative to the center
+        of a pixel. Every frame of a sequence must use a different
+        offset, e.g. taken from a low-discrepancy sequence covering
+        the [-0.5, 0.5] x [-0.5, 0.5] domain.
+        This parameter is optional, by default it is zero.
+
+    reset: Discard the history which was accumulated from the previous
+        frames. This should be set whenever the frame that is passed to
+        the denoiser is not temporally related to the previous one.
+        This parameter is optional, by default it is false. It is
+        implicitly true for the first invocation.
+
+Returns:
+    The denoised input, at the ``output_size`` resolution and with the
+    same number of channels as the ``noisy`` argument.)doc";
+
+static const char *__doc_mitsuba_DLSSDenoiser_operator_call_2 =
+R"doc(Apply denoiser on inputs which are `Bitmap` objects.
+
+The ``noisy`` parameter must use the `Bitmap.PixelFormat.MultiChannel`
+pixel format, as the denoiser always requires additional guiding
+information.
+
+Args:
+    noisy: A multichannel `Bitmap` holding the noisy input as well as all
+        guiding layers.
+
+    albedo_ch: The name of the layer in the ``noisy`` parameter which
+        contains the diffuse albedo.
+
+    normals_ch: The name of the layer in the ``noisy`` parameter which
+        contains the shading normals.
+
+    depth_ch: The name of the layer in the ``noisy`` parameter which
+        contains the linear camera-space depth.
+
+    specular_albedo_ch: The name of the layer in the ``noisy`` parameter
+        which contains the specular albedo.
+        This parameter is optional.
+
+    roughness_ch: The name of the layer in the ``noisy`` parameter which
+        contains the surface roughness.
+        This parameter is optional.
+
+    flow_ch: The name of the layer in the ``noisy`` parameter which
+        contains the screen-space motion vectors.
+        This parameter is optional.
+
+    specular_flow_ch: The name of the layer in the ``noisy`` parameter
+        which contains the specular screen-space motion vectors.
+        This parameter is optional.
+
+    to_sensor: An `AffineTransform4f` which is applied to the normals
+        before denoising.
+        This parameter is optional, by default no transformation is
+        applied.
+
+    jitter: The subpixel camera offset of the noisy input, in pixels.
+        This parameter is optional, by default it is zero.
+
+    reset: Discard the history accumulated from the previous frames.
+        This parameter is optional, by default it is false.
+
+    noisy_ch: The name of the layer in the ``noisy`` parameter which
+        contains the noisy image to be denoised.
+
+Returns:
+    The denoised input.)doc";
+
+static const char *__doc_mitsuba_DLSSDenoiser_release = R"doc(Release the NGX feature and all CUDA arrays)doc";
+
+static const char *__doc_mitsuba_DLSSDenoiser_to_string = R"doc()doc";
+
+static const char *__doc_mitsuba_DLSSDenoiser_validate_input = R"doc(Helper function to validate tensor sizes)doc";
 
 static const char *__doc_mitsuba_DateTimeRecord = R"doc()doc";
 

--- a/include/mitsuba/render/dlssdenoiser.h
+++ b/include/mitsuba/render/dlssdenoiser.h
@@ -1,0 +1,297 @@
+#pragma once
+
+#if defined(MI_ENABLE_CUDA) && defined(MI_ENABLE_DLSS)
+
+#include <mitsuba/core/bitmap.h>
+#include <mitsuba/core/transform.h>
+#include <mitsuba/render/fwd.h>
+#include <drjit/tensor.h>
+
+// Opaque NGX types, so that the DLSS SDK headers do not leak into this file
+struct NVSDK_NGX_Handle;
+struct NVSDK_NGX_CUDADevice;
+
+NAMESPACE_BEGIN(mitsuba)
+
+/**
+ * Wrapper for the NVIDIA DLSS Ray Reconstruction denoiser
+ *
+ * DLSS Ray Reconstruction (also known as DLSS-D) is a real-time denoiser which
+ * additionally performs temporal antialiasing and optional upscaling. It is
+ * wrapped in this object such that it can work directly with Mitsuba types and
+ * its conventions.
+ *
+ * In contrast to `OptixDenoiser`, this denoiser is inherently temporal: it
+ * expects a sequence of independently rendered frames (typically a single
+ * sample per pixel each), the subpixel jitter that was applied to the camera of
+ * every frame, and screen-space motion vectors relating consecutive frames. It
+ * accumulates information across the frames that are passed to it, which means
+ * that the output of the very first frames of a sequence will be considerably
+ * noisier than that of later ones.
+ *
+ * The implementation is loaded from the NVIDIA display driver at runtime. It
+ * requires driver version 590 or newer, an RTX GPU, and the DLSS Ray
+ * Reconstruction library (``nvngx_dlssd.dll`` on Windows,
+ * ``libnvidia-ngx-dlssd.so.*`` on Linux) to be installed in one of the
+ * directories which are searched by the NGX driver. Use `is_available()` to
+ * query whether all of these requirements are met before constructing an
+ * instance of this class. The environment variable ``MI_DLSS_LIBRARY_PATH``
+ * can be used to add a directory to that search path.
+ */
+template <typename Float, typename Spectrum>
+class MI_EXPORT_LIB DLSSDenoiser : public Object {
+public:
+    MI_IMPORT_TYPES()
+
+    /**
+     * Check whether DLSS Ray Reconstruction can be used on this system
+     *
+     * This queries the NGX driver for the availability of the feature on the
+     * CUDA device which is currently active. It returns ``false`` when Mitsuba
+     * was compiled without DLSS support, when the driver is too old, when the
+     * GPU is unsupported, or when the DLSS Ray Reconstruction library could not
+     * be found.
+     */
+    static bool is_available();
+
+    /**
+     * Constructs a DLSS denoiser
+     *
+     * Args:
+     *     input_size: Resolution of the noisy images that will be fed to the
+     *         denoiser.
+     *
+     *     output_size: Resolution of the denoised images produced by the
+     *         denoiser. When it is larger than ``input_size``, DLSS will
+     *         upscale the input.
+     *         This parameter is optional, by default it is equal to
+     *         ``input_size`` (i.e. no upscaling, DLAA mode).
+     *
+     *     quality: Quality/performance tradeoff of the upscaling step, one of
+     *         ``"high"``, ``"balanced"`` or ``"fast"``. This parameter has no
+     *         effect when ``output_size`` is equal to ``input_size``.
+     *         This parameter is optional, by default it is ``"high"``.
+     *
+     * Returns:
+     *     A callable object which will apply the DLSS denoiser.
+     */
+    DLSSDenoiser(const ScalarVector2u &input_size,
+                 const ScalarVector2u &output_size = ScalarVector2u(0, 0),
+                 const std::string &quality = "high");
+
+    DLSSDenoiser(const DLSSDenoiser &other) = delete;
+
+    DLSSDenoiser &operator=(const DLSSDenoiser &other) = delete;
+
+    ~DLSSDenoiser();
+
+    /**
+     * Apply denoiser on inputs which are `TensorXf` objects.
+     *
+     * All input tensors must have the resolution which was passed to the
+     * constructor as ``input_size``.
+     *
+     * Args:
+     *     noisy: The noisy input. (tensor shape: (height, width, 3 | 4))
+     *
+     *     albedo: Diffuse albedo of the noisy rendering. Values are clamped to
+     *         the [0, 1] range. (tensor shape: (height, width, 3))
+     *
+     *     normals: Shading normals of the noisy rendering. They should be given
+     *         in the same coordinate frame which was used to compute the
+     *         ``flow`` and ``depth`` arguments (typically world space), and can
+     *         be transformed with the ``to_sensor`` argument.
+     *         (tensor shape: (height, width, 3))
+     *
+     *     depth: Linear camera-space depth of the noisy rendering, i.e. the
+     *         distance of the shading point to the plane of the sensor rather
+     *         than the distance to the sensor itself.
+     *         (tensor shape: (height, width, 1))
+     *
+     *     specular_albedo: Specular albedo of the noisy rendering. Leaving this
+     *         parameter unspecified degrades the quality of reflections.
+     *         This parameter is optional, by default it is zero.
+     *         (tensor shape: (height, width, 3))
+     *
+     *     roughness: Surface roughness of the noisy rendering.
+     *         This parameter is optional, by default it is zero.
+     *         (tensor shape: (height, width, 1))
+     *
+     *     flow: Screen-space motion vectors, in pixels of the input resolution,
+     *         pointing from the position of a pixel in the current frame to its
+     *         position in the previous frame.
+     *         This parameter is optional, by default it is zero, which will
+     *         produce ghosting whenever the camera or the scene moves.
+     *         (tensor shape: (height, width, 2))
+     *
+     *     specular_flow: Screen-space motion vectors of the virtual image seen
+     *         in specular surfaces, in the same units as ``flow``.
+     *         This parameter is optional, by default it is zero.
+     *         (tensor shape: (height, width, 2))
+     *
+     *     to_sensor: An `AffineTransform4f` which is applied to the ``normals``
+     *         parameter before denoising.
+     *         This parameter is optional, by default no transformation is
+     *         applied.
+     *
+     *     jitter: The subpixel offset which was applied to the camera when
+     *         rendering the noisy input, in pixels and relative to the center
+     *         of a pixel. Every frame of a sequence must use a different
+     *         offset, e.g. taken from a low-discrepancy sequence covering
+     *         the [-0.5, 0.5] x [-0.5, 0.5] domain.
+     *         This parameter is optional, by default it is zero.
+     *
+     *     reset: Discard the history which was accumulated from the previous
+     *         frames. This should be set whenever the frame that is passed to
+     *         the denoiser is not temporally related to the previous one.
+     *         This parameter is optional, by default it is false. It is
+     *         implicitly true for the first invocation.
+     *
+     * Returns:
+     *     The denoised input, at the ``output_size`` resolution and with the
+     *     same number of channels as the ``noisy`` argument.
+     */
+    TensorXf operator()(const TensorXf &noisy,
+                        const TensorXf &albedo,
+                        const TensorXf &normals,
+                        const TensorXf &depth,
+                        const TensorXf &specular_albedo = TensorXf(),
+                        const TensorXf &roughness = TensorXf(),
+                        const TensorXf &flow = TensorXf(),
+                        const TensorXf &specular_flow = TensorXf(),
+                        const AffineTransform4f &to_sensor = AffineTransform4f(),
+                        const ScalarPoint2f &jitter = ScalarPoint2f(0.f),
+                        bool reset = false) const;
+
+    /**
+     * Apply denoiser on inputs which are `Bitmap` objects.
+     *
+     * The ``noisy`` parameter must use the `Bitmap.PixelFormat.MultiChannel`
+     * pixel format, as the denoiser always requires additional guiding
+     * information.
+     *
+     * Args:
+     *     noisy: A multichannel `Bitmap` holding the noisy input as well as all
+     *         guiding layers.
+     *
+     *     albedo_ch: The name of the layer in the ``noisy`` parameter which
+     *         contains the diffuse albedo.
+     *
+     *     normals_ch: The name of the layer in the ``noisy`` parameter which
+     *         contains the shading normals.
+     *
+     *     depth_ch: The name of the layer in the ``noisy`` parameter which
+     *         contains the linear camera-space depth.
+     *
+     *     specular_albedo_ch: The name of the layer in the ``noisy`` parameter
+     *         which contains the specular albedo.
+     *         This parameter is optional.
+     *
+     *     roughness_ch: The name of the layer in the ``noisy`` parameter which
+     *         contains the surface roughness.
+     *         This parameter is optional.
+     *
+     *     flow_ch: The name of the layer in the ``noisy`` parameter which
+     *         contains the screen-space motion vectors.
+     *         This parameter is optional.
+     *
+     *     specular_flow_ch: The name of the layer in the ``noisy`` parameter
+     *         which contains the specular screen-space motion vectors.
+     *         This parameter is optional.
+     *
+     *     to_sensor: An `AffineTransform4f` which is applied to the normals
+     *         before denoising.
+     *         This parameter is optional, by default no transformation is
+     *         applied.
+     *
+     *     jitter: The subpixel camera offset of the noisy input, in pixels.
+     *         This parameter is optional, by default it is zero.
+     *
+     *     reset: Discard the history accumulated from the previous frames.
+     *         This parameter is optional, by default it is false.
+     *
+     *     noisy_ch: The name of the layer in the ``noisy`` parameter which
+     *         contains the noisy image to be denoised.
+     *
+     * Returns:
+     *     The denoised input.
+     */
+    ref<Bitmap> operator()(const ref<Bitmap> &noisy,
+                           const std::string &albedo_ch,
+                           const std::string &normals_ch,
+                           const std::string &depth_ch,
+                           const std::string &specular_albedo_ch = "",
+                           const std::string &roughness_ch = "",
+                           const std::string &flow_ch = "",
+                           const std::string &specular_flow_ch = "",
+                           const AffineTransform4f &to_sensor = AffineTransform4f(),
+                           const ScalarPoint2f &jitter = ScalarPoint2f(0.f),
+                           bool reset = false,
+                           const std::string &noisy_ch = "<root>") const;
+
+    virtual std::string to_string() const override;
+
+    MI_DECLARE_CLASS(DLSSDenoiser)
+
+private:
+    /// A 2D CUDA array along with the texture and surface objects viewing it
+    struct CUDATexture {
+        void init(uint32_t width, uint32_t height, uint32_t n_channels);
+        void destroy();
+
+        /// Copy `n_channels` interleaved floats per pixel from device memory
+        void upload(const void *src) const;
+
+        /// Copy `n_channels` interleaved floats per pixel to device memory
+        void download(void *dst) const;
+
+        /// Pointers to the handles, in the form in which NGX expects them
+        void *texture_ptr() const {
+            return const_cast<uint64_t *>(&texture_handle);
+        }
+        void *surface_ptr() const {
+            return const_cast<uint64_t *>(&surface_handle);
+        }
+
+        void *array = nullptr;
+        uint64_t texture_handle = 0;
+        uint64_t surface_handle = 0;
+        uint32_t width = 0;
+        uint32_t height = 0;
+        uint32_t n_channels = 0;
+    };
+
+    /// Helper function to validate tensor sizes
+    void validate_input(const TensorXf &noisy, const TensorXf &albedo,
+                        const TensorXf &normals, const TensorXf &depth,
+                        const TensorXf &specular_albedo,
+                        const TensorXf &roughness, const TensorXf &flow,
+                        const TensorXf &specular_flow) const;
+
+    /// Release the NGX feature and all CUDA arrays
+    void release();
+
+    ScalarVector2u m_input_size;
+    ScalarVector2u m_output_size;
+    std::string m_quality;
+
+    NVSDK_NGX_Handle *m_handle = nullptr;
+    NVSDK_NGX_CUDADevice *m_device = nullptr;
+
+    CUDATexture m_color;
+    CUDATexture m_depth;
+    CUDATexture m_diffuse_albedo;
+    CUDATexture m_specular_albedo;
+    CUDATexture m_normal_roughness;
+    CUDATexture m_motion;
+    CUDATexture m_specular_motion;
+    CUDATexture m_output;
+
+    /// DLSS has no history for the first invocation, force a reset
+    mutable bool m_reset = true;
+};
+
+MI_EXTERN_CLASS(DLSSDenoiser)
+NAMESPACE_END(mitsuba)
+
+#endif // defined(MI_ENABLE_CUDA) && defined(MI_ENABLE_DLSS)

--- a/include/mitsuba/render/fwd.h
+++ b/include/mitsuba/render/fwd.h
@@ -10,6 +10,7 @@ struct BSDFContext;
 struct ShapeIR;
 template <typename Float, typename Spectrum> class BSDF;
 template <typename Float, typename Spectrum> class DirectedEdge;
+template <typename Float, typename Spectrum> class DLSSDenoiser;
 template <typename Float, typename Spectrum> class OptixDenoiser;
 template <typename Float, typename Spectrum> class Emitter;
 template <typename Float, typename Spectrum> class Endpoint;
@@ -126,6 +127,7 @@ template <typename Float_, typename Spectrum_> struct RenderAliases {
     using MonteCarloIntegrator   = mitsuba::MonteCarloIntegrator<Float, Spectrum>;
     using AdjointIntegrator      = mitsuba::AdjointIntegrator<Float, Spectrum>;
     using BSDF                   = mitsuba::BSDF<Float, Spectrum>;
+    using DLSSDenoiser           = mitsuba::DLSSDenoiser<Float, Spectrum>;
     using OptixDenoiser          = mitsuba::OptixDenoiser<Float, Spectrum>;
     using Sensor                 = mitsuba::Sensor<Float, Spectrum>;
     using ProjectiveCamera       = mitsuba::ProjectiveCamera<Float, Spectrum>;
@@ -213,6 +215,7 @@ template <typename Float_, typename Spectrum_> struct RenderAliases {
     using MonteCarloIntegrator   = typename RenderAliases::MonteCarloIntegrator;                   \
     using AdjointIntegrator      = typename RenderAliases::AdjointIntegrator;                      \
     using BSDF                   = typename RenderAliases::BSDF;                                   \
+    using DLSSDenoiser           = typename RenderAliases::DLSSDenoiser;                           \
     using OptixDenoiser          = typename RenderAliases::OptixDenoiser;                          \
     using Sensor                 = typename RenderAliases::Sensor;                                 \
     using ProjectiveCamera       = typename RenderAliases::ProjectiveCamera;                       \

--- a/src/cmake/FindDLSS.cmake
+++ b/src/cmake/FindDLSS.cmake
@@ -1,0 +1,43 @@
+# Find the NVIDIA DLSS SDK. This module defines
+#  DLSS_INCLUDE_DIR, where to find the NGX headers for DLSS
+#  DLSS_FOUND, if the DLSS SDK was found.
+#
+# Only the headers of the SDK are needed, the implementation is loaded from the
+# NVIDIA display driver at runtime. Point ``DLSS_SDK_ROOT`` (either as a CMake
+# variable or an environment variable) at a checkout of
+# https://github.com/NVIDIA/DLSS to enable DLSS support.
+
+find_path(DLSS_INCLUDE_DIR
+  NAMES
+    "nvsdk_ngx.h"
+  PATHS
+    "${DLSS_SDK_ROOT}/include"
+    "$ENV{DLSS_SDK_ROOT}/include"
+)
+
+# The Ray Reconstruction implementation library. It is loaded by the NGX
+# component of the driver, which looks for it next to the running executable, so
+# the build copies it next to the Mitsuba binaries when it is found here.
+if (WIN32)
+  find_file(DLSS_RR_LIBRARY
+    NAMES
+      "nvngx_dlssd.dll"
+    PATHS
+      "${DLSS_SDK_ROOT}/lib/Windows_x86_64/rel"
+      "$ENV{DLSS_SDK_ROOT}/lib/Windows_x86_64/rel"
+  )
+else()
+  file(GLOB DLSS_RR_LIBRARY_CANDIDATES
+    "${DLSS_SDK_ROOT}/lib/Linux_x86_64/rel/libnvidia-ngx-dlssd.so*"
+    "$ENV{DLSS_SDK_ROOT}/lib/Linux_x86_64/rel/libnvidia-ngx-dlssd.so*"
+  )
+  if (DLSS_RR_LIBRARY_CANDIDATES)
+    list(GET DLSS_RR_LIBRARY_CANDIDATES 0 DLSS_RR_LIBRARY)
+  endif()
+endif()
+
+include(FindPackageHandleStandardArgs)
+
+find_package_handle_standard_args(DLSS REQUIRED_VARS DLSS_INCLUDE_DIR)
+
+mark_as_advanced(DLSS_INCLUDE_DIR DLSS_RR_LIBRARY)

--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -321,7 +321,8 @@ if (UNIX)
   # Turn on every optional backend so that the generated docstrings don't
   # depend on the platform and configuration used to generate them
   list(APPEND MKDOC_CXXFLAGS -DMI_ENABLE_AUTODIFF=1 -DMI_ENABLE_CUDA=1
-       -DMI_ENABLE_LLVM=1 -DMI_ENABLE_METAL=1 -DMI_ENABLE_EMBREE=1)
+       -DMI_ENABLE_LLVM=1 -DMI_ENABLE_METAL=1 -DMI_ENABLE_EMBREE=1
+       -DMI_ENABLE_DLSS=1)
 
   add_custom_target(docstrings USES_TERMINAL COMMAND
     ${Python_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/../../resources/mkdocs.py

--- a/src/python/main_v.cpp
+++ b/src/python/main_v.cpp
@@ -99,6 +99,7 @@ MI_PY_DECLARE(Medium);
 MI_PY_DECLARE(mueller);
 MI_PY_DECLARE(MicrofacetDistribution);
 MI_PY_DECLARE(MicroflakeDistribution);
+MI_PY_DECLARE(DLSSDenoiser);
 MI_PY_DECLARE(OptixDenoiser);
 MI_PY_DECLARE(PositionSample);
 MI_PY_DECLARE(PhaseFunction);
@@ -230,6 +231,7 @@ NB_MODULE(MI_VARIANT_NAME, m) {
     MI_PY_IMPORT_SUBMODULE(mueller);
     MI_PY_IMPORT(MicrofacetDistribution);
     MI_PY_IMPORT(MicroflakeDistribution);
+    MI_PY_IMPORT(DLSSDenoiser);
     MI_PY_IMPORT(OptixDenoiser);
     MI_PY_IMPORT(PhaseFunction);
     MI_PY_IMPORT(Sampler);

--- a/src/render/CMakeLists.txt
+++ b/src/render/CMakeLists.txt
@@ -41,6 +41,7 @@ endif()
 if (MI_ENABLE_CUDA)
   set(LIBRENDER_EXTRA_SRC
     optixdenoiser.cpp ${INC_DIR}/optixdenoiser.h
+    dlssdenoiser.cpp ${INC_DIR}/dlssdenoiser.h
     optix/accel.cpp optix/accel.h
     ${LIBRENDER_EXTRA_SRC}
   )

--- a/src/render/dlssdenoiser.cpp
+++ b/src/render/dlssdenoiser.cpp
@@ -1,0 +1,938 @@
+#if defined(MI_ENABLE_CUDA) && defined(MI_ENABLE_DLSS)
+
+#include <mitsuba/render/dlssdenoiser.h>
+
+#include <mitsuba/core/filesystem.h>
+#include <mitsuba/core/logger.h>
+#include <mitsuba/core/util.h>
+
+#include <drjit-core/jit.h>
+
+#include <cstdlib>
+#include <filesystem>
+#include <mutex>
+#include <unordered_map>
+
+#include <nvsdk_ngx.h>
+#include <nvsdk_ngx_defs_dlssd.h>
+
+#if defined(_WIN32)
+#  include <windows.h>
+#else
+#  include <dlfcn.h>
+#endif
+
+NAMESPACE_BEGIN(mitsuba)
+
+// =====================================================
+//     Minimal subset of the CUDA driver API
+// =====================================================
+//
+// Mitsuba does not link against the CUDA driver, all entry points are resolved
+// dynamically through Dr.Jit (which loads the driver library itself). Only the
+// handful of array/texture functions that DLSS needs are declared here, the
+// struct layouts mirror those of the CUDA driver API.
+
+NAMESPACE_BEGIN(cuda)
+
+using CUarray      = void *;
+using CUtexObject  = unsigned long long;
+using CUsurfObject = unsigned long long;
+using CUstream     = void *;
+using CUresult     = int;
+
+#define CUDA_SUCCESS                    0
+#define CU_AD_FORMAT_FLOAT              0x20
+#define CU_RESOURCE_TYPE_ARRAY          0
+#define CU_TR_ADDRESS_MODE_CLAMP        1
+#define CU_TRSF_NORMALIZED_COORDINATES  2
+#define CU_MEMORYTYPE_DEVICE            2
+#define CU_MEMORYTYPE_ARRAY             3
+
+struct CUDA_ARRAY_DESCRIPTOR {
+    size_t Width;
+    size_t Height;
+    int Format;
+    unsigned int NumChannels;
+};
+
+struct CUDA_RESOURCE_DESC {
+    int resType;
+    union {
+        struct { CUarray hArray; } array;
+        struct { int reserved[32]; } reserved;
+    } res;
+    unsigned int flags;
+};
+
+struct CUDA_TEXTURE_DESC {
+    int addressMode[3];
+    int filterMode;
+    unsigned int flags;
+    unsigned int maxAnisotropy;
+    int mipmapFilterMode;
+    float mipmapLevelBias;
+    float minMipmapLevelClamp;
+    float maxMipmapLevelClamp;
+    float borderColor[4];
+    int reserved[12];
+};
+
+struct CUDA_MEMCPY2D {
+    size_t srcXInBytes;
+    size_t srcY;
+    int srcMemoryType;
+    const void *srcHost;
+    const void *srcDevice;
+    CUarray srcArray;
+    size_t srcPitch;
+    size_t dstXInBytes;
+    size_t dstY;
+    int dstMemoryType;
+    void *dstHost;
+    void *dstDevice;
+    CUarray dstArray;
+    size_t dstPitch;
+    size_t WidthInBytes;
+    size_t Height;
+};
+
+static CUresult (*ArrayCreate)(CUarray *, const CUDA_ARRAY_DESCRIPTOR *) = nullptr;
+static CUresult (*ArrayDestroy)(CUarray) = nullptr;
+static CUresult (*TexObjectCreate)(CUtexObject *, const CUDA_RESOURCE_DESC *,
+                                   const CUDA_TEXTURE_DESC *, const void *) = nullptr;
+static CUresult (*TexObjectDestroy)(CUtexObject) = nullptr;
+static CUresult (*SurfObjectCreate)(CUsurfObject *, const CUDA_RESOURCE_DESC *) = nullptr;
+static CUresult (*SurfObjectDestroy)(CUsurfObject) = nullptr;
+static CUresult (*Memcpy2DAsync)(const CUDA_MEMCPY2D *, CUstream) = nullptr;
+static CUresult (*GetErrorString)(CUresult, const char **) = nullptr;
+
+/// Resolve the CUDA driver entry points listed above (idempotent)
+static void initialize() {
+    if (ArrayCreate)
+        return;
+
+    #define L(name, symbol)                                                    \
+        name = (decltype(name)) jit_cuda_lookup(symbol)
+
+    L(TexObjectCreate,  "cuTexObjectCreate");
+    L(TexObjectDestroy, "cuTexObjectDestroy");
+    L(SurfObjectCreate, "cuSurfObjectCreate");
+    L(SurfObjectDestroy,"cuSurfObjectDestroy");
+    L(ArrayDestroy,     "cuArrayDestroy");
+    L(GetErrorString,   "cuGetErrorString");
+    // Versioned entry points
+    L(Memcpy2DAsync,    "cuMemcpy2DAsync_v2");
+    L(ArrayCreate,      "cuArrayCreate_v2");
+
+    #undef L
+}
+
+static void check(CUresult rv, const char *name) {
+    if (rv == CUDA_SUCCESS)
+        return;
+    const char *msg = nullptr;
+    if (GetErrorString)
+        GetErrorString(rv, &msg);
+    Throw("DLSSDenoiser: %s() failed: %s (%i)", name, msg ? msg : "unknown", rv);
+}
+
+NAMESPACE_END(cuda)
+
+#define cuda_check(call) cuda::check(cuda::call, #call)
+
+/// Scoped activation of the CUDA context that Dr.Jit uses
+struct scoped_cuda_context {
+    scoped_cuda_context() { jit_cuda_push_context(jit_cuda_context()); }
+    ~scoped_cuda_context() { jit_cuda_pop_context(); }
+};
+
+// =====================================================
+//              NGX driver entry points
+// =====================================================
+//
+// The NGX component of the NVIDIA display driver (``_nvngx.dll`` on Windows,
+// ``libnvidia-ngx.so.1`` on Linux) provides the actual DLSS implementation. It
+// is loaded dynamically and queried for the entry points below, which is the
+// same approach that the Cycles renderer of Blender takes. The signatures of
+// the driver-level entry points differ slightly from the declarations in the
+// DLSS SDK headers, hence the explicit function types.
+//
+// Adapted from `intern/cycles/integrator/denoiser_dlss.cpp` of Blender
+// (SPDX-FileCopyrightText: 2025 NVIDIA Corporation, Apache-2.0).
+
+struct NGXDriver {
+    using tInit_Ext1 = NVSDK_NGX_Result (*)(unsigned long long, const wchar_t *,
+                                            NVSDK_NGX_CUDADevice *,
+                                            NVSDK_NGX_Version,
+                                            const NVSDK_NGX_FeatureCommonInfo *);
+    using tShutdown1 = NVSDK_NGX_Result (*)(NVSDK_NGX_CUDADevice *, unsigned int &);
+    using tGetFeatureRequirements = decltype(&NVSDK_NGX_CUDA_GetFeatureRequirements);
+    using tCreateFeature1 = decltype(&NVSDK_NGX_CUDA_CreateFeature1);
+    using tEvaluateFeature = decltype(&NVSDK_NGX_CUDA_EvaluateFeature);
+    using tReleaseFeature = decltype(&NVSDK_NGX_CUDA_ReleaseFeature);
+    using tAllocateParameters = decltype(&NVSDK_NGX_CUDA_AllocateParameters);
+    using tDestroyParameters = decltype(&NVSDK_NGX_CUDA_DestroyParameters);
+
+    tInit_Ext1 Init_Ext1 = nullptr;
+    tShutdown1 Shutdown1 = nullptr;
+    tGetFeatureRequirements GetFeatureRequirements = nullptr;
+    tCreateFeature1 CreateFeature1 = nullptr;
+    tEvaluateFeature EvaluateFeature = nullptr;
+    tReleaseFeature ReleaseFeature = nullptr;
+    tAllocateParameters AllocateParameters = nullptr;
+    tDestroyParameters DestroyParameters = nullptr;
+
+    explicit operator bool() const {
+        return Init_Ext1 && Shutdown1 && CreateFeature1 && EvaluateFeature &&
+               ReleaseFeature && AllocateParameters && DestroyParameters;
+    }
+
+    bool init() {
+        if (*this)
+            return true;
+
+#if defined(_WIN32)
+        WCHAR ngx_path[MAX_PATH] = L"";
+        {
+            HKEY ngx_key = nullptr;
+            LSTATUS result = RegOpenKeyExW(
+                HKEY_LOCAL_MACHINE,
+                L"System\\CurrentControlSet\\Services\\nvlddmkm\\Parameters\\NGXCore",
+                0, KEY_READ, &ngx_key);
+            if (result != ERROR_SUCCESS)
+                result = RegOpenKeyExW(
+                    HKEY_LOCAL_MACHINE,
+                    L"System\\CurrentControlSet\\Services\\nvlddmkm\\NGXCore",
+                    0, KEY_READ, &ngx_key);
+            if (result == ERROR_SUCCESS) {
+                DWORD ngx_path_size = sizeof(ngx_path);
+                result = RegQueryValueExW(ngx_key, L"NGXPath", 0, nullptr,
+                                          reinterpret_cast<LPBYTE>(ngx_path),
+                                          &ngx_path_size);
+                RegCloseKey(ngx_key);
+            }
+            if (result != ERROR_SUCCESS)
+                return false;
+
+#  if defined(_M_ARM64)
+            wcscat_s(ngx_path, L"\\_arm64_nvngx.dll");
+#  else
+            wcscat_s(ngx_path, L"\\_nvngx.dll");
+#  endif
+        }
+
+        void *const module = (void *) LoadLibraryW(ngx_path);
+        if (!module)
+            return false;
+        #define find(symbol)                                                   \
+            reinterpret_cast<t##symbol>(GetProcAddress(                        \
+                static_cast<HMODULE>(module), "NVSDK_NGX_CUDA_" #symbol))
+#else
+        void *const module = dlopen("libnvidia-ngx.so.1", RTLD_NOW);
+        if (!module)
+            return false;
+        #define find(symbol)                                                   \
+            reinterpret_cast<t##symbol>(                                       \
+                dlsym(module, "NVSDK_NGX_CUDA_" #symbol))
+#endif
+
+        Init_Ext1              = find(Init_Ext1);
+        Shutdown1              = find(Shutdown1);
+        GetFeatureRequirements = find(GetFeatureRequirements);
+        CreateFeature1         = find(CreateFeature1);
+        EvaluateFeature        = find(EvaluateFeature);
+        ReleaseFeature         = find(ReleaseFeature);
+        AllocateParameters     = find(AllocateParameters);
+        DestroyParameters      = find(DestroyParameters);
+
+        #undef find
+
+        if (*this)
+            return true;
+
+        *this = NGXDriver();
+#if defined(_WIN32)
+        FreeLibrary(static_cast<HMODULE>(module));
+#else
+        dlclose(module);
+#endif
+        return false;
+    }
+};
+
+static NGXDriver ngx;
+static std::mutex ngx_mutex;
+
+/**
+ * Application ID used to identify Mitsuba to the NGX driver.
+ *
+ * NVIDIA assigns these IDs to applications, Mitsuba does not have one. The
+ * placeholder below can be overridden through the ``MI_DLSS_APPLICATION_ID``
+ * environment variable.
+ */
+static unsigned long long ngx_application_id() {
+    if (const char *env = std::getenv("MI_DLSS_APPLICATION_ID"))
+        return std::strtoull(env, nullptr, 10);
+    return 0x4D495453ull; // 'MITS'
+}
+
+/// Directory in which NGX may store its logs and other temporary files
+static std::wstring ngx_data_path() {
+    std::filesystem::path path;
+    if (const char *env = std::getenv("MI_DLSS_APP_DATA_PATH"))
+        path = std::filesystem::path(env);
+    else
+        path = std::filesystem::temp_directory_path() / "mitsuba-dlss";
+
+    std::error_code ec;
+    std::filesystem::create_directories(path, ec);
+
+    return path.wstring();
+}
+
+/**
+ * Directory in which the NGX driver should look for the DLSS Ray
+ * Reconstruction library, in addition to the directory of the executable.
+ */
+static std::wstring ngx_library_path() {
+    if (const char *env = std::getenv("MI_DLSS_LIBRARY_PATH"))
+        return std::filesystem::path(env).wstring();
+    return std::filesystem::path(util::library_path().parent_path().native())
+        .wstring();
+}
+
+static void ngx_log_callback(const char *message, NVSDK_NGX_Logging_Level,
+                             NVSDK_NGX_Feature) {
+    Log(Debug, "DLSS: %s", message);
+}
+
+/**
+ * Information that is common to all NGX calls: the directories in which the
+ * DLSS implementation library should be looked for (in addition to the
+ * directory of the running executable), and the logging callback.
+ *
+ * The result borrows ``paths``, which must outlive it.
+ */
+static NVSDK_NGX_FeatureCommonInfo
+ngx_feature_info(const wchar_t *const *paths, unsigned int n_paths) {
+    NVSDK_NGX_FeatureCommonInfo info = {};
+    info.PathListInfo.Path = paths;
+    info.PathListInfo.Length = n_paths;
+    // NGX diagnostics are forwarded to Mitsuba's logger, and only requested
+    // when Mitsuba itself runs at a verbose log level. Note that the NGX
+    // component of the driver prints a fair amount of information to the
+    // console during initialization no matter what is configured here.
+    Logger *log = mitsuba::logger();
+    bool verbose = log && log->log_level() <= Debug;
+
+    info.LoggingInfo.LoggingCallback = &ngx_log_callback;
+    info.LoggingInfo.MinimumLoggingLevel = verbose
+                                               ? NVSDK_NGX_LOGGING_LEVEL_ON
+                                               : NVSDK_NGX_LOGGING_LEVEL_OFF;
+    return info;
+}
+
+// =====================================================
+//                   CUDA textures
+// =====================================================
+
+MI_VARIANT
+void DLSSDenoiser<Float, Spectrum>::CUDATexture::init(uint32_t width_,
+                                                      uint32_t height_,
+                                                      uint32_t n_channels_) {
+    // CUDA arrays only support 1, 2 or 4 channels per element
+    Assert(n_channels_ == 1 || n_channels_ == 2 || n_channels_ == 4);
+
+    width = width_;
+    height = height_;
+    n_channels = n_channels_;
+
+    cuda::CUDA_ARRAY_DESCRIPTOR desc = {};
+    desc.Width = width;
+    desc.Height = height;
+    desc.Format = CU_AD_FORMAT_FLOAT;
+    desc.NumChannels = n_channels;
+
+    cuda_check(ArrayCreate((cuda::CUarray *) &array, &desc));
+
+    cuda::CUDA_TEXTURE_DESC tex_desc = {};
+    tex_desc.addressMode[0] = CU_TR_ADDRESS_MODE_CLAMP;
+    tex_desc.addressMode[1] = CU_TR_ADDRESS_MODE_CLAMP;
+    tex_desc.addressMode[2] = CU_TR_ADDRESS_MODE_CLAMP;
+    tex_desc.flags = CU_TRSF_NORMALIZED_COORDINATES;
+
+    cuda::CUDA_RESOURCE_DESC res_desc = {};
+    res_desc.resType = CU_RESOURCE_TYPE_ARRAY;
+    res_desc.res.array.hArray = (cuda::CUarray) array;
+
+    cuda_check(TexObjectCreate((cuda::CUtexObject *) &texture_handle, &res_desc,
+                               &tex_desc, nullptr));
+    cuda_check(SurfObjectCreate((cuda::CUsurfObject *) &surface_handle, &res_desc));
+}
+
+MI_VARIANT void DLSSDenoiser<Float, Spectrum>::CUDATexture::destroy() {
+    if (!array)
+        return;
+
+    cuda::SurfObjectDestroy((cuda::CUsurfObject) surface_handle);
+    cuda::TexObjectDestroy((cuda::CUtexObject) texture_handle);
+    cuda::ArrayDestroy((cuda::CUarray) array);
+
+    surface_handle = 0;
+    texture_handle = 0;
+    array = nullptr;
+}
+
+MI_VARIANT
+void DLSSDenoiser<Float, Spectrum>::CUDATexture::upload(const void *src) const {
+    cuda::CUDA_MEMCPY2D op = {};
+    op.srcMemoryType = CU_MEMORYTYPE_DEVICE;
+    op.srcDevice = src;
+    op.srcPitch = width * n_channels * sizeof(float);
+    op.dstMemoryType = CU_MEMORYTYPE_ARRAY;
+    op.dstArray = (cuda::CUarray) array;
+    op.WidthInBytes = width * n_channels * sizeof(float);
+    op.Height = height;
+
+    cuda_check(Memcpy2DAsync(&op, (cuda::CUstream) jit_cuda_stream()));
+}
+
+MI_VARIANT
+void DLSSDenoiser<Float, Spectrum>::CUDATexture::download(void *dst) const {
+    cuda::CUDA_MEMCPY2D op = {};
+    op.srcMemoryType = CU_MEMORYTYPE_ARRAY;
+    op.srcArray = (cuda::CUarray) array;
+    op.dstMemoryType = CU_MEMORYTYPE_DEVICE;
+    op.dstDevice = dst;
+    op.dstPitch = width * n_channels * sizeof(float);
+    op.WidthInBytes = width * n_channels * sizeof(float);
+    op.Height = height;
+
+    cuda_check(Memcpy2DAsync(&op, (cuda::CUstream) jit_cuda_stream()));
+}
+
+// =====================================================
+//                    DLSSDenoiser
+// =====================================================
+
+MI_VARIANT bool DLSSDenoiser<Float, Spectrum>::is_available() {
+    if constexpr (!dr::is_cuda_v<Float>) {
+        return false;
+    } else {
+        // `GetFeatureRequirements` is fairly expensive, cache the outcome
+        static std::unordered_map<int, bool> cached;
+
+        std::lock_guard<std::mutex> guard(ngx_mutex);
+
+        try {
+            int device = jit_cuda_device_raw();
+
+            if (auto it = cached.find(device); it != cached.end())
+                return it->second;
+
+            // The NGX driver only exposes `GetFeatureRequirements` in
+            // sufficiently recent drivers (590 or newer)
+            bool result = false;
+            if (ngx.init() && ngx.GetFeatureRequirements) {
+                const std::wstring data_path = ngx_data_path(),
+                                   library_path = ngx_library_path();
+                const wchar_t *const search_paths[] = { library_path.c_str() };
+                NVSDK_NGX_FeatureCommonInfo feature_info =
+                    ngx_feature_info(search_paths, 1);
+
+                NVSDK_NGX_FeatureDiscoveryInfo info = {};
+                info.SDKVersion = NVSDK_NGX_Version_API;
+                info.FeatureID = NVSDK_NGX_Feature_RayReconstruction;
+                info.Identifier.IdentifierType =
+                    NVSDK_NGX_Application_Identifier_Type_Application_Id;
+                info.Identifier.v.ApplicationId = ngx_application_id();
+                info.ApplicationDataPath = data_path.c_str();
+                info.FeatureInfo = &feature_info;
+
+                // A zero-initialized requirement means 'supported'
+                NVSDK_NGX_FeatureRequirement req = {};
+
+                NVSDK_NGX_Result rv =
+                    ngx.GetFeatureRequirements(device, &info, &req);
+
+                result = NVSDK_NGX_SUCCEED(rv) &&
+                         req.FeatureSupported ==
+                             NVSDK_NGX_FeatureSupportResult_Supported;
+            }
+
+            cached.emplace(device, result);
+            return result;
+        } catch (const std::exception &e) {
+            Log(Debug, "DLSSDenoiser::is_available(): %s", e.what());
+            return false;
+        }
+    }
+}
+
+MI_VARIANT
+DLSSDenoiser<Float, Spectrum>::DLSSDenoiser(const ScalarVector2u &input_size,
+                                            const ScalarVector2u &output_size,
+                                            const std::string &quality)
+    : m_input_size(input_size),
+      m_output_size(dr::all(output_size == 0) ? input_size : output_size),
+      m_quality(quality) {
+    if constexpr (!dr::is_cuda_v<Float>)
+        Throw("DLSSDenoiser is only available in CUDA mode!");
+
+    if (dr::any(m_input_size == 0))
+        Throw("DLSSDenoiser: the input size must be non-zero!");
+
+    if (dr::any(m_output_size < m_input_size))
+        Throw("DLSSDenoiser: the output size (%u x %u) cannot be smaller than "
+              "the input size (%u x %u), DLSS does not downscale!",
+              m_output_size.x(), m_output_size.y(), m_input_size.x(),
+              m_input_size.y());
+
+    // DLSS refuses to create a feature below this resolution
+    if (m_input_size.x() < 32 || m_input_size.y() < 32)
+        Throw("DLSSDenoiser: the input size (%u x %u) is too small, DLSS "
+              "requires at least 32 x 32 pixels!",
+              m_input_size.x(), m_input_size.y());
+
+    NVSDK_NGX_PerfQuality_Value perf_quality = NVSDK_NGX_PerfQuality_Value_DLAA;
+    const float upscale_factor =
+        m_output_size.x() / (float) m_input_size.x();
+    if (upscale_factor > 1.f) {
+        if (m_quality == "high")
+            perf_quality = NVSDK_NGX_PerfQuality_Value_MaxQuality;
+        else if (m_quality == "balanced")
+            perf_quality = NVSDK_NGX_PerfQuality_Value_Balanced;
+        else if (m_quality == "fast")
+            perf_quality = upscale_factor >= 3.f
+                               ? NVSDK_NGX_PerfQuality_Value_UltraPerformance
+                               : NVSDK_NGX_PerfQuality_Value_MaxPerf;
+        else
+            Throw("DLSSDenoiser: unknown quality mode \"%s\", expected one of "
+                  "\"high\", \"balanced\" or \"fast\"!", m_quality);
+    } else if (m_quality != "high" && m_quality != "balanced" &&
+               m_quality != "fast") {
+        Throw("DLSSDenoiser: unknown quality mode \"%s\", expected one of "
+              "\"high\", \"balanced\" or \"fast\"!", m_quality);
+    }
+
+    if (!is_available())
+        Throw("DLSSDenoiser: DLSS Ray Reconstruction is not available on this "
+              "system. It requires an NVIDIA RTX GPU, driver version 590 or "
+              "newer, and the DLSS Ray Reconstruction library (nvngx_dlssd.dll "
+              "or libnvidia-ngx-dlssd.so) to be present next to the "
+              "executable or in the directory given by the "
+              "MI_DLSS_LIBRARY_PATH environment variable.");
+
+    cuda::initialize();
+
+    scoped_cuda_context context_guard;
+
+    const std::wstring data_path = ngx_data_path(),
+                       library_path = ngx_library_path();
+    const wchar_t *const search_paths[] = { library_path.c_str() };
+
+    NVSDK_NGX_FeatureCommonInfo feature_info =
+        ngx_feature_info(search_paths, 1);
+
+    m_device = new NVSDK_NGX_CUDADevice{ jit_cuda_context(), jit_cuda_stream() };
+
+    {
+        std::lock_guard<std::mutex> guard(ngx_mutex);
+        NVSDK_NGX_Result rv =
+            ngx.Init_Ext1(ngx_application_id(), data_path.c_str(), m_device,
+                          NVSDK_NGX_Version_API, &feature_info);
+        if (NVSDK_NGX_FAILED(rv)) {
+            delete m_device;
+            m_device = nullptr;
+            Throw("DLSSDenoiser: failed to initialize the NGX driver (0x%x)!",
+                  (unsigned) rv);
+        }
+    }
+
+    NVSDK_NGX_Parameter *params = nullptr;
+    if (NVSDK_NGX_FAILED(ngx.AllocateParameters(&params))) {
+        release();
+        Throw("DLSSDenoiser: failed to allocate NGX parameters!");
+    }
+
+    params->Set(NVSDK_NGX_Parameter_Width, m_input_size.x());
+    params->Set(NVSDK_NGX_Parameter_Height, m_input_size.y());
+    params->Set(NVSDK_NGX_Parameter_OutWidth, m_output_size.x());
+    params->Set(NVSDK_NGX_Parameter_OutHeight, m_output_size.y());
+    params->Set(NVSDK_NGX_Parameter_PerfQualityValue, perf_quality);
+
+    params->Set(NVSDK_NGX_Parameter_DLSS_Denoise_Mode,
+                NVSDK_NGX_DLSS_Denoise_Mode_DLUnified);
+    // Mitsuba renders high dynamic range images, and the motion vectors that
+    // this class expects are given at the input resolution
+    params->Set(NVSDK_NGX_Parameter_DLSS_Feature_Create_Flags,
+                NVSDK_NGX_DLSS_Feature_Flags_IsHDR |
+                    NVSDK_NGX_DLSS_Feature_Flags_MVLowRes);
+    params->Set(NVSDK_NGX_Parameter_DLSS_Enable_Output_Subrects, 0);
+    params->Set(NVSDK_NGX_Parameter_Use_HW_Depth,
+                NVSDK_NGX_DLSS_Depth_Type_Linear);
+    // The roughness is packed into the fourth channel of the normals
+    params->Set(NVSDK_NGX_Parameter_DLSS_Roughness_Mode,
+                NVSDK_NGX_DLSS_Roughness_Mode_Packed);
+
+    NVSDK_NGX_Result rv = ngx.CreateFeature1(
+        m_device, NVSDK_NGX_Feature_RayReconstruction, params, &m_handle);
+
+    ngx.DestroyParameters(params);
+
+    if (NVSDK_NGX_FAILED(rv)) {
+        release();
+        Throw("DLSSDenoiser: failed to create the DLSS feature (0x%x)!",
+              (unsigned) rv);
+    }
+
+    m_color.init(m_input_size.x(), m_input_size.y(), 4);
+    m_depth.init(m_input_size.x(), m_input_size.y(), 1);
+    m_diffuse_albedo.init(m_input_size.x(), m_input_size.y(), 4);
+    m_specular_albedo.init(m_input_size.x(), m_input_size.y(), 4);
+    m_normal_roughness.init(m_input_size.x(), m_input_size.y(), 4);
+    m_motion.init(m_input_size.x(), m_input_size.y(), 2);
+    m_specular_motion.init(m_input_size.x(), m_input_size.y(), 2);
+    m_output.init(m_output_size.x(), m_output_size.y(), 4);
+}
+
+MI_VARIANT DLSSDenoiser<Float, Spectrum>::~DLSSDenoiser() { release(); }
+
+MI_VARIANT void DLSSDenoiser<Float, Spectrum>::release() {
+    if constexpr (dr::is_cuda_v<Float>) {
+        scoped_cuda_context context_guard;
+
+        m_color.destroy();
+        m_depth.destroy();
+        m_diffuse_albedo.destroy();
+        m_specular_albedo.destroy();
+        m_normal_roughness.destroy();
+        m_motion.destroy();
+        m_specular_motion.destroy();
+        m_output.destroy();
+
+        std::lock_guard<std::mutex> guard(ngx_mutex);
+
+        if (m_handle) {
+            ngx.ReleaseFeature(m_handle);
+            m_handle = nullptr;
+        }
+
+        if (m_device) {
+            unsigned int n = 0;
+            ngx.Shutdown1(m_device, n);
+            delete m_device;
+            m_device = nullptr;
+        }
+    }
+}
+
+MI_VARIANT
+typename DLSSDenoiser<Float, Spectrum>::TensorXf
+DLSSDenoiser<Float, Spectrum>::operator()(
+    const TensorXf &noisy, const TensorXf &albedo, const TensorXf &normals,
+    const TensorXf &depth, const TensorXf &specular_albedo,
+    const TensorXf &roughness, const TensorXf &flow,
+    const TensorXf &specular_flow, const AffineTransform4f &to_sensor,
+    const ScalarPoint2f &jitter, bool reset) const {
+    using TensorArray = typename TensorXf::Array;
+
+    validate_input(noisy, albedo, normals, depth, specular_albedo, roughness,
+                   flow, specular_flow);
+
+    const size_t n_in  = (size_t) m_input_size.x() * m_input_size.y(),
+                 n_out = (size_t) m_output_size.x() * m_output_size.y();
+    const uint32_t noisy_channels = (uint32_t) noisy.shape(2);
+
+    /// Copy one channel of `src` into one channel of `dst`
+    auto copy_channel = [](TensorArray &dst, uint32_t dst_channels,
+                           uint32_t dst_channel, const TensorArray &src,
+                           uint32_t src_channels, uint32_t src_channel) {
+        UInt32 index = dr::arange<UInt32>(dst.size() / dst_channels);
+        dr::scatter(dst,
+                    dr::gather<Float>(src, index * src_channels + src_channel),
+                    index * dst_channels + dst_channel);
+    };
+
+    /// Set one channel of `dst` to a constant
+    auto fill_channel = [](TensorArray &dst, uint32_t dst_channels,
+                           uint32_t dst_channel, Float value) {
+        UInt32 index = dr::arange<UInt32>(dst.size() / dst_channels);
+        dr::scatter(dst, value, index * dst_channels + dst_channel);
+    };
+
+    // ------------- Assemble the inputs expected by DLSS -------------
+
+    // DLSS reads the color from an RGBA texture
+    TensorArray color = dr::zeros<TensorArray>(n_in * 4);
+    for (uint32_t i = 0; i < 3; ++i)
+        copy_channel(color, 4, i, noisy.array(), noisy_channels, i);
+    if (noisy_channels == 4)
+        copy_channel(color, 4, 3, noisy.array(), 4, 3);
+    else
+        fill_channel(color, 4, 3, Float(1.f));
+
+    // An albedo is a reflectance, values outside of [0, 1] confuse the network
+    TensorArray diffuse_albedo = dr::zeros<TensorArray>(n_in * 4);
+    TensorArray albedo_clamped = dr::clip(albedo.array(), 0.f, 1.f);
+    for (uint32_t i = 0; i < 3; ++i)
+        copy_channel(diffuse_albedo, 4, i, albedo_clamped, 3, i);
+    fill_channel(diffuse_albedo, 4, 3, Float(1.f));
+
+    TensorArray spec_albedo = dr::zeros<TensorArray>(n_in * 4);
+    if (specular_albedo.ndim() != 0) {
+        TensorArray spec_albedo_clamped =
+            dr::clip(specular_albedo.array(), 0.f, 1.f);
+        for (uint32_t i = 0; i < 3; ++i)
+            copy_channel(spec_albedo, 4, i, spec_albedo_clamped, 3, i);
+    }
+    fill_channel(spec_albedo, 4, 3, Float(1.f));
+
+    // The normals are transformed into the requested frame, the roughness is
+    // packed into the fourth channel
+    TensorArray normal_roughness = dr::zeros<TensorArray>(n_in * 4);
+    {
+        UInt32 index = dr::arange<UInt32>(n_in);
+        Normal3f n;
+        for (size_t i = 0; i < 3; ++i)
+            n[i] = dr::gather<Float>(normals.array(), index * 3 + (uint32_t) i);
+
+        n = to_sensor * n;
+
+        for (uint32_t i = 0; i < 3; ++i)
+            dr::scatter(normal_roughness, n[i], index * 4 + i);
+    }
+    if (roughness.ndim() != 0)
+        copy_channel(normal_roughness, 4, 3, roughness.array(), 1, 0);
+
+    // Depth and the two motion vector fields are used as-is
+    TensorArray depth_data = depth.array();
+    TensorArray motion = flow.ndim() != 0 ? flow.array()
+                                          : dr::zeros<TensorArray>(n_in * 2);
+    TensorArray specular_motion =
+        specular_flow.ndim() != 0 ? specular_flow.array()
+                                  : dr::zeros<TensorArray>(n_in * 2);
+
+    TensorArray output = dr::empty<TensorArray>(n_out * 4);
+
+    // All arrays must be backed by actual device memory before they can be
+    // handed to DLSS. Note that ``dr::eval()`` is not sufficient here: a
+    // zero-initialized tensor is represented as a literal constant and stays
+    // that way, without ever receiving a data pointer.
+    dr::make_opaque(color, diffuse_albedo, spec_albedo, normal_roughness,
+                    depth_data, motion, specular_motion, output);
+
+    // ------------- Run DLSS -------------
+
+    scoped_cuda_context context_guard;
+
+    m_color.upload(color.data());
+    m_diffuse_albedo.upload(diffuse_albedo.data());
+    m_specular_albedo.upload(spec_albedo.data());
+    m_normal_roughness.upload(normal_roughness.data());
+    m_depth.upload(depth_data.data());
+    m_motion.upload(motion.data());
+    m_specular_motion.upload(specular_motion.data());
+
+    NVSDK_NGX_Parameter *params = nullptr;
+    if (NVSDK_NGX_FAILED(ngx.AllocateParameters(&params)))
+        Throw("DLSSDenoiser: failed to allocate NGX parameters!");
+
+    params->Set(NVSDK_NGX_Parameter_Reset, (reset || m_reset) ? 1 : 0);
+
+    params->Set(NVSDK_NGX_Parameter_Jitter_Offset_X, (float) jitter.x());
+    params->Set(NVSDK_NGX_Parameter_Jitter_Offset_Y, (float) jitter.y());
+
+    params->Set(NVSDK_NGX_Parameter_Color, m_color.texture_ptr());
+    params->Set(NVSDK_NGX_Parameter_Depth, m_depth.texture_ptr());
+    params->Set(NVSDK_NGX_Parameter_DiffuseAlbedo,
+                m_diffuse_albedo.texture_ptr());
+    params->Set(NVSDK_NGX_Parameter_SpecularAlbedo,
+                m_specular_albedo.texture_ptr());
+    params->Set(NVSDK_NGX_Parameter_GBuffer_Normals,
+                m_normal_roughness.texture_ptr());
+    params->Set(NVSDK_NGX_Parameter_GBuffer_Roughness,
+                m_normal_roughness.texture_ptr());
+    params->Set(NVSDK_NGX_Parameter_MotionVectors, m_motion.texture_ptr());
+    params->Set(NVSDK_NGX_Parameter_GBuffer_SpecularMvec,
+                m_specular_motion.texture_ptr());
+    params->Set(NVSDK_NGX_Parameter_Output, m_output.surface_ptr());
+
+    params->Set(NVSDK_NGX_Parameter_DLSS_Render_Subrect_Dimensions_Width,
+                m_input_size.x());
+    params->Set(NVSDK_NGX_Parameter_DLSS_Render_Subrect_Dimensions_Height,
+                m_input_size.y());
+
+    // Mitsuba images are stored top to bottom, just like the textures that
+    // DLSS expects
+    params->Set(NVSDK_NGX_Parameter_DLSS_Indicator_Invert_Y_Axis, 0);
+
+    NVSDK_NGX_Result rv = ngx.EvaluateFeature(m_handle, params, nullptr);
+
+    ngx.DestroyParameters(params);
+
+    if (NVSDK_NGX_FAILED(rv))
+        Throw("DLSSDenoiser: failed to evaluate DLSS (0x%x)!", (unsigned) rv);
+
+    m_reset = false;
+
+    m_output.download(output.data());
+
+    // ------------- Assemble the result -------------
+
+    TensorArray result = dr::zeros<TensorArray>(n_out * noisy_channels);
+    for (uint32_t i = 0; i < 3; ++i)
+        copy_channel(result, noisy_channels, i, output, 4, i);
+
+    if (noisy_channels == 4) {
+        // DLSS does not upscale the alpha channel, copy it from the nearest
+        // pixel of the noisy input instead
+        UInt32 index = dr::arange<UInt32>(n_out);
+        UInt32 x = index % m_output_size.x(), y = index / m_output_size.x();
+        UInt32 source = (y * m_input_size.y() / m_output_size.y()) *
+                            m_input_size.x() +
+                        (x * m_input_size.x() / m_output_size.x());
+        dr::scatter(result, dr::gather<Float>(noisy.array(), source * 4 + 3),
+                    index * 4 + 3);
+    }
+
+    return TensorXf(std::move(result),
+                    { m_output_size.y(), m_output_size.x(), noisy_channels });
+}
+
+MI_VARIANT
+ref<Bitmap> DLSSDenoiser<Float, Spectrum>::operator()(
+    const ref<Bitmap> &noisy, const std::string &albedo_ch,
+    const std::string &normals_ch, const std::string &depth_ch,
+    const std::string &specular_albedo_ch, const std::string &roughness_ch,
+    const std::string &flow_ch, const std::string &specular_flow_ch,
+    const AffineTransform4f &to_sensor, const ScalarPoint2f &jitter,
+    bool reset, const std::string &noisy_ch) const {
+    if (noisy->pixel_format() != Bitmap::PixelFormat::MultiChannel)
+        Throw("DLSSDenoiser: the noisy input must use the MultiChannel pixel "
+              "format, as DLSS always requires additional guiding layers!");
+
+    // Search for each layer
+    std::vector<std::pair<std::string, ref<Bitmap>>> layers = noisy->split();
+
+    auto find_layer = [&](const std::string &name,
+                          bool required) -> ref<const Bitmap> {
+        if (name.empty()) {
+            if (required)
+                Throw("DLSSDenoiser: the name of the layer holding the "
+                      "guiding information must be specified!");
+            return nullptr;
+        }
+        for (auto &layer : layers) {
+            if (layer.first == name)
+                return layer.second.get();
+        }
+        Throw("Could not find layer with channel name '%s' in Bitmap:\n%s",
+              name, noisy->to_string());
+        return nullptr; // Unreachable, `Throw` does not return
+    };
+
+    ref<const Bitmap> noisy_bmp = find_layer(noisy_ch, true),
+                      albedo_bmp = find_layer(albedo_ch, true),
+                      normals_bmp = find_layer(normals_ch, true),
+                      depth_bmp = find_layer(depth_ch, true),
+                      spec_albedo_bmp = find_layer(specular_albedo_ch, false),
+                      roughness_bmp = find_layer(roughness_ch, false),
+                      flow_bmp = find_layer(flow_ch, false),
+                      spec_flow_bmp = find_layer(specular_flow_ch, false);
+
+    // Transfer every layer into a TensorXf object
+    auto setup_tensor = [](const ref<const Bitmap> &bmp,
+                           size_t channel_count) -> TensorXf {
+        if (bmp == nullptr)
+            return TensorXf();
+        return TensorXf(bmp->data(),
+                        { bmp->height(), bmp->width(), channel_count });
+    };
+
+    size_t noisy_channel_count = noisy_bmp->channel_count();
+
+    TensorXf denoised =
+        (*this)(setup_tensor(noisy_bmp, noisy_channel_count),
+                setup_tensor(albedo_bmp, 3), setup_tensor(normals_bmp, 3),
+                setup_tensor(depth_bmp, 1), setup_tensor(spec_albedo_bmp, 3),
+                setup_tensor(roughness_bmp, 1), setup_tensor(flow_bmp, 2),
+                setup_tensor(spec_flow_bmp, 2), to_sensor, jitter, reset);
+
+    void *denoised_data =
+        jit_malloc_migrate(denoised.data(), JitBackend::None, false);
+    ref<Bitmap> output = new Bitmap(
+        noisy_bmp->pixel_format(), sj::Type::Float32,
+        { denoised.shape(1), denoised.shape(0) }, denoised.shape(2), {});
+
+    jit_sync_thread(); // Wait for `denoised_data` to be ready
+    memcpy(output->data(), denoised_data, output->buffer_size());
+    jit_free(denoised_data);
+
+    return output;
+}
+
+MI_VARIANT std::string DLSSDenoiser<Float, Spectrum>::to_string() const {
+    std::ostringstream oss;
+    oss << "DLSSDenoiser[" << std::endl
+        << "  input_size = " << m_input_size << "," << std::endl
+        << "  output_size = " << m_output_size << "," << std::endl
+        << "  quality = \"" << m_quality << "\"" << std::endl
+        << "]";
+    return oss.str();
+}
+
+MI_VARIANT
+void DLSSDenoiser<Float, Spectrum>::validate_input(
+    const TensorXf &noisy, const TensorXf &albedo, const TensorXf &normals,
+    const TensorXf &depth, const TensorXf &specular_albedo,
+    const TensorXf &roughness, const TensorXf &flow,
+    const TensorXf &specular_flow) const {
+    if (albedo.ndim() == 0)
+        Throw("DLSSDenoiser: a diffuse albedo layer must be specified!");
+    if (normals.ndim() == 0)
+        Throw("DLSSDenoiser: a normals layer must be specified!");
+    if (depth.ndim() == 0)
+        Throw("DLSSDenoiser: a depth layer must be specified!");
+
+    auto check_resolution = [&](const TensorXf &tensor) {
+        if (tensor.ndim() != 0 && (m_input_size.x() != tensor.shape(1) ||
+                                   m_input_size.y() != tensor.shape(0)))
+            Throw("The denoiser was created for inputs of size %u x %u (width "
+                  "x height). At least one of the input arguments does not "
+                  "have this size. You must create a new denoiser object for "
+                  "inputs of different sizes!",
+                  m_input_size.x(), m_input_size.y());
+    };
+    check_resolution(noisy);
+    check_resolution(albedo);
+    check_resolution(normals);
+    check_resolution(depth);
+    check_resolution(specular_albedo);
+    check_resolution(roughness);
+    check_resolution(flow);
+    check_resolution(specular_flow);
+
+    auto check_channels = [](const TensorXf &tensor, size_t expected,
+                             const char *name) {
+        if (tensor.ndim() != 0 && tensor.shape(2) != expected)
+            Throw("DLSSDenoiser: the %s must have exactly %zu channel(s)!",
+                  name, expected);
+    };
+    if (noisy.shape(2) != 3 && noisy.shape(2) != 4)
+        Throw("The noisy input must have at least 3 channels and at most 4!");
+    check_channels(albedo, 3, "diffuse albedo");
+    check_channels(normals, 3, "normals");
+    check_channels(depth, 1, "depth");
+    check_channels(specular_albedo, 3, "specular albedo");
+    check_channels(roughness, 1, "roughness");
+    check_channels(flow, 2, "optical flow");
+    check_channels(specular_flow, 2, "specular optical flow");
+}
+
+MI_INSTANTIATE_CLASS(DLSSDenoiser)
+
+NAMESPACE_END(mitsuba)
+
+#endif // defined(MI_ENABLE_CUDA) && defined(MI_ENABLE_DLSS)

--- a/src/render/python/CMakeLists.txt
+++ b/src/render/python/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(RENDER_PY_V_SRC
   ${CMAKE_CURRENT_SOURCE_DIR}/bsdf_v.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/dedge_v.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/dlssdenoiser_v.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/emitter_v.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/endpoint_v.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/film_v.cpp

--- a/src/render/python/dlssdenoiser_v.cpp
+++ b/src/render/python/dlssdenoiser_v.cpp
@@ -1,0 +1,130 @@
+#if defined(MI_ENABLE_CUDA) && defined(MI_ENABLE_DLSS)
+
+#include <nanobind/nanobind.h>
+#include <mitsuba/render/dlssdenoiser.h>
+#include <mitsuba/python/python.h>
+
+#include <nanobind/stl/string.h>
+
+MI_PY_EXPORT(DLSSDenoiser) {
+    MI_PY_IMPORT_TYPES(DLSSDenoiser)
+    MI_PY_CLASS(DLSSDenoiser, Object)
+        .def_static("is_available", &DLSSDenoiser::is_available,
+                    D(DLSSDenoiser, is_available))
+        .def(nb::init<const ScalarVector2u &, const ScalarVector2u &,
+                      const std::string &>(),
+             "input_size"_a, "output_size"_a = ScalarVector2u(0, 0),
+             "quality"_a = "high", D(DLSSDenoiser, DLSSDenoiser))
+        .def(
+            "__call__",
+            [](const DLSSDenoiser &denoiser, const TensorXf &noisy,
+               const TensorXf &albedo, const TensorXf &normals,
+               const TensorXf &depth, const TensorXf &specular_albedo,
+               const TensorXf &roughness, const TensorXf &flow,
+               const TensorXf &specular_flow, const nb::object &transform,
+               const ScalarPoint2f &jitter, bool reset) {
+                AffineTransform4f to_sensor;
+                if (!transform.is(nb::none()))
+                    to_sensor = nb::cast<AffineTransform4f>(transform);
+
+                return denoiser(noisy, albedo, normals, depth, specular_albedo,
+                                roughness, flow, specular_flow, to_sensor,
+                                jitter, reset);
+            },
+            "noisy"_a, "albedo"_a, "normals"_a, "depth"_a,
+            "specular_albedo"_a = TensorXf(), "roughness"_a = TensorXf(),
+            "flow"_a = TensorXf(), "specular_flow"_a = TensorXf(),
+            "to_sensor"_a = nb::none(), "jitter"_a = ScalarPoint2f(0.f),
+            "reset"_a = false, D(DLSSDenoiser, operator_call))
+        .def(
+            "__call__",
+            [](const DLSSDenoiser &denoiser, const ref<Bitmap> &noisy,
+               const std::string &albedo_ch, const std::string &normals_ch,
+               const std::string &depth_ch,
+               const std::string &specular_albedo_ch,
+               const std::string &roughness_ch, const std::string &flow_ch,
+               const std::string &specular_flow_ch,
+               const nb::object &transform, const ScalarPoint2f &jitter,
+               bool reset, const std::string &noisy_ch) {
+                AffineTransform4f to_sensor;
+                if (!transform.is(nb::none()))
+                    to_sensor = nb::cast<AffineTransform4f>(transform);
+
+                return denoiser(noisy, albedo_ch, normals_ch, depth_ch,
+                                specular_albedo_ch, roughness_ch, flow_ch,
+                                specular_flow_ch, to_sensor, jitter, reset,
+                                noisy_ch);
+            },
+            "noisy"_a, "albedo_ch"_a, "normals_ch"_a, "depth_ch"_a,
+            "specular_albedo_ch"_a = "", "roughness_ch"_a = "",
+            "flow_ch"_a = "", "specular_flow_ch"_a = "",
+            "to_sensor"_a = nb::none(), "jitter"_a = ScalarPoint2f(0.f),
+            "reset"_a = false, "noisy_ch"_a = "<root>",
+            D(DLSSDenoiser, operator_call, 2));
+}
+
+#else // defined(MI_ENABLE_CUDA) && defined(MI_ENABLE_DLSS)
+
+#include <nanobind/nanobind.h>
+#include <mitsuba/core/bitmap.h>
+#include <mitsuba/render/fwd.h>
+#include <mitsuba/python/python.h>
+#include <drjit/tensor.h>
+
+#include <nanobind/stl/string.h>
+
+NAMESPACE_BEGIN(mitsuba)
+
+// Stand-in for the denoiser on builds without DLSS support. It mirrors the
+// interface of the real class so that the generated documentation does not
+// depend on the platform it was produced on, and raises an exception when used.
+template <typename Float, typename Spectrum> struct DLSSDenoiserStub : Object {
+    [[noreturn]] static void fail() {
+        Throw("DLSSDenoiser is only available in CUDA-enabled builds of "
+              "Mitsuba which were compiled with MI_ENABLE_DLSS.");
+    }
+};
+
+NAMESPACE_END(mitsuba)
+
+MI_PY_EXPORT(DLSSDenoiser) {
+    MI_PY_IMPORT_TYPES()
+    using Denoiser = DLSSDenoiserStub<Float, Spectrum>;
+
+    nb::class_<Denoiser, Object>(m, "DLSSDenoiser", D(DLSSDenoiser))
+        .def_static("is_available", []() { return false; },
+                    D(DLSSDenoiser, is_available))
+        .def(
+            "__init__",
+            [](Denoiser *, const ScalarVector2u &, const ScalarVector2u &,
+               const std::string &) { Denoiser::fail(); },
+            "input_size"_a, "output_size"_a = ScalarVector2u(0, 0),
+            "quality"_a = "high", D(DLSSDenoiser, DLSSDenoiser))
+        .def(
+            "__call__",
+            [](const Denoiser &, const TensorXf &, const TensorXf &,
+               const TensorXf &, const TensorXf &, const TensorXf &,
+               const TensorXf &, const TensorXf &, const TensorXf &,
+               const nb::object &, const ScalarPoint2f &,
+               bool) -> TensorXf { Denoiser::fail(); },
+            "noisy"_a, "albedo"_a, "normals"_a, "depth"_a,
+            "specular_albedo"_a = TensorXf(), "roughness"_a = TensorXf(),
+            "flow"_a = TensorXf(), "specular_flow"_a = TensorXf(),
+            "to_sensor"_a = nb::none(), "jitter"_a = ScalarPoint2f(0.f),
+            "reset"_a = false, D(DLSSDenoiser, operator_call))
+        .def(
+            "__call__",
+            [](const Denoiser &, const ref<Bitmap> &, const std::string &,
+               const std::string &, const std::string &, const std::string &,
+               const std::string &, const std::string &, const std::string &,
+               const nb::object &, const ScalarPoint2f &, bool,
+               const std::string &) -> ref<Bitmap> { Denoiser::fail(); },
+            "noisy"_a, "albedo_ch"_a, "normals_ch"_a, "depth_ch"_a,
+            "specular_albedo_ch"_a = "", "roughness_ch"_a = "",
+            "flow_ch"_a = "", "specular_flow_ch"_a = "",
+            "to_sensor"_a = nb::none(), "jitter"_a = ScalarPoint2f(0.f),
+            "reset"_a = false, "noisy_ch"_a = "<root>",
+            D(DLSSDenoiser, operator_call, 2));
+}
+
+#endif // defined(MI_ENABLE_CUDA) && defined(MI_ENABLE_DLSS)

--- a/src/render/tests/test_dlssdenoiser.py
+++ b/src/render/tests/test_dlssdenoiser.py
@@ -1,0 +1,172 @@
+import pytest
+import mitsuba as mi
+import drjit as dr
+
+from mitsuba.scalar_rgb.test.util import find_resource
+
+###
+### DLSS Ray Reconstruction is a temporal, real-time denoiser whose output is
+### not reproducible across driver and DLSS library versions. These tests
+### therefore only check the plumbing (shapes, error handling, sanity of the
+### output) rather than comparing against reference images.
+###
+### They are skipped unless Mitsuba was compiled with `MI_ENABLE_DLSS` and DLSS
+### Ray Reconstruction is actually supported by the driver and the GPU.
+###
+
+
+def skip_if_unavailable():
+    if not mi.DLSSDenoiser.is_available():
+        pytest.skip("DLSS Ray Reconstruction is not available on this system")
+
+
+def make_inputs(res, seed=0):
+    """Generate a plausible set of noisy inputs of resolution ``res``"""
+    width, height = res
+    n = width * height
+
+    def random(channels, scale=1.0, offset=0.0):
+        rng = mi.PCG32(size=n * channels, initstate=seed * 7919 + channels)
+        values = rng.next_float32() * scale + offset
+        return mi.TensorXf(values, shape=(height, width, channels))
+
+    def constant(channels, value):
+        values = dr.full(mi.Float, value, n * channels)
+        return mi.TensorXf(values, shape=(height, width, channels))
+
+    normals = constant(3, 0.0)
+    normals[..., 2] = 1.0
+
+    return dict(
+        noisy=random(3, 10.0),
+        albedo=random(3),
+        normals=normals,
+        depth=random(1, 10.0, 1.0),
+        specular_albedo=random(3),
+        roughness=random(1),
+        flow=constant(2, 0.0),
+    )
+
+
+def test01_construct(variants_any_cuda):
+    skip_if_unavailable()
+
+    denoiser = mi.DLSSDenoiser([64, 48])
+    assert str(denoiser) == (
+        'DLSSDenoiser[\n  input_size = [64, 48],\n'
+        '  output_size = [64, 48],\n  quality = "high"\n]'
+    )
+
+    with pytest.raises(Exception, match="too small"):
+        mi.DLSSDenoiser([16, 16])
+
+    with pytest.raises(Exception, match="cannot be smaller"):
+        mi.DLSSDenoiser([64, 48], [32, 24])
+
+    with pytest.raises(Exception, match="unknown quality mode"):
+        mi.DLSSDenoiser([64, 48], [128, 96], "ultra")
+
+
+def test02_denoise(variant_cuda_ad_rgb):
+    skip_if_unavailable()
+
+    res = [64, 48]
+    denoiser = mi.DLSSDenoiser(res)
+    denoised = denoiser(**make_inputs(res))
+
+    assert denoised.shape == (res[1], res[0], 3)
+    assert dr.all(dr.isfinite(denoised.array))
+    assert dr.all(denoised.array >= 0.0)
+
+
+def test03_denoise_upscale(variant_cuda_ad_rgb):
+    skip_if_unavailable()
+
+    res, out_res = [64, 48], [128, 96]
+    denoiser = mi.DLSSDenoiser(res, out_res)
+    denoised = denoiser(**make_inputs(res))
+
+    assert denoised.shape == (out_res[1], out_res[0], 3)
+    assert dr.all(dr.isfinite(denoised.array))
+
+
+def test04_denoise_alpha_is_preserved(variant_cuda_ad_rgb):
+    skip_if_unavailable()
+
+    res = [64, 48]
+    inputs = make_inputs(res)
+
+    # Append an opaque alpha channel to the noisy input
+    noisy, rgb = dr.zeros(mi.TensorXf, (res[1], res[0], 4)), inputs["noisy"]
+    for i in range(3):
+        noisy[..., i] = rgb[..., i]
+    noisy[..., 3] = 1.0
+    inputs["noisy"] = noisy
+
+    denoiser = mi.DLSSDenoiser(res)
+    denoised = denoiser(**inputs)
+
+    assert denoised.shape == (res[1], res[0], 4)
+    assert dr.allclose(mi.TensorXf(denoised)[..., 3].array, 1.0)
+
+
+def test05_denoise_sequence(variant_cuda_ad_rgb):
+    skip_if_unavailable()
+
+    res = [64, 48]
+    denoiser = mi.DLSSDenoiser(res)
+
+    # A temporal sequence with a different subpixel offset per frame, DLSS
+    # accumulates information across these invocations
+    jitters = [[0.0, 0.0], [-0.25, 0.25], [0.25, -0.25], [0.375, 0.125]]
+    for i, jitter in enumerate(jitters):
+        denoised = denoiser(**make_inputs(res, seed=i), jitter=jitter,
+                            reset=(i == 0))
+        assert dr.all(dr.isfinite(denoised.array))
+
+    assert denoised.shape == (res[1], res[0], 3)
+
+
+def test06_validate_input(variant_cuda_ad_rgb):
+    skip_if_unavailable()
+
+    res = [64, 48]
+    denoiser = mi.DLSSDenoiser(res)
+    inputs = make_inputs(res)
+
+    with pytest.raises(Exception, match="does not have this size"):
+        denoiser(**dict(inputs, albedo=make_inputs([80, 48])["albedo"]))
+
+    with pytest.raises(Exception, match="exactly 1 channel"):
+        denoiser(**dict(inputs, depth=inputs["albedo"]))
+
+    with pytest.raises(Exception, match="exactly 2 channel"):
+        denoiser(**dict(inputs, flow=inputs["albedo"]))
+
+
+def test07_denoise_multichannel_bitmap(variant_cuda_ad_rgb):
+    skip_if_unavailable()
+
+    scene = mi.load_file(find_resource("resources/data/scenes/cbox/cbox-rgb.xml"), res=64)
+    sensor = scene.sensors()[0]
+    integrator = mi.load_dict({
+        'type': 'aov',
+        'aovs': 'albedo:albedo,sh_normal:sh_normal,depth:depth',
+        'img': {
+            'type': 'path',
+            'max_depth': 6,
+        }
+    })
+    mi.render(scene, spp=2, integrator=integrator, sensor=sensor)
+    multichannel = sensor.film().bitmap()
+
+    denoiser = mi.DLSSDenoiser(multichannel.size())
+    denoised = denoiser(multichannel, "albedo", "sh_normal", "depth",
+                        to_sensor=sensor.world_transform().inverse())
+
+    assert dr.all(denoised.size() == multichannel.size())
+    dr.eval(mi.TensorXf(denoised.convert(
+        component_format=mi.Struct.Type.Float32)))
+
+    with pytest.raises(Exception, match="Could not find layer"):
+        denoiser(multichannel, "albedo", "sh_normal", "missing")


### PR DESCRIPTION
The implementation is following Mitsuba's OptiX denoiser as well as [Blender's DLSS integration (PR #153077)](https://projects.blender.org/blender/blender/pulls/153077).
Proof of Concept, prompted collaboratively with @WeiPhil via Claude.
Feel free to close this if not needed.

# Using DLSS with a pre-built Mitsuba (Vibed)

Two independent gates: the first is decided when Mitsuba is compiled, the second on the machine that runs it.

## Gate 1: compile

Enable via `MI_ENABLE_DLSS`, with the entire class body sitting behind `#if defined(MI_ENABLE_CUDA) && defined(MI_ENABLE_DLSS)`. Without it the bindings fall back to a stub whose `is_available()` is a hardcoded `return false`. For the build only the headers are needed.

## Gate 2: the runtime library

A wheel built with the flag on still couldn't bundle `nvngx_dlssd.dll`; the same licensing reason Blender declined, and why `CMakeLists.txt` keeps it out of `install`. Therefore it needs to be manually provided by the user:

1. `pip install mitsuba`
2. Download [NVIDIA/DLSS](https://github.com/NVIDIA/DLSS) and take
   `lib/Windows_x86_64/rel/nvngx_dlssd.dll` (or
   `lib/Linux_x86_64/rel/libnvidia-ngx-dlssd.so.*`)
3. Either drop it into `site-packages/mitsuba/`, or point `MI_DLSS_LIBRARY_PATH`
   at the directory holding it
4. RTX GPU, driver 590+, and `mi.set_variant('cuda_ad_rgb')`
5. Confirm with `mi.DLSSDenoiser.is_available()`

# Run
<details>
<summary>Show Real-Time Example Code (requires: 'imgui-bundle' and 'pyopengl') (DLSS part is vibed)</summary>

```python
import drjit as dr
from drjit.auto import TensorXf, Quaternion4f, Array3f, Float
import mitsuba as mi
from imgui_bundle import imgui, immapp
mi.set_variant('cuda_ad_rgb' if dr.has_backend(dr.JitBackend.CUDA) else 'llvm_ad_rgb')

# DLSS Ray Reconstruction is only present in CUDA builds that were configured
# with `MI_ENABLE_DLSS`, and only usable on a supported driver/GPU combination.
# `is_available()` checks all of that, and returns false under a non-CUDA
# variant, so it subsumes a backend test.
DLSS_AVAILABLE = mi.DLSSDenoiser.is_available()

class GlTexture:
    def __init__(self, width, height):
        import OpenGL.GL as gl
        self.width, self.height, self.id = width, height, gl.glGenTextures(1)
        gl.glBindTexture(gl.GL_TEXTURE_2D, self.id)
        gl.glTexParameteri(gl.GL_TEXTURE_2D, gl.GL_TEXTURE_MIN_FILTER, gl.GL_LINEAR)
        gl.glTexParameteri(gl.GL_TEXTURE_2D, gl.GL_TEXTURE_MAG_FILTER, gl.GL_LINEAR)
        gl.glTexImage2D(
            gl.GL_TEXTURE_2D, 0, gl.GL_RGBA32F, width, height, 0,
            gl.GL_RGBA, gl.GL_FLOAT, None
        )
        try:
            self.interop = dr.cuda.GLInterop.from_texture(self.id)
        except Exception as e:
            print("Warning: Could not create CUDA-OpenGL interop:", e)
            self.interop = None

    def upload(self, img):
        if dr.backend_v(img) == dr.JitBackend.CUDA:
            self.interop.map().upload(img).unmap()
        elif dr.backend_v(img) == dr.JitBackend.LLVM:
            import OpenGL.GL as gl
            gl.glBindTexture(gl.GL_TEXTURE_2D, self.id)
            gl.glTexSubImage2D(
                gl.GL_TEXTURE_2D, 0, 0, 0, self.width, self.height,
                gl.GL_RGBA, gl.GL_FLOAT, img.to_numpy()
            )

class Camera:
    def __init__(self):
        self.q, self.c, self.d = Quaternion4f(0, 0, 0, 1), Array3f(0, 0, 0), Float(14.0)
        self.resolution, self.scale = dr.scalar.Array2u(256), 1.0
        self.gl_texture: GlTexture | None = None
        self.start_pos = None
        self.sensor = mi.load_dict({
            'type': 'perspective',
            'fov': 39.3077,
            'to_world': mi.ScalarTransform4f(),
            'sampler': {
                'type': 'independent',
                'sample_count': 1
            },
            'film': {
                'type': 'hdrfilm',
                'width': self.resolution[0],
                'height': self.resolution[1],
                # Both the accumulation loop and the denoisers want unfiltered
                # samples: a filter spanning several pixels is indistinguishable
                # from scene detail to a denoiser.
                'rfilter': {
                    'type': 'box',
                },
                'pixel_format': 'rgb',
            },
        })
        self.params = mi.traverse(self.sensor)
        self.update()
        # Camera of the frame that was rendered last, used to derive the
        # screen-space motion vectors that DLSS needs
        self.prev_to_world = self.to_world

    def map_to_sphere(self, px, py, size):
        x = -(1.0 - (px / size[0]) * 2.0)
        y = (1.0 - (py / size[1]) * 2.0)
        length2 = x*x + y*y
        if length2 > 1.0:
            return Array3f(x, y, 0.0) / dr.sqrt(length2)
        else:
            return Array3f(x, y, dr.sqrt(max(0.0, 1.0 - length2)))

    def rotate(self, a, b, size):
        a = self.map_to_sphere(*a, size)
        b = self.map_to_sphere(*b, size)
        perp = dr.cross(b, a)
        if dr.norm(perp) > 1e-5:
            q = Quaternion4f(perp.x, perp.y, perp.z, dr.dot(a, b))
        else:
            q = Quaternion4f(0, 0, 0, 1)
        return dr.normalize(self.q * q)

    def update(self, q=Quaternion4f(0, 0, 0, 1)):
        self.to_world = mi.Transform4f().look_at(
                origin=dr.quat_apply(q, Array3f(0, 0, self.d)) + self.c,
                target=self.c,
                up=dr.quat_apply(q, Array3f(0, 1, 0))
            )
        self.params['to_world'] = self.to_world
        self.params['film.size'] = self.resolution
        self.film = dr.zeros(TensorXf, shape=(self.resolution[1], self.resolution[0], 4))
        self.params.update()

    def set_resolution(self, resolution):
        """
        Resize the film, returning whether anything changed.

        This is the only place that may touch `self.resolution`: the film size
        of the sensor and the accumulation buffer have to be updated together,
        and going through `update()` guarantees that.
        """
        resolution = dr.scalar.Array2u(resolution)
        if dr.all(resolution == self.resolution):
            return False
        self.resolution = resolution
        self.update(self.q)
        return True

    def handle_gl_texture(self, resolution):
        ' Only call if gl texture is needed and with a valid opengl context '
        if not self.gl_texture or self.gl_texture.width != resolution[0] or self.gl_texture.height != resolution[1]:
            self.gl_texture = GlTexture(resolution[0], resolution[1])

    def process_imgui_inputs(self, pos, size):
        """
        Handle the mouse inputs of a viewport of `size` pixels at `pos`.

        The arcball is parameterized by the extent that the image covers *on
        screen*, which is not the render resolution: `scale` magnifies it, and
        DLSS upscaling makes the rendered frame smaller than the one shown.
        """
        from imgui_bundle import imgui
        io = imgui.get_io()
        if imgui.is_mouse_clicked(0):
            self.start_pos = io.mouse_pos - pos
        if imgui.is_mouse_released(0) and self.start_pos:
            self.q = self.rotate(self.start_pos, io.mouse_pos - pos, size)
            self.update(self.q)
            self.start_pos = None
        if imgui.is_mouse_dragging(0) and self.start_pos:
            self.update(self.rotate(self.start_pos, io.mouse_pos - pos, size))
        elif imgui.is_mouse_dragging(1):
            # Pan by the world-space distance that the cursor travelled on the
            # plane through the target, so that the scene keeps up with the
            # cursor at any viewport extent
            fov = dr.deg2rad(self.params['x_fov'][0])
            per_pixel = 2.0 * dr.tan(0.5 * fov) * self.d / size[0]
            self.c += dr.quat_apply(
                self.q, Array3f(-io.mouse_delta.x, io.mouse_delta.y, 0.0) * per_pixel)
            self.update(self.q)
        if io.mouse_wheel != 0:
            self.d = self.d - io.mouse_wheel * 0.3
            if self.d < 0.1:
                self.d = 0.1
            self.update(self.q)


class Denoiser:
    """
    Drives `mi.DLSSDenoiser` from the frames produced by this viewport.

    DLSS Ray Reconstruction consumes one independently rendered frame at a
    time together with a G-buffer (diffuse albedo, shading normals, linear
    camera-space depth) and screen-space motion vectors, and accumulates
    detail across frames. The G-buffer is obtained by wrapping the scene
    integrator in an `aov` integrator, the motion vectors are derived by
    reprojecting the shading points of the current frame into the camera of
    the previous one.
    """

    AOVS = 'albedo:albedo,sh_normal:sh_normal,depth:depth'
    QUALITIES = ['high', 'balanced', 'fast']
    UPSCALE_FACTORS = [1, 2, 3]

    def __init__(self, scene):
        self.integrator = mi.load_dict({
            'type': 'aov',
            'aovs': Denoiser.AOVS,
            'img': scene.integrator(),
        })
        self.quality = 'high'
        self.upscale = 1
        self.active = False
        self.invalidate()

    def output_resolution(self, resolution):
        return dr.scalar.Array2u(resolution * self.upscale)

    def invalidate(self):
        """Force the denoiser (and its temporal history) to be rebuilt"""
        self.denoiser = None
        self.rays = None

    def prepare(self, camera):
        out_res = self.output_resolution(camera.resolution)
        if self.denoiser is None:
            self.denoiser = mi.DLSSDenoiser(mi.ScalarVector2u(camera.resolution),
                                            mi.ScalarVector2u(out_res),
                                            self.quality)
            self.rays = self.pixel_rays(camera)
        return out_res

    def pixel_rays(self, camera):
        """Per-pixel camera-space near plane point and direction (cached)"""
        width, height = int(camera.resolution[0]), int(camera.resolution[1])
        index = dr.arange(mi.UInt32, width * height)
        px = mi.Float(index % width) + 0.5
        py = mi.Float(index // width) + 0.5

        projection = camera.sensor.projection_transform()
        near_p = mi.Point3f(projection.inverse() @
                            mi.Point3f(px / width, py / height, 0.0))

        return projection, near_p, dr.normalize(mi.Vector3f(near_p)), px, py

    def __call__(self, camera, img):
        """Denoise one rendered frame, given as the `aov` integrator output"""
        width, height = int(camera.resolution[0]), int(camera.resolution[1])
        projection, near_p, direction, px, py = self.rays

        # Channel layout of the `aov` integrator: the nested image comes first,
        # followed by the AOVs in the order they were requested
        noisy = img[..., 0:3]
        albedo = img[..., 3:6]
        normals = img[..., 6:9]

        # The `depth` AOV is the distance travelled along the ray, and rays
        # start on the near plane rather than at the camera origin. Rays that
        # left the scene are pushed far away so that they still receive
        # plausible motion vectors.
        t = img[..., 9:10].array
        t = dr.select(t > 0.0, t, 1e7)

        p_camera = near_p + direction * t
        p_world = camera.to_world @ mi.Point3f(p_camera)

        # Reproject into the previous frame to obtain the motion vectors. Note
        # that Mitsuba's samplers always jitter randomly inside a pixel, so the
        # exact subpixel offset of a frame is not known to us and no jitter is
        # reported to DLSS. The random offsets still provide the sample
        # diversity that DLSS relies on.
        p_prev = mi.Point3f(camera.prev_to_world.inverse() @ p_world)
        uv_prev = projection @ p_prev
        visible = p_prev.z > 0.0

        flow = dr.concat((
            mi.TensorXf(dr.select(visible, uv_prev.x * width - px, 0.0),
                        shape=(height, width, 1)),
            mi.TensorXf(dr.select(visible, uv_prev.y * height - py, 0.0),
                        shape=(height, width, 1))), axis=2)

        # DLSS expects a linear camera-space depth
        depth = mi.TensorXf(p_camera.z, shape=(height, width, 1))

        return self.denoiser(noisy, albedo, normals, depth, flow=flow)


class State:
    def __init__(self, scene_file):
        self.scene = mi.load_file(scene_file)
        self.frame = dr.opaque(dr.auto.UInt, 0)
        self.accumulate = True
        self.camera = Camera()
        self.resolution_slider = int(self.camera.resolution[0])
        self.denoiser = Denoiser(self.scene) if DLSS_AVAILABLE else None

    def process_inputs(self, pos, size):
        if imgui.table_get_hovered_column() == 0:
            self.camera.process_imgui_inputs(pos, size)

# `dr.freeze` keys its recordings on the structure of the Dr.Jit variables it
# can discover, and the film resolution is not among them: it is a scalar C++
# member, and a change in the *width* of the film storage is explicitly allowed
# to replay an existing recording. Without the film size as additional state, a
# resolution change would therefore keep replaying a recording made for another
# resolution and hand back an image of the previous size.
#
# Each film size (and each integrator) thus gets its own recording, which means
# that re-tracing is by design here: the warning is disabled, and an LRU cache
# bounds the memory that the recordings occupy instead.
@dr.freeze(limit=8, warn_after=None,
           state_fn=lambda scene, seed=0, sensor=0, integrator=None:
               tuple(sensor.film().crop_size()))
def render(scene, seed=0, sensor=0, integrator=None):
    return mi.render(scene, spp=1, seed=seed, sensor=sensor,
                     integrator=integrator)

def show_image():
    camera = state.camera
    denoiser = state.denoiser

    if denoiser is not None and denoiser.active:
        denoiser.prepare(camera)
        img = render(state.scene, seed=state.frame, sensor=camera.sensor,
                     integrator=denoiser.integrator)
        # DLSS accumulates across frames on its own, so every frame is shown
        # as it comes out of the denoiser
        out = add_alpha(dr.linear_to_srgb(denoiser(camera, img)))
    else:
        img = add_alpha(render(state.scene, seed=state.frame, sensor=camera.sensor))
        # The accumulated samples are only meaningful for the film size they
        # were rendered at, so a resolution change restarts the accumulation
        if state.accumulate and camera.film.shape == img.shape:
            camera.film = camera.film + img
        else:
            camera.film = img
        # use alpha channel to store the sample count
        out = dr.linear_to_srgb(camera.film / camera.film[0][0][3])

    # Size the texture from the image that is about to be uploaded rather than
    # from the resolution that was requested, so that the two cannot disagree
    resolution = (out.shape[1], out.shape[0])
    camera.handle_gl_texture(resolution)
    camera.gl_texture.upload(out)

    camera.prev_to_world = camera.to_world
    state.frame += 1

    w = float(resolution[0]) * camera.scale
    h = float(resolution[1]) * camera.scale
    x = imgui.get_column_width()//2 - w//2
    y = imgui.get_window_viewport().size.y//2 - h//2
    imgui.set_cursor_pos_x(x)
    imgui.set_cursor_pos_y(y)
    imgui.image(imgui.ImTextureRef(camera.gl_texture.id), (w, h))
    state.process_inputs((x, y), (w, h))

def add_alpha(img):
    if img.shape[2] == 4:
        return TensorXf(img)
    alpha = dr.ones(TensorXf, shape=(img.shape[0], img.shape[1], 1))
    return dr.concat((TensorXf(img), alpha), axis=2)

def denoiser_settings():
    if state.denoiser is None:
        imgui.text_disabled("DLSS Ray Reconstruction is unavailable")
        imgui.text_disabled("(needs MI_ENABLE_DLSS, an RTX GPU, driver 590+)")
        return

    denoiser = state.denoiser
    changed, denoiser.active = imgui.checkbox("DLSS Ray Reconstruction",
                                              denoiser.active)
    if changed:
        denoiser.invalidate()
        state.camera.update(state.camera.q)

    if not denoiser.active:
        return

    changed, index = imgui.combo("Quality", Denoiser.QUALITIES.index(denoiser.quality),
                                 Denoiser.QUALITIES)
    if changed:
        denoiser.quality = Denoiser.QUALITIES[index]
        denoiser.invalidate()

    labels = [f"{f}x" for f in Denoiser.UPSCALE_FACTORS]
    changed, index = imgui.combo("Upscaling",
                                 Denoiser.UPSCALE_FACTORS.index(denoiser.upscale),
                                 labels)
    if changed:
        denoiser.upscale = Denoiser.UPSCALE_FACTORS[index]
        denoiser.invalidate()

def gui():
    imgui.set_next_window_size(imgui.get_io().display_size)
    imgui.set_next_window_pos((0, 0))
    if imgui.begin("##FullscreenWindow", None, imgui.WindowFlags_.no_resize | imgui.WindowFlags_.no_decoration | imgui.WindowFlags_.no_background | imgui.WindowFlags_.no_focus_on_appearing):
        if imgui.begin_table("Table", 2, imgui.TableFlags_.resizable | imgui.TableFlags_.sizing_stretch_prop, (-1, -1)):
            imgui.table_setup_column("Rendering", imgui.TableColumnFlags_.width_stretch)
            imgui.table_setup_column("Settings", imgui.TableColumnFlags_.width_fixed, 400)
            imgui.table_next_row()
            imgui.table_set_column_index(0)
            show_image()
            imgui.table_set_column_index(1)
            if imgui.begin_tab_bar("Settings"):
                if imgui.begin_tab_item("General")[0]:
                    if imgui.collapsing_header("Film", imgui.TreeNodeFlags_.default_open):
                        _, state.camera.scale = imgui.slider_float("Scale", state.camera.scale, 1.0, 10.0)
                        _, state.resolution_slider = imgui.slider_int("Resolution", state.resolution_slider, 64, 2048)
                        # Applying every intermediate value of a drag would
                        # re-trace `render()` dozens of times, so the film is
                        # only resized once the slider is let go of
                        if imgui.is_item_deactivated_after_edit():
                            changed = state.camera.set_resolution(state.resolution_slider)
                            if changed and state.denoiser is not None:
                                state.denoiser.invalidate()
                    denoising = state.denoiser is not None and state.denoiser.active
                    imgui.begin_disabled(denoising)
                    state.accumulate = imgui.checkbox("Accumulate", state.accumulate)[1]
                    imgui.end_disabled()
                    if imgui.collapsing_header("Denoiser", imgui.TreeNodeFlags_.default_open):
                        denoiser_settings()
                    imgui.end_tab_item()
                if imgui.begin_tab_item("Other")[0]:
                    imgui.text("More settings can be added here.")
                    imgui.end_tab_item()
                imgui.end_tab_bar()
            imgui.set_cursor_pos_y(imgui.get_cursor_pos_y() + imgui.get_content_region_avail().y - imgui.get_text_line_height_with_spacing())
            imgui.separator()
            imgui.text(f"{imgui.get_io().framerate :.2f} FPS | { 1000.0 / imgui.get_io().framerate :.1f} ms")
            imgui.end_table()
        imgui.end()

if __name__ == "__main__":
    state = State("scenes/cbox.xml")
    immapp.run(gui_function=gui, window_title="Real-Time Mitsuba", window_size=(1280, 720), fps_idle=0)

```

</details>