### PR TITLE
heterogeneous: add a majorant_factor parameter

### DIFF
--- a/src/media/heterogeneous.cpp
+++ b/src/media/heterogeneous.cpp
@@ -38,6 +38,11 @@ Heterogeneous medium (:monosp:`heterogeneous`)
      units, or to simply tweak the density of the medium. (Default: 1)
    - |exposed|
 
+ * - majorant_factor
+   - |float|
+   - Safety factor on the majorant used by delta tracking. A value above 1
+     keeps the majorant strictly above the densest voxel. (Default: 1.2)
+
  * - sample_emitters
    - |bool|
    - Flag to specify whether shadow rays should be cast from inside the volume (Default: |true|)
@@ -159,8 +164,11 @@ public:
 
         m_scale = props.get<ScalarFloat>("scale", 1.0f);
         m_has_spectral_extinction = props.get<bool>("has_spectral_extinction", true);
+        m_majorant_factor = props.get<ScalarFloat>("majorant_factor", 1.2f);
+        if (m_majorant_factor <= 1.f)
+            Log(Warn, "'majorant_factor' is suggested being > 1, or delta tracking may generate bias");
 
-        m_max_density = dr::opaque<Float>(m_scale * m_sigmat->max());
+        m_max_density = dr::opaque<Float>(m_scale * m_majorant_factor * m_sigmat->max());
     }
 
     void traverse(TraversalCallback *cb) override {
@@ -171,7 +179,7 @@ public:
     }
 
     void parameters_changed(const std::vector<std::string> &/*keys*/ = {}) override {
-        m_max_density = dr::opaque<Float>(m_scale * m_sigmat->max());
+        m_max_density = dr::opaque<Float>(m_scale * m_majorant_factor * m_sigmat->max());
     }
 
     UnpolarizedSpectrum
@@ -206,6 +214,7 @@ public:
             << "  albedo  = " << string::indent(m_albedo) << std::endl
             << "  sigma_t = " << string::indent(m_sigmat) << std::endl
             << "  scale   = " << string::indent(m_scale) << std::endl
+            << "  majorant_factor = " << m_majorant_factor << std::endl
             << "]";
         return oss.str();
     }
@@ -213,7 +222,7 @@ public:
     MI_DECLARE_CLASS(HeterogeneousMedium)
 private:
     ref<Volume> m_sigmat, m_albedo;
-    ScalarFloat m_scale;
+    ScalarFloat m_scale, m_majorant_factor;
     Float m_max_density;
 
     MI_TRAVERSE_CB(Base, m_sigmat, m_albedo, m_max_density)

--- a/src/media/tests/test_heterogeneous.py
+++ b/src/media/tests/test_heterogeneous.py
@@ -1,0 +1,49 @@
+"""Tests for the majorant of the `heterogeneous` medium."""
+
+import pytest
+import drjit as dr
+import mitsuba as mi
+
+
+def make_grid(value):
+    import numpy as np
+    return mi.VolumeGrid(np.full((4, 4, 4, 1), value, dtype=np.float32))
+
+
+def make_medium(sigma_t, *, albedo=None, scale=1.0, majorant_factor=None):
+    d = {'type': 'heterogeneous', 'scale': scale,
+         'sigma_t': {'type': 'gridvolume', 'grid': make_grid(sigma_t)}}
+    if albedo is not None:
+        d['albedo'] = {'type': 'gridvolume', 'grid': make_grid(albedo)}
+    if majorant_factor is not None:
+        d['majorant_factor'] = majorant_factor
+    return mi.load_dict(d)
+
+
+def interaction(medium):
+    mei = dr.zeros(mi.MediumInteraction3f)
+    mei.p = mi.Point3f(0.5, 0.5, 0.5)
+    mei.wi = mi.Vector3f(0, 0, 1)
+    mei.sh_frame = mi.Frame3f(mei.wi)
+    mei.wavelengths = mi.Color0f()
+    mei.medium = mi.MediumPtr(medium)
+    return mei
+
+
+def test01_majorant_factor(variants_vec_backends_once_rgb):
+    """The factor only raises the majorant; the coefficients stay the same."""
+    m0 = make_medium(0.7, albedo=0.4, scale=2.0, majorant_factor=1.0)
+    m1 = make_medium(0.7, albedo=0.4, scale=2.0, majorant_factor=1.3)
+    mei0, mei1 = interaction(m0), interaction(m1)
+    assert dr.allclose(m0.get_majorant(mei0), 2.0 * 0.7)
+    assert dr.allclose(m1.get_majorant(mei1), 2.0 * 0.7 * 1.3)
+    s0, n0, t0 = m0.get_scattering_coefficients(mei0)
+    s1, n1, t1 = m1.get_scattering_coefficients(mei1)
+    assert dr.allclose(t0, t1) and dr.allclose(s0, s1)
+    assert dr.allclose(n0, 0.0) and dr.allclose(n1, 2.0 * 0.7 * 0.3)
+    # Test default value, if left unspecified, the factor is 1.2
+    m = make_medium(0.7, scale=2.0)
+    assert dr.allclose(m.get_majorant(interaction(m)), 2.0 * 0.7 * 1.2)
+    # A factor at or below 1 is kept as given; the constructor only warns
+    m = make_medium(0.7, scale=2.0, majorant_factor=0.9)
+    assert dr.allclose(m.get_majorant(interaction(m)), 2.0 * 0.7 * 0.9)


### PR DESCRIPTION
Adds a `majorant_factor` parameter to `heterogeneous`: the delta tracking majorant becomes a multiple of the maximum density. Delta tracking often needs that relation under control.

## Checklist

- [x] My code follows the [style guidelines](https://mitsuba.readthedocs.io/en/latest/src/developer_guide.html#coding-style) of this project
- [x] My changes generate no new warnings
- [x] My code also compiles for `cuda_*` and `llvm_*` variants. If you can't test this, please leave below
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 3 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba/blob/master/LICENSE)
