### PR TITLE
Fix the spectral majorant of gridvolume and a transmittance underflow

### DIFF
--- a/src/render/medium.cpp
+++ b/src/render/medium.cpp
@@ -89,8 +89,11 @@ Medium<Float, Spectrum>::transmittance_eval_pdf(const MediumInteraction3f &mi,
                                                 Mask active) const {
     MI_MASKED_FUNCTION(ProfilerPhase::MediumEvaluate, active);
 
-    Float t      = dr::minimum(mi.t, si.t) - mi.mint;
-    UnpolarizedSpectrum tr  = dr::exp(-t * mi.combined_extinction);
+    Float t = dr::minimum(mi.t, si.t) - mi.mint;
+    // Clamp the optical depth: callers use the ratio tr / pdf, and on a long
+    // flight under a large majorant both would underflow to zero
+    UnpolarizedSpectrum tau = dr::minimum(t * mi.combined_extinction, 80.f);
+    UnpolarizedSpectrum tr  = dr::exp(-tau);
     UnpolarizedSpectrum pdf = dr::select(si.t < mi.t, tr, tr * mi.combined_extinction);
     return { tr, pdf };
 }

--- a/src/volumes/grid.cpp
+++ b/src/volumes/grid.cpp
@@ -314,8 +314,19 @@ public:
 
             m_texture.update_inplace();
 
-            if (!m_fixed_max)
-                m_max = (float) dr::max_nested(dr::detach(m_texture.value()));
+            if (!m_fixed_max) {
+                if (is_spectral_v<Spectrum> && m_texture.channel_count() == 4 && !m_raw) {
+                    // Spectral upsampling stores (c0, c1, c2, scale) per voxel.
+                    // The model spectrum is bounded by 1, so the scale channel
+                    // bounds the volume; the coefficients do not.
+                    using Array = typename TensorXf::Array;
+                    const Array &data = m_texture.tensor().array();
+                    auto idx = dr::arange<dr::uint32_array_t<Array>>(data.size() / 4) * 4 + 3;
+                    m_max = (float) dr::max_nested(dr::gather<Array>(dr::detach(data), idx));
+                } else {
+                    m_max = (float) dr::max_nested(dr::detach(m_texture.value()));
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Two bugs in spectral variants. They give abnormal gradients.

**1. `gridvolume` returns the wrong maximum.** Delta tracking needs a majorant above the largest density in the grid. The medium asks the volume for it with `max()`. In spectral variants an RGB grid stores four numbers per voxel: three spectral upsampling coefficients and a scale. However, `max()` returns the largest of (c0, c1, c2, scale), and c0, c1, c2 are not densities.

**Fix.** `max()` takes the scale alone, because the curve built from c0, c1, c2 stays between 0 and 1.

**2. Transmittance underflows.** `exp(-majorant * t)` underflows to zero once `majorant * t` passes about 87. `prbvolpath` and `prbvolpath_sm` then get 0/0 in the free flight weight `tr / pdf` and drop the path, leading to black pixels.

**Fix.** The optical depth is clamped to 80 before the exponential to avoid that.

## Checklist

- [x] My code follows the [style guidelines](https://mitsuba.readthedocs.io/en/latest/src/developer_guide.html#coding-style) of this project
- [x] My changes generate no new warnings
- [x] My code also compiles for `cuda_*` and `llvm_*` variants. If you can't test this, please leave below
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 3 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba/blob/master/LICENSE)
