### PR TITLE
A better ray epsilon

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -27,9 +27,6 @@ Mitsuba 3.10.0
     makes it possible to use normal maps authored elsewhere in Mitsuba
     and optimize maps in Mitsuba for use in other tools.
 
-  - It adds early support for per-face material assignments. (Though this
-    will require further work in the renderer.)
-
   - Mesh orientation is now a property of the mesh data rather than of the
     scene description. The face winding order defines the orientation of the
     surface, and the ``flip_normals`` and ``to_world`` properties are baked
@@ -71,10 +68,9 @@ Mitsuba 3.10.0
     vertex attribute ``[dV]``      ``(V, d)``, and ``(F, d)`` per face
     ============================== ==========================================
 
-    The ``position_index`` ``[V]``, ``normal_index`` ``[V]``, and
-    ``bsdf_index`` ``[F]`` entries are new and writable. These maps are empty
-    by default and indicate that there is no indirection for positions/normals,
-    or no per-face material assignment.
+    The ``position_index`` ``[V]`` and ``normal_index`` ``[V]`` entries are
+    new and writable. These maps are empty by default and indicate that there
+    is no indirection for positions/normals.
 
     Because the values are now shaped tensors, the flat-buffer bookkeeping that
     used to surround an edit tends to disappear:
@@ -130,7 +126,7 @@ Mitsuba 3.10.0
                        positions=vertex_pos)                 # (P, 3) TensorXf
 
     The constructor optionally also accepts ``normals``, ``texcoords``,
-    ``position_index``, ``normal_index``, and ``bsdf_index``. Alternatively,
+    ``position_index``, and ``normal_index``. Alternatively,
     an empty mesh created via ``mi.Mesh(name)`` can be built by calling
     ``from_fields()`` (the same parameters as above), ``from_corners()``
     (corner-indexed data as produced by OBJ files or DCC applications), or
@@ -228,6 +224,20 @@ Mitsuba 3.10.0
   tracing queries, while skipping null BSDF surfaces and returning the
   associated transmittance.
 
+- **Ray epsilon**. Rays spawned from a surface must be offset by a small
+  distance to avoid self-intersection. Mitsuba previously used a fixed fraction
+  (1500 ULP) of the largest coordinate magnitude and an even larger fraction
+  (15000 ULP) for the far end of shadow rays. These are >2-3 orders of
+  magnitude larger than what the backends actually require in practice (~1-8
+  ULP), and it introduces light leaks and breaks ray tracing of small scenes or
+  closely spaced surfaces.
+
+  Shapes now explicitly bound the rounding error of their intersections via new
+  fields - `Interaction3f.p_err` and `PositionSample3f.p_err`.
+  `Interaction3f.spawn_ray` uses it to offset the ray origin, and a new
+  overload of `Interaction3f.spawn_ray_to`  uses it to also handle the bounds
+  on both sides of a shadow ray test. The bounds are close to the hardware's
+  actual needs and adapts to the scene scale and the surface orientation.
 
 Mitsuba 3.9.1
 -------------

--- a/docs/src/plugin_reference/section_shapes.rst
+++ b/docs/src/plugin_reference/section_shapes.rst
@@ -152,11 +152,6 @@ surface points, and ``N`` normal groups:
    - Vertex indices of each triangle, in ``[0, V)``
    - |exposed|, |discontinuous|
 
- * - bsdf_index
-   - :paramtype:`UInt32` ``(F,)``
-   - Per-face BSDF index. An empty list indicates that all faces use BSDF entry 0.
-   - |exposed|
-
  * - position_index
    - :paramtype:`UInt32` ``(V,)``
    - Surface point of each vertex, in ``[0, P)``. An empty list encodes the

--- a/include/mitsuba/core/math.h
+++ b/include/mitsuba/core/math.h
@@ -14,13 +14,37 @@ NAMESPACE_BEGIN(math)
 // Useful constants in various precisions
 // -----------------------------------------------------------------------
 
-#if (MI_ENABLE_EMBREE)
-template <typename T> constexpr auto RayEpsilon = dr::Epsilon<dr::float32_array_t<T>> * 1500;
+/**
+ * Floating point type in which the ray tracing backend operates
+ *
+ * Embree, OptiX and Metal trace in single precision regardless of the
+ * variant. Only the native kd-tree works in the precision of the variant.
+ */
+template <typename T> using trace_float_t =
+#if defined(MI_ENABLE_EMBREE)
+    dr::float32_array_t<T>;
 #else
-template <typename T> constexpr auto RayEpsilon = dr::Epsilon<T> * 1500;
+    std::conditional_t<dr::is_cuda_v<T> || dr::is_metal_v<T>,
+                       dr::float32_array_t<T>, T>;
 #endif
+
+/// Unit roundoff of the ray tracing backend
+template <typename T> constexpr auto TraceEpsilon = dr::Epsilon<trace_float_t<T>>;
+
+/**
+ * Unit roundoff times a safety factor, which scales the position error
+ * bounds that shapes report (see `Interaction3f.p_err`)
+ */
+template <typename T> constexpr auto PositionEpsilon = TraceEpsilon<T> * 32;
+
+/// Generic tolerance used by a few sensors, emitters and shapes
+template <typename T> constexpr auto RayEpsilon = TraceEpsilon<T> * 1500;
+
+/**
+ * Relative amount by which `Interaction3f.spawn_ray_to` shortens a ray
+ * towards a bare point that carries no error bound of its own
+ */
 template <typename T> constexpr auto ShadowEpsilon = RayEpsilon<T> * 10;
-template <typename T> constexpr auto ShapeEpsilon = RayEpsilon<T> / 80;
 
 // -----------------------------------------------------------------------
 

--- a/include/mitsuba/core/transform.h
+++ b/include/mitsuba/core/transform.h
@@ -111,6 +111,36 @@ struct Transform {
         return result;
     }
 
+    /**
+     * Bound the rounding error of a transformed point
+     *
+     * Returns a bound on the rounding error of ``(*this) * p`` along a unit
+     * vector ``n``. Every matrix entry and every coordinate of ``p`` is
+     * assumed to carry a relative error of ``mi.math.PositionEpsilon``, and
+     * the coordinates of ``p`` additionally carry the absolute error
+     * ``in_err``. Its default value equals the relative error and therefore
+     * suits inputs of unit magnitude. Shapes use this function to fill in
+     * `Interaction3f.p_err`. Only valid for affine transformations.
+     */
+    template <typename T, typename N, typename Expr = dr::expr_t<Float, T>>
+    Expr position_error(const mitsuba::Point<T, Size - 1> &p, const N &n,
+                        Expr in_err = math::PositionEpsilon<Expr>) const {
+        constexpr Scalar eps = math::PositionEpsilon<Expr>;
+        Matrix m = dr::abs(dr::detach(matrix));
+        auto pd = dr::abs(dr::detach(p));
+        auto nd = dr::abs(dr::detach(n));
+        in_err = dr::detach(in_err);
+        Expr result = 0.f;
+        for (size_t i = 0; i < Size - 1; ++i) {
+            Expr row = m.entry(i, Size - 1) * eps;
+            for (size_t k = 0; k < Size - 1; ++k)
+                row = dr::fmadd(m.entry(i, k),
+                                dr::fmadd(pd.entry(k), eps, in_err), row);
+            result = dr::fmadd(nd.entry(i), row, result);
+        }
+        return result;
+    }
+
     template<typename OtherPoint, bool OtherAffine>
     Transform& operator=(const Transform<OtherPoint, OtherAffine> &t) {
         matrix = Matrix(t.matrix);

--- a/include/mitsuba/python/docstr.h
+++ b/include/mitsuba/python/docstr.h
@@ -2753,10 +2753,6 @@ static const char *__doc_mitsuba_CornerMesh_attr_count = R"doc()doc";
 
 static const char *__doc_mitsuba_CornerMesh_attrs = R"doc(Custom ``vertex_*`` attributes (``attr_count`` entries))doc";
 
-static const char *__doc_mitsuba_CornerMesh_bsdf_index =
-R"doc(Optional per-face BSDF indices (one entry per input face,
-replicated when a polygon fans into several triangles))doc";
-
 static const char *__doc_mitsuba_CornerMesh_corner_count = R"doc(Number of face corners)doc";
 
 static const char *__doc_mitsuba_CornerMesh_corner_index =
@@ -5068,10 +5064,7 @@ static const char *__doc_mitsuba_Interaction_n = R"doc(Geometric normal (only va
 
 static const char *__doc_mitsuba_Interaction_name = R"doc()doc";
 
-static const char *__doc_mitsuba_Interaction_offset_p =
-R"doc(Compute an offset position, used when spawning a ray from this
-interaction. When the interaction is on the surface of a shape, the
-position is offset along the surface normal to prevent self intersection.)doc";
+static const char *__doc_mitsuba_Interaction_offset_p = R"doc(Offset ``p`` along ``n`` towards the side of ``d`` by ``p_err``)doc";
 
 static const char *__doc_mitsuba_Interaction_operator_assign = R"doc()doc";
 
@@ -5079,9 +5072,27 @@ static const char *__doc_mitsuba_Interaction_operator_assign_2 = R"doc()doc";
 
 static const char *__doc_mitsuba_Interaction_p = R"doc(Position of the interaction in world coordinates)doc";
 
+static const char *__doc_mitsuba_Interaction_p_err =
+R"doc(Bound on the rounding error of ``p`` along ``n``, filled in by shapes.
+`Interaction3f.spawn_ray` offsets the ray origin by this amount.)doc";
+
 static const char *__doc_mitsuba_Interaction_spawn_ray = R"doc(Spawn a semi-infinite ray towards the given direction)doc";
 
-static const char *__doc_mitsuba_Interaction_spawn_ray_to = R"doc(Spawn a finite ray towards the given position)doc";
+static const char *__doc_mitsuba_Interaction_spawn_ray_to =
+R"doc(Spawn a finite ray towards a bare point
+
+The segment is shortened by ``mi.math.ShadowEpsilon`` since the point
+carries no error bound. Prefer the `PositionSample3f` overload when the
+target lies on a shape.)doc";
+
+static const char *__doc_mitsuba_Interaction_spawn_ray_to_2 =
+R"doc(Spawn a finite ray towards a sampled position
+
+The segment stops short of the target by `PositionSample3f.p_err`
+projected onto the segment, plus a relative amount that absorbs the
+rounding of the distance. The endpoint moves back along the ray rather
+than along ``ps.n``, which is more robust when ``ps.n`` is a shading
+normal.)doc";
 
 static const char *__doc_mitsuba_Interaction_t = R"doc(Distance traveled along the ray)doc";
 
@@ -5235,9 +5246,7 @@ static const char *__doc_mitsuba_JitObject_unregister =
 R"doc(Withdraw this instance from the JIT registry. This can be useful when
 an instance should not be reached by traced function calls.)doc";
 
-static const char *__doc_mitsuba_Layout = R"doc(Content of the packed records of a `Mesh`)doc";
-
-static const char *__doc_mitsuba_Layout_FaceBSDFs = R"doc(The face records carry per-face BSDF indices)doc";
+static const char *__doc_mitsuba_Layout = R"doc(Content of the packed vertex records of a `Mesh`)doc";
 
 static const char *__doc_mitsuba_Layout_Normals = R"doc(Shading normals)doc";
 
@@ -5783,8 +5792,7 @@ static const char *__doc_mitsuba_MergeKey_exterior_medium = R"doc()doc";
 static const char *__doc_mitsuba_MergeKey_interior_medium = R"doc()doc";
 
 static const char *__doc_mitsuba_MergeKey_layout =
-R"doc(Packed record layout, without the ``FaceBSDFs`` bit that a merge
-unions
+R"doc(Packed record layout
 
 The face-normal setting needs no separate field, since a built mesh
 carries the ``Normals`` bit exactly when it shades with vertex normals.)doc";
@@ -5856,7 +5864,6 @@ Name                Type              Shape       Range       Optional
 ``positions``       ``TensorXf32``    ``(P, 3)``
 ``normals``         ``TensorXf32``    ``(N, 3)``              x
 ``texcoords``       ``TensorXf32``    ``(V, 2)``              x
-``bsdf_index``      ``UInt32`` array  ``F``       ``[0, B)``  x
 ==================  ================  ==========  ==========  ========
 
 The fields have the following roles:
@@ -5874,8 +5881,6 @@ The fields have the following roles:
 - ``positions``: surface positions.
 
 - ``normals`` (optional): surface normals.
-
-- ``bsdf_index`` (optional): per-face index into a set of ``B`` materials.
 
 .. rubric:: Example usage
 
@@ -6041,10 +6046,6 @@ static const char *__doc_mitsuba_Mesh_bbox_2 = R"doc()doc";
 
 static const char *__doc_mitsuba_Mesh_bbox_3 = R"doc()doc";
 
-static const char *__doc_mitsuba_Mesh_bsdf_index =
-R"doc(Return the per-face BSDF index (size `face_count()`). An empty
-buffer stands for zeros, see ``has_face_bsdfs()``.)doc";
-
 static const char *__doc_mitsuba_Mesh_build_parameterization =
 R"doc(Initialize the ``m_parameterization`` field for mapping UV
 coordinates to positions
@@ -6144,6 +6145,8 @@ static const char *__doc_mitsuba_Mesh_face_normal = R"doc(Returns the normal dir
 
 static const char *__doc_mitsuba_Mesh_face_normal_2 = R"doc(Returns the normal direction of the face with index ``index``)doc";
 
+static const char *__doc_mitsuba_Mesh_face_position_error = R"doc(Decode the position error bound stored in a packed face record)doc";
+
 static const char *__doc_mitsuba_Mesh_faces = R"doc(Return the vertex index triplets as an ``(F, 3)`` tensor)doc";
 
 static const char *__doc_mitsuba_Mesh_find_attribute = R"doc(Return the mesh attribute ``name`` or NULL)doc";
@@ -6154,9 +6157,8 @@ static const char *__doc_mitsuba_Mesh_flip_winding =
 R"doc(Reverse the corner order of every face, which flips the
 geometric normals
 
-The orientation of each face's UV triangle reverses along with it, so
-the packed tangent frames are updated to match. The caller is
-responsible for the subsequent ``refresh()``.)doc";
+The caller is responsible for the subsequent ``refresh()``, which
+also recomputes the UV orientation bits.)doc";
 
 static const char *__doc_mitsuba_Mesh_from_corners =
 R"doc(Build the mesh from corner-indexed data
@@ -6205,9 +6207,7 @@ Args:
 
     normal_index: Optional map from vertex index to normal group. An empty map
         encodes the identity, or the position map when the normal count
-        matches the surface position count.
-
-    bsdf_index: Optional per-face material index. An empty buffer stands for zeros.)doc";
+        matches the surface position count.)doc";
 
 static const char *__doc_mitsuba_Mesh_from_packed =
 R"doc(Build the mesh from a packed representation
@@ -6219,9 +6219,9 @@ call raises an exception; later mesh changes must go through
 the parameter interface.
 
 The function checks the tensor shapes for consistency but trusts that
-any specified indices are in-bounds and that the per-face UV
-orientation bits of a tangent layout are consistent with the stored
-texture coordinates.
+any specified indices are in-bounds. The fourth word of the face
+records is derived data that the mesh regenerates, so the caller may
+leave it zero.
 
 The operation is differentiable in the sense that derivatives propagate
 between function parameters and the resulting mesh state.
@@ -6243,7 +6243,13 @@ Args:
         is nonempty.
 
     normal_count: Number of normal groups. Only needed when ``normal_index`` is
-        nonempty.)doc";
+        nonempty.
+
+    bbox: Bounding box of the positions, if known.
+
+    face_state_valid: Set when the fourth face word already holds the
+        derived data (see ``update_face_state()``), which lets a mesh
+        with usable records skip the kernel that recomputes it.)doc";
 
 static const char *__doc_mitsuba_Mesh_from_packed_2 =
 R"doc(Build the mesh from host-side staging data
@@ -6268,8 +6274,6 @@ seams. It is used by features like `Mesh.dedge` and the
 mesh Laplacian in ``mitsuba.ad.largesteps``.)doc";
 
 static const char *__doc_mitsuba_Mesh_has_attribute = R"doc()doc";
-
-static const char *__doc_mitsuba_Mesh_has_face_bsdfs = R"doc(Does this mesh have a per-face BSDF assignment?)doc";
 
 static const char *__doc_mitsuba_Mesh_has_face_normals = R"doc(Does this mesh use face normals?)doc";
 
@@ -6298,8 +6302,6 @@ static const char *__doc_mitsuba_Mesh_m_area_pmf = R"doc()doc";
 static const char *__doc_mitsuba_Mesh_m_bbox = R"doc(Bounding box of the mesh positions, computed on demand by `bbox()`)doc";
 
 static const char *__doc_mitsuba_Mesh_m_bbox_valid = R"doc(Does `m_bbox` reflect the current positions?)doc";
-
-static const char *__doc_mitsuba_Mesh_m_bsdf_index = R"doc()doc";
 
 static const char *__doc_mitsuba_Mesh_m_built = R"doc(Set by the first successful build; construction is one-shot)doc";
 
@@ -6333,7 +6335,7 @@ representative vertex)doc";
 
 static const char *__doc_mitsuba_Mesh_m_normals = R"doc()doc";
 
-static const char *__doc_mitsuba_Mesh_m_packed_faces = R"doc(Packed faces, material IDs and UV orientation bits (4 x UInt32 per face))doc";
+static const char *__doc_mitsuba_Mesh_m_packed_faces = R"doc(Packed faces: vertex indices and a derived word (4 x UInt32 per face))doc";
 
 static const char *__doc_mitsuba_Mesh_m_packed_vertices = R"doc(Packed per-vertex state (8 x Float32 per vertex))doc";
 
@@ -6512,15 +6514,17 @@ static const char *__doc_mitsuba_Mesh_recompute_normals = R"doc((Re-) compute sm
 static const char *__doc_mitsuba_Mesh_refresh =
 R"doc(Regenerate everything downstream of the packed state
 
-Every mutation ends with a call to this method. It rebuilds the
-bounding box (adopting ``bbox`` when given), the area sampling table
-of emitter/sensor meshes, the UV parameterization of spatially
-varying emitters, and the silhouette structures of gradient-enabled
-meshes, refreshes the raw data pointers, marks the scene
-acceleration structure dirty, and rebinds the field views unless
-they are dormant. The directed edge structure is not touched here:
-it is expensive and purely topological, so `Object.parameters_changed()`
-clears it only when a topology write occurs.)doc";
+Every mutation ends with a call to this method. It recomputes the
+derived word of every face record, rebuilds the bounding box
+(adopting ``bbox`` when given), the area sampling table of
+emitter/sensor meshes, the UV parameterization of spatially varying
+emitters, and the silhouette structures of gradient-enabled meshes,
+refreshes the raw data pointers, marks the scene acceleration
+structure dirty, and rebinds the field views unless they are dormant.
+The directed edge structure is not touched here: it is expensive and
+purely topological, so `Object.parameters_changed()` clears it only
+when a topology write occurs. ``face_state_valid`` skips the
+recomputation of the face state when the caller already derived them.)doc";
 
 static const char *__doc_mitsuba_Mesh_remove_attribute =
 R"doc(Remove an attribute with the given ``name``.
@@ -6572,6 +6576,12 @@ static const char *__doc_mitsuba_Mesh_traverse = R"doc()doc";
 static const char *__doc_mitsuba_Mesh_traverse_cb = R"doc()doc";
 
 static const char *__doc_mitsuba_Mesh_traverse_cb_fields = R"doc()doc";
+
+static const char *__doc_mitsuba_Mesh_update_face_state =
+R"doc(Recompute the state word of every packed face record
+
+The word holds derived data, see ``face_state()``. It comes from the
+packed vertex records, so the pass must run whenever those change.)doc";
 
 static const char *__doc_mitsuba_Mesh_validate =
 R"doc(Check the field views for consistency
@@ -7396,6 +7406,13 @@ R"doc(Transform mesh data written so far
 Producers that fill ``PackedMesh`` directly without ``set_vertex()``
 and ``set_face()`` should call this method at the end.)doc";
 
+static const char *__doc_mitsuba_PackedMesh_update_face_state =
+R"doc(Compute the state word of every face record on the host
+
+See ``face_state()``, whose ``eps`` is the ``mi.math.PositionEpsilon``
+of the variant. Call this last, after the records are transformed
+and tangents are added.)doc";
+
 static const char *__doc_mitsuba_PackedMesh_vertex_count = R"doc(Sizes of the vertex/face/position/normal arrays)doc";
 
 static const char *__doc_mitsuba_PackedMesh_vertices = R"doc()doc";
@@ -7779,6 +7796,11 @@ static const char *__doc_mitsuba_PositionSample_operator_assign = R"doc()doc";
 static const char *__doc_mitsuba_PositionSample_operator_assign_2 = R"doc()doc";
 
 static const char *__doc_mitsuba_PositionSample_p = R"doc(Sampled position)doc";
+
+static const char *__doc_mitsuba_PositionSample_p_err =
+R"doc(Bound on the rounding error of ``p``, see `Interaction3f.p_err`. Records
+built from a surface interaction carry the bound along the geometric
+normal while ``n`` holds the shading normal.)doc";
 
 static const char *__doc_mitsuba_PositionSample_pdf = R"doc(Probability density at the sample)doc";
 
@@ -9368,7 +9390,9 @@ static const char *__doc_mitsuba_Scene_m_environment = R"doc()doc";
 
 static const char *__doc_mitsuba_Scene_m_has_null_shapes = R"doc(Does the scene contain shapes with 'null' BSDFs?)doc";
 
-static const char *__doc_mitsuba_Scene_m_instance_transforms = R"doc(Flattened sequence of instance ``to_world`` matrices (12 floats each))doc";
+static const char *__doc_mitsuba_Scene_m_instance_transforms =
+R"doc(Flattened sequence of instance ``to_world`` matrices and their
+inverses (2 x 12 floats each))doc";
 
 static const char *__doc_mitsuba_Scene_m_instances = R"doc(Instances in order of appearance in ``m_shapes``.)doc";
 
@@ -9399,35 +9423,29 @@ static const char *__doc_mitsuba_Scene_m_silhouette_shapes_dr = R"doc()doc";
 static const char *__doc_mitsuba_Scene_m_thread_reordering = R"doc()doc";
 
 static const char *__doc_mitsuba_Scene_null_walk =
-R"doc(Walk along ``ray`` through surfaces with null transmission
+R"doc(Walk along ``ray`` and accumulate transmittance due to surfaces with
+``null`` BSDFs
 
 The walk visits the shapes matching ``ray_mask`` from front to back
-and accumulates the product of their `BSDF.eval_null()` values. It
-provides the shared implementation of `ray_test_tr()` and
-`ray_intersect_tr()`.
+and accumulates the product of their `BSDF.eval_null()` values.
 
 Args:
-    ray: The ray to follow. It may be attached to AD variables and
-        stays unchanged.
+    ray: The ray to follow.
     ray_flags: Only the `RayFlags.FollowShape` and
-        `RayFlags.DetachShape` bits are used. They select how the
-        crossed surfaces attach to the ray.
+        `RayFlags.DetachShape` bits are used. It influences
+        the derivative computation of intersected surfaces.
     ray_mask: Visibility mask of the shapes to consider.
-    stop_at_surface: When ``true``, the walk crosses null shapes until
-        it reaches a shape that is opaque or an emitter, and the
-        returned intersection refers to that shape with ``t``
-        measured from ``ray.o``. When ``false``, the walk crosses
-        every shape it meets until the ray leaves the scene or the
-        transmittance reaches zero. The caller must then restrict
-        ``ray_mask`` to null shapes, and the returned intersection
-        is always invalid.
-    active: Mask of the lanes that take part in the walk.
+    stop_at_surface: When ``true``, the walk continues until it
+        encounters a shape that is opaque or an emitter.
+        When ``false``, it continues until no more intersections
+        can be found or when the transmittance reaches zero.
+        The caller should restrict ``ray_mask`` to null shapes
+        in this cae, and the returned intersection is always invalid.
+    active: Active mask
 
 Returns:
     A pair ``(pi, tr)`` of the preliminary intersection and the
-    transmittance product. The latter is one when no shape was
-    crossed and follows the conventions of `ray_test_tr()` in
-    polarized and differentiable modes.)doc";
+    transmittance product.)doc";
 
 static const char *__doc_mitsuba_Scene_parameters_changed = R"doc(Update internal state following a parameter update)doc";
 
@@ -12209,6 +12227,17 @@ Args:
 
     far: Far clipping plane)doc";
 
+static const char *__doc_mitsuba_Transform_position_error =
+R"doc(Bound the rounding error of a transformed point
+
+Returns a bound on the rounding error of ``(*this) * p`` along a unit
+vector ``n``. Every matrix entry and every coordinate of ``p`` is
+assumed to carry a relative error of ``mi.math.PositionEpsilon``, and
+the coordinates of ``p`` additionally carry the absolute error
+``in_err``. Its default value equals the relative error and therefore
+suits inputs of unit magnitude. Shapes use this function to fill in
+`Interaction3f.p_err`. Only valid for affine transformations.)doc";
+
 static const char *__doc_mitsuba_Transform_rotate = R"doc(Create a rotation transformation around an arbitrary axis in 3D. The angle is specified in degrees)doc";
 
 static const char *__doc_mitsuba_Transform_rotate_2 = R"doc(Create a rotation transformation in 2D. The angle is specified in degrees)doc";
@@ -12844,6 +12873,17 @@ static const char *__doc_mitsuba_end = R"doc()doc";
 static const char *__doc_mitsuba_eval_reflectance = R"doc()doc";
 
 static const char *__doc_mitsuba_eval_transmittance = R"doc()doc";
+
+static const char *__doc_mitsuba_face_state =
+R"doc(Face state word of a triangle with the given vertex positions
+
+The word stores the position error bound along the face normal (see
+``FaceErrorMask``), with ``eps`` the ``mi.math.PositionEpsilon`` of the
+variant. The overload with texture coordinates additionally sets
+``FaceUVFlipped`` when the UV triangle is mirrored, which decides the
+handedness of the interpolated tangent frame.)doc";
+
+static const char *__doc_mitsuba_face_state_2 = R"doc()doc";
 
 static const char *__doc_mitsuba_field =
 R"doc(Convenience wrapper to simultaneously instantiate a host and a device
@@ -14434,6 +14474,8 @@ Returns:
 
 static const char *__doc_mitsuba_radical_inverse_2 = R"doc(Van der Corput radical inverse in base 2)doc";
 
+static const char *__doc_mitsuba_ray_error = R"doc(Bound on the rounding error of the point ``ray(t)`` along the unit vector ``n``)doc";
+
 static const char *__doc_mitsuba_reduce_bbox =
 R"doc(Compute the bounding box of an interleaved position buffer.
 
@@ -15108,6 +15150,19 @@ static const char *__doc_mitsuba_string_to_upper = R"doc(Return a upper-case ver
 static const char *__doc_mitsuba_string_tokenize = R"doc(Chop up the string given a set of delimiters (warning: not unicode compliant))doc";
 
 static const char *__doc_mitsuba_string_trim = R"doc(Remove leading and trailing characters)doc";
+
+static const char *__doc_mitsuba_triangle_position_error =
+R"doc(Bound on the rounding error of a position on the triangle ``(p0, p1,
+p2)`` along the unit vector ``n``, in units of ``eps``
+
+The bound must cover the rounding of the barycentric interpolation that
+produces the position, and the rounding of the intersection test that a
+ray spawned from it undergoes against the same triangle. The first part
+scales with the largest vertex magnitude per axis. The second part scales
+with the two edges that the intersection routine forms from one of the
+vertices, and its cross products mix all of their coordinates into every
+axis. Which vertex the ray tracing backend picks is unknown, hence the sum
+of the two largest edges covers every choice.)doc";
 
 static const char *__doc_mitsuba_tuple_hasher = R"doc()doc";
 

--- a/include/mitsuba/render/interaction.h
+++ b/include/mitsuba/render/interaction.h
@@ -170,6 +170,7 @@ struct Interaction {
     using Spectrum = Spectrum_;
     MI_IMPORT_RENDER_BASIC_TYPES()
     MI_IMPORT_OBJECT_TYPES()
+    using PositionSample3f = typename RenderAliases::PositionSample3f;
 
     // =============================================================
 
@@ -192,6 +193,12 @@ struct Interaction {
     /// Geometric normal (only valid for `SurfaceInteraction3f`)
     Normal3f n;
 
+    /**
+     * Bound on the rounding error of ``p`` along ``n``, filled in by shapes.
+     * `Interaction3f.spawn_ray` offsets the ray origin by this amount.
+     */
+    Float p_err = 0.f;
+
     // =============================================================
 
     // =============================================================
@@ -200,8 +207,9 @@ struct Interaction {
 
     /// Constructor
     Interaction(Float t, Float time, const Wavelength &wavelengths,
-                const Point3f &p, const Normal3f &n = 0.f)
-        : t(t), time(time), wavelengths(wavelengths), p(p), n(n) { }
+                const Point3f &p, const Normal3f &n = 0.f, Float p_err = 0.f)
+        : t(t), time(time), wavelengths(wavelengths), p(p), n(n),
+          p_err(p_err) { }
 
     /// Virtual destructor
     virtual ~Interaction() = default;
@@ -217,6 +225,7 @@ struct Interaction {
         wavelengths = dr::zeros<Wavelength>(size);
         p           = dr::zeros<Point3f>(size);
         n           = dr::zeros<Normal3f>(size);
+        p_err       = dr::zeros<Float>(size);
     }
 
     /// Is the current interaction valid?
@@ -229,7 +238,13 @@ struct Interaction {
         return Ray3f(offset_p(d), d, dr::Largest<Float>, time, wavelengths);
     }
 
-    /// Spawn a finite ray towards the given position
+    /**
+     * Spawn a finite ray towards a bare point
+     *
+     * The segment is shortened by ``mi.math.ShadowEpsilon`` since the point
+     * carries no error bound. Prefer the `PositionSample3f` overload when the
+     * target lies on a shape.
+     */
     Ray3f spawn_ray_to(const Point3f &t) const {
         Point3f o = offset_p(t - p);
         Vector3f d = t - o;
@@ -239,22 +254,46 @@ struct Interaction {
                      wavelengths);
     }
 
+    /**
+     * Spawn a finite ray towards a sampled position
+     *
+     * The segment stops short of the target by `PositionSample3f.p_err`
+     * projected onto the segment, plus a relative amount that absorbs the
+     * rounding of the distance. The endpoint moves back along the ray rather
+     * than along ``ps.n``, which is more robust when ``ps.n`` is a shading
+     * normal.
+     */
+    Ray3f spawn_ray_to(const PositionSample3f &ps) const {
+        Point3f o = offset_p(ps.p - p);
+        Vector3f d = ps.p - o;
+        Float dist = dr::norm(d);
+        d /= dist;
+        Float cos_theta = dr::maximum(dr::abs_dot(ps.n, d), 0.1f),
+              maxt = dr::fnmadd(dist, math::PositionEpsilon<Float>, dist) -
+                     dr::detach(ps.p_err) / cos_theta;
+        return Ray3f(o, d, dr::maximum(maxt, 0.f), time, wavelengths);
+    }
+
     // =============================================================
 
-    DRJIT_STRUCT(Interaction, t, time, wavelengths, p, n);
+    DRJIT_STRUCT(Interaction, t, time, wavelengths, p, n, p_err);
 
 private:
-    /**
-     * Compute an offset position, used when spawning a ray from this
-     * interaction. When the interaction is on the surface of a shape, the
-     * position is offset along the surface normal to prevent self intersection.
-     */
+    /// Offset ``p`` along ``n`` towards the side of ``d`` by ``p_err``
     Point3f offset_p(const Vector3f &d) const {
-        Float mag = (1.f + dr::max(dr::abs(p))) * math::RayEpsilon<Float>;
-        mag = dr::detach(dr::mulsign(mag, dr::dot(n, d)));
+        Float mag = dr::detach(dr::mulsign(p_err, dr::dot(n, d)));
         return dr::fmadd(mag, dr::detach(n), p);
     }
 };
+
+/// Bound on the rounding error of the point ``ray(t)`` along the unit vector ``n``
+template <typename Ray3f, typename Float, typename Normal3f>
+Float ray_error(const Ray3f &ray, const Float &t, const Normal3f &n) {
+    using Vector = typename Ray3f::Vector;
+    Vector mag = Vector(dr::abs(dr::detach(ray.o))) +
+                 dr::abs(dr::detach(ray.d) * dr::detach(t));
+    return dr::dot(dr::abs(dr::detach(n)), mag) * math::PositionEpsilon<Float>;
+}
 
 // -----------------------------------------------------------------------------
 
@@ -273,7 +312,7 @@ struct SurfaceInteraction : Interaction<Float_, Spectrum_> {
     using Spectrum = Spectrum_;
 
     // Make parent fields/functions visible
-    MI_IMPORT_BASE(Interaction, t, time, wavelengths, p, n, is_valid)
+    MI_IMPORT_BASE(Interaction, t, time, wavelengths, p, n, p_err, is_valid)
 
     MI_IMPORT_RENDER_BASIC_TYPES()
     MI_IMPORT_OBJECT_TYPES()
@@ -337,7 +376,7 @@ struct SurfaceInteraction : Interaction<Float_, Spectrum_> {
      */
     explicit SurfaceInteraction(const PositionSample3f &ps,
                                 const Wavelength &wavelengths)
-        : Base(0.f, ps.time, wavelengths, ps.p, ps.n), uv(ps.uv),
+        : Base(0.f, ps.time, wavelengths, ps.p, ps.n, ps.p_err), uv(ps.uv),
           sh_frame(Frame3f(ps.n)), dp_du(0), dp_dv(0), dn_du(0), dn_dv(0),
           wi(0), prim_index(0) {}
 
@@ -618,7 +657,7 @@ struct SurfaceInteraction : Interaction<Float_, Spectrum_> {
 
     // =============================================================
 
-    DRJIT_STRUCT(SurfaceInteraction, t, time, wavelengths, p, n, shape, uv,
+    DRJIT_STRUCT(SurfaceInteraction, t, time, wavelengths, p, n, p_err, shape, uv,
                  sh_frame, frame_flipped, dp_du, dp_dv, dn_du, dn_dv, wi,
                  prim_index, instance_index)
 };
@@ -639,7 +678,7 @@ struct MediumInteraction : Interaction<Float_, Spectrum_> {
     using Index = typename CoreAliases::UInt32;
 
     // Make parent fields/functions visible
-    MI_IMPORT_BASE(Interaction, t, time, wavelengths, p, n, is_valid)
+    MI_IMPORT_BASE(Interaction, t, time, wavelengths, p, n, p_err, is_valid)
     // =============================================================
 
 
@@ -695,7 +734,7 @@ struct MediumInteraction : Interaction<Float_, Spectrum_> {
 
     // =============================================================
 
-    DRJIT_STRUCT(MediumInteraction, t, time, wavelengths, p, n, medium,
+    DRJIT_STRUCT(MediumInteraction, t, time, wavelengths, p, n, p_err, medium,
                  sh_frame, wi, sigma_s, sigma_n, sigma_t,
                  combined_extinction, mint)
 };

--- a/include/mitsuba/render/mesh.h
+++ b/include/mitsuba/render/mesh.h
@@ -79,7 +79,6 @@ NAMESPACE_BEGIN(mitsuba)
  * ``positions``       ``TensorXf32``    ``(P, 3)``
  * ``normals``         ``TensorXf32``    ``(N, 3)``              x
  * ``texcoords``       ``TensorXf32``    ``(V, 2)``              x
- * ``bsdf_index``      ``UInt32`` array  ``F``       ``[0, B)``  x
  * ==================  ================  ==========  ==========  ========
  *
  * The fields have the following roles:
@@ -97,8 +96,6 @@ NAMESPACE_BEGIN(mitsuba)
  * - ``positions``: surface positions.
  *
  * - ``normals`` (optional): surface normals.
- *
- * - ``bsdf_index`` (optional): per-face index into a set of ``B`` materials.
  *
  * .. rubric:: Example usage
  *
@@ -225,7 +222,6 @@ public:
          const TensorXf32 &texcoords = TensorXf32(),
          const IndexBuffer &position_index = IndexBuffer(),
          const IndexBuffer &normal_index = IndexBuffer(),
-         const IndexBuffer &bsdf_index = IndexBuffer(),
          bool face_normals = false,
          bool flip_normals = false);
 
@@ -271,16 +267,13 @@ public:
      *     normal_index: Optional map from vertex index to normal group. An empty map
      *         encodes the identity, or the position map when the normal count
      *         matches the surface position count.
-     *
-     *     bsdf_index: Optional per-face material index. An empty buffer stands for zeros.
      */
     void from_fields(const TensorXu32 &faces,
                      const TensorXf32 &positions,
                      const TensorXf32 &normals = TensorXf32(),
                      const TensorXf32 &texcoords = TensorXf32(),
                      const IndexBuffer &position_index = IndexBuffer(),
-                     const IndexBuffer &normal_index = IndexBuffer(),
-                     const IndexBuffer &bsdf_index = IndexBuffer());
+                     const IndexBuffer &normal_index = IndexBuffer());
 
     /**
      * Build the mesh from a packed representation
@@ -292,9 +285,9 @@ public:
      * the parameter interface.
      *
      * The function checks the tensor shapes for consistency but trusts that
-     * any specified indices are in-bounds and that the per-face UV
-     * orientation bits of a tangent layout are consistent with the stored
-     * texture coordinates.
+     * any specified indices are in-bounds. The fourth word of the face
+     * records is derived data that the mesh regenerates, so the caller may
+     * leave it zero.
      *
      * The operation is differentiable in the sense that derivatives propagate
      * between function parameters and the resulting mesh state.
@@ -317,6 +310,12 @@ public:
      *
      *     normal_count: Number of normal groups. Only needed when ``normal_index`` is
      *         nonempty.
+     *
+     *     bbox: Bounding box of the positions, if known.
+     *
+     *     face_state_valid: Set when the fourth face word already holds the
+     *         derived data (see ``update_face_state()``), which lets a mesh
+     *         with usable records skip the kernel that recomputes it.
      */
     void from_packed(Layout layout,
                      const TensorXu32 &packed_faces,
@@ -325,7 +324,8 @@ public:
                      const IndexBuffer &normal_index = IndexBuffer(),
                      size_t position_count = 0,
                      size_t normal_count = 0,
-                     const ScalarBoundingBox3f *bbox = nullptr);
+                     const ScalarBoundingBox3f *bbox = nullptr,
+                     bool face_state_valid = false);
 
     /**
      * Build the mesh from host-side staging data
@@ -462,13 +462,6 @@ public:
      */
     TensorXu32 geometric_faces() const;
 
-    /// Return the per-face BSDF index (size `face_count()`). An empty
-    /// buffer stands for zeros, see ``has_face_bsdfs()``.
-    const IndexBuffer &bsdf_index() const {
-        ensure_views();
-        return m_bsdf_index;
-    }
-
     /// Return the surface position positions as a ``(P, 3)`` tensor
     const TensorXf32 &positions() const {
         ensure_views();
@@ -517,9 +510,6 @@ public:
 
     /// Does the mesh provide interpolated tangents?
     bool has_tangents() const { return has_normals() && has_texcoords(); }
-
-    /// Does this mesh have a per-face BSDF assignment?
-    bool has_face_bsdfs() const { return has_flag(m_layout, Layout::FaceBSDFs); }
 
     /// Does the mesh store per-vertex tangents?
     bool packs_tangent() const { return has_flag(m_layout, Layout::Tangents); }
@@ -710,6 +700,15 @@ public:
     MI_INLINE PackedFace<Index>
     packed_face(Index index, dr::mask_t<Index> active = true) const {
         return dr::gather<PackedFace<Index>>(m_packed_faces, index, active);
+    }
+
+    /// Decode the position error bound stored in a packed face record
+    template <typename Record>
+    static MI_INLINE auto face_position_error(const Record &rec) {
+        using Word    = dr::value_t<Record>;
+        using Value32 = dr::float32_array_t<Word>;
+        using Value   = dr::replace_scalar_t<Word, ScalarFloat>;
+        return Value(dr::reinterpret_array<Value32>(rec[3] & FaceErrorMask));
     }
 
     /**
@@ -1075,9 +1074,8 @@ protected:
      * Reverse the corner order of every face, which flips the
      * geometric normals
      *
-     * The orientation of each face's UV triangle reverses along with it, so
-     * the packed tangent frames are updated to match. The caller is
-     * responsible for the subsequent ``refresh()``.
+     * The caller is responsible for the subsequent ``refresh()``, which
+     * also recomputes the UV orientation bits.
      */
     void flip_winding();
 
@@ -1114,17 +1112,28 @@ protected:
     /**
      * Regenerate everything downstream of the packed state
      *
-     * Every mutation ends with a call to this method. It rebuilds the
-     * bounding box (adopting ``bbox`` when given), the area sampling table
-     * of emitter/sensor meshes, the UV parameterization of spatially
-     * varying emitters, and the silhouette structures of gradient-enabled
-     * meshes, refreshes the raw data pointers, marks the scene
-     * acceleration structure dirty, and rebinds the field views unless
-     * they are dormant. The directed edge structure is not touched here:
-     * it is expensive and purely topological, so `Object.parameters_changed()`
-     * clears it only when a topology write occurs.
+     * Every mutation ends with a call to this method. It recomputes the
+     * derived word of every face record, rebuilds the bounding box
+     * (adopting ``bbox`` when given), the area sampling table of
+     * emitter/sensor meshes, the UV parameterization of spatially varying
+     * emitters, and the silhouette structures of gradient-enabled meshes,
+     * refreshes the raw data pointers, marks the scene acceleration
+     * structure dirty, and rebinds the field views unless they are dormant.
+     * The directed edge structure is not touched here: it is expensive and
+     * purely topological, so `Object.parameters_changed()` clears it only
+     * when a topology write occurs. ``face_state_valid`` skips the
+     * recomputation of the face state when the caller already derived them.
      */
-    void refresh(const ScalarBoundingBox3f *bbox = nullptr);
+    void refresh(const ScalarBoundingBox3f *bbox = nullptr,
+                 bool face_state_valid = false);
+
+    /**
+     * Recompute the state word of every packed face record
+     *
+     * The word holds derived data, see ``face_state()``. It comes from the
+     * packed vertex records, so the pass must run whenever those change.
+     */
+    void update_face_state();
 
     /// (Re-)compute the bounding box from the packed positions.
     void recompute_bbox() const;
@@ -1273,7 +1282,7 @@ protected:
     /// Set by the first successful build; construction is one-shot
     bool m_built = false;
 
-    /// Packed faces, material IDs and UV orientation bits (4 x UInt32 per face)
+    /// Packed faces: vertex indices and a derived word (4 x UInt32 per face)
     IndexBuffer m_packed_faces;
 
     /// Packed per-vertex state (8 x Float32 per vertex)
@@ -1297,7 +1306,6 @@ protected:
     TensorXf32 m_normals;
     TensorXf32 m_texcoords;
     TensorXu32 m_faces;
-    IndexBuffer m_bsdf_index;
     TensorXf32 m_tangents;
 
     /// Provenance records, see `parts()`. Usually empty.

--- a/include/mitsuba/render/mesh_utils.h
+++ b/include/mitsuba/render/mesh_utils.h
@@ -31,30 +31,28 @@ constexpr uint32_t PackedFrameOffset = 3;
 /// Offset of the texture coordinates (2 floats)
 constexpr uint32_t PackedTexcoordOffset = 6;
 
-/// Bit flag which indicates a face with flipped UVs
+/// Bit of the face state word which indicates a face with flipped UVs
 constexpr uint32_t FaceUVFlipped = 0x80000000u;
 
-/// Bit mask used to encode the BSDF index
-constexpr uint32_t FaceBSDFIndexMask = 0x7fffffffu;
+/// Bits of the face state word that store the rounding error bound
+constexpr uint32_t FaceErrorMask = 0x7fffffffu;
 
-/// Content of the packed records of a `Mesh`
+/// Content of the packed vertex records of a `Mesh`
 enum class Layout : uint32_t {
     Positions = 0x0,  ///< Every vertex record carries positions
     Normals   = 0x1,  ///< Shading normals
     Tangents  = 0x2,  ///< Shading tangents
     Texcoords = 0x4,  ///< Texture coordinates
-    FaceBSDFs = 0x8,  ///< The face records carry per-face BSDF indices
 };
 
 MI_DECLARE_ENUM_OPERATORS(Layout)
 
 /// Assemble the `Layout` flags of the packed records
 constexpr Layout make_layout(bool normals, bool texcoords,
-                             bool tangents = false, bool face_bsdfs = false) {
+                             bool tangents = false) {
     return (Layout) ((normals    ? (uint32_t) Layout::Normals   : 0u) |
                      (texcoords  ? (uint32_t) Layout::Texcoords : 0u) |
-                     (tangents   ? (uint32_t) Layout::Tangents  : 0u) |
-                     (face_bsdfs ? (uint32_t) Layout::FaceBSDFs : 0u));
+                     (tangents   ? (uint32_t) Layout::Tangents  : 0u));
 }
 
 /**
@@ -68,8 +66,7 @@ struct MergeKey {
     const Object *bsdf, *emitter, *sensor, *interior_medium, *exterior_medium;
 
     /**
-     * Packed record layout, without the ``FaceBSDFs`` bit that a merge
-     * unions
+     * Packed record layout
      *
      * The face-normal setting needs no separate field, since a built mesh
      * carries the ``Normals`` bit exactly when it shades with vertex normals.
@@ -99,6 +96,79 @@ struct MergeKeyHasher {
         return (size_t) h;
     }
 };
+
+/**
+ * Bound the position error of a ray-triangle intersection along the normal
+ *
+ * This function computes the ``p_err`` bound used to offset spawned rays
+ * and avoid self-intersections. It covers two sources of rounding errors:
+ *
+ * 1. The interpolation that produces a hit position interpolates three
+ *    vertices with barycentric weights. Rounding error is proportional to
+ *    the maximum vertex magnitude projected onto ``n``. This term vanishes
+ *    for a triangle in a coordinate plane through the origin.
+ *
+ * 2. Intersection tests typically express the vertices relative to the ray
+ *    origin, and then form a cross product of the edges or edge functions
+ *    that are parameterized by them. A spawned ray starts on the triangle,
+ *    so these relative vertices are at most an edge long, and the terms of
+ *    the resulting expressions are bounded by the Euclidean lengths of the
+ *    edges. We do not know which vertex the backend will use as base
+ *    vertex, hence the calculation sums the largest two edge lengths to be
+ *    conservative.
+ *
+ * ``eps`` is used to provide an appropriate floating point epsilon such as
+ * ``mi.math.PositionEpsilon``, which is the variant-dependent unit roundoff
+ * times a safety factor.
+ */
+template <typename Value>
+Value triangle_position_error(const Point<Value, 3> &p0,
+                              const Point<Value, 3> &p1,
+                              const Point<Value, 3> &p2,
+                              const Normal<Value, 3> &n,
+                              dr::scalar_t<Value> eps) {
+    Value e0 = dr::norm(p1 - p0), e1 = dr::norm(p2 - p0),
+          e2 = dr::norm(p2 - p1);
+    Vector<Value, 3> mag =
+        dr::maximum(dr::abs(p0), dr::maximum(dr::abs(p1), dr::abs(p2)));
+    return (dr::dot(dr::abs(n), mag) +
+            (e0 + e1 + e2 - dr::minimum(e0, dr::minimum(e1, e2)))) *
+           eps;
+}
+
+/**
+ * Face state word of a triangle with the given vertex positions
+ *
+ * The word stores the position error bound along the face normal (see
+ * ``FaceErrorMask``), with ``eps`` the ``mi.math.PositionEpsilon`` of the
+ * variant. The overload with texture coordinates additionally sets
+ * ``FaceUVFlipped`` when the UV triangle is mirrored, which decides the
+ * handedness of the interpolated tangent frame.
+ */
+template <typename Value>
+dr::uint32_array_t<Value> face_state(const Point<Value, 3> &p0,
+                                     const Point<Value, 3> &p1,
+                                     const Point<Value, 3> &p2,
+                                     dr::scalar_t<Value> eps) {
+    Normal<Value, 3> n = dr::normalize(dr::cross(p1 - p0, p2 - p0));
+    return dr::reinterpret_array<dr::uint32_array_t<Value>>(
+        triangle_position_error(p0, p1, p2, n, eps));
+}
+
+template <typename Value>
+dr::uint32_array_t<Value> face_state(const Point<Value, 3> &p0,
+                                     const Point<Value, 3> &p1,
+                                     const Point<Value, 3> &p2,
+                                     const Point<Value, 2> &uv0,
+                                     const Point<Value, 2> &uv1,
+                                     const Point<Value, 2> &uv2,
+                                     dr::scalar_t<Value> eps) {
+    using UInt32 = dr::uint32_array_t<Value>;
+    Vector<Value, 2> t1 = uv1 - uv0, t2 = uv2 - uv0;
+    auto flipped = dr::fmsub(t1.x(), t2.y(), t1.y() * t2.x()) < 0.f;
+    return face_state(p0, p1, p2, eps) |
+           dr::select(flipped, UInt32(FaceUVFlipped), UInt32(0));
+}
 
 /**
  * Encode a unit normal ``n`` and a tangent ``s`` into three floats
@@ -175,6 +245,7 @@ frame_decode(const Vector<Value, 3> &p) {
 struct MI_EXPORT_LIB PackedMesh {
     using ScalarPoint3f  = Point<float, 3>;
     using ScalarNormal3f = Normal<float, 3>;
+    using ScalarPoint2f  = Point<float, 2>;
     using ScalarVector2f = Vector<float, 2>;
     using ScalarVector3f = Vector<float, 3>;
     using ScalarVector3u = Vector<uint32_t, 3>;
@@ -224,9 +295,7 @@ struct MI_EXPORT_LIB PackedMesh {
                     const ScalarVector2f &uv = { 0.f, 0.f });
 
     /// Write one face record, checking that its indices are in bounds
-    void set_face(size_t i,
-                  const ScalarVector3u &indices,
-                  uint32_t bsdf = 0);
+    void set_face(size_t i, const ScalarVector3u &indices);
 
     /**
      * Allocate a custom attribute and return a pointer to its buffer
@@ -249,6 +318,15 @@ struct MI_EXPORT_LIB PackedMesh {
      * transformed.
      */
     void add_tangents();
+
+    /**
+     * Compute the state word of every face record on the host
+     *
+     * See ``face_state()``, whose ``eps`` is the ``mi.math.PositionEpsilon``
+     * of the variant. Call this last, after the records are transformed
+     * and tangents are added.
+     */
+    void update_face_state(float eps);
 
     /// Dr.Jit backend of the allocated buffers
     JitBackend backend = JitBackend::None;
@@ -353,10 +431,6 @@ struct CornerMesh {
      */
     const uint32_t *face_offsets = nullptr;
 
-    /// Optional per-face BSDF indices (one entry per input face,
-    /// replicated when a polygon fans into several triangles)
-    const uint32_t *bsdf_index = nullptr;
-
     /// Shading normals (3 channels); optional
     CornerAttribute normals { "normals", 3 };
 
@@ -396,9 +470,14 @@ corner_to_packed_mesh(JitBackend backend, const CornerMesh &desc,
                       bool flip_normals = false,
                       const PackedMesh::ScalarAffineTransform4f &to_world = {});
 
-/// Magic number and current version of the ``.serialized`` mesh encoding,
-/// whose reader and writer are ``SerializedMesh::load_v5()`` and
-/// ``Mesh::write_serialized(Stream*)``. Keep the two in step.
+/**
+ * Magic number and current version of the ``.serialized`` mesh encoding,
+ * whose reader and writer are ``SerializedMesh::load_v5()`` and
+ * ``Mesh::write_serialized(Stream*)``. Keep the two in step.
+ *
+ * The face records are stored verbatim. Their fourth word is derived data
+ * that the loader regenerates.
+ */
 constexpr uint16_t SerializedMagic   = 0x041C;
 constexpr uint16_t SerializedVersion = 0x0005;
 

--- a/include/mitsuba/render/records.h
+++ b/include/mitsuba/render/records.h
@@ -40,6 +40,13 @@ struct PositionSample {
     Normal3f n;
 
     /**
+     * Bound on the rounding error of ``p``, see `Interaction3f.p_err`. Records
+     * built from a surface interaction carry the bound along the geometric
+     * normal while ``n`` holds the shading normal.
+     */
+    Float p_err = 0.f;
+
+    /**
      * Optional: 2D sample position associated with the record
      *
      * In some uses of this record, a sampled position may be associated with
@@ -72,8 +79,8 @@ struct PositionSample {
      * instance in path tracing with multiple importance sampling.
      */
     PositionSample(const SurfaceInteraction3f &si)
-        : p(si.p), n(si.sh_frame.n), uv(si.uv), time(si.time), pdf(0.f),
-          delta(false) { }
+        : p(si.p), n(si.sh_frame.n), p_err(si.p_err), uv(si.uv),
+          time(si.time), pdf(0.f), delta(false) { }
 
     /// Basic field constructor
     PositionSample(const Point3f &p, const Normal3f &n, const Point2f &uv,
@@ -82,7 +89,7 @@ struct PositionSample {
 
     // =============================================================
 
-    DRJIT_STRUCT(PositionSample, p, n, uv, time, pdf, delta)
+    DRJIT_STRUCT(PositionSample, p, n, p_err, uv, time, pdf, delta)
 };
 
 // -----------------------------------------------------------------------------
@@ -111,7 +118,7 @@ struct DirectionSample : public PositionSample<Float_, Spectrum_> {
     using Float    = Float_;
     using Spectrum = Spectrum_;
 
-    MI_IMPORT_BASE(PositionSample, p, n, uv, time, pdf, delta)
+    MI_IMPORT_BASE(PositionSample, p, n, p_err, uv, time, pdf, delta)
     MI_IMPORT_RENDER_BASIC_TYPES()
 
     using Interaction3f        = typename RenderAliases::Interaction3f;
@@ -194,7 +201,7 @@ struct DirectionSample : public PositionSample<Float_, Spectrum_> {
 
     // =============================================================
 
-    DRJIT_STRUCT(DirectionSample, p, n, uv, time, pdf, delta, d, dist, emitter)
+    DRJIT_STRUCT(DirectionSample, p, n, p_err, uv, time, pdf, delta, d, dist, emitter)
 };
 
 // -----------------------------------------------------------------------------

--- a/include/mitsuba/render/scene.h
+++ b/include/mitsuba/render/scene.h
@@ -786,7 +786,8 @@ protected:
     /// Instances in order of appearance in ``m_shapes``.
     std::vector<const Shape *> m_instances;
 
-    /// Flattened sequence of instance ``to_world`` matrices (12 floats each)
+    /// Flattened sequence of instance ``to_world`` matrices and their
+    /// inverses (2 x 12 floats each)
     DynamicBuffer<Float> m_instance_transforms;
 
     /// Instancing-aware expansion of a preliminary intersection (see

--- a/include/mitsuba/render/shape.h
+++ b/include/mitsuba/render/shape.h
@@ -90,7 +90,7 @@ struct SilhouetteSample : public PositionSample<Float_, Spectrum_> {
     using Float    = Float_;
     using Spectrum = Spectrum_;
 
-    MI_IMPORT_BASE(PositionSample, p, n, uv, time, pdf, delta)
+    MI_IMPORT_BASE(PositionSample, p, n, p_err, uv, time, pdf, delta)
 
     MI_IMPORT_RENDER_BASIC_TYPES()
     MI_IMPORT_OBJECT_TYPES()
@@ -178,13 +178,13 @@ struct SilhouetteSample : public PositionSample<Float_, Spectrum_> {
      */
     Ray3f spawn_ray(Wavelength wavelengths = dr::zeros<Wavelength>()) const {
         Vector3f o_offset = (1 + dr::max(dr::abs(p))) *
-                            (d * offset + n * math::ShapeEpsilon<Float>);
+                            (d * offset + n * math::PositionEpsilon<Float>);
         return Ray3f(p + o_offset, d, 0.f, wavelengths);
     }
 
     // =============================================================
 
-    DRJIT_STRUCT(SilhouetteSample, p, n, uv, time, pdf, delta,
+    DRJIT_STRUCT(SilhouetteSample, p, n, p_err, uv, time, pdf, delta,
                  discontinuity_type, d, silhouette_d, prim_index, scene_index,
                  flags, projection_index, shape, foreshortening, offset)
 };

--- a/src/core/python/math_v.cpp
+++ b/src/core/python/math_v.cpp
@@ -15,7 +15,7 @@ MI_PY_EXPORT(math) {
 
     m.attr("RayEpsilon")      = nb::cast(math::RayEpsilon<Float>);
     m.attr("ShadowEpsilon")   = nb::cast(math::ShadowEpsilon<Float>);
-    m.attr("ShapeEpsilon")    = nb::cast(math::ShapeEpsilon<Float>);
+    m.attr("PositionEpsilon") = nb::cast(math::PositionEpsilon<Float>);
 
     m.def("legendre_p",
           nb::overload_cast<int, Float>(math::legendre_p<Float>),

--- a/src/emitters/area.cpp
+++ b/src/emitters/area.cpp
@@ -172,6 +172,7 @@ public:
 
             ds.p = si.p;
             ds.n = si.n;
+            ds.p_err = si.p_err;
             ds.uv = si.uv;
             ds.time = it.time;
             ds.delta = false;

--- a/src/integrators/ptracer.cpp
+++ b/src/integrators/ptracer.cpp
@@ -349,7 +349,7 @@ public:
         // The segment toward the sensor corresponds to a directly visible
         // (camera) ray, so shapes hidden from the camera do not occlude it.
         // Surfaces with null transmission attenuate it instead.
-        Ray3f sensor_ray = si.spawn_ray_to(sensor_ds.p);
+        Ray3f sensor_ray = si.spawn_ray_to(sensor_ds);
         Spectrum tr = scene->ray_test_tr(sensor_ray, +RayFlags::Default, false,
                                          +RayMask::Primary, active);
         active &= dr::any(unpolarized_spectrum(tr) != 0.f);

--- a/src/integrators/tests/test_integrators.py
+++ b/src/integrators/tests/test_integrators.py
@@ -150,17 +150,23 @@ WINDOW_BSDFS = [
 ]
 WINDOW_IDS = ['mask', 'thindielectric', 'null']
 BELOW = ([0, -0.5, 0], [0, -1, 0], [0, 0, 1])
+PYTHON_INTEGRATORS = ('prb', 'prb_basic', 'prb_projective', 'prbvolpath',
+                      'direct_projective')
+UNPOLARIZED_INTEGRATORS = ('volpathmis', 'prbvolpath')
 
 
 @pytest.mark.parametrize('integrator, reference, camera, ref_depth', [
     ('path', 'volpath', None, 6),
     ('direct', 'path', BELOW, 2),
+    ('volpath', 'path', None, 6),
+    ('volpathmis', 'path', None, 6),
     ('prb', 'path', None, 6),
     ('prb_basic', 'path', None, 6),
     ('prb_projective', 'path', None, 6),
+    ('prbvolpath', 'path', None, 6),
     ('direct_projective', 'path', BELOW, 2),
-], ids=['path', 'direct', 'prb', 'prb_basic', 'prb_projective',
-        'direct_projective'])
+], ids=['path', 'direct', 'volpath', 'volpathmis', 'prb', 'prb_basic',
+        'prb_projective', 'prbvolpath', 'direct_projective'])
 @pytest.mark.parametrize('bsdf', WINDOW_BSDFS, ids=WINDOW_IDS)
 def test03_null_consistency(variants_all_rgb, integrator, reference, camera,
                             ref_depth, bsdf):
@@ -170,9 +176,10 @@ def test03_null_consistency(variants_all_rgb, integrator, reference, camera,
     same transmittance, and crossings do not count as path vertices. The
     direct integrators are compared against a path tracer of depth two,
     with the camera below the window."""
-    if not integrator.startswith(('path', 'direct')) or 'projective' in integrator:
-        if '_ad_' not in mi.variant():
-            pytest.skip('Python integrators require an AD variant')
+    if integrator in PYTHON_INTEGRATORS and '_ad_' not in mi.variant():
+        pytest.skip('Python integrators require an AD variant')
+    if integrator in UNPOLARIZED_INTEGRATORS and mi.is_polarized:
+        pytest.skip('Integrator does not support polarized variants')
     kwargs = dict(window=dict(bsdf=bsdf))
     if camera is not None:
         kwargs['camera'] = camera

--- a/src/integrators/volpath.cpp
+++ b/src/integrators/volpath.cpp
@@ -402,7 +402,7 @@ public:
             return { emitter_val, ds };
         }
 
-        Ray3f ray = ref_interaction.spawn_ray_to(ds.p);
+        Ray3f ray = ref_interaction.spawn_ray_to(ds);
         Float max_dist = ray.maxt;
 
         // Potentially escaping the medium if this is the current medium's boundary
@@ -525,6 +525,12 @@ public:
 
             // Update the ray with new origin & t parameter
             dr::masked(ray, active_surface) = si.spawn_ray(ray.d);
+
+            // Account for the rounding-related ray epsilon that Mitsuba
+            // adds when spawning rays
+            dr::masked(total_dist, active_surface) +=
+                dr::detach(dr::dot(ray.o - si.p, ray.d));
+
             ray.maxt = remaining_dist;
             needs_intersection |= active_surface;
 

--- a/src/integrators/volpathmis.cpp
+++ b/src/integrators/volpathmis.cpp
@@ -456,7 +456,7 @@ public:
             return { p_over_f_nee, p_over_f_uni, emitter_val, ds};
         }
 
-        Ray3f ray = ref_interaction.spawn_ray_to(ds.p);
+        Ray3f ray = ref_interaction.spawn_ray_to(ds);
         Float max_dist = ray.maxt;
 
         // Potentially escaping the medium if this is the current medium's boundary
@@ -583,6 +583,12 @@ public:
             }
 
             dr::masked(ray, active_surface) = si.spawn_ray(ray.d);
+
+            // Account for the rounding-related ray epsilon that Mitsuba
+            // adds when spawning rays
+            dr::masked(total_dist, active_surface) +=
+                dr::detach(dr::dot(ray.o - si.p, ray.d));
+
             ray.maxt = remaining_dist;
             needs_intersection |= active_surface;
 

--- a/src/python/python/ad/integrators/direct_projective.py
+++ b/src/python/python/ad/integrators/direct_projective.py
@@ -252,7 +252,7 @@ class DirectProjectiveIntegrator(PSIntegrator):
             elif self.project_seed == "emitter":
                 # Return emitter sampling rays including the ones that fail
                 # `test_visibility`
-                ray_em = si.spawn_ray_to(ds_em.p)
+                ray_em = si.spawn_ray_to(ds_em)
                 ray_em.maxt = dr.largest(mi.Float)
 
                 # Directions towards the interior have no contribution for
@@ -262,7 +262,7 @@ class DirectProjectiveIntegrator(PSIntegrator):
                 guide_seed = [dr.detach(ray_em), mi.Bool(active_guide)]
             elif self.project_seed == "both":
                 # By default we use the emitter sample as the seed ray
-                ray_seed = si.spawn_ray_to(ds_em.p)
+                ray_seed = si.spawn_ray_to(ds_em)
                 ray_seed.maxt = dr.largest(mi.Float)
                 active_guide = active_em_ & (dr.dot(si.n, ray_seed.d) > 0)
 

--- a/src/python/python/ad/integrators/prb_projective.py
+++ b/src/python/python/ad/integrators/prb_projective.py
@@ -290,7 +290,7 @@ class PathProjectiveIntegrator(PSIntegrator):
                     # We assume that `ray` intersects the scene
                     ray_seed_cand = ray_next
                 elif dr.hint(self.project_seed == "emitter", mode='scalar'):
-                    ray_seed_cand = si.spawn_ray_to(ds.p)
+                    ray_seed_cand = si.spawn_ray_to(ds)
                     ray_seed_cand.maxt = dr.largest(mi.Float)
                     # Directions towards the interior have no contribution
                     # unless we hit a transmissive BSDF
@@ -304,7 +304,7 @@ class PathProjectiveIntegrator(PSIntegrator):
                     mask_replace = (dr.dot(si.n, ray_seed_cand.d) > 0) | \
                                     mi.has_flag(bsdf_flags, mi.BSDFFlags.Transmission)
                     mask_replace &= sampler.next_1d(active_seed_cand) > 0.5
-                    ray_seed_cand[mask_replace] = si.spawn_ray_to(ds.p)
+                    ray_seed_cand[mask_replace] = si.spawn_ray_to(ds)
                     ray_seed_cand.maxt = dr.largest(mi.Float)
 
                 # Resovoir sampling: do we use this candidate seed ray?

--- a/src/python/python/ad/integrators/prbvolpath.py
+++ b/src/python/python/ad/integrators/prbvolpath.py
@@ -367,7 +367,7 @@ class PRBVolpathIntegrator(RBIntegrator):
         medium = dr.select(active, medium, dr.zeros(mi.MediumPtr))
         medium[(active_surface & si.is_medium_transition())] = si.target_medium(ds.d)
 
-        ray = ref_interaction.spawn_ray_to(ds.p)
+        ray = ref_interaction.spawn_ray_to(ds)
         max_dist = mi.Float(ray.maxt)
         total_dist = mi.Float(0.0)
         si = dr.zeros(mi.SurfaceInteraction3f)
@@ -431,6 +431,11 @@ class PRBVolpathIntegrator(RBIntegrator):
             # Continue tracing through scene if non-zero weights exist
             active &= (active_medium | active_surface) & dr.any(transmittance != 0.0)
             total_dist[active] += dr.select(active_medium, mei.t, si.t)
+
+            # Account for the rounding-related ray epsilon that Mitsuba
+            # adds when spawning rays
+            total_dist[active & active_surface] += \
+                dr.detach(dr.dot(ray.o - si.p, ray.d))
 
             # If a medium transition is taking place: Update the medium pointer
             has_medium_trans = active_surface & si.is_medium_transition()

--- a/src/python/python/test/util.py
+++ b/src/python/python/test/util.py
@@ -287,15 +287,12 @@ def faces_of(mesh):
 
 
 def face_records(mesh):
-    """(F, 4) vertex indices + BSDF index from the parameter interface"""
+    """(F, 4) packed face records built from the parameter interface. The
+    fourth word is zero: the mesh regenerates the position error bound."""
     import numpy as np
     import mitsuba as mi
-    params = mi.traverse(mesh)
-    faces = np.array(params['faces'])
-    bsdf_index = np.array(params['bsdf_index'])
-    if bsdf_index.size == 0:  # an empty assignment stands for zeros
-        bsdf_index = np.zeros(faces.shape[0], dtype=np.uint32)
-    return np.column_stack([faces, bsdf_index])
+    faces = np.array(mi.traverse(mesh)['faces'])
+    return np.column_stack([faces, np.zeros(faces.shape[0], dtype=np.uint32)])
 
 
 def rows(value, dim):

--- a/src/render/mesh.cpp
+++ b/src/render/mesh.cpp
@@ -213,11 +213,10 @@ MI_VARIANT Mesh<Float, Spectrum>::Mesh(std::string_view name,
                                        const TensorXf32 &texcoords,
                                        const IndexBuffer &position_index,
                                        const IndexBuffer &normal_index,
-                                       const IndexBuffer &bsdf_index,
                                        bool face_normals, bool flip_normals)
     : Mesh(name, face_normals, flip_normals) {
     from_fields(faces, positions, normals, texcoords, position_index,
-                normal_index, bsdf_index);
+                normal_index);
 }
 
 /// Raise when the mesh was already built
@@ -244,8 +243,7 @@ void Mesh<Float, Spectrum>::from_fields(const TensorXu32 &faces,
                                         const TensorXf32 &normals,
                                         const TensorXf32 &texcoords,
                                         const IndexBuffer &position_index,
-                                        const IndexBuffer &normal_index,
-                                        const IndexBuffer &bsdf_index) {
+                                        const IndexBuffer &normal_index) {
     require_unbuilt(m_built, m_filename, "from_fields");
     drop_views();
 
@@ -264,7 +262,6 @@ void Mesh<Float, Spectrum>::from_fields(const TensorXu32 &faces,
     m_positions      = positions;
     m_texcoords      = texcoords;
     m_position_index = position_index;
-    m_bsdf_index     = bsdf_index;
     m_normals        = m_face_normals ? TensorXf32() : normals;
     m_normal_index   = m_face_normals ? IndexBuffer() : normal_index;
 
@@ -279,7 +276,6 @@ MI_VARIANT void Mesh<Float, Spectrum>::drop_views() {
     m_texcoords  = TensorXf32(FloatBuffer(), { 0, 2 });
     m_faces      = TensorXu32(IndexBuffer(), { 0, 3 });
     m_tangents   = TensorXf32(FloatBuffer(), { 0, 3 });
-    m_bsdf_index = IndexBuffer();
 }
 
 MI_VARIANT void
@@ -290,7 +286,8 @@ Mesh<Float, Spectrum>::from_packed(Layout layout,
                                    const IndexBuffer &normal_index,
                                    size_t position_count,
                                    size_t normal_count,
-                                   const ScalarBoundingBox3f *bbox) {
+                                   const ScalarBoundingBox3f *bbox,
+                                   bool face_state_valid) {
     require_unbuilt(m_built, m_filename, "from_packed");
     require_baked(m_flip_normals ||
                   m_to_world.scalar() != ScalarAffineTransform4f(),
@@ -358,7 +355,7 @@ Mesh<Float, Spectrum>::from_packed(Layout layout,
              /* flip_normals */ false, /* updating */ false, bbox);
         drop_views();
     } else {
-        refresh(bbox);
+        refresh(bbox, face_state_valid);
         m_built = true;
     }
 }
@@ -397,15 +394,6 @@ MI_VARIANT void Mesh<Float, Spectrum>::build_views() {
             return dr::gather<UInt32>(m_packed_faces, f * 4u + lane);
         }),
         { F, 3 });
-
-    if (has_face_bsdfs())
-        m_bsdf_index = element_view<IndexBuffer>(
-            F, 1, [&](const UInt32 &f, const UInt32 &) {
-                return dr::gather<UInt32>(m_packed_faces, f * 4u + 3u) &
-                       FaceBSDFIndexMask;
-            });
-    else
-        m_bsdf_index = IndexBuffer();
 
     // Invert the index maps, reusing the cached result when the maps did
     // not change. An empty map is the identity and needs no inverse.
@@ -517,11 +505,6 @@ MI_VARIANT void Mesh<Float, Spectrum>::validate_impl(bool check_bounds,
               "(%zu) or an explicit 'normal_index' map.%s", m_filename, N, V,
               stale("normals"));
 
-    size_t wb = m_bsdf_index.size();
-    if (wb != 0 && wb != F)
-        Throw("Mesh \"%s\": 'bsdf_index' has %zu entries, expected one per "
-              "face (%zu).%s", m_filename, wb, F, stale("bsdf_index"));
-
     if (packs_tangent() && !(has_normals() && has_texcoords()))
         Throw("Mesh \"%s\": tangent computation requires both normals and "
               "texture coordinates.", m_filename);
@@ -613,10 +596,9 @@ void Mesh<Float, Spectrum>::pack(bool regenerate_normals, bool flip_normals,
     bool normals   = !m_face_normals,
          texcoords = !m_texcoords.array().empty(),
          tangents  = normals && texcoords && m_bsdf &&
-                     has_flag(m_bsdf->flags(), BSDFFlags::NeedsTangents),
-         has_bsdf  = !m_bsdf_index.empty();
+                     has_flag(m_bsdf->flags(), BSDFFlags::NeedsTangents);
 
-    m_layout = make_layout(normals, texcoords, tangents, has_bsdf);
+    m_layout = make_layout(normals, texcoords, tangents);
 
     if (normals && regenerate_normals)
         m_normals = compute_normals();
@@ -625,28 +607,13 @@ void Mesh<Float, Spectrum>::pack(bool regenerate_normals, bool flip_normals,
     if (tangents)
         tan = compute_tangents();
 
+    // The fourth word is derived data that refresh() fills in
     m_packed_faces = interleaved<MeshFaceStride, IndexBuffer>(
         m_face_count, [&](const UInt32 &f) {
             Vector3u fi = deinterleave<3>(m_faces, f);
             if (flip_normals)
                 fi = Vector3u(fi[2], fi[1], fi[0]);
-
-            UInt32 flags = has_bsdf ? dr::gather<UInt32>(m_bsdf_index, f)
-                                    : UInt32(0);
-
-            if (tangents) {
-                auto uv = [&](const UInt32 &v) {
-                    return dr::detach(deinterleave<2>(m_texcoords, v));
-                };
-                auto uv0 = uv(fi[0]), duv0 = uv(fi[1]) - uv0,
-                                      duv1 = uv(fi[2]) - uv0;
-                auto flipped =
-                    dr::fmsub(duv0.x(), duv1.y(), duv0.y() * duv1.x()) < 0.f;
-
-                flags |= dr::select(flipped, UInt32(FaceUVFlipped), UInt32(0));
-            }
-
-            return dr::Array<UInt32, MeshFaceStride>(fi[0], fi[1], fi[2], flags);
+            return dr::Array<UInt32, MeshFaceStride>(fi[0], fi[1], fi[2], 0u);
         });
 
     m_packed_vertices = interleaved<MeshVertexStride, FloatBuffer>(
@@ -702,6 +669,10 @@ MI_VARIANT void Mesh<Float, Spectrum>::from_packed(PackedMesh &&data) {
         has_flag(data.layout, Layout::Texcoords))
         data.add_tangents();
 
+    // Derive the fourth face word here, so that the records can be adopted
+    // without a kernel launch
+    data.update_face_state((float) math::PositionEpsilon<Float>);
+
     size_t V = data.vertex_count, F = data.face_count;
 
     ScalarBoundingBox3f bbox = data.bbox;
@@ -744,7 +715,8 @@ MI_VARIANT void Mesh<Float, Spectrum>::from_packed(PackedMesh &&data) {
     from_packed(data.layout,
                 TensorXu32(std::move(faces), { F, MeshFaceStride }),
                 TensorXf32(std::move(vertices), { V, MeshVertexStride }),
-                pidx, nidx, data.position_count, data.normal_count, &bbox);
+                pidx, nidx, data.position_count, data.normal_count, &bbox,
+                /* face_state_valid */ true);
 
     // In spectral variants, color data converts to rgb2spec coefficients
     // in-place in the staging buffer, unless the producer opts out.
@@ -795,8 +767,35 @@ Mesh<Float, Spectrum>::geometric_faces() const {
         { m_face_count, 3 });
 }
 
+MI_VARIANT void Mesh<Float, Spectrum>::update_face_state() {
+    dr::suspend_grad<Float> guard;
+    bool tangents = packs_tangent();
+    float eps = (float) math::PositionEpsilon<Float>;
+
+    m_packed_faces = interleaved<MeshFaceStride, IndexBuffer>(
+        m_face_count, [&](const UInt32 &f) {
+            PackedFace<UInt32> rec = packed_face(f);
+            Point<Float32, 3> p0 = vertex_position(rec[0]),
+                              p1 = vertex_position(rec[1]),
+                              p2 = vertex_position(rec[2]);
+
+            if (tangents)
+                rec[3] = face_state(p0, p1, p2, vertex_texcoord(rec[0]),
+                                    vertex_texcoord(rec[1]),
+                                    vertex_texcoord(rec[2]), eps);
+            else
+                rec[3] = face_state(p0, p1, p2, eps);
+
+            return rec;
+        });
+}
+
 MI_VARIANT
-void Mesh<Float, Spectrum>::refresh(const ScalarBoundingBox3f *bbox) {
+void Mesh<Float, Spectrum>::refresh(const ScalarBoundingBox3f *bbox,
+                                    bool face_state_valid) {
+    if (!face_state_valid)
+        update_face_state();
+
     if (bbox) {
         m_bbox = *bbox;
         m_bbox_valid = true;
@@ -848,7 +847,6 @@ MI_VARIANT void Mesh<Float, Spectrum>::traverse(TraversalCallback *cb) {
 
     cb->put("faces", m_faces,
             ParamFlags::NonDifferentiable | ParamFlags::Discontinuous);
-    cb->put("bsdf_index", m_bsdf_index, ParamFlags::NonDifferentiable);
     cb->put("position_index", m_position_index,
             ParamFlags::NonDifferentiable | ParamFlags::Discontinuous);
     cb->put("normal_index", m_normal_index, ParamFlags::NonDifferentiable);
@@ -863,8 +861,7 @@ MI_VARIANT void Mesh<Float, Spectrum>::parameters_changed(const std::vector<std:
 
     bool topology = has("faces") || has("position_index"),
          fields   = topology || has("positions") || has("normals") ||
-                    has("normal_index") || has("texcoords") ||
-                    has("bsdf_index");
+                    has("normal_index") || has("texcoords");
 
     if (fields) {
         // The group count of a written 'normal_index' would only be
@@ -1084,7 +1081,7 @@ MI_VARIANT void Mesh<Float, Spectrum>::write_ply(Stream *stream) const {
         // Write vertex count
         stream->write(&vertex_indices_count, sizeof(uint8_t));
 
-        // Write the vertex indices, skipping the per-face BSDF lane
+        // Write the vertex indices, skipping the error bound lane
         stream->write(face_ptr, 3 * sizeof(ScalarIndex));
         face_ptr += 4;
 
@@ -1226,13 +1223,10 @@ void Mesh<Float, Spectrum>::transform(const AffineTransform4f &t) {
 }
 
 MI_VARIANT void Mesh<Float, Spectrum>::flip_winding() {
-    bool tangents = packs_tangent();
-
     m_packed_faces = interleaved<MeshFaceStride, IndexBuffer>(
         m_face_count, [&](const UInt32 &f) {
             PackedFace<UInt32> rec = packed_face(f);
-            UInt32 flags = tangents ? rec[3] ^ UInt32(FaceUVFlipped) : rec[3];
-            return PackedFace<UInt32>(rec[2], rec[1], rec[0], flags);
+            return PackedFace<UInt32>(rec[2], rec[1], rec[0], rec[3]);
         });
 
     // Invalidate directed edge data structure
@@ -1470,8 +1464,7 @@ Mesh<Float, Spectrum>::sil_dedge_pmf() const {
 
 MI_VARIANT MergeKey Mesh<Float, Spectrum>::merge_key() const {
     return { m_bsdf.get(), m_emitter.get(), m_sensor.get(),
-             m_interior_medium.get(), m_exterior_medium.get(),
-             (Layout) (m_layout & ~Layout::FaceBSDFs),
+             m_interior_medium.get(), m_exterior_medium.get(), m_layout,
              (uint32_t) m_visibility };
 }
 
@@ -1499,7 +1492,7 @@ Mesh<Float, Spectrum>::merge(const std::vector<Shape<Float, Spectrum> *> &shapes
     MergeKey key = first->merge_key();
 
     size_t V = 0, F = 0, P = 0, N = 0;
-    bool any_pmap = false, any_nmap = false, any_bsdf = false;
+    bool any_pmap = false, any_nmap = false;
     ScalarBoundingBox3f bbox;
     std::vector<Part> parts;
     parts.reserve(meshes.size());
@@ -1526,7 +1519,6 @@ Mesh<Float, Spectrum>::merge(const std::vector<Shape<Float, Spectrum> *> &shapes
         P += m->m_position_count; N += m->m_normal_count;
         any_pmap |= m->m_position_index.size() != 0;
         any_nmap |= m->m_normal_index.size() != 0;
-        any_bsdf |= m->has_face_bsdfs();
         bbox.expand(m->bbox());
     }
 
@@ -1644,11 +1636,7 @@ Mesh<Float, Spectrum>::merge(const std::vector<Shape<Float, Spectrum> *> &shapes
     result->m_filename = filename;
     result->m_visibility = first->m_visibility;
 
-    Layout layout = first->m_layout;
-    if (any_bsdf)
-        layout |= Layout::FaceBSDFs;
-
-    result->from_packed(layout,
+    result->from_packed(first->m_layout,
                         TensorXu32(std::move(faces), { F, MeshFaceStride }),
                         TensorXf32(std::move(vertices), { V, MeshVertexStride }),
                         pidx, nidx, any_pmap ? P : 0, any_nmap ? N : 0, &bbox);
@@ -1745,7 +1733,8 @@ Mesh<Float, Spectrum>::sample_position(Float time, const Point2f &sample_, Mask 
     std::tie(face_idx, sample.y()) =
         m_area_pmf.sample_reuse(sample.y(), active);
 
-    Vector3u fi = face_indices(face_idx, active);
+    PackedFace<Index> frec = packed_face(face_idx, active);
+    Vector3u fi(frec[0], frec[1], frec[2]);
 
     Point3f p0 = vertex_position(fi[0], active),
             p1 = vertex_position(fi[1], active),
@@ -1783,6 +1772,7 @@ Mesh<Float, Spectrum>::sample_position(Float time, const Point2f &sample_, Mask 
     }
 
     ps.n = dr::normalize(ps.n);
+    ps.p_err = face_position_error(frec);
 
     return ps;
 }
@@ -2373,6 +2363,7 @@ Mesh<Float, Spectrum>::compute_surface_interaction(const Ray3f &ray,
     si.t = pi.t;
     si.p = dr::detach(p_att);
     si.n = dr::detach(n_geo);
+    si.p_err = face_position_error(frec);
 
     si.attach_motion(ray, p_att, ray_flags);
 

--- a/src/render/mesh_utils.cpp
+++ b/src/render/mesh_utils.cpp
@@ -93,11 +93,8 @@ void PackedMesh::transform_records() {
 
     if (reverse_winding) {
         uint32_t *rec = faces.data();
-        for (size_t i = 0; i < face_count; ++i, rec += MeshFaceStride) {
+        for (size_t i = 0; i < face_count; ++i, rec += MeshFaceStride)
             std::swap(rec[0], rec[2]);
-            if (tangents)
-                rec[3] ^= FaceUVFlipped;
-        }
     }
 
     m_transform = m_negate_normals = reverse_winding = false;
@@ -137,8 +134,7 @@ void PackedMesh::set_vertex(size_t i, const ScalarPoint3f &p_,
     bbox.expand(p);
 }
 
-void PackedMesh::set_face(size_t i, const ScalarVector3u &indices,
-                          uint32_t bsdf) {
+void PackedMesh::set_face(size_t i, const ScalarVector3u &indices) {
     using PackedFace = dr::Array<uint32_t, MeshFaceStride>;
     Assert(i < face_count);
     m_written = true;
@@ -149,15 +145,13 @@ void PackedMesh::set_face(size_t i, const ScalarVector3u &indices,
               "vertices (%u, %u, %u), but the mesh only has %zu vertices.",
               i, indices.x(), indices.y(), indices.z(), vertex_count);
 
-    if (bsdf != 0)
-        layout |= Layout::FaceBSDFs;
-
     uint32_t i0 = indices.x(), i2 = indices.z();
     if (reverse_winding)
         std::swap(i0, i2);
 
+    // The fourth word is derived data, see Mesh::update_face_state()
     dr::store(faces.data() + i * MeshFaceStride,
-              PackedFace(i0, indices.y(), i2, bsdf));
+              PackedFace(i0, indices.y(), i2, 0u));
 }
 
 float *PackedMesh::add_attribute(std::string_view name, size_t dim,
@@ -222,8 +216,6 @@ void PackedMesh::add_tangents() {
 
         ScalarVector2f t1 = uv[1] - uv[0], t2 = uv[2] - uv[0];
         float area2 = dr::fmsub(t1.x(), t2.y(), t1.y() * t2.x());
-        if (area2 < 0.f)
-            frec[3] |= FaceUVFlipped;
 
         ScalarVector3f vos =
             dr::fmsub(t2.y(), p[1] - p[0], t1.y() * (p[2] - p[0]));
@@ -274,6 +266,30 @@ void PackedMesh::add_tangents() {
     }
 
     layout |= Layout::Tangents;
+}
+
+void PackedMesh::update_face_state(float eps) {
+    bool tangents = has_flag(layout, Layout::Tangents);
+    const float *vrec = vertices.data();
+    uint32_t *frec = faces.data();
+
+    for (size_t f = 0; f < face_count; ++f, frec += MeshFaceStride) {
+        const float *v[3] = { vrec + (size_t) frec[0] * MeshVertexStride,
+                              vrec + (size_t) frec[1] * MeshVertexStride,
+                              vrec + (size_t) frec[2] * MeshVertexStride };
+        ScalarPoint3f p0 = dr::load<ScalarPoint3f>(v[0] + PackedPositionOffset),
+                      p1 = dr::load<ScalarPoint3f>(v[1] + PackedPositionOffset),
+                      p2 = dr::load<ScalarPoint3f>(v[2] + PackedPositionOffset);
+
+        if (tangents)
+            frec[3] = face_state(p0, p1, p2,
+                                 dr::load<ScalarPoint2f>(v[0] + PackedTexcoordOffset),
+                                 dr::load<ScalarPoint2f>(v[1] + PackedTexcoordOffset),
+                                 dr::load<ScalarPoint2f>(v[2] + PackedTexcoordOffset),
+                                 eps);
+        else
+            frec[3] = face_state(p0, p1, p2, eps);
+    }
 }
 
 /// Missing indexed corner entries resolve to zeros
@@ -384,7 +400,7 @@ PackedMesh corner_to_packed_mesh(
     // tri_corner maps back to the input face corners. Triangles pass through.
     // Quads split along corners 0-2. Larger polygons fan around corner 0.
 
-    std::vector<uint32_t> tri_corner, tri_bsdf;
+    std::vector<uint32_t> tri_corner;
     size_t n_tris = n_corners / 3;
     if (desc.face_offsets) {
         const uint32_t *off = desc.face_offsets;
@@ -402,16 +418,12 @@ PackedMesh corner_to_packed_mesh(
         }
 
         tri_corner.reserve(3 * n_tris);
-        if (desc.bsdf_index)
-            tri_bsdf.reserve(n_tris);
         for (size_t f = 0; f < n_faces; ++f) {
             uint32_t begin = off[f], n = off[f + 1] - off[f];
             for (uint32_t i = 1; i + 1 < n; ++i) {
                 tri_corner.push_back(begin);
                 tri_corner.push_back(begin + i);
                 tri_corner.push_back(begin + i + 1);
-                if (desc.bsdf_index)
-                    tri_bsdf.push_back(desc.bsdf_index[f]);
             }
         }
     }
@@ -509,11 +521,9 @@ PackedMesh corner_to_packed_mesh(
              *nidx_out = pm.normal_index.data(),
              *faces_out = pm.faces.data();
 
+    // The fourth word is derived data, see Mesh::update_face_state()
     for (size_t t = 0; t < n_tris; ++t)
-        faces_out[t * MeshFaceStride + 3] =
-            desc.bsdf_index
-                ? (desc.face_offsets ? tri_bsdf[t] : desc.bsdf_index[t])
-                : 0;
+        faces_out[t * MeshFaceStride + 3] = 0;
 
     // Weld each surface point's corners in turn, so that ids follow the
     // source vertex order: conflict-free input keeps its vertex order

--- a/src/render/python/interaction_v.cpp
+++ b/src/render/python/interaction_v.cpp
@@ -17,20 +17,26 @@ MI_PY_EXPORT(Interaction) {
         .def_field(Interaction3f, wavelengths, D(Interaction, wavelengths))
         .def_field(Interaction3f, p,           D(Interaction, p))
         .def_field(Interaction3f, n,           D(Interaction, n))
+        .def_field(Interaction3f, p_err,       D(Interaction, p_err))
         // Methods
         .def(nb::init<>(), D(Interaction, Interaction))
         .def(nb::init<const Interaction3f &>(), "Copy constructor")
-        .def(nb::init<Float, Float, Wavelength, Point3f, Normal3f>(),
-             "t"_a, "time"_a, "wavelengths"_a, "p"_a, "n"_a = 0,
+        .def(nb::init<Float, Float, Wavelength, Point3f, Normal3f, Float>(),
+             "t"_a, "time"_a, "wavelengths"_a, "p"_a, "n"_a = 0, "p_err"_a = 0,
              D(Interaction, Interaction, 2))
         .def("zero_",        &Interaction3f::zero_, "size"_a = 1)
         .def("spawn_ray",    &Interaction3f::spawn_ray, "d"_a,    D(Interaction, spawn_ray))
-        .def("spawn_ray_to", &Interaction3f::spawn_ray_to, "t"_a, D(Interaction, spawn_ray_to))
+        .def("spawn_ray_to",
+             nb::overload_cast<const PositionSample3f &>(&Interaction3f::spawn_ray_to, nb::const_),
+             "ps"_a, D(Interaction, spawn_ray_to, 2))
+        .def("spawn_ray_to",
+             nb::overload_cast<const Point3f &>(&Interaction3f::spawn_ray_to, nb::const_),
+             "t"_a, D(Interaction, spawn_ray_to))
         .def("is_valid",     &Interaction3f::is_valid,     D(Interaction, is_valid))
         .def("zero_",        &Interaction3f::zero_, D(Interaction, zero))
         .def_repr(Interaction3f);
 
-    MI_PY_DRJIT_STRUCT(it, Interaction3f, t, time, wavelengths, p, n)
+    MI_PY_DRJIT_STRUCT(it, Interaction3f, t, time, wavelengths, p, n, p_err)
 }
 
 MI_PY_EXPORT(SurfaceInteraction) {
@@ -84,8 +90,8 @@ MI_PY_EXPORT(SurfaceInteraction) {
         .def_repr(SurfaceInteraction3f);
 
     MI_PY_DRJIT_STRUCT(si, SurfaceInteraction3f, t, time, wavelengths, p, n,
-                       shape, uv, sh_frame, frame_flipped, dp_du, dp_dv, dn_du,
-                       dn_dv, wi, prim_index, instance_index)
+                       p_err, shape, uv, sh_frame, frame_flipped, dp_du, dp_dv,
+                       dn_du, dn_dv, wi, prim_index, instance_index)
 }
 
 MI_PY_EXPORT(MediumInteraction) {
@@ -111,7 +117,7 @@ MI_PY_EXPORT(MediumInteraction) {
         .def_repr(MediumInteraction3f);
 
     MI_PY_DRJIT_STRUCT(mi, MediumInteraction3f, t, time, wavelengths, p, n,
-                       medium, sh_frame, wi, sigma_s, sigma_n, sigma_t,
+                       p_err, medium, sh_frame, wi, sigma_s, sigma_n, sigma_t,
                        combined_extinction, mint)
 }
 

--- a/src/render/python/records_v.cpp
+++ b/src/render/python/records_v.cpp
@@ -15,13 +15,14 @@ MI_PY_EXPORT(PositionSample) {
             "si"_a, D(PositionSample, PositionSample))
         .def_rw("p",      &PositionSample3f::p,      D(PositionSample, p))
         .def_rw("n",      &PositionSample3f::n,      D(PositionSample, n))
+        .def_rw("p_err",  &PositionSample3f::p_err,  D(PositionSample, p_err))
         .def_rw("uv",     &PositionSample3f::uv,     D(PositionSample, uv))
         .def_rw("time",   &PositionSample3f::time,   D(PositionSample, time))
         .def_rw("pdf",    &PositionSample3f::pdf,    D(PositionSample, pdf))
         .def_rw("delta",  &PositionSample3f::delta,  D(PositionSample, delta))
         .def_repr(PositionSample3f);
 
-    MI_PY_DRJIT_STRUCT(pos, PositionSample3f, p, n, uv, time, pdf, delta)
+    MI_PY_DRJIT_STRUCT(pos, PositionSample3f, p, n, p_err, uv, time, pdf, delta)
 }
 
 MI_PY_EXPORT(DirectionSample) {
@@ -44,5 +45,5 @@ MI_PY_EXPORT(DirectionSample) {
         .def_rw("emitter", &DirectionSample3f::emitter, D(DirectionSample, emitter))
         .def_repr(DirectionSample3f);
 
-    MI_PY_DRJIT_STRUCT(pos, DirectionSample3f, p, n, uv, time, pdf, delta, emitter, d, dist)
+    MI_PY_DRJIT_STRUCT(pos, DirectionSample3f, p, n, p_err, uv, time, pdf, delta, emitter, d, dist)
 }

--- a/src/render/python/shape.cpp
+++ b/src/render/python/shape.cpp
@@ -9,8 +9,7 @@ MI_PY_EXPORT(DiscontinuityFlags) {
         .def_value(Layout, Positions)
         .def_value(Layout, Normals)
         .def_value(Layout, Texcoords)
-        .def_value(Layout, Tangents)
-        .def_value(Layout, FaceBSDFs);
+        .def_value(Layout, Tangents);
 
     auto disc_flags = nb::enum_<DiscontinuityFlags>(m, "DiscontinuityFlags", nb::is_arithmetic(), D(DiscontinuityFlags))
         .def_value(DiscontinuityFlags, Empty)

--- a/src/render/python/shape_v.cpp
+++ b/src/render/python/shape_v.cpp
@@ -52,7 +52,7 @@ MI_PY_EXPORT(SilhouetteSample) {
              "wavelengths"_a = nb::none(), D(SilhouetteSample, spawn_ray))
         .def_repr(SilhouetteSample3f);
 
-    MI_PY_DRJIT_STRUCT(ss, SilhouetteSample3f, p, discontinuity_type, n, uv,
+    MI_PY_DRJIT_STRUCT(ss, SilhouetteSample3f, p, discontinuity_type, n, p_err, uv,
                        time, pdf, delta, d, silhouette_d, prim_index,
                        scene_index, flags, projection_index, shape,
                        foreshortening, offset)
@@ -73,10 +73,10 @@ public:
     PyMesh(std::string_view name, const TensorXu32 &faces,
            const TensorXf32 &positions, const TensorXf32 &normals,
            const TensorXf32 &texcoords, const IndexBuffer &position_index,
-           const IndexBuffer &normal_index, const IndexBuffer &bsdf_index,
-           bool face_normals, bool flip_normals)
+           const IndexBuffer &normal_index, bool face_normals,
+           bool flip_normals)
         : Mesh(name, faces, positions, normals, texcoords, position_index,
-               normal_index, bsdf_index, face_normals, flip_normals) { }
+               normal_index, face_normals, flip_normals) { }
     std::string to_string() const override {
         NB_OVERRIDE(to_string);
     }
@@ -387,9 +387,6 @@ Args:
         corner, which assumes convex polygons. Without it, every three
         consecutive corners form a triangle.
 
-    bsdf_index: Optional ``(face_count,)`` array of per-face material
-        indices
-
     normals: Optional ``(record_count, 3)`` array of shading normals
         (float32), which are normalized on the way in. Meshes using face
         normals ignore them, and meshes without them receive generated
@@ -410,7 +407,6 @@ static void mesh_from_corners(Mesh &mesh, NdPoints positions,
                               NdIndex corner_vertex,
                               std::optional<NdIndex> corner_index,
                               std::optional<NdIndex> face_offsets,
-                              std::optional<NdIndex> bsdf_index,
                               std::optional<NdPoints> normals,
                               std::optional<NdTexcoords> texcoords,
                               nb::dict attrs) {
@@ -432,15 +428,6 @@ static void mesh_from_corners(Mesh &mesh, NdPoints positions,
                   "entries.");
         desc.face_count = face_offsets->shape(0) - 1;
         desc.face_offsets = index_data(*face_offsets, "face_offsets");
-    }
-
-    if (bsdf_index) {
-        size_t n_faces =
-            face_offsets ? desc.face_count : desc.corner_count / 3;
-        if (bsdf_index->shape(0) != n_faces)
-            Throw("from_corners(): 'bsdf_index' needs one entry per face "
-                  "(%zu).", n_faces);
-        desc.bsdf_index = index_data(*bsdf_index, "bsdf_index");
     }
 
     std::vector<NdArrayF> views;
@@ -529,12 +516,11 @@ MI_PY_EXPORT(Shape) {
         .def(nb::init<std::string_view, const TensorXu32 &,
                       const TensorXf32 &, const TensorXf32 &,
                       const TensorXf32 &, const IndexBuffer &,
-                      const IndexBuffer &, const IndexBuffer &, bool, bool>(),
+                      const IndexBuffer &, bool, bool>(),
              "name"_a, "faces"_a, "positions"_a,
              "normals"_a = TensorXf32(), "texcoords"_a = TensorXf32(),
              "position_index"_a = IndexBuffer(),
-             "normal_index"_a = IndexBuffer(),
-             "bsdf_index"_a = IndexBuffer(), "face_normals"_a = false,
+             "normal_index"_a = IndexBuffer(), "face_normals"_a = false,
              "flip_normals"_a = false, D(Mesh, Mesh, 3))
         .def("write_ply",
              nb::overload_cast<const fs::path &>(&Mesh::write_ply, nb::const_),
@@ -570,7 +556,6 @@ MI_PY_EXPORT(Shape) {
         .def("texcoords", &Mesh::texcoords, D(Mesh, texcoords))
         .def("tangents", &Mesh::tangents, D(Mesh, tangents))
         .def("faces", &Mesh::faces, D(Mesh, faces))
-        .def("bsdf_index", &Mesh::bsdf_index, D(Mesh, bsdf_index))
         .def("packed_vertices", nb::overload_cast<>(&Mesh::packed_vertices),
              D(Mesh, packed_vertices))
 
@@ -600,15 +585,13 @@ MI_PY_EXPORT(Shape) {
         .def("from_corners", &mesh_from_corners<Mesh>,
              "positions"_a, "corner_vertex"_a,
              "corner_index"_a = nb::none(), "face_offsets"_a = nb::none(),
-             "bsdf_index"_a = nb::none(), "normals"_a = nb::none(),
-             "texcoords"_a = nb::none(), "attrs"_a = nb::dict(),
-             doc_from_corners)
+             "normals"_a = nb::none(), "texcoords"_a = nb::none(),
+             "attrs"_a = nb::dict(), doc_from_corners)
         .def("from_fields", &Mesh::from_fields,
              "faces"_a, "positions"_a, "normals"_a = TensorXf32(),
              "texcoords"_a = TensorXf32(),
              "position_index"_a = IndexBuffer(),
-             "normal_index"_a = IndexBuffer(),
-             "bsdf_index"_a = IndexBuffer(), D(Mesh, from_fields))
+             "normal_index"_a = IndexBuffer(), D(Mesh, from_fields))
         .def("from_packed",
              [](Mesh &self, uint32_t layout, const TensorXu32 &packed_faces,
                 const TensorXf32 &packed_vertices,

--- a/src/render/scene.cpp
+++ b/src/render/scene.cpp
@@ -274,23 +274,28 @@ MI_VARIANT Scene<Float, Spectrum>::~Scene() {
 
 // -----------------------------------------------------------------------
 
-/// Stash the 3x4 affine part of a transformation into a flat list
+/**
+ * Stash a transformation into a flat instance record: the 3x4 affine parts
+ * of the matrix and of its inverse, each column-major (24 values)
+ */
 template <typename Value, typename Transform>
-static void pack_matrix(Value *rec, const Transform &t) {
-    for (size_t col = 0; col < 4; ++col)
-        for (size_t row = 0; row < 3; ++row)
-            rec[col * 3 + row] = t.matrix(row, col);
+static void pack_transform(Value *rec, const Transform &t) {
+    for (size_t col = 0; col < 4; ++col) {
+        for (size_t row = 0; row < 3; ++row) {
+            rec[col * 3 + row]      = t.matrix(row, col);
+            rec[col * 3 + row + 12] = t.inverse_transpose(col, row);
+        }
+    }
 }
 
-/// Reassemble a transformation from a flat column-major 3x4 list
-template <typename AffineTransform4f, typename Rec>
-static AffineTransform4f unpack_matrix(const Rec &rec) {
-    using Matrix = typename AffineTransform4f::Matrix;
-    return AffineTransform4f(Matrix(
-        rec[0], rec[3], rec[6], rec[9],
-        rec[1], rec[4], rec[7], rec[10],
-        rec[2], rec[5], rec[8], rec[11],
-        0.f,    0.f,    0.f,    1.f));
+/// Reassemble a 4x4 matrix from a flat column-major 3x4 list
+template <typename Matrix, typename Rec>
+static Matrix unpack_matrix(const Rec &rec, size_t off = 0) {
+    return Matrix(
+        rec[off + 0], rec[off + 3], rec[off + 6], rec[off + 9],
+        rec[off + 1], rec[off + 4], rec[off + 7], rec[off + 10],
+        rec[off + 2], rec[off + 5], rec[off + 8], rec[off + 11],
+        0.f,          0.f,          0.f,          1.f);
 }
 
 MI_VARIANT void Scene<Float, Spectrum>::update_portal_data() {
@@ -323,11 +328,11 @@ MI_VARIANT void Scene<Float, Spectrum>::update_instance_transforms() {
 
     // Pack the primal transform data on the host
     size_t n = m_instances.size();
-    std::unique_ptr<ScalarFloat[]> data(new ScalarFloat[12 * n]);
+    std::unique_ptr<ScalarFloat[]> data(new ScalarFloat[24 * n]);
     for (size_t i = 0; i < n; ++i)
-        pack_matrix(data.get() + 12 * i, m_instances[i]->to_world_scalar());
+        pack_transform(data.get() + 24 * i, m_instances[i]->to_world_scalar());
     m_instance_transforms =
-        dr::load<DynamicBuffer<Float>>(data.get(), 12 * n);
+        dr::load<DynamicBuffer<Float>>(data.get(), 24 * n);
 
     // Overlay the records of differentiated instances so that gradients
     // flow from the packed buffer back to each instance's ``to_world``.
@@ -336,8 +341,8 @@ MI_VARIANT void Scene<Float, Spectrum>::update_instance_transforms() {
             AffineTransform4f t = m_instances[i]->to_world();
             if (!dr::grad_enabled(t))
                 continue;
-            dr::Array<Float, 12> rec;
-            pack_matrix(rec.data(), t);
+            dr::Array<Float, 24> rec;
+            pack_transform(rec.data(), t);
             dr::scatter(m_instance_transforms, rec, UInt32((uint32_t) i),
                         true, ReduceMode::NoConflicts);
         }
@@ -389,10 +394,10 @@ Scene<Float, Spectrum>::compute_surface_interaction_instanced(
         [this, detach_shape](const Point3f &o, const Vector3f &d,
                              const UInt32 &index) {
             DRJIT_MARK_USED(detach_shape);
-            AffineTransform4f to_object =
-                unpack_matrix<AffineTransform4f>(
-                    dr::gather<dr::Array<Float, 12>>(m_instance_transforms,
-                                                     index - 1u)).inverse();
+            Matrix4f to_object_m = unpack_matrix<Matrix4f>(
+                dr::gather<dr::Array<Float, 12>>(m_instance_transforms,
+                                                 2u * (index - 1u) + 1u));
+            AffineTransform4f to_object(to_object_m, dr::identity<Matrix4f>());
 
             if constexpr (dr::is_diff_v<Float>) {
                 if (detach_shape)
@@ -425,36 +430,47 @@ Scene<Float, Spectrum>::compute_surface_interaction_instanced(
             DRJIT_MARK_USED(detach_shape);
             DRJIT_MARK_USED(follow_shape);
             DRJIT_MARK_USED(grad_enabled);
-            AffineTransform4f to_world =
-                unpack_matrix<AffineTransform4f>(
-                    dr::gather<dr::Array<Float, 12>>(m_instance_transforms, index - 1u));
+            // The inverse transpose of the transform is the transpose of the
+            // stored inverse, so no inversion happens per hit
+            auto rec = dr::gather<dr::Array<Float, 24>>(m_instance_transforms,
+                                                        index - 1u);
+            AffineTransform4f to_world(
+                unpack_matrix<Matrix4f>(rec),
+                dr::transpose(unpack_matrix<Matrix4f>(rec, 12)));
             if constexpr (dr::is_diff_v<Float>) {
                 if (detach_shape)
                     to_world = dr::detach(to_world);
             }
 
-            AffineTransform4f to_world_d = dr::detach(to_world);
+            Normal3f n = to_world * si.n;
+            Float inv_len = dr::rsqrt(dr::squared_norm(n));
+            n *= inv_len;
+            si.n = n;
 
-            // Hit point `si.p` is only attached to the surface motion
+            // The reciprocal length 'inv_len' converts the nested error bound
+            // to world space. position_error() adds the rounding of the matrix
+            // product, which depends on the magnitude of the object-space position.
+            si.p_err = dr::fmadd(si.p_err, dr::detach(inv_len),
+                                 to_world.position_error(si.p, n, Float(0.f)));
+
             si.p = to_world * si.p;
-            si.n = dr::normalize(to_world_d * si.n);
 
             if (likely(has_flag(ray_flags, RayFlags::Shading))) {
                 // Transforming a normal applies the inverse transpose,
                 // which does not preserve its length. Differentiating the
                 // re-normalization projects the transformed partials back
                 // onto the tangent plane.
-                Normal3f n = to_world_d * si.sh_frame.n;
-                Float inv_len = dr::rcp(dr::norm(n));
-                n *= inv_len;
-                si.sh_frame.n = n;
+                Normal3f sh_n = to_world * si.sh_frame.n;
+                Float sh_inv_len = dr::rcp(dr::norm(sh_n));
+                sh_n *= sh_inv_len;
+                si.sh_frame.n = sh_n;
 
                 if (has_flag(ray_flags, RayFlags::NormalPartials)) {
-                    Vector3f dn_du = to_world_d * Normal3f(si.dn_du) * inv_len,
-                             dn_dv = to_world_d * Normal3f(si.dn_dv) * inv_len;
+                    Vector3f dn_du = to_world * Normal3f(si.dn_du) * sh_inv_len,
+                             dn_dv = to_world * Normal3f(si.dn_dv) * sh_inv_len;
 
-                    si.dn_du = dr::fnmadd(n, dr::dot(n, dn_du), dn_du);
-                    si.dn_dv = dr::fnmadd(n, dr::dot(n, dn_dv), dn_dv);
+                    si.dn_du = dr::fnmadd(sh_n, dr::dot(sh_n, dn_du), dn_du);
+                    si.dn_dv = dr::fnmadd(sh_n, dr::dot(sh_n, dn_dv), dn_dv);
                 }
 
                 // A tangent direction supplied by the nested shape
@@ -462,9 +478,9 @@ Scene<Float, Spectrum>::compute_surface_interaction_instanced(
                 // orthonormalizes it against the transformed normal and
                 // derives the bitangent. A mirroring instance transform
                 // flips the orientation of the nested parameterization.
-                si.sh_frame.s = to_world_d * si.sh_frame.s;
+                si.sh_frame.s = to_world * si.sh_frame.s;
                 si.frame_flipped ^=
-                    dr::det(Matrix3f(to_world_d.matrix)) < 0.f;
+                    dr::det(Matrix3f(to_world.matrix)) < 0.f;
 
                 si.dp_du = to_world * si.dp_du;
                 si.dp_dv = to_world * si.dp_dv;
@@ -485,6 +501,7 @@ Scene<Float, Spectrum>::compute_surface_interaction_instanced(
                     si.t = (dr::dot(si.n, si.p) - dr::dot(si.n, ray.o)) /
                             dr::dot(si.n, ray.d);
                     si.p = ray(si.t);
+                    si.p_err = dr::maximum(si.p_err, ray_error(ray, si.t, si.n));
                 }
             }
 
@@ -701,14 +718,13 @@ Scene<Float, Spectrum>::null_walk(const Ray3f &ray, uint32_t ray_flags,
                 ls.rel += relative_grad(unpolarized_spectrum(value)) - 1.f;
 
             // A crossed shape is not the result of the query. Continue past
-            // it with an offset analogous to spawn_ray().
+            // it by the error bound of the crossing, measured along the ray
+            // as in spawn_ray().
             dr::masked(ls.pi.valid, ls.active) = false;
 
-            Point3f p = dr::detach(si.p);
-            Normal3f n = dr::detach(si.n);
-            Float mag = (1.f + dr::max(dr::abs(p))) * math::RayEpsilon<Float>,
-                  cos_theta = dr::maximum(dr::abs(dr::dot(n, query.d)), 1e-2f);
-            ls.t = ls.pi.t + mag / cos_theta;
+            Float cos_theta = dr::maximum(
+                dr::abs_dot(dr::detach(si.n), query.d), 1e-2f);
+            ls.t = ls.pi.t + dr::detach(si.p_err) / cos_theta;
 
             ls.active &= ls.t < dr::detach(ls.ray.maxt) &&
                          dr::any(unpolarized_spectrum(ls.tr) != 0.f);
@@ -857,7 +873,7 @@ Scene<Float, Spectrum>::sample_emitter_direction(const Interaction3f &ref, const
     // Shadow ray that passes through null surfaces and returns their
     // transmittance (zero when occluded)
     if (test_visibility && dr::any_or<true>(active)) {
-        Spectrum tr = ray_test_tr(ref.spawn_ray_to(ds.p), +RayFlags::Default,
+        Spectrum tr = ray_test_tr(ref.spawn_ray_to(ds), +RayFlags::Default,
                                   false, +RayMask::Secondary, active);
         Mask occluded = !dr::any(unpolarized_spectrum(tr) != 0.f);
         spec *= tr;

--- a/src/render/tests/test_interaction.py
+++ b/src/render/tests/test_interaction.py
@@ -41,6 +41,7 @@ def test02_intersection_construction(variant_scalar_rgb):
   wavelengths=[],
   p=[1, 2, 3],
   n=[4, 5, 6],
+  p_err=0,
   shape=0x0,
   uv=[7, 8],
   sh_frame=Frame[

--- a/src/render/tests/test_mesh_build.py
+++ b/src/render/tests/test_mesh_build.py
@@ -496,9 +496,6 @@ def test12_construction_errors(variants_all_rgb, capfd):
         (lambda: m.from_fields(faces=faces, positions=zeros,
                                normal_index=np.uint32([0, 0, 0, 0])),
          RuntimeError, "requires a 'normals'"),
-        (lambda: m.from_fields(faces=faces, positions=zeros,
-                               bsdf_index=np.uint32([0, 0])),
-         RuntimeError, "'bsdf_index' has 2 entries"),
         # from_corners(). The dtype and shape of an argument are enforced
         # by the binding signature, hence the TypeError
         (lambda: m.from_corners(positions=positions[:, :2].copy(),
@@ -578,8 +575,8 @@ def test12_construction_errors(variants_all_rgb, capfd):
 # Merge
 # -------------------------------------------------------------------
 
-def _merge_input(name, offset, bsdf=None, bsdf_index=None, seam=False,
-                 normals=None, texcoords=False):
+def _merge_input(name, offset, bsdf=None, seam=False, normals=None,
+                 texcoords=False):
     """
     Build an input mesh for the Mesh.merge() tests, translated by ``offset``.
 
@@ -588,8 +585,6 @@ def _merge_input(name, offset, bsdf=None, bsdf_index=None, seam=False,
     positions instead, which gives merge() a non-identity map to renumber.
     """
     kwargs = {}
-    if bsdf_index is not None:
-        kwargs['bsdf_index'] = np.uint32(bsdf_index)
     if normals is not None:
         kwargs['normals'] = normals
     if texcoords:
@@ -610,11 +605,10 @@ def _merge_input(name, offset, bsdf=None, bsdf_index=None, seam=False,
 
 def test13_merge_batch(variants_all_rgb):
     """Mesh.merge() concatenates every level of the representation. The
-    vertex index lanes and maps shift by prefix offsets, while the BSDF
-    lane passes through unchanged."""
+    vertex index lanes and maps shift by prefix offsets."""
     bsdf = mi.load_dict({'type': 'diffuse'})
-    a = _merge_input("a", 0, bsdf, bsdf_index=[1])
-    b = _merge_input("b", 10, bsdf, bsdf_index=[2, 3], seam=True)
+    a = _merge_input("a", 0, bsdf)
+    b = _merge_input("b", 10, bsdf, seam=True)
     c = _merge_input("c", 20, bsdf)
 
     # Errors: empty input, non-mesh entries, incompatible meshes
@@ -635,10 +629,8 @@ def test13_merge_batch(variants_all_rgb):
     assert m.vertex_count() == 12 and m.face_count() == 4
     assert m.position_count() == 10
 
-    rec = face_records(m)
-    assert np.all(rec == [[0, 1, 2, 1],
-                          [3, 4, 5, 2], [6, 7, 8, 3],
-                          [9, 10, 11, 0]])
+    assert np.all(faces_of(m) == [[0, 1, 2], [3, 4, 5], [6, 7, 8],
+                                  [9, 10, 11]])
     assert np.all(np.array(m.position_index())
                   == [0, 1, 2, 3, 4, 5, 3, 5, 6, 7, 8, 9])
     assert np.allclose(np.array(m.positions()),

--- a/src/render/tests/test_mesh_shading.py
+++ b/src/render/tests/test_mesh_shading.py
@@ -421,29 +421,35 @@ def test09_tangent_weighting_convention(variants_all_rgb):
 
 
 def test10_uv_flip_bits(variants_all_rgb):
-    """The cached UV orientation bits share a lane with the per-face BSDF
-    index, and follow texture coordinate edits without disturbing it."""
+    """The cached UV orientation bits share a lane with the position error
+    bound, and follow texture coordinate edits without disturbing it."""
     positions = np.float32([[0, 0, 0], [1, 0, 0], [0, 1, 0],
-                            [2, 0, 0], [3, 0, 0], [2, 1, 0]])
+                            [2, 0, 2], [3, 0, 2], [2, 1, 2]])
     uv = np.float32([[0, 0], [1, 0], [0, 1],    # det > 0
                      [0, 0], [0, 1], [1, 0]])   # det < 0
     m = mi.Mesh("mirrored")
     m.from_fields(faces=np.arange(6, dtype=np.uint32).reshape(2, 3),
                   positions=positions, texcoords=uv,
-                  normals=np.tile(np.float32([0, 0, 1]), (6, 1)),
-                  bsdf_index=np.uint32([3, 5]))
+                  normals=np.tile(np.float32([0, 0, 1]), (6, 1)))
     m.set_bsdf(anisotropic_bsdf())
     assert m.packs_tangent()
 
-    def flipped():
+    def hits():
         scene = mi.load_dict({'type': 'scene', 'm': m})
-        return [bool(dr.all(scene.ray_intersect(mi.Ray3f(
-                    mi.Point3f(x, 0.25, 1), mi.Vector3f(0, 0, -1)
-                )).frame_flipped)) for x in (0.25, 2.25)]
+        return [scene.ray_intersect(mi.Ray3f(
+                    mi.Point3f(x, 0.25, 3), mi.Vector3f(0, 0, -1)
+                )) for x in (0.25, 2.25)]
+
+    def flipped():
+        return [bool(dr.all(si.frame_flipped)) for si in hits()]
+
+    # Each face stores a bound along its normal: both faces have the same
+    # edges, and the second one sits at height 2
+    p_err = [float(dr.slice(si.p_err)) for si in hits()]
+    assert p_err[0] > 0
+    assert dr.allclose(p_err[1] - p_err[0], 2 * mi.math.PositionEpsilon)
 
     assert flipped() == [False, True]
-    assert np.all(np.array(m.bsdf_index()) == [3, 5])
-    assert np.all(np.array(mi.traverse(m)['bsdf_index']) == [3, 5])
     assert np.all(np.array(m.faces()) == np.arange(6).reshape(2, 3))
 
     # Mirroring every texture coordinate swaps both orientations
@@ -453,16 +459,12 @@ def test10_uv_flip_bits(variants_all_rgb):
     params['texcoords'] = edited
     params.update()
     assert flipped() == [True, False]
-    assert np.all(np.array(m.bsdf_index()) == [3, 5])
+    assert [float(dr.slice(si.p_err)) for si in hits()] == p_err
 
-    # The BSDF index lane is writable and survives a 'faces' rewrite at an
-    # unchanged face count
-    params['bsdf_index'] = np.uint32([4, 6])
-    params.update()
-    assert np.all(np.array(m.bsdf_index()) == [4, 6])
+    # A 'faces' rewrite at an unchanged face count keeps the bounds
     params['faces'] = np.array(params['faces'])[[1, 0]].copy()
     params.update()
-    assert np.all(np.array(m.bsdf_index()) == [4, 6])
+    assert [float(dr.slice(si.p_err)) for si in hits()] == p_err
 
 
 @fresolver_append_path

--- a/src/render/tests/test_mesh_state.py
+++ b/src/render/tests/test_mesh_state.py
@@ -147,8 +147,6 @@ def test05_views_stay_symbolic(variant_llvm_ad_rgb):
         for view in (m.positions(), m.normals(), m.texcoords(), m.faces(),
                      m.tangents()):
             assert view.array.state == dr.VarState.Unevaluated
-        # No per-face materials: the view stays empty
-        assert dr.width(m.bsdf_index()) == 0
 
     mi.traverse(m)
     check_symbolic()
@@ -173,7 +171,6 @@ def test06_write_rules(variants_all_rgb):
     # Index fields accept writes at unchanged counts
     faces = np.array(params['faces'])
     params['faces'] = faces[[1, 0]].copy()
-    params['bsdf_index'] = np.uint32([0, 0])
     params.update()
     assert np.all(np.array(m.faces()) == faces[[1, 0]])
 
@@ -234,11 +231,9 @@ def test07_update_geometry_accel(variants_vec_rgb):
 
     # Structural phase: remesh through the parameter map. Fanning every
     # face into three around its centroid leaves the surface unchanged
-    # but resizes all buffers; the per-face material assignment written
-    # below must be rewritten in the same batch.
+    # but resizes all buffers, so the texture coordinates must be
+    # rewritten in the same batch.
     translate([0, 0, 0])
-    params['rect.bsdf_index'] = np.uint32([7, 9])
-    params.update()
 
     faces = np.array(params['rect.faces'])
     pos = np.array(params['rect.positions'])
@@ -253,25 +248,21 @@ def test07_update_geometry_accel(variants_vec_rgb):
                                     center], axis=1) for k in range(3)])
     fan_pos = np.vstack([pos, pos[faces].mean(axis=1)])
     fan_uv = np.vstack([uv, uv[faces].mean(axis=1)])
-    fan_bsdf = np.uint32(np.arange(3 * F) % 2)
 
     params['rect.faces'] = fan
     params['rect.positions'] = fan_pos
-    params['rect.texcoords'] = fan_uv
-    with pytest.raises(RuntimeError, match="'bsdf_index' has 2 entries"):
+    with pytest.raises(RuntimeError, match="'texcoords' has 4 rows"):
         params.update()
 
     params['rect.faces'] = fan
     params['rect.positions'] = fan_pos
     params['rect.texcoords'] = fan_uv
-    params['rect.bsdf_index'] = fan_bsdf
     params.update()
 
     # The old handles remained valid across the repack; the AD identity
     # of the resized tensor was dropped
     assert params['rect.positions'].shape == (V + F, 3)
     assert not dr.grad_enabled(params['rect.positions'])
-    assert np.all(np.array(params['rect.bsdf_index']) == fan_bsdf)
 
     t = scene.ray_intersect_preliminary(ray, coherent=True).t
     dr.assert_allclose(t, init_t)
@@ -301,7 +292,6 @@ def test08_scalar_and_jit_kernels_agree(variants_vec_rgb):
             'tangents': np.array(m.tangents()),
             'packed': np.array(m.packed_vertices()),
             'faces': np.array(mi.traverse(m)['faces']),
-            'bsdf_index': np.array(m.bsdf_index()),
         }
 
     jit = build_and_snapshot()
@@ -318,7 +308,6 @@ def test08_scalar_and_jit_kernels_agree(variants_vec_rgb):
     assert np.allclose(jit['tangents'], scalar['tangents'], atol=1e-5)
     assert np.allclose(jit['packed'], scalar['packed'], atol=1e-5)
     assert np.array_equal(jit['faces'], scalar['faces'])
-    assert np.array_equal(jit['bsdf_index'], scalar['bsdf_index'])
 
 
 def test09_transform(variants_all_rgb):

--- a/src/render/tests/test_ray_offset.py
+++ b/src/render/tests/test_ray_offset.py
@@ -1,0 +1,200 @@
+"""
+Rays spawned from surface interactions must not hit the surface they start
+on, shadow rays between two surfaces must not be falsely occluded, and the
+error bounds that shapes report must stay close to the actual roundoff.
+"""
+
+import numpy as np
+import pytest
+import drjit as dr
+import mitsuba as mi
+
+# Shapes that report ray(t) as the hit point. Their bound grows with the
+# distance of the ray origin.
+RAY_BASED = ('sdfgrid', 'linearcurve', 'bsplinecurve', 'ellipsoids')
+
+SHAPES = ['sphere', 'cube', 'cylinder', 'disk', 'rectangle', 'instance',
+          'ellipsoidsmesh', *RAY_BASED]
+
+# Shapes that implement sample_position()
+SAMPLED = ['sphere', 'cube', 'cylinder', 'disk', 'rectangle']
+
+# Single-sided shapes, whose rays spawned on the inside legitimately hit the
+# far wall
+OPEN = ('cylinder', 'linearcurve', 'bsplinecurve')
+
+# Two-sided planar shapes, whose samples are visible from both sides
+PLANAR = ('disk', 'rectangle')
+
+CONFIGS = [(0.0, 1.0), (1e3, 1.0), (0.0, 1e-3), (1e4, 1e3)]
+
+
+def shape_dict(shape, center, scale, tmp_path=None, flip=False):
+    """Dictionary of a unit-sized ``shape`` scaled by ``scale`` and centered
+    at ``center``. ``flip`` turns it upside down. Returns the dictionary and
+    the size of the shape. The curve shapes write a file to ``tmp_path``."""
+    T = mi.ScalarTransform4f().translate(center)
+    if flip:
+        T = T @ mi.ScalarTransform4f().rotate([1, 0, 0], 180)
+    T = T @ mi.ScalarTransform4f().scale(scale)
+    size = scale
+    if shape == 'sdfgrid':
+        # Level set of a plane through the center of the grid
+        z = ((np.arange(16) + 0.5) / 16 - 0.5).astype(np.float32)
+        grid = np.broadcast_to(z[:, None, None, None], (16, 16, 16, 1))
+        d = {'type': 'sdfgrid', 'grid': mi.TensorXf(grid)}
+        T = T @ mi.ScalarTransform4f().translate([-0.5] * 3)
+        size = 0.5 * scale
+    elif shape == 'instance':
+        # A rotated instance of a cube, which exercises the transport of the
+        # nested bound through a non-axis-aligned transform
+        d = {'type': 'instance', 'shapegroup': {'type': 'ref', 'id': 'grp'}}
+        T = T @ mi.ScalarTransform4f().rotate(dr.normalize(mi.ScalarVector3f(1, 1, 0)), 30)
+    elif shape == 'cylinder':
+        # Lying on its side so that the wall faces up and down
+        d = {'type': 'cylinder'}
+        T = T @ mi.ScalarTransform4f().rotate([0, 1, 0], 90).translate([0, 0, -0.5])
+    elif shape in ('linearcurve', 'bsplinecurve'):
+        # A tube along the x axis. Curve radii ignore the 'to_world' scale,
+        # so the file is written at the final size
+        fname = tmp_path / f'{shape}_{scale}.txt'
+        fname.write_text(''.join(f'{x * scale} 0 0 {scale}\n'
+                                 for x in (-1.5, -1, -0.3, 0.3, 1, 1.5)))
+        d = {'type': shape, 'filename': str(fname)}
+        T = mi.ScalarTransform4f().translate(center)
+    elif shape in ('ellipsoids', 'ellipsoidsmesh'):
+        # A sphere given as an ellipsoid, which does not accept 'to_world'
+        # together with a data tensor. The mesh variant tessellates it.
+        data = np.float32([[*center, scale, scale, scale, 0, 0, 0, 1]])
+        d = {'type': shape, 'data': mi.TensorXf(data), 'extent': 1.0}
+        if shape == 'ellipsoidsmesh':
+            d['shell'] = 'ico_sphere'
+        return d, size
+    else:
+        d = {'type': shape}
+    d['to_world'] = T
+    return d, size
+
+
+def make_scene(shape, offset, scale, tmp_path=None, receiver='rectangle'):
+    """A ``shape`` scaled by ``scale`` and translated by ``offset`` along
+    every axis, plus a downward-facing 'receiver' shape above it. Returns
+    the scene, the center and the size of the shape."""
+    center = mi.ScalarPoint3f([offset] * 3)
+    d, size = shape_dict(shape, center, scale, tmp_path)
+    rsize = 2 * size if receiver == 'rectangle' else size
+    r, _ = shape_dict(receiver, center + [0, 0, 3 * size], rsize, tmp_path, flip=True)
+    d = {'type': 'scene', 'shape': d, 'receiver': r}
+    if shape == 'instance':
+        d['grp'] = {'type': 'shapegroup', 'inner': {'type': 'cube'}}
+    return mi.load_dict(d), center, size
+
+
+def shape_by_id(scene, id):
+    return next((s for s in scene.shapes() if s.id() == id), None)
+
+
+def hits(scene, center, size, n, dist=4.0, front_only=False):
+    """Hit the shape under test with ``n`` rays from ``dist`` shape sizes
+    away, aimed at random points inside the shape. The normals are flipped
+    to face the ray origins. Returns the interactions, the mask of hits on
+    the shape and the sampler."""
+    sampler = mi.load_dict({'type': 'independent'})
+    sampler.seed(0, n)
+    center = mi.Point3f(center)
+    o = center + dist * size * mi.warp.square_to_uniform_sphere(sampler.next_2d())
+    r = dr.cbrt(sampler.next_1d()) * 0.8 * size
+    target = center + r * mi.warp.square_to_uniform_sphere(sampler.next_2d())
+    ray = mi.Ray3f(o, dr.normalize(target - o))
+    si = scene.ray_intersect(ray)
+    front = dr.dot(si.n, ray.d) < 0
+    si.n = dr.select(front, si.n, -si.n)
+    # Instanced hits report the nested shape, so exclude the receiver instead
+    active = si.is_valid()
+    receiver = shape_by_id(scene, 'receiver')
+    if receiver is not None:
+        active &= si.shape != mi.ShapePtr(receiver)
+    if front_only:
+        active &= front
+    return si, active, sampler
+
+
+def check_linearcurve(shape, scale):
+    """At small scales, Embree returns the curve parameter of a joint sphere
+    for hits on the constant-radius segments of a linear curve. The normals
+    then tilt along the axis by up to 0.17, and rays spawned around them
+    enter the tube. Mitsuba's own intersector on Metal is unaffected."""
+    embree = mi.MI_ENABLE_EMBREE and mi.variant().startswith(('scalar', 'llvm'))
+    if shape == 'linearcurve' and scale < 1e-2 and embree:
+        pytest.xfail('Embree misreports the curve parameter at small scales')
+
+
+def error_limit(shape, center, size, dist=0.0):
+    """Upper limit for the reported bound: a small multiple of the roundoff
+    of the coordinate magnitudes that enter the hit point. The SDF grid
+    additionally stops its root finder at a fixed distance."""
+    reach = dr.sum(dr.abs(mi.ScalarPoint3f(center))) + size
+    if shape in RAY_BASED:
+        reach += dist * size
+    limit = 12 * mi.math.PositionEpsilon * reach
+    if shape == 'sdfgrid':
+        limit += 1e-5
+    return limit
+
+
+@pytest.mark.parametrize('shape', SHAPES)
+@pytest.mark.parametrize('offset, scale, dist', [(*c, 4.0) for c in CONFIGS] + [(0.0, 1.0, 1e4)])
+def test01_spawn_ray_no_self_hit(variants_vec_backends_once, shape, offset, scale, dist, tmp_path):
+    """Rays spawned into the hemisphere around the normal do not hit the
+    surface they start on. The reported error bound is positive and stays
+    within a small multiple of the roundoff of the quantities involved."""
+    # The last configuration places the ray origins far away from a shape
+    # near the world origin, which catches bounds that ignore the ray extent
+    check_linearcurve(shape, scale)
+    scene, center, size = make_scene(shape, offset, scale, tmp_path)
+    si, active, sampler = hits(scene, center, size, 1 << 14, dist,
+                               front_only=shape in OPEN)
+    assert dr.count(active)[0] > 1000
+
+    limit = error_limit(shape, center, size, dist)
+    assert dr.all(~active | ((si.p_err > 0) & (si.p_err < limit)))
+
+    d = mi.Frame3f(si.n).to_world(mi.warp.square_to_uniform_hemisphere(sampler.next_2d()))
+    si2 = scene.ray_intersect(si.spawn_ray(d), active=active)
+    assert dr.none(active & si2.is_valid() & (si2.t < 1e-3 * size))
+
+
+@pytest.mark.parametrize('shape', SHAPES)
+@pytest.mark.parametrize('receiver', ['rectangle', 'same'])
+@pytest.mark.parametrize('offset, scale', CONFIGS)
+def test02_spawn_ray_to_no_false_occlusion(variants_vec_backends_once, shape,
+                                           receiver, offset, scale, tmp_path):
+    """Shadow rays from hits on the shape to sampled positions on a receiver
+    above it are unoccluded. The receiver is a rectangle or a copy of the
+    shape, which covers the bound reported by every ``sample_position()``."""
+    if receiver == 'same':
+        if shape not in SAMPLED:
+            pytest.skip('Shape does not implement sample_position()')
+        receiver = shape
+    check_linearcurve(shape, scale)
+    scene, center, size = make_scene(shape, offset, scale, tmp_path, receiver)
+    si, active, sampler = hits(scene, center, size, 1 << 14, front_only=shape in OPEN)
+
+    target = shape_by_id(scene, 'receiver')
+    ps = target.sample_position(mi.Float(0.0), sampler.next_2d())
+    rsize = 2 * size if receiver == 'rectangle' else size
+    limit = error_limit(receiver, center + [0, 0, 3 * size], rsize)
+    assert dr.all((ps.p_err > 0) & (ps.p_err < limit))
+
+    # Connect hits to positions that are visible from them: the hit faces
+    # the target, and the target faces the hit unless it is two-sided
+    d = dr.normalize(ps.p - si.p)
+    active &= dr.dot(si.n, d) > 0.1
+    if receiver not in PLANAR:
+        active &= dr.dot(ps.n, d) < -0.1
+    assert dr.count(active)[0] > 300
+    assert dr.none(active & scene.ray_test(si.spawn_ray_to(ps), active=active))
+
+    # The bare-point overload only offsets the origin and shortens the segment
+    assert dr.none(active & scene.ray_test(si.spawn_ray_to(ps.p), active=active))
+

--- a/src/render/tests/test_records.py
+++ b/src/render/tests/test_records.py
@@ -20,6 +20,7 @@ def test01_position_sample_construction_single(variant_scalar_rgb):
     expected = """PositionSample[
   p=[0, 42, 0],
   n=[0, 0, 0.4],
+  p_err=0,
   uv=[1, 2],
   time=0,
   pdf=0.002,
@@ -58,6 +59,7 @@ def test02_position_sample_construction_vec(variants_vec_backends_once):
      [0, 0, 0],
      [0, 0, 0],
      [0, 0, 0]],
+  p_err=[0, 0, 0, 0, 0],
   uv=[[0, 0],
       [0, 0],
       [0, 0],
@@ -90,6 +92,7 @@ def test04_direction_sample_construction_single(variants_vec_backends_once):
     assert str(record) == """DirectionSample[
   p=[[1, 2, 3]],
   n=[[4, 5, 6]],
+  p_err=[0],
   uv=[[7, 8]],
   time=[],
   pdf=[0.002],

--- a/src/render/tests/test_shape.py
+++ b/src/render/tests/test_shape.py
@@ -14,6 +14,7 @@ def test01_ss_repr(variants_vec_backends_once_rgb):
   n=[[0, 0, 0],
      [0, 0, 0],
      [0, 0, 0]],
+  p_err=[0, 0, 0],
   uv=[[0, 0],
       [0, 0],
       [0, 0]],

--- a/src/sensors/irradiancemeter.cpp
+++ b/src/sensors/irradiancemeter.cpp
@@ -91,10 +91,10 @@ public:
                                active);
 
         Vector3f d = Frame3f(ps.n).to_world(local);
-        Point3f o = ps.p + d * math::RayEpsilon<Float>;
+        Interaction3f it(0.f, time, wavelengths, ps.p, ps.n, ps.p_err);
 
         return {
-            Ray3f(o, d, time, wavelengths),
+            it.spawn_ray(d),
             depolarizer<Spectrum>(wav_weight) * dr::Pi<ScalarFloat>
         };
     }

--- a/src/shapes/bsplinecurve.cpp
+++ b/src/shapes/bsplinecurve.cpp
@@ -907,6 +907,7 @@ public:
             (dr::squared_norm(dr::detach(dc_dv)) -
              dr::dot(rad_vec_d, dr::detach(dc_dvv))) * rad_vec_d -
             (dr::detach(dr_dv) * dr::detach(radius)) * dr::detach(dc_dv));
+        si.p_err = ray_error(ray, pi.t, si.n);
 
         // Surface position at the detached parameterization: the angular
         // coordinate does not move with the curve.

--- a/src/shapes/cylinder.cpp
+++ b/src/shapes/cylinder.cpp
@@ -278,6 +278,7 @@ public:
         PositionSample3f ps = dr::zeros<PositionSample3f>();
         ps.p     = to_world * p;
         ps.n     = dr::normalize(to_world * n);
+        ps.p_err = to_world.position_error(p, ps.n);
         ps.pdf   = m_inv_surface_area;
         ps.time  = time;
         ps.delta = false;
@@ -700,6 +701,7 @@ public:
         si.p = dr::detach(to_world) * local;
         si.n = Normal3f(dr::normalize(
             dr::detach(to_world) * Normal3f(local.x(), local.y(), 0.f)));
+        si.p_err = to_world.position_error(local, si.n);
 
         // The local coordinates are static as the cylinder moves
         Point3f p_att = to_world * local;

--- a/src/shapes/disk.cpp
+++ b/src/shapes/disk.cpp
@@ -178,10 +178,12 @@ public:
         Point2f p = warp::square_to_uniform_disk_concentric(sample);
 
         PositionSample3f ps = dr::zeros<PositionSample3f>();
-        ps.p    = m_to_world.value() * Point3f(p.x(), p.y(), 0.f);
-        ps.n    = m_frame.n;
-        ps.pdf  = m_inv_surface_area;
-        ps.time = time;
+        Point3f local(p.x(), p.y(), 0.f);
+        ps.p     = m_to_world.value() * local;
+        ps.n     = m_frame.n;
+        ps.p_err = m_to_world.value().position_error(local, ps.n);
+        ps.pdf   = m_inv_surface_area;
+        ps.time  = time;
         ps.delta = false;
 
         Float r = dr::norm(p);
@@ -466,6 +468,7 @@ public:
         Point2f prim_uv(local.x(), local.y());
 
         si.n = m_frame.n;
+        si.p_err = to_world.position_error(local, si.n);
 
         if (likely(has_flag(ray_flags, RayFlags::Shading))) {
             Float r_2   = dr::squared_norm(prim_uv),

--- a/src/shapes/ellipsoids.cpp
+++ b/src/shapes/ellipsoids.cpp
@@ -398,6 +398,7 @@ public:
 
         si.n = dr::detach(
             dr::normalize(rot * (local_d / dr::square(ellipsoid.scale))));
+        si.p_err = ray_error(ray, pi.t, si.n);
 
         Point3f p_att = ellipsoid.center +
                         rot * (ellipsoid.scale *

--- a/src/shapes/ellipsoidsmesh.cpp
+++ b/src/shapes/ellipsoidsmesh.cpp
@@ -387,7 +387,7 @@ private:
             UInt32 offset = idx * uint32_t(nb_vertices);
             for (int i = 0; i < nb_faces; ++i) {
                 Vector3u face = m_shell_faces[i];
-                // 4-word face records; the BSDF index lane is zero
+                // 4-word face records; the fourth word is derived below
                 Vector4u rec(face[0] + offset, face[1] + offset,
                              face[2] + offset, 0u);
                 dr::scatter(m_packed_faces, rec, idx * nb_faces + i, true,
@@ -398,6 +398,7 @@ private:
             // Mesh::refresh(), which would build data structures that it
             // does not need. The field views now describe stale records
             // and rebuild on demand.
+            this->update_face_state();
             this->drop_views();
 #if defined(MI_ENABLE_LLVM) && !defined(MI_ENABLE_EMBREE)
             m_packed_vertices_ptr = m_packed_vertices.data();
@@ -444,21 +445,22 @@ private:
                 UInt32 offset = (uint32_t) i * uint32_t(nb_vertices);
                 for (size_t j = 0; j < nb_faces; ++j) {
                     Vector3u face = m_shell_faces[j];
-                    // 4-word face records; the BSDF index lane stays zero
+                    // 4-word face records; the fourth word is derived below
                     for (size_t k = 0; k < 3; ++k)
                         m_packed_faces[i * nb_faces * 4 + j * 4 + k] = face[k] + offset;
                 }
-
-                // Skips Mesh::refresh(), see above
-                this->drop_views();
-#if defined(MI_ENABLE_LLVM) && !defined(MI_ENABLE_EMBREE)
-                m_packed_vertices_ptr = m_packed_vertices.data();
-                m_packed_faces_ptr = m_packed_faces.data();
-#endif
-                if (initialized)
-                    recompute_bbox();
-                mark_dirty();
             }
+
+            // Skips Mesh::refresh(), see above
+            this->update_face_state();
+            this->drop_views();
+#if defined(MI_ENABLE_LLVM) && !defined(MI_ENABLE_EMBREE)
+            m_packed_vertices_ptr = m_packed_vertices.data();
+            m_packed_faces_ptr = m_packed_faces.data();
+#endif
+            if (initialized)
+                recompute_bbox();
+            mark_dirty();
         }
     }
 

--- a/src/shapes/linearcurve.cpp
+++ b/src/shapes/linearcurve.cpp
@@ -358,6 +358,7 @@ public:
 
         Vector3f rad_vec_d = si.p - dr::detach(c);
         si.n = dr::normalize(rad_vec_d);
+        si.p_err = ray_error(ray, pi.t, si.n);
 
         // Surface position at the detached parameterization: the offset from the
         // center line is held fixed in the curve's frame, so that it rotates

--- a/src/shapes/rectangle.cpp
+++ b/src/shapes/rectangle.cpp
@@ -161,13 +161,14 @@ public:
         MI_MASK_ARGUMENT(active);
 
         PositionSample3f ps = dr::zeros<PositionSample3f>();
-        ps.p = m_to_world.value() *
-            Point3f(dr::fmadd(sample.x(), 2.f, -1.f),
-                    dr::fmadd(sample.y(), 2.f, -1.f), 0.f);
-        ps.n    = m_frame.n;
-        ps.pdf  = m_inv_surface_area;
-        ps.uv   = sample;
-        ps.time = time;
+        Point3f local(dr::fmadd(sample.x(), 2.f, -1.f),
+                      dr::fmadd(sample.y(), 2.f, -1.f), 0.f);
+        ps.p     = m_to_world.value() * local;
+        ps.n     = m_frame.n;
+        ps.p_err = m_to_world.value().position_error(local, ps.n);
+        ps.pdf   = m_inv_surface_area;
+        ps.uv    = sample;
+        ps.time  = time;
         ps.delta = false;
 
         return ps;
@@ -214,11 +215,12 @@ public:
 
     SurfaceInteraction3f eval_parameterization(const Point2f &uv, uint32_t, Mask active) const override {
         SurfaceInteraction3f si{};
-        si.p = m_to_world.value() *
-            Point3f(dr::fmadd(uv.x(), 2.f, - 1.f),
-                    dr::fmadd(uv.y(), 2.f, - 1.f), 0.f);
+        Point3f local(dr::fmadd(uv.x(), 2.f, - 1.f),
+                      dr::fmadd(uv.y(), 2.f, - 1.f), 0.f);
+        si.p = m_to_world.value() * local;
         si.sh_frame  = m_frame;
         si.n         = m_frame.n;
+        si.p_err     = m_to_world.value().position_error(local, si.n);
         si.dp_du     = m_frame.s;
         si.dp_dv     = m_frame.t;
         si.uv        = uv;

--- a/src/shapes/sdfgrid.cpp
+++ b/src/shapes/sdfgrid.cpp
@@ -115,6 +115,9 @@ public:
                    parameters_grad_enabled)
     MI_IMPORT_TYPES()
 
+    /// Termination threshold of the numerical root finder, in ray parameter units
+    static constexpr float NumSolveEpsilon = 1e-5f;
+
     // Grid texture is always stored in single precision
     using InputFloat     = dr::replace_scalar_t<Float, float>;
     using InputTexture3f = dr::Texture<InputFloat, 3>;
@@ -356,9 +359,18 @@ public:
         Vector3f local_grad = dr::detach(sdf_grad(local_p));
         Normal3f local_n = dr::normalize(local_grad);
 
+        // Detached normal for the error bound, written so that its primal
+        // ops coincide with those of the attached normal computed below
         si.t = pi.t;
         si.p = dr::detach(to_world) * local_p;
-        si.n = dr::normalize(dr::detach(to_world) * local_n);
+        si.n = dr::normalize(dr::detach(to_world) * Normal3f(local_grad));
+
+        // The hit point is not reprojected onto the level set. Its error
+        // grows with the ray extent, and the root finder tolerance displaces
+        // it further along the ray.
+        si.p_err = to_world.position_error(local_p, si.n) +
+                   ray_error(ray, pi.t, si.n) +
+                   dr::detach(dr::abs_dot(si.n, ray.d)) * NumSolveEpsilon;
 
         Point3f p_att = si.p;
         if constexpr (dr::is_diff_v<Float>) {
@@ -374,10 +386,14 @@ public:
 
         si.attach_motion(ray, p_att, ray_flags);
 
-        Vector3f grad = sdf_grad(m_to_world.value().inverse() * si.p);
+        // Local hit point whose derivative follows the attached world
+        // position. Its primal value is 'local_p', so the grid lookups of
+        // the attached normal are shared with those of 'local_grad'.
+        Point3f local_p_att = local_p;
+        if constexpr (dr::is_diff_v<Float>)
+            local_p_att = dr::replace_grad(local_p, to_object * si.p);
 
-        si.n =
-            dr::normalize(m_to_world.value() * Normal3f(grad));
+        si.n = dr::normalize(to_world * Normal3f(sdf_grad(local_p_att)));
 
         if (likely(has_flag(ray_flags, RayFlags::Shading))) {
             switch (m_normal_method) {
@@ -385,8 +401,7 @@ public:
                     si.sh_frame.n = si.n;
                     break;
                 case Smooth:
-                    si.sh_frame.n =
-                        smooth(m_to_world.value().inverse() * si.p);
+                    si.sh_frame.n = smooth(local_p_att);
                     break;
                 default:
                     Throw("Unknown normal computation.");
@@ -798,7 +813,6 @@ private:
         auto numerical_solve = [&](FloatP t_near, FloatP t_far, FloatP f_near,
                                    FloatP f_far) -> FloatP {
             static constexpr uint32_t num_solve_max_iter = 50;
-            static constexpr float num_solve_epsilon     = 1e-5f;
 
             FloatP t   = 0;
             FloatP f_t = 0;
@@ -814,7 +828,7 @@ private:
 
                 t_near = dr::select(condition > 0.f, t, t_near);
                 f_near = dr::select(condition > 0.f, f_t, f_near);
-                done   = (dr::abs(t_near - t_far) < num_solve_epsilon) ||
+                done   = (dr::abs(t_near - t_far) < NumSolveEpsilon) ||
                        (num_solve_max_iter < ++i);
             }
 

--- a/src/shapes/sphere.cpp
+++ b/src/shapes/sphere.cpp
@@ -130,6 +130,13 @@ public:
     using typename Base::ScalarSize;
     using typename Base::ScalarIndex;
 
+    /// Bound on the rounding error of a position on the sphere along ``n``
+    Float position_error(const Normal3f &n) const {
+        Vector3f mag = dr::abs(Vector3f(dr::detach(m_center.value()))) +
+                       dr::detach(m_radius.value());
+        return dr::dot(dr::abs(dr::detach(n)), mag) * math::PositionEpsilon<Float>;
+    }
+
     Sphere(const Properties &props) : Base(props) {
         /// Are the sphere normals pointing inwards? default: no
         m_flip_normals = props.get<bool>("flip_normals", false);
@@ -217,10 +224,12 @@ public:
         MI_MASK_ARGUMENT(active);
 
         Point3f local = warp::square_to_uniform_sphere(sample);
+        Vector3f dir = m_to_world.value() * Vector3f(local);
 
         PositionSample3f ps = dr::zeros<PositionSample3f>();
-        ps.p = m_to_world.value() * local;
-        ps.n = local;
+        ps.p = m_center.value() + dir;
+        ps.n = dr::normalize(dir);
+        ps.p_err = position_error(ps.n);
 
         if (m_flip_normals)
             ps.n = -ps.n;
@@ -284,6 +293,7 @@ public:
             DirectionSample3f ds = dr::zeros<DirectionSample3f>();
             ds.p        = dr::fmadd(d, m_radius.value(), m_center.value());
             ds.n        = d;
+            ds.p_err    = position_error(ds.n);
             ds.d        = ds.p - it.p;
 
             Float dist2 = dr::squared_norm(ds.d);
@@ -301,6 +311,7 @@ public:
             DirectionSample3f ds = dr::zeros<DirectionSample3f>();
             ds.p        = dr::fmadd(d, m_radius.value(), m_center.value());
             ds.n        = d;
+            ds.p_err    = position_error(ds.n);
             ds.d        = ds.p - it.p;
 
             Float dist2 = dr::squared_norm(ds.d);
@@ -649,6 +660,7 @@ public:
         si.t = pi.t;
         si.n = dr::detach(dr::normalize(ray(pi.t) - center));
         si.p = dr::detach(dr::fmadd(si.n, radius, center));
+        si.p_err = position_error(si.n);
 
         // Surface position at the detached parameterization: the local
         // coordinates are static as the sphere moves.


### PR DESCRIPTION
Mitsuba previously used an extremely conservative ray epsilon heuristic (`RayEpsilon * (1 + max|p|)`) tuned to shift the intersection by 1500 ULP. This is ~2 orders of magnitude larger than what the ray tracing backends actually require in practice (~1-8 ULP). The ``1+`` floor causes an offset of >=~9e-5, which can be too big when the scene uses units that cause it to occupy a small numeric range (e.g. ~1e-3). The ``max|p|`` term also does not consider surface orientation. For example, an intersection point at some large ``x`` value does not need a proportional offset when the normal points into the ``y`` axis. Finally, `spawn_ray_to()` for shadow rays used an even larger ``ShadowEpsilon`` of approximately 15'000 ULP.

Following this commit, shapes now directly specify the expected rounding error along the normal via `Interaction::p_err` and `PositionSample::p_err`. `Interaction::spawn_ray()` simply uses this value in place of the current heuristic. The bound is the sum of the coordinate magnitudes that enter the position computation, projected onto the normal and multiplied by an epsilon factor. The CUDA/Metal/LLVM backends require an epsilon of 1-8 ULP, and the current value of `math::PositionEpsilon` (32) leaves a >4x safety margin.

The bounds are computed as follows:

- Meshes: the `triangle_position_error()` computes the maximum possible sum of per-component position and edge tangents and projects that onto the normal. Computing this bound has some cost, and Mitsuba therefore stores it in the packed per-face data instead of recomputing it at every hit.

- Instances transport the nested bound exactly by checking how the face normal transforms. They also account for rounding error of the transformation itself. The scene now stores the instance transformation's forward and inverse maps together to faciliate the computation.

- Spheres compute the bound using `|center| + radius`.

- Cylinder, disk, rectangle use local coordinates with unit magnitude. Their bound arises from the ``to_world`` transformation and is computed via `Transform::position_error()`.

- Curves and ellipsoids use `ray(t)` as the hit point, and the new `ray_error()` bounds it by `|o| + |d t|`.

- The SDF grid uses the ray bound plus a termination threshold of the root finder.